### PR TITLE
Add an end of study uploading notification

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,4 @@ VITE_FIREBASE_CONFIG='
   appId: "1:811568460432:web:995f6b4f1fc8042b5dde15"
 }
 '
+VITE_STORAGE_ENGINE="firebase" # "firebase" or "localStorage" or your own custom storage engine

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "husky install",
     "generate-schema:StudyConfig": "ts-json-schema-generator --path src/parser/types.ts --out src/parser/StudyConfigSchema.json --type StudyConfig",
     "generate-schema:GlobalConfig": "ts-json-schema-generator --path src/parser/types.ts --out src/parser/GlobalConfigSchema.json --type GlobalConfig",
-    "test": "playwright test"
+    "test": "VITE_STORAGE_ENGINE=localStorage playwright test"
   },
   "lint-staged": {
     "*.{tsx,jsx,ts,js}": "yarn lint"

--- a/src/components/DownloadPanel.tsx
+++ b/src/components/DownloadPanel.tsx
@@ -74,7 +74,7 @@ export function DownloadPanel({ studyConfig }: { studyConfig: StudyConfig }) {
         mr="0.5em"
         onClick={async () => {
           if (!storageEngine) return;
-          const participants = await storageEngine.getAllParticpantsData();
+          const participants = await storageEngine.getAllParticipantsData();
           download(JSON.stringify(participants, null, 2), `${baseFilename}_all.json`);
         }}
         display="block"

--- a/src/components/DownloadTidy.tsx
+++ b/src/components/DownloadTidy.tsx
@@ -50,7 +50,7 @@ export async function downloadTidy(
   storageEngine: StorageEngine,
   studyConfig: StudyConfig,
 ) {
-  const allParticipantData = await storageEngine.getAllParticpantsData();
+  const allParticipantData = await storageEngine.getAllParticipantsData();
 
   const rows = allParticipantData
     .map((participantSession) => processToRow(participantSession, studyConfig, properties))

--- a/src/components/GlobalInitializer.tsx
+++ b/src/components/GlobalInitializer.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useStorageEngine } from '../store/storageEngineHooks';
 import { GlobalConfigParser } from './GlobalConfigParser';
-import { initalizeStorageEngine } from '../storage/initialize';
+import { initializeStorageEngine } from '../storage/initialize';
 
 export function GlobalInitializer() {
   // Initialize storage engine
@@ -10,7 +10,7 @@ export function GlobalInitializer() {
     if (storageEngine !== undefined) return;
 
     async function fn() {
-      const storageEngine = await initalizeStorageEngine();
+      const storageEngine = await initializeStorageEngine();
       setStorageEngine(storageEngine);
     }
     fn();

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -1,22 +1,45 @@
-import { Center, Flex, Text } from '@mantine/core';
+import { Center, Flex, Loader, Space, Text } from '@mantine/core';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
 import ReactMarkdownWrapper from './ReactMarkdownWrapper';
+import { useStorageEngine } from '../store/storageEngineHooks';
+import { useEffect, useState } from 'react';
 
 
 export function StudyEnd() {
   const config = useStudyConfig();
+  const { storageEngine } = useStorageEngine();
+
+  const [completed, setCompleted] = useState(false);
+  useEffect(() => {
+    // verify that storageEngine.verifyCompletion() returns true, loop until it does
+    const interval = setInterval(async () => {
+      const isComplete = await storageEngine!.verifyCompletion();
+      if (isComplete) {
+        setCompleted(true);
+        clearInterval(interval);
+      }
+    }, 1000);
+  }, []);
 
   return (
       <>
         <Center style={{ height: '100%' }}>
           <Flex direction="column">
-            <Center>
-              <Text size="xl" display="block">
-                {config.uiConfig.studyEndMsg
-                    ? <ReactMarkdownWrapper text={config.uiConfig.studyEndMsg} />
-                    : 'Thank you for completing the study. You may close this window now.'}
-              </Text>
-            </Center>
+              {completed ? 
+                <Text size="xl" display="block">
+                  {config.uiConfig.studyEndMsg
+                      ? <ReactMarkdownWrapper text={config.uiConfig.studyEndMsg} />
+                      : 'Thank you for completing the study. You may close this window now.'}
+                </Text>
+              :
+                <>
+                  <Text size="xl" display="block">Please wait while your answers are uploaded.</Text>
+                  <Space h="lg" />
+                  <Center>
+                    <Loader color="blue" />
+                  </Center>
+                </>
+              }
           </Flex>
         </Center>
       </>

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -337,13 +337,14 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
 
     // Loop over the sequence and check if all answers are present
-    participantData.sequence.forEach((step) => {
-      if (!participantData.answers[step]) {
-        return false;
+    const allAnswersPresent = participantData.sequence.every((step) => {
+      if (step === 'end') {
+        return true;
       }
+      return participantData.answers[step] !== undefined;
     });
 
-    return true;
+    return allAnswersPresent;
   }
 
   private _verifyStudyDatabase(db: CollectionReference<DocumentData, DocumentData> | undefined): db is CollectionReference<DocumentData, DocumentData>  {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -325,6 +325,27 @@ export class FirebaseStorageEngine extends StorageEngine {
     return participant;
   }
 
+  async verifyCompletion() {
+    if (!this._verifyStudyDatabase(this.studyCollection)) {
+      throw new Error('Study database not initialized');
+    }
+
+    // Get the participantData
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    // Loop over the sequence and check if all answers are present
+    participantData.sequence.forEach((step) => {
+      if (!participantData.answers[step]) {
+        return false;
+      }
+    });
+
+    return true;
+  }
+
   private _verifyStudyDatabase(db: CollectionReference<DocumentData, DocumentData> | undefined): db is CollectionReference<DocumentData, DocumentData>  {
     return db !== undefined;
   }

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -228,7 +228,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return currentRow;
   }
 
-  async getAllParticpantsData() {
+  async getAllParticipantsData() {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -46,11 +46,10 @@ export class FirebaseStorageEngine extends StorageEngine {
       await signInAnonymously(auth);
       if (!auth.currentUser) throw new Error('Login failed with firebase');
       enableNetwork(this.firestore);
+      this.connected = true;
     } catch (e) {
       console.warn('Failed to connect to Firebase');
     }
-
-    this.connected = true;
   }
 
   async initializeStudyDb(studyId: string, config: object) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -222,13 +222,14 @@ export class LocalStorageEngine extends StorageEngine {
     }
 
     // Loop over the sequence and check if all answers are present
-    participantData.sequence.forEach((step) => {
-      if (!participantData.answers[step]) {
-        return false;
+    const allAnswersPresent = participantData.sequence.every((step) => {
+      if (step === 'end') {
+        return true;
       }
+      return participantData.answers[step] !== undefined;
     });
 
-    return true;
+    return allAnswersPresent;
   }
 
   private _verifyStudyDatabase(db: LocalForage | undefined): db is LocalForage  {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -210,6 +210,27 @@ export class LocalStorageEngine extends StorageEngine {
     return participant as ParticipantData;
   }
 
+  async verifyCompletion() {
+    if (!this._verifyStudyDatabase(this.studyDatabase)) {
+      throw new Error('Study database not initialized');
+    }
+
+    // Get the participantData
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    // Loop over the sequence and check if all answers are present
+    participantData.sequence.forEach((step) => {
+      if (!participantData.answers[step]) {
+        return false;
+      }
+    });
+
+    return true;
+  }
+
   private _verifyStudyDatabase(db: LocalForage | undefined): db is LocalForage  {
     return db !== undefined;
   }

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -153,7 +153,7 @@ export class LocalStorageEngine extends StorageEngine {
     return await this.studyDatabase.getItem('sequenceArray') as string[][] | null;
   }
 
-  async getAllParticpantsData() {
+  async getAllParticipantsData() {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -39,4 +39,6 @@ export abstract class StorageEngine {
   abstract getParticipantData(): Promise<ParticipantData | null>;
 
   abstract nextParticipant(): Promise<ParticipantData>;
+
+  abstract verifyCompletion(): Promise<boolean>;
 }

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -35,7 +35,7 @@ export abstract class StorageEngine {
   abstract getSequenceArray(): Promise<string[][] | null>;
   abstract getSequence(): Promise<string[]>;
 
-  abstract getAllParticpantsData(): Promise<ParticipantData[]>;
+  abstract getAllParticipantsData(): Promise<ParticipantData[]>;
   abstract getParticipantData(): Promise<ParticipantData | null>;
 
   abstract nextParticipant(): Promise<ParticipantData>;

--- a/src/storage/initialize.ts
+++ b/src/storage/initialize.ts
@@ -2,7 +2,7 @@ import { LocalStorageEngine } from './engines/LocalStorageEngine';
 import { FirebaseStorageEngine } from './engines/FirebaseStorageEngine';
 import { StorageEngine } from './engines/StorageEngine';
 
-export async function initalizeStorageEngine() {
+export async function initializeStorageEngine() {
   let storageEngine: StorageEngine | undefined;
 
   const storageEngineName: string = import.meta.env.VITE_STORAGE_ENGINE; 

--- a/src/storage/initialize.ts
+++ b/src/storage/initialize.ts
@@ -3,26 +3,29 @@ import { FirebaseStorageEngine } from './engines/FirebaseStorageEngine';
 import { StorageEngine } from './engines/StorageEngine';
 
 export async function initalizeStorageEngine() {
-  let storageEngine: StorageEngine;
-  let fallback = false;
+  let storageEngine: StorageEngine | undefined;
 
-  if (import.meta.env.PROD) {
+  const storageEngineName: string = import.meta.env.VITE_STORAGE_ENGINE; 
+
+  if (storageEngineName === 'firebase') {
     const firebaseStorageEngine = new FirebaseStorageEngine();
     await firebaseStorageEngine.connect();
 
     if (firebaseStorageEngine.isConnected()) {
       storageEngine = firebaseStorageEngine;
-    } else {
-      fallback = true;
     }
   }
 
-  if (import.meta.env.DEV || fallback) {
+  if (storageEngineName === 'localStorage') {
     const localStorageEngine = new LocalStorageEngine();
     await localStorageEngine.connect();
 
     storageEngine = localStorageEngine;
   }
 
-  return storageEngine!;
+  if (!storageEngine) {
+    throw new Error(`The requested storage engine "${storageEngineName}" could not be initialized.`);
+  }
+
+  return storageEngine;
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #195 

### Give a longer description of what this PR addresses and why it's needed
This adds a screen before the end of study screen that shows the user that the answers are uploading. I decided to add a method to loop through the sequence and verify that they were answers for each step. This works well, since even steps without responses save an empty object in the answers, but shows the spinner forever if you jump to the end as an admin

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/revisit-studies/study/assets/36867477/78e26285-cd8b-4eb6-a80e-700b3097d7dc)

### Are there any additional TODOs before this PR is ready to go?
No