### PR TITLE
Add ability to capture url parameters

### DIFF
--- a/public/VLAT/config-VLAT.hjson
+++ b/public/VLAT/config-VLAT.hjson
@@ -26,7 +26,17 @@
         introduction: {
             type: markdown
             path: VLAT/introduction.md
-            response: []
+            response: [
+                {
+                    id: prolificId
+                    prompt: Please enter your Prolific ID
+                    required: true
+                    location: belowStimulus
+                    type: shortText
+                    placeholder: Prolific ID
+                    paramCapture: PROLIFIC_ID
+                }
+            ]
         }
         q0: {
             meta: {

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -26,10 +26,10 @@ export function NextButton({
       onClick={async () => {
         if (process) process();
         if (to === 'auto' && computedTo) {
-          navigate(`${computedTo}`);
+          navigate(`${computedTo}${window.location.search}`);
         }
         if (to !== 'auto') {
-          navigate(to);
+          navigate(`${to}${window.location.search}`);
         }
       }}
     >

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mantine/core';
+import { useSearchParams } from 'react-router-dom';
 import { Nullable, Response } from '../../parser/types';
 import { TrialResult } from '../../store/types';
 import CheckBoxInput from './CheckBoxInput';
@@ -26,38 +27,67 @@ export default function ResponseSwitcher({
   answer,
   storedAnswer,
 }: Props) {
+  const [params] = useSearchParams();
 
-  const ans: any = storedAnswer ? { value: storedAnswer } : answer;
+  let paramCapture;
+  if (response.paramCapture) {
+    const value = params.get(response.paramCapture);
+    if (value) {
+      paramCapture = { value };
+    }
+  }
+
+  const isDisabled = disabled || !!paramCapture;
+
+  const ans: any = storedAnswer
+    ? { value: storedAnswer }
+    : paramCapture || answer;
 
   return (
     <>
       <Box sx={{ margin: 10, padding: 5 }}>
         {response.type === 'numerical' && (
-          <NumericInput response={response} disabled={disabled} answer={ans} />
+          <NumericInput
+            response={response}
+            disabled={isDisabled}
+            answer={ans}
+          />
         )}
         {response.type === 'shortText' && (
-          <StringInput response={response}  disabled={disabled} answer={ans} />
+          <StringInput response={response} disabled={isDisabled} answer={ans} />
         )}
         {response.type === 'longText' && (
-          <TextAreaInput response={response} disabled={disabled} answer={ans} />
+          <TextAreaInput
+            response={response}
+            disabled={isDisabled}
+            answer={ans}
+          />
         )}
         {response.type === 'likert' && (
-          <LikertInput response={response} disabled={disabled} answer={ans} />
+          <LikertInput response={response} disabled={isDisabled} answer={ans} />
         )}
         {response.type === 'dropdown' && (
-          <DropdownInput response={response} disabled={disabled} answer={ans} />
+          <DropdownInput
+            response={response}
+            disabled={isDisabled}
+            answer={ans}
+          />
         )}
         {response.type === 'slider' && (
-          <SliderInput response={response} disabled={disabled} answer={ans} />
+          <SliderInput response={response} disabled={isDisabled} answer={ans} />
         )}
         {response.type === 'radio' && (
-          <RadioInput response={response} disabled={disabled} answer={ans} />
+          <RadioInput response={response} disabled={isDisabled} answer={ans} />
         )}
         {response.type === 'checkbox' && (
-          <CheckBoxInput response={response} disabled={disabled} answer={ans} />
+          <CheckBoxInput
+            response={response}
+            disabled={isDisabled}
+            answer={ans}
+          />
         )}
         {response.type === 'iframe' && (
-          <IframeInput response={response} disabled={disabled} answer={ans} />
+          <IframeInput response={response} disabled={isDisabled} answer={ans} />
         )}
       </Box>
     </>

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -45,6 +45,9 @@
           },
           "type": "array"
         },
+        "paramCapture": {
+          "type": "string"
+        },
         "prompt": {
           "type": "string"
         },
@@ -86,6 +89,9 @@
           },
           "type": "array"
         },
+        "paramCapture": {
+          "type": "string"
+        },
         "placeholder": {
           "type": "string"
         },
@@ -123,6 +129,9 @@
         },
         "location": {
           "$ref": "#/definitions/ResponseBlockLocation"
+        },
+        "paramCapture": {
+          "type": "string"
         },
         "prompt": {
           "type": "string"
@@ -252,6 +261,9 @@
         "location": {
           "$ref": "#/definitions/ResponseBlockLocation"
         },
+        "paramCapture": {
+          "type": "string"
+        },
         "preset": {
           "type": "number"
         },
@@ -292,6 +304,9 @@
         },
         "location": {
           "$ref": "#/definitions/ResponseBlockLocation"
+        },
+        "paramCapture": {
+          "type": "string"
         },
         "placeholder": {
           "type": "string"
@@ -388,6 +403,9 @@
         },
         "min": {
           "type": "number"
+        },
+        "paramCapture": {
+          "type": "string"
         },
         "placeholder": {
           "type": "string"
@@ -607,6 +625,9 @@
           },
           "type": "array"
         },
+        "paramCapture": {
+          "type": "string"
+        },
         "prompt": {
           "type": "string"
         },
@@ -741,6 +762,9 @@
         "location": {
           "$ref": "#/definitions/ResponseBlockLocation"
         },
+        "paramCapture": {
+          "type": "string"
+        },
         "placeholder": {
           "type": "string"
         },
@@ -783,6 +807,9 @@
             "$ref": "#/definitions/Option"
           },
           "type": "array"
+        },
+        "paramCapture": {
+          "type": "string"
         },
         "prompt": {
           "type": "string"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -65,6 +65,7 @@ export interface BaseResponse {
   location: ResponseBlockLocation;
   requiredValue?: unknown;
   requiredLabel?: string;
+  paramCapture?: string;
 }
 
 /**


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed
Parameters such as prolific id will to be automatically populated in the forms.
If there is such parameter, the field is disabled.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/revisit-studies/study/assets/3049313/0648c8ca-b8c3-41e9-991a-d7a153f411ad)

**Example config**

```json
{
  "response": [
    {
      "id": "prolificId",
      "prompt": "Please enter your Prolific ID",
      "required": true,
      "location": "belowStimulus",
      "type": "shortText",
      "placeholder": "Prolific ID",
      "paramCapture": "PROLIFIC_ID"
    }
  ]
}
```
