### PR TITLE
Add typedoc generation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,9 +23,18 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@v3
+        name: Deploy
+        id: deploy
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+
+      - uses: peter-evans/repository-dispatch@v2
+        name: Build documentation in revisit.dev
+        if: ${{ steps.deploy.outcome == 'success' }}
+        with:
+          token: ${{ secrets.PAT }}
+          repository: revisit-studies/reVISit-studies.github.io
+          event-type: study_repo_publish

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist-ssr
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+docs/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
+    "buildDocs": "yarn typedoc --plugin typedoc-plugin-markdown src/parser/types.ts",
     "serve": "vite --host=0.0.0.0 --port=8080",
     "build": "tsc && vite build",
     "lint": "eslint src",
@@ -38,7 +39,9 @@
     "react-markdown": "^8.0.5",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.10.0",
-    "ts-json-schema-generator": "^1.2.0"
+    "ts-json-schema-generator": "^1.2.0",
+    "typedoc": "^0.24.8",
+    "typedoc-plugin-markdown": "^3.15.4"
   },
   "devDependencies": {
     "@playwright/test": "^1.35.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "buildDocs": "yarn typedoc --plugin typedoc-plugin-markdown src/parser/types.ts",
+    "buildDocs": "yarn typedoc",
     "serve": "vite --host=0.0.0.0 --port=8080",
     "build": "tsc && vite build",
     "lint": "eslint src",
@@ -41,6 +41,7 @@
     "react-router-dom": "^6.10.0",
     "ts-json-schema-generator": "^1.2.0",
     "typedoc": "^0.24.8",
+    "typedoc-plugin-frontmatter": "^0.0.2",
     "typedoc-plugin-markdown": "^3.15.4"
   },
   "devDependencies": {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,4 +1,7 @@
-// Global config types
+/**
+ * The GlobalConfig is used to generate the list of available studies in the UI.
+ * This list is displayed on the landing page when running the app.
+*/ 
 export interface GlobalConfig {
   configs: {
     [key: string]: {
@@ -8,7 +11,11 @@ export interface GlobalConfig {
   configsList: string[];
 }
 
-// Study config types
+/** 
+ * The StudyMetadata is used to describe certain properties of a study.
+ * Some of this data is displayed on the landing page when running the app, such as the title and description.
+ * This data is also included in the data file that is downloaded at the end of the study, to help identify the study and version.
+*/
 export interface StudyMetadata {
   title: string;
   version: string;
@@ -18,6 +25,11 @@ export interface StudyMetadata {
   organizations: string[];
 }
 
+/**
+ * The UIConfig is used to configure the UI of the app.
+ * This includes the logo, contact email, and whether to show a progress bar.
+ * The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses.
+ */
 export type UIConfig = {
   contactEmail: string;
   helpTextPath?: string;
@@ -29,11 +41,21 @@ export type UIConfig = {
   sidebar: boolean;
 };
 
+/**
+ * The Option interface is used to define the options for a dropdown, slider, radio, or checkbox response.
+ * The label is the text that is displayed to the user, and the value is the value that is stored in the data file.
+ * The Option interface is used in the Response interface.
+ */
 export interface Option {
   label: string;
   value: string | number;
 }
 
+/**
+ * The BaseResponse interface is used to define the required fields for all responses.
+ * Other Response interfaces inherit properties from the BaseResponse interface.
+ * Therefore, all responses must include these properties.
+ */
 interface BaseResponse {
   // Required fields for all responses
   id: string;
@@ -42,6 +64,10 @@ interface BaseResponse {
   location: ResponseBlockLocation;
 }
 
+/**
+ * The NumericalResponse interface is used to define the properties of a numerical response.
+ * NumericalResponses render as a text input that only accepts numbers, and can optionally have a min and max value, or a placeholder.
+ */
 export interface NumericalResponse extends BaseResponse {
   type: 'numerical';
   placeholder?: string;
@@ -49,54 +75,90 @@ export interface NumericalResponse extends BaseResponse {
   max?: number;
 }
 
+/**
+ * The ShortTextResponse interface is used to define the properties of a short text response.
+ * ShortTextResponses render as a text input that accepts any text and can optionally have a placeholder.
+ */
 export interface ShortTextResponse extends BaseResponse {
   type: 'shortText';
   placeholder?: string;
 }
 
+/**
+ * The LongTextResponse interface is used to define the properties of a long text response.
+ * LongTextResponses render as a text area that accepts any text and can optionally have a placeholder.
+ */
 export interface LongTextResponse extends BaseResponse {
   type: 'longText';
   placeholder?: string;
 }
 
+/**
+ * The LikertResponse interface is used to define the properties of a likert response.
+ * LikertResponses render as radio buttons with a user specified number of options, which can be controlled through the preset. For example, preset: 5 will render 5 radio buttons, and preset: 7 will render 7 radio buttons.
+ * LikertResponses can also have a description, and left and right labels.
+ * The left and right labels are used to label the left and right ends of the likert scale with values such as 'Strongly Disagree' and 'Strongly Agree'.
+ */
 export interface LikertResponse extends BaseResponse {
   type: 'likert';
   preset: number;
   desc?: string;
-  rightLabel?: string;
   leftLabel?: string;
+  rightLabel?: string;
 }
 
+/**
+ * The DropdownResponse interface is used to define the properties of a dropdown response.
+ * DropdownResponses render as a select input with user specified options.
+ */
 export interface DropdownResponse extends BaseResponse {
   type: 'dropdown';
   placeholder?: string;
   options: Option[];
 }
 
+/**
+ * The SliderResponse interface is used to define the properties of a slider response.
+ * SliderResponses render as a slider input with user specified steps. For example, you could have steps of 0, 50, and 100.
+ */
 export interface SliderResponse extends BaseResponse {
   type: 'slider';
   options: Option[];
 }
 
+/**
+ * The RadioResponse interface is used to define the properties of a radio response.
+ * RadioResponses render as a radio input with user specified options, and optionally left and right labels.
+ */
 export interface RadioResponse extends BaseResponse {
   type: 'radio';
   options: Option[];
-  rightLabel?: string;
   leftLabel?: string;
+  rightLabel?: string;
 }
 
+/**
+ * The CheckboxResponse interface is used to define the properties of a checkbox response.
+ * CheckboxResponses render as a checkbox input with user specified options.
+ */
 export interface CheckboxResponse extends BaseResponse {
   type: 'checkbox';
   options: Option[];
 }
 
+/**
+ * The IFrameResponse interface is used to define the properties of an iframe response.
+ * IFrameResponses render as a list, that is connected to a WebsiteComponent. When data is sent from the WebsiteComponent, it is displayed in the list.
+ */
 export interface IFrameResponse extends BaseResponse {
   type: 'iframe';
 }
 
 export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | IFrameResponse;
 
-
+/**
+ * The Answer interface is used to define the properties of an answer. Answers are used to define the correct answer for a task. These are generally used in training tasks.
+ */
 export interface Answer {
   id: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,13 +169,26 @@ export interface Answer {
   answerRegex?: string;
 }
 
+/**
+ * @ignore
+ */
 export const responseBlockLocations = [
   'sidebar',
   'aboveStimulus',
   'belowStimulus',
 ] as const;
+/**
+ * @ignore
+ */
 export type ResponseBlockLocation = (typeof responseBlockLocations)[number];
 
+/**
+ * The BaseIndividualComponent interface is used to define the required fields for all components. The only exception is the ContainerComponent, which is used to group components together.
+ * 
+ * All components must include the response field, which is an array of Response interfaces.
+ * There are additional optional fields that can be included in a component that help layout the task. These include the nextButtonText, nextButtonLocation, instructionLocation, correctAnswer.
+ * There are other fields that can be included in a component that are used to identify the task in the admin panel. These include the meta, description, instruction, and title fields.
+ */
 export interface BaseIndividualComponent {
   // Required fields for all components
   response: Response[];
@@ -129,23 +204,35 @@ export interface BaseIndividualComponent {
   title?: string;
 }
 
+/**
+ * The MarkdownComponent interface is used to define the properties of a markdown component. The components can be used to render many different things, such as consent forms, instructions, and debriefs. Additionally, you can use the markdown component to render images, videos, and other media, with supporting text.
+ */
 export interface MarkdownComponent extends BaseIndividualComponent {
   type: 'markdown';
   path: string;
 }
 
+/**
+ * The ReactComponent interface is used to define the properties of a react component. This component is used to render react code with certain parameters. These parameters can be used within your react code to render different things.
+ */
 export interface ReactComponent extends BaseIndividualComponent {
   type: 'react-component';
   path: string;
   parameters?: Record<string, unknown>;
 }
 
+/**
+ * The ImageComponent interface is used to define the properties of an image component. This component is used to render an image with optional styling.
+ */
 export interface ImageComponent extends BaseIndividualComponent {
   type: 'image';
   path: string;
   style?: Record<string, string>;
 }
 
+/**
+ * The WebsiteComponent interface is used to define the properties of a website component. A WebsiteComponent is used to render an iframe with a website inside of it. This can be used to display an external website or an html file that is located in the public folder.
+ */
 export interface WebsiteComponent extends BaseIndividualComponent {
   type: 'website';
   path: string;
@@ -153,12 +240,19 @@ export interface WebsiteComponent extends BaseIndividualComponent {
   parameters?: Record<string, unknown>;
 }
 
+/**
+ * The QuestionnaireComponent interface is used to define the properties of a questionnaire component. A QuestionnaireComponent is used to render questions with different response types. The response types are also defined with these documentation. The main use case of this component type is to ask participants questions, without using markdown, websites, images, etc.
+ */
 export interface QuestionnaireComponent extends BaseIndividualComponent {
   type: 'questionnaire';
 }
 
+
 export type IndividualComponent = MarkdownComponent | ReactComponent | ImageComponent | WebsiteComponent | QuestionnaireComponent;
 
+/**
+ * ContainerComponents are used to group components together. They are used to define the order of sub components and can be used to group related tasks, task blocks, or other components together. Ultimately, the plan is to support nesting of ContainerComponents, but this is not currently supported. Additionally, we plan to support randomization of sub components, but this is also not currently supported, either.
+ */
 export interface ContainerComponent {
   type: 'container';
   order: string[];
@@ -171,6 +265,9 @@ export interface StudyComponents {
   [key: string]: StudyComponent;
 }
 
+/**
+ * The StudyConfig interface is used to define the properties of a study configuration. These are the hjson files that live in the public folder. In our repo, one example of this would be public/cleveland/config-cleveland.hjson. 
+ */
 export interface StudyConfig {
   $schema: string;
   studyMetadata: StudyMetadata;
@@ -180,11 +277,13 @@ export interface StudyConfig {
 }
 
 /**
+ * @ignore
  * Helper type to avoid writing Type | undefined | null
  */
 export type Nullable<T> = T | undefined | null;
 
 /**
+ * @ignore
  * Helper type to make reading derived union and intersection types easier.
  * Purely aesthetic
  */
@@ -193,7 +292,10 @@ export type Prettify<T> = {
   /* eslint-disable */
 } & {};
 
-// Typecase helper for ContainerComponent
+/**
+ * @ignore
+ * Typecase helper for ContainerComponent
+ */
 export function isContainerComponent(component: StudyComponent): component is ContainerComponent {
   return component.type === 'container';
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,17 @@
+{
+    "entryPoints": [
+        "src/parser/types.ts"
+    ],
+    "plugin": [
+        "typedoc-plugin-markdown",
+        "typedoc-plugin-frontmatter"
+    ],
+    "name": "",
+    "githubPages": false,
+    "readme": "none",
+    "entryDocument": "index.md",
+    "hideBreadcrumbs": true,
+    "frontmatterGlobals": {
+      "layout": "docs",
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1945,6 +1945,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -3209,6 +3214,18 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+handlebars@^4.7.7:
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -3584,6 +3601,11 @@ json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonc-parser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
@@ -3718,6 +3740,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -3729,6 +3756,11 @@ magic-string@^0.26.7:
   integrity sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==
   dependencies:
     sourcemap-codec "^1.4.8"
+
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 mdast-util-definitions@^5.0.0:
   version "5.1.1"
@@ -4014,7 +4046,14 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimatch@^9.0.0:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -4048,6 +4087,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 node-fetch@2.6.7:
   version "2.6.7"
@@ -4629,6 +4673,16 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shiki@^0.14.1:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.3.tgz#d1a93c463942bdafb9866d74d619a4347d0bbf64"
+  integrity sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==
+  dependencies:
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -4683,6 +4737,11 @@ source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sourcemap-codec@^1.4.8:
   version "1.4.8"
@@ -4931,6 +4990,23 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
+typedoc-plugin-markdown@^3.15.4:
+  version "3.15.4"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.4.tgz#928755d9cf8e2f12c98229920a251760a82247b6"
+  integrity sha512-KpjFL/NDrQAbY147oIoOgob2vAdEchsMcTVd6+e6H2lC1l5xhi48bhP/fMJI7qYQ8th5nubervgqw51z7gY66A==
+  dependencies:
+    handlebars "^4.7.7"
+
+typedoc@^0.24.8:
+  version "0.24.8"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.24.8.tgz#cce9f47ba6a8d52389f5e583716a2b3b4335b63e"
+  integrity sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.3.0"
+    minimatch "^9.0.0"
+    shiki "^0.14.1"
+
 typescript@^4.6.4:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
@@ -4940,6 +5016,11 @@ typescript@~4.9.3:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+uglify-js@^3.1.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -5093,6 +5174,16 @@ vite@^4.3.9:
   optionalDependencies:
     fsevents "~2.3.2"
 
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -5154,6 +5245,11 @@ word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,6 +4990,13 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
+typedoc-plugin-frontmatter@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-frontmatter/-/typedoc-plugin-frontmatter-0.0.2.tgz#2014e6507ec90602e5aa06b8c2ff3d0c5972d894"
+  integrity sha512-xPw76L4S4/zbd01Tt89CVsJdPiMxztlmkXaA2Wu/l0KEbIrsqSHPv/sGsPI1O+pkZrSpaFr94qLA3ls1MrpKKw==
+  dependencies:
+    yaml "^2.2.2"
+
 typedoc-plugin-markdown@^3.15.4:
   version "3.15.4"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.4.tgz#928755d9cf8e2f12c98229920a251760a82247b6"
@@ -5293,6 +5300,11 @@ yaml@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
   integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
+
+yaml@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
+  integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
 
 yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #153 

### Give a longer description of what this PR addresses and why it's needed
This PR adds the ability to automatically generate type documentation from the TS parser files. I'm using typedoc with some plugins (markdown and frontmatter) — this lets us generate files that Jekyll can parse. This then goes into the build for revisit.dev.

I'm attempting to trigger the build from all pushes to main here. We'll have to see if that works :)

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Check if the hooks work