### PR TITLE
Use task.id as task title in the admin panel

### DIFF
--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -52,7 +52,7 @@ export default function AppAside() {
           <React.Fragment key={`admin_${task.id}`}>
             <Paper radius={0} p={0} withBorder>
               <Paper bg={isCorrect ? 'blue.0' : 'red.0'} radius={0} p="xl">
-                <Flex>
+                <Flex style={{ justifyContent: 'space-between'}}>
                   <Text c="gray.9">
                     <Text
                       span
@@ -62,8 +62,9 @@ export default function AppAside() {
                     >
                       Task {index + 1}:
                     </Text>{' '}
-                    {task.instruction}
+                    {task.id}
                   </Text>
+                  <Space></Space>
                   <ActionIcon
                     bg="white"
                     onClick={() =>
@@ -76,15 +77,6 @@ export default function AppAside() {
               </Paper>
 
               <Paper radius={0} p="xl">
-                {task.id && (
-                  <Text fw={900}>
-                    Task ID:{' '}
-                    <Text component="span" fw={400}>
-                      {task.id}
-                    </Text>
-                  </Text>
-                )}
-
                 {task.description && (
                   <Text fw={900}>
                     Description:{' '}


### PR DESCRIPTION
### Does this PR close any open issues?
Depends #148 
Closes #95 

### Give a longer description of what this PR addresses and why it's needed
This PR makes the admin panel use `task.id` instead of `task.instruction`.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/revisit-studies/study/assets/36867477/c2925f96-4afa-4bf5-b804-eea8383dd6cb)

### Are there any additional TODOs before this PR is ready to go?
No