### PR TITLE
Track all events for later rehydration

### DIFF
--- a/public/html-demo/config-html-demo.hjson
+++ b/public/html-demo/config-html-demo.hjson
@@ -21,6 +21,7 @@
         withProgressBar: true
         autoDownloadStudy: false
         sidebar: true
+        windowEventDebounceTime: 200
     }
     components: {
         introduction: {

--- a/src/components/DownloadTidy.tsx
+++ b/src/components/DownloadTidy.tsx
@@ -83,7 +83,7 @@ function processToRow(session: ParticipantData, studyConfig: StudyConfig, proper
 
     // Get the answer for this trial or an empty answer if it doesn't exist
     const trialAns = session.answers[trialId];
-    const trialAnswer: StoredAnswer = trialAns !== undefined ? trialAns : { answer: {}, startTime: -1, endTime: -1 };
+    const trialAnswer: StoredAnswer = trialAns !== undefined ? trialAns : { answer: {}, startTime: -1, endTime: -1, windowEvents: [] };
 
     const duration = trialAnswer.endTime - trialAnswer.startTime;
 

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -25,15 +25,94 @@ export function StepRenderer() {
 
   // Attach event listeners
   useEffect(() => {
-    const mouseMoveListener = debounce(
-      (e: MouseEvent) => {
-        windowEvents.current.push([Date.now(), 'mousemove', [e.clientX, e.clientY]]);
-      },
-      100,
-      {maxWait: 100}
-    );
+    // Clipboard
+    const copyListener = debounce((e: ClipboardEvent) => {
+      windowEvents.current.push([Date.now(), 'copy', e.clipboardData?.getData('text') ?? '']);
+    }, 100, {maxWait: 100});
+  
+    // Drag'n'drop
+    const dragListener = debounce((e: DragEvent) => {
+      windowEvents.current.push([Date.now(), 'drag', [e.clientX, e.clientY]]);
+    }, 100, {maxWait: 100});
+  
+    // Wheel
+    const wheelListener = debounce((e: WheelEvent) => {
+      windowEvents.current.push([Date.now(), 'wheel', [e.deltaX, e.deltaY]]);
+    }, 100, {maxWait: 100});
+  
+    // Focus
+    const focusListener = debounce((e: FocusEvent) => {
+      windowEvents.current.push([Date.now(), 'focus', e.target instanceof HTMLElement ? e.target.tagName : '']);
+    }, 100, {maxWait: 100});
+  
+    // Inputs
+    const inputListener = debounce((e: InputEvent) => {
+      windowEvents.current.push([Date.now(), 'input', e.data ?? '']);
+    }, 100, {maxWait: 100});
+  
+    // Keyboard
+    const keypressListener = debounce((e: KeyboardEvent) => {
+      windowEvents.current.push([Date.now(), 'keypress', e.key]);
+    }, 100, {maxWait: 100});
+  
+    // Mouse/Pointer/Touch
+    const clickListener = debounce((e: MouseEvent) => {
+      windowEvents.current.push([Date.now(), 'click', [e.clientX, e.clientY]]);
+    }, 100, {maxWait: 100});
+  
+    // Text selection
+    const selectionListener = debounce(() => {
+      const selection = window.getSelection()?.toString();
+      windowEvents.current.push([Date.now(), 'selection', selection ?? '']);
+    }, 100, {maxWait: 100});
+  
+    // Window resizing
+    const resizeListener = debounce(() => {
+      windowEvents.current.push([Date.now(), 'resize', [window.innerWidth, window.innerHeight]]);
+    }, 100, {maxWait: 100});
+
+    // Mouse movement
+    const mouseMoveListener = debounce((e: MouseEvent) => {
+      windowEvents.current.push([Date.now(), 'mousemove', [e.clientX, e.clientY]]);
+    }, 100, {maxWait: 100});
+
+    // Scroll
+    const scrollListener = debounce(() => {
+      windowEvents.current.push([Date.now(), 'scroll', [window.scrollX, window.scrollY]]);
+    }, 100, {maxWait: 100});
+
+    // Visibility change
+    const visibilityListener = debounce(() => {
+      windowEvents.current.push([Date.now(), 'visibility', document.visibilityState]);
+    }, 100, {maxWait: 100});
+  
+    window.addEventListener('copy', copyListener);
+    window.addEventListener('drag', dragListener);
+    window.addEventListener('wheel', wheelListener);
+    window.addEventListener('focus', focusListener, true);
+    window.addEventListener('input', inputListener as () => void);
+    window.addEventListener('keypress', keypressListener);
+    window.addEventListener('click', clickListener);
+    document.addEventListener('selectionchange', selectionListener);
+    window.addEventListener('resize', resizeListener);
     window.addEventListener('mousemove', mouseMoveListener);
-    return () => window.removeEventListener('mousemove', mouseMoveListener);
+    window.addEventListener('scroll', scrollListener);
+    document.addEventListener('visibilitychange', visibilityListener);
+  
+    return () => {
+      window.removeEventListener('copy', copyListener);
+      window.removeEventListener('drag', dragListener);
+      window.removeEventListener('wheel', wheelListener);
+      window.removeEventListener('focus', focusListener, true);
+      window.removeEventListener('input', inputListener as () => void);
+      window.removeEventListener('keypress', keypressListener);
+      window.removeEventListener('click', clickListener);
+      document.removeEventListener('selectionchange', selectionListener);
+      window.removeEventListener('resize', resizeListener);
+      window.removeEventListener('mousemove', mouseMoveListener);
+      window.removeEventListener('scroll', scrollListener);
+      document.removeEventListener('visibilitychange', visibilityListener);
+    };
   }, []);
 
   return (

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -69,26 +69,22 @@ export function StepRenderer() {
       windowEvents.current.push([Date.now(), 'visibility', document.visibilityState]);
     }, 100, {maxWait: 100});
 
-    window.addEventListener('drag', dragListener);
     window.addEventListener('focus', focusListener, true);
     window.addEventListener('input', inputListener as () => void);
     window.addEventListener('keypress', keypressListener);
     window.addEventListener('mousedown', mouseDownListener);
     window.addEventListener('mouseup', mouseUpListener);
-    document.addEventListener('selectionchange', selectionListener);
     window.addEventListener('resize', resizeListener);
     window.addEventListener('mousemove', mouseMoveListener);
     window.addEventListener('scroll', scrollListener);
     document.addEventListener('visibilitychange', visibilityListener);
   
     return () => {
-      window.removeEventListener('drag', dragListener);
       window.removeEventListener('focus', focusListener, true);
       window.removeEventListener('input', inputListener as () => void);
       window.removeEventListener('keypress', keypressListener);
       window.addEventListener('mousedown', mouseDownListener);
       window.addEventListener('mouseup', mouseUpListener);
-      document.removeEventListener('selectionchange', selectionListener);
       window.removeEventListener('resize', resizeListener);
       window.removeEventListener('mousemove', mouseMoveListener);
       window.removeEventListener('scroll', scrollListener);

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -8,6 +8,7 @@ import { AlertModal } from './interface/AlertModal';
 import { createContext, useContext, useEffect, useRef } from 'react';
 import debounce from 'lodash.debounce';
 import { EventType } from '../store/types';
+import { useStudyConfig } from '../store/hooks/useStudyConfig';
 
 // Create a context
 const WindowEventsContext = createContext<React.Ref<EventType[]>>(null);
@@ -23,51 +24,55 @@ export function useWindowEvents(): React.Ref<EventType[]> {
 export function StepRenderer() {
   const windowEvents = useRef<EventType[]>([]);
 
+  const studyConfig = useStudyConfig();
+  const windowEventDebounceTime = studyConfig.uiConfig.windowEventDebounceTime ?? 100;
+  console.log(windowEventDebounceTime);
+
   // Attach event listeners
   useEffect(() => {
     // Focus
     const focusListener = debounce((e: FocusEvent) => {
       windowEvents.current.push([Date.now(), 'focus', e.target instanceof HTMLElement ? e.target.tagName : '']);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
   
     // Inputs
     const inputListener = debounce((e: InputEvent) => {
       windowEvents.current.push([Date.now(), 'input', e.data ?? '']);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
   
     // Keyboard
     const keypressListener = debounce((e: KeyboardEvent) => {
       windowEvents.current.push([Date.now(), 'keypress', e.key]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
   
     // Mouse/Pointer/Touch
     const mouseDownListener = debounce((e: MouseEvent) => {
       windowEvents.current.push([Date.now(), 'mousedown', [e.clientX, e.clientY]]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     const mouseUpListener = debounce((e: MouseEvent) => {
       windowEvents.current.push([Date.now(), 'mouseup', [e.clientX, e.clientY]]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
   
     // Window resizing
     const resizeListener = debounce(() => {
       windowEvents.current.push([Date.now(), 'resize', [window.innerWidth, window.innerHeight]]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     // Mouse movement
     const mouseMoveListener = debounce((e: MouseEvent) => {
       windowEvents.current.push([Date.now(), 'mousemove', [e.clientX, e.clientY]]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     // Scroll
     const scrollListener = debounce(() => {
       windowEvents.current.push([Date.now(), 'scroll', [window.scrollX, window.scrollY]]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     // Visibility change
     const visibilityListener = debounce(() => {
       windowEvents.current.push([Date.now(), 'visibility', document.visibilityState]);
-    }, 100, {maxWait: 100});
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     window.addEventListener('focus', focusListener, true);
     window.addEventListener('input', inputListener as () => void);

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -26,7 +26,6 @@ export function StepRenderer() {
 
   const studyConfig = useStudyConfig();
   const windowEventDebounceTime = studyConfig.uiConfig.windowEventDebounceTime ?? 100;
-  console.log(windowEventDebounceTime);
 
   // Attach event listeners
   useEffect(() => {

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -25,21 +25,6 @@ export function StepRenderer() {
 
   // Attach event listeners
   useEffect(() => {
-    // Clipboard
-    const copyListener = debounce((e: ClipboardEvent) => {
-      windowEvents.current.push([Date.now(), 'copy', e.clipboardData?.getData('text') ?? '']);
-    }, 100, {maxWait: 100});
-  
-    // Drag'n'drop
-    const dragListener = debounce((e: DragEvent) => {
-      windowEvents.current.push([Date.now(), 'drag', [e.clientX, e.clientY]]);
-    }, 100, {maxWait: 100});
-  
-    // Wheel
-    const wheelListener = debounce((e: WheelEvent) => {
-      windowEvents.current.push([Date.now(), 'wheel', [e.deltaX, e.deltaY]]);
-    }, 100, {maxWait: 100});
-  
     // Focus
     const focusListener = debounce((e: FocusEvent) => {
       windowEvents.current.push([Date.now(), 'focus', e.target instanceof HTMLElement ? e.target.tagName : '']);
@@ -56,14 +41,12 @@ export function StepRenderer() {
     }, 100, {maxWait: 100});
   
     // Mouse/Pointer/Touch
-    const clickListener = debounce((e: MouseEvent) => {
-      windowEvents.current.push([Date.now(), 'click', [e.clientX, e.clientY]]);
+    const mouseDownListener = debounce((e: MouseEvent) => {
+      windowEvents.current.push([Date.now(), 'mousedown', [e.clientX, e.clientY]]);
     }, 100, {maxWait: 100});
-  
-    // Text selection
-    const selectionListener = debounce(() => {
-      const selection = window.getSelection()?.toString();
-      windowEvents.current.push([Date.now(), 'selection', selection ?? '']);
+
+    const mouseUpListener = debounce((e: MouseEvent) => {
+      windowEvents.current.push([Date.now(), 'mouseup', [e.clientX, e.clientY]]);
     }, 100, {maxWait: 100});
   
     // Window resizing
@@ -85,14 +68,13 @@ export function StepRenderer() {
     const visibilityListener = debounce(() => {
       windowEvents.current.push([Date.now(), 'visibility', document.visibilityState]);
     }, 100, {maxWait: 100});
-  
-    window.addEventListener('copy', copyListener);
+
     window.addEventListener('drag', dragListener);
-    window.addEventListener('wheel', wheelListener);
     window.addEventListener('focus', focusListener, true);
     window.addEventListener('input', inputListener as () => void);
     window.addEventListener('keypress', keypressListener);
-    window.addEventListener('click', clickListener);
+    window.addEventListener('mousedown', mouseDownListener);
+    window.addEventListener('mouseup', mouseUpListener);
     document.addEventListener('selectionchange', selectionListener);
     window.addEventListener('resize', resizeListener);
     window.addEventListener('mousemove', mouseMoveListener);
@@ -100,13 +82,12 @@ export function StepRenderer() {
     document.addEventListener('visibilitychange', visibilityListener);
   
     return () => {
-      window.removeEventListener('copy', copyListener);
       window.removeEventListener('drag', dragListener);
-      window.removeEventListener('wheel', wheelListener);
       window.removeEventListener('focus', focusListener, true);
       window.removeEventListener('input', inputListener as () => void);
       window.removeEventListener('keypress', keypressListener);
-      window.removeEventListener('click', clickListener);
+      window.addEventListener('mousedown', mouseDownListener);
+      window.addEventListener('mouseup', mouseUpListener);
       document.removeEventListener('selectionchange', selectionListener);
       window.removeEventListener('resize', resizeListener);
       window.removeEventListener('mousemove', mouseMoveListener);

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -5,8 +5,28 @@ import AppHeader from './interface/AppHeader';
 import AppNavBar from './interface/AppNavBar';
 import HelpModal from './interface/HelpModal';
 import { AlertModal } from './interface/AlertModal';
+import { useEffect, useRef } from 'react';
+import debounce from 'lodash.debounce';
+
+// timestamp, event type, event data
+type EventType = [number, 'mousemove', number[]]
 
 export function StepRenderer() {
+  const windowEvents = useRef<EventType[]>([]);
+
+  // Attach event listeners
+  useEffect(() => {
+    const mouseMoveListener = debounce(
+      (e: MouseEvent) => {
+        windowEvents.current.push([Date.now(), 'mousemove', [e.clientX, e.clientY]]);
+      },
+      100,
+      {maxWait: 100}
+    );
+    window.addEventListener('mousemove', mouseMoveListener);
+    return () => window.removeEventListener('mousemove', mouseMoveListener);
+  }, []);
+
   return (
     <AppShell
       navbar={<AppNavBar />}
@@ -15,7 +35,7 @@ export function StepRenderer() {
     >
       <HelpModal />
       <AlertModal/>
-      <Outlet />
+      <Outlet context={[windowEvents]}/>
     </AppShell>
   );
 }

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -5,11 +5,20 @@ import AppHeader from './interface/AppHeader';
 import AppNavBar from './interface/AppNavBar';
 import HelpModal from './interface/HelpModal';
 import { AlertModal } from './interface/AlertModal';
-import { useEffect, useRef } from 'react';
+import { createContext, useContext, useEffect, useRef } from 'react';
 import debounce from 'lodash.debounce';
+import { EventType } from '../store/types';
 
-// timestamp, event type, event data
-type EventType = [number, 'mousemove', number[]]
+// Create a context
+const WindowEventsContext = createContext<React.Ref<EventType[]>>(null);
+
+export function useWindowEvents(): React.Ref<EventType[]> {
+  const context = useContext(WindowEventsContext);
+  if (!context) {
+    throw new Error('useWindowEvents must be used within a WindowEventsProvider');
+  }
+  return context;
+}
 
 export function StepRenderer() {
   const windowEvents = useRef<EventType[]>([]);
@@ -28,14 +37,16 @@ export function StepRenderer() {
   }, []);
 
   return (
-    <AppShell
-      navbar={<AppNavBar />}
-      aside={<AppAside />}
-      header={<AppHeader />}
-    >
-      <HelpModal />
-      <AlertModal/>
-      <Outlet context={[windowEvents]}/>
-    </AppShell>
+    <WindowEventsContext.Provider value={windowEvents}>
+      <AppShell
+        navbar={<AppNavBar />}
+        aside={<AppAside />}
+        header={<AppHeader />}
+      >
+        <HelpModal />
+        <AlertModal />
+        <Outlet />
+      </AppShell>
+    </WindowEventsContext.Provider>
   );
 }

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -14,6 +14,7 @@ import { IndividualComponent } from '../parser/types';
 import { disableBrowserBack } from '../utils/disableBrowserBack';
 import { useStorageEngine } from '../store/storageEngineHooks';
 import { useStoreActions, useStoreDispatch } from '../store/store';
+import { useOutletContext } from 'react-router-dom';
 
 // current active stimuli presented to the user
 export default function ComponentController() {
@@ -21,6 +22,10 @@ export default function ComponentController() {
   const studyConfig = useStudyConfig();
   const currentStep = useCurrentStep();
   const stepConfig = studyConfig.components[currentStep];
+
+  const [windowEvents] = useOutletContext();
+
+  console.log(windowEvents.current);
   
   // If we have a trial, use that config to render the right component else use the step
   const status = useStoredAnswer();

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -14,7 +14,6 @@ import { IndividualComponent } from '../parser/types';
 import { disableBrowserBack } from '../utils/disableBrowserBack';
 import { useStorageEngine } from '../store/storageEngineHooks';
 import { useStoreActions, useStoreDispatch } from '../store/store';
-import { useOutletContext } from 'react-router-dom';
 
 // current active stimuli presented to the user
 export default function ComponentController() {
@@ -22,10 +21,6 @@ export default function ComponentController() {
   const studyConfig = useStudyConfig();
   const currentStep = useCurrentStep();
   const stepConfig = studyConfig.components[currentStep];
-
-  const [windowEvents] = useOutletContext();
-
-  console.log(windowEvents.current);
   
   // If we have a trial, use that config to render the right component else use the step
   const status = useStoredAnswer();

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -974,6 +974,9 @@
         "studyEndMsg": {
           "type": "string"
         },
+        "windowEventDebounceTime": {
+          "type": "number"
+        },
         "withProgressBar": {
           "type": "boolean"
         }

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -40,6 +40,7 @@ export interface UIConfig {
   autoDownloadTime?: number;
   studyEndMsg?: string;
   sidebar: boolean;
+  windowEventDebounceTime?: number;
 }
 
 /**

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -351,7 +351,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return db !== undefined;
   }
 
-  private async _getFromFirebaseStorage<T extends 'provenance' | 'windowEvents'>(participantId: string, type: T): Promise<Record<string, T extends 'provenance' ? TrrackedProvenance : EventType[]>> {
+  private async _getFromFirebaseStorage<T extends 'provenance' | 'windowEvents'>(participantId: string, type: T) {
     const storage = getStorage();
     const storageRef = ref(storage, `${this.studyId}/${participantId}_${type}`);
 

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -62,6 +62,9 @@ export function useNextStep() {
     const provenanceGraph = trialValidationCopy.provenanceGraph;
     const endTime = Date.now();
 
+    // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
+    const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ?  windowEvents.current.splice(0, windowEvents.current.length) : [];
+
     if (Object.keys(storedAnswer || {}).length === 0) {
       storeDispatch(
         saveTrialAnswer({
@@ -70,13 +73,11 @@ export function useNextStep() {
           startTime,
           endTime,
           provenanceGraph,
+          windowEvents: currentWindowEvents,
         })
       );
       // Update database
       if (storageEngine) {
-        // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
-        const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ?  windowEvents.current.splice(0, windowEvents.current.length) : [];
-
         storageEngine.saveAnswer(
           currentStep, 
           {

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -12,6 +12,7 @@ import { deepCopy } from '../../utils/deepCopy';
 import { ValidationStatus } from '../types';
 import { useStorageEngine } from '../storageEngineHooks';
 import { useStoredAnswer } from './useStoredAnswer';
+import { useWindowEvents } from '../../components/StepRenderer';
 
 export function useNextStep() {
   const currentStep = useCurrentStep();
@@ -48,6 +49,7 @@ export function useNextStep() {
     return Date.now();
   }, []);
 
+  const windowEvents = useWindowEvents();
   const goToNextStep = useCallback(() => {
     // Get answer from across the 3 response blocks and the provenance graph
     const trialValidationCopy = deepCopy(trialValidation[currentStep]);
@@ -59,6 +61,8 @@ export function useNextStep() {
     }, {});
     const provenanceGraph = trialValidationCopy.provenanceGraph;
     const endTime = Date.now();
+
+    console.log(windowEvents?.current);
 
     if (Object.keys(storedAnswer || {}).length === 0) {
       storeDispatch(

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -62,8 +62,6 @@ export function useNextStep() {
     const provenanceGraph = trialValidationCopy.provenanceGraph;
     const endTime = Date.now();
 
-    console.log(windowEvents?.current);
-
     if (Object.keys(storedAnswer || {}).length === 0) {
       storeDispatch(
         saveTrialAnswer({
@@ -76,12 +74,19 @@ export function useNextStep() {
       );
       // Update database
       if (storageEngine) {
-        storageEngine.saveAnswer(currentStep, {
-          answer,
-          startTime,
-          endTime,
-          provenanceGraph,
-        });
+        // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
+        const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ?  windowEvents.current.splice(0, windowEvents.current.length) : [];
+
+        storageEngine.saveAnswer(
+          currentStep, 
+          {
+            answer,
+            startTime,
+            endTime,
+            provenanceGraph,
+            windowEvents: currentWindowEvents,
+          },
+        );
       }
       storeDispatch(setIframeAnswers([]));
     }
@@ -98,6 +103,7 @@ export function useNextStep() {
     currentStep,
     saveTrialAnswer,
     computedTo,
+    windowEvents,
   ]);
 
   return {

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -2,7 +2,7 @@ import { createSlice, configureStore, type PayloadAction } from '@reduxjs/toolki
 import { createContext, useContext } from 'react';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { ResponseBlockLocation, StudyConfig } from '../parser/types';
-import { RootState, StoredAnswer, TrialValidation, TrrackedProvenance, StoreState } from './types';
+import { RootState, StoredAnswer, TrialValidation, TrrackedProvenance, StoreState, EventType } from './types';
 
 export async function studyStoreCreator(
   studyId: string,
@@ -89,15 +89,17 @@ export async function studyStoreCreator(
           startTime: number;
           endTime: number;
           provenanceGraph?: TrrackedProvenance;
+          windowEvents: EventType[];
         }>
       ) {
-        const { currentStep, answer, startTime, endTime, provenanceGraph } = payload;
+        const { currentStep, answer, startTime, endTime, provenanceGraph, windowEvents } = payload;
 
         state.answers[currentStep] = {
           answer: answer,
           startTime: startTime,
           endTime: endTime,
           provenanceGraph,
+          windowEvents,
         };
       },
     },

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -2,7 +2,7 @@ import { createSlice, configureStore, type PayloadAction } from '@reduxjs/toolki
 import { createContext, useContext } from 'react';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { ResponseBlockLocation, StudyConfig } from '../parser/types';
-import { RootState, StoredAnswer, TrialValidation, TrrackedProvenance, StoreState, EventType } from './types';
+import { RootState, StoredAnswer, TrialValidation, TrrackedProvenance, StoreState } from './types';
 
 export async function studyStoreCreator(
   studyId: string,
@@ -83,14 +83,7 @@ export async function studyStoreCreator(
         state,
         {
           payload,
-        }: PayloadAction<{
-          currentStep: string;
-          answer: Record<string, Record<string, unknown>>;
-          startTime: number;
-          endTime: number;
-          provenanceGraph?: TrrackedProvenance;
-          windowEvents: EventType[];
-        }>
+        }: PayloadAction<{ currentStep: string } & StoredAnswer>
       ) {
         const { currentStep, answer, startTime, endTime, provenanceGraph, windowEvents } = payload;
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -43,3 +43,6 @@ export interface StoreState {
   trialValidation: TrialValidation;
   iframeAnswers: string[];
 }
+
+// timestamp, event type, event data
+export type EventType = [number, 'mousemove', number[]]

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -46,17 +46,14 @@ export interface StoreState {
 }
 
 // timestamp, event type, event data
-type CopyEvent = [number, 'copy', string];
-type DragEvent = [number, 'drag', number[]];
-type WheelEvent = [number, 'wheel', number[]];
 type FocusEvent = [number, 'focus', string];
 type InputEvent = [number, 'input', string];
 type KeypressEvent = [number, 'keypress', string];
-type ClickEvent = [number, 'click', number[]];
-type SelectionEvent = [number, 'selection', string];
+type MouseDownEvent = [number, 'mousedown', number[]];
+type MouseUpEvent = [number, 'mouseup', number[]];
 type MouseMoveEvent = [number, 'mousemove', number[]];
 type ResizeEvent = [number, 'resize', number[]];
 type ScrollEvent = [number, 'scroll', number[]];
 type VisibilityEvent = [number, 'visibility', string];
 
-export type EventType = MouseMoveEvent | ClickEvent | KeypressEvent | ScrollEvent | CopyEvent | DragEvent | WheelEvent | FocusEvent | InputEvent | SelectionEvent | ResizeEvent | VisibilityEvent;
+export type EventType = MouseMoveEvent | MouseDownEvent | MouseUpEvent | KeypressEvent | ScrollEvent | FocusEvent | InputEvent | ResizeEvent | VisibilityEvent;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -23,6 +23,7 @@ export interface StoredAnswer {
   startTime: number;
   endTime: number;
   provenanceGraph?: TrrackedProvenance,
+  windowEvents: EventType[];
 }
 
 export interface StimulusParams<T> {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -45,4 +45,17 @@ export interface StoreState {
 }
 
 // timestamp, event type, event data
-export type EventType = [number, 'mousemove', number[]]
+type CopyEvent = [number, 'copy', string];
+type DragEvent = [number, 'drag', number[]];
+type WheelEvent = [number, 'wheel', number[]];
+type FocusEvent = [number, 'focus', string];
+type InputEvent = [number, 'input', string];
+type KeypressEvent = [number, 'keypress', string];
+type ClickEvent = [number, 'click', number[]];
+type SelectionEvent = [number, 'selection', string];
+type MouseMoveEvent = [number, 'mousemove', number[]];
+type ResizeEvent = [number, 'resize', number[]];
+type ScrollEvent = [number, 'scroll', number[]];
+type VisibilityEvent = [number, 'visibility', string];
+
+export type EventType = MouseMoveEvent | ClickEvent | KeypressEvent | ScrollEvent | CopyEvent | DragEvent | WheelEvent | FocusEvent | InputEvent | SelectionEvent | ResizeEvent | VisibilityEvent;


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This tracks all mouse, keypresses, scroll, change tab, etc. events so that they can be rehydrated later. The interval can be modified in the `studyConfig.uiConfig` using `windowEventDebounceTime` which takes a time in ms to debounce by. For example, `100` would give events 10 times per second and `200` would be 5 times per second.

The way that the windowEvents are saved is similar to the provenance. That is, stored as an array on the answers for a particular step, so it can be retrieved in a similar way. Additionally, this makes the logic to save and load the events the same as the provenanceGraph. As such, I've simplified the logic for these two properties in the firebaseStorageEngine to remove as much code duplication as possible

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation (#233)
- [x] Add some options for these events to the config
- [x] Do something with the data, save it somewhere
- [x] Add storageEngine method to get all event data
- [x] Consolidate the firebase storage getters and setters into 1 function