### PR TITLE
Add trialId as key in response block

### DIFF
--- a/src/components/interface/AppNavBar.tsx
+++ b/src/components/interface/AppNavBar.tsx
@@ -37,7 +37,7 @@ export default function AppNavBar() {
       {trialHasSideBarResponses && (
         <Navbar.Section bg="gray.1" p="xl" grow>
           {config && (
-            <ResponseBlock status={status} config={config} location="sidebar" correctAnswer={
+            <ResponseBlock key={trialId} status={status} config={config} location="sidebar" correctAnswer={
               config.type === 'practice' && stimulus
                 ? stimulus.stimulus.correctAnswer
                 : null


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #115 

### Give a longer description of what this PR addresses and why it's needed
All the props passed to ResponseBlock could be same for different stimuli preventing re-rendering of the component.
So, adding key fixes the issue of not re-rendering when stimuli is updated.
