### PR TITLE
Capture all urlparams and allow using the URL params to set the participantID

### DIFF
--- a/public/VLAT-full-randomized/config-VLAT-full-randomized.json
+++ b/public/VLAT-full-randomized/config-VLAT-full-randomized.json
@@ -21,7 +21,8 @@
         "withProgressBar": true,
         "autoDownloadStudy": false,
         "sidebar": true,
-        "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: https://app.prolific.com/submissions/complete?cc=CE96X7ST"
+        "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: https://app.prolific.com/submissions/complete?cc=CE96X7ST",
+        "urlParticipantIdParam": "PROLIFIC_ID"
     },
     "components": {
         "introduction": {

--- a/public/VLAT-mini-randomized/config-VLAT-mini-randomized.json
+++ b/public/VLAT-mini-randomized/config-VLAT-mini-randomized.json
@@ -21,7 +21,8 @@
         "withProgressBar": true,
         "autoDownloadStudy": false,
         "sidebar": true,
-        "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=CE96X7ST](https://app.prolific.com/submissions/complete?cc=CE96X7ST)"
+        "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=CE96X7ST](https://app.prolific.com/submissions/complete?cc=CE96X7ST)",
+        "urlParticipantIdParam": "PROLIFIC_ID"
     },
     "components": {
         "introduction": {

--- a/public/brush-interactions/config.json
+++ b/public/brush-interactions/config.json
@@ -21,7 +21,8 @@
         "withProgressBar": true,
         "autoDownloadStudy": false,
         "sidebar": true,
-        "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=C1MXB7XQ](https://app.prolific.com/submissions/complete?cc=C1MXB7XQ)"
+        "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=C1MXB7XQ](https://app.prolific.com/submissions/complete?cc=C1MXB7XQ)",
+        "urlParticipantIdParam": "PROLIFIC_PID"
     },
     "baseComponents": {
         "scatterPlot": {

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -71,7 +71,8 @@ export function Shell({ globalConfig }: {
       }
 
       // Get or generate participant session
-      const participantSession = await storageEngine.initializeParticipantSession(searchParams);
+      const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) : undefined;
+      const participantSession = await storageEngine.initializeParticipantSession(searchParams, urlParticipantId);
 
       // Initialize the redux stores
       const store = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, participantSession.answers);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -3,7 +3,7 @@ import {
   useState,
 } from 'react';
 import { Provider } from 'react-redux';
-import { RouteObject, useParams, useRoutes } from 'react-router-dom';
+import { RouteObject, useParams, useRoutes, useSearchParams } from 'react-router-dom';
 import { parseStudyConfig } from '../parser/parser';
 import {
   GlobalConfig,
@@ -57,6 +57,7 @@ export function Shell({ globalConfig }: {
   const [routes, setRoutes] = useState<RouteObject[]>([]);
   const [store, setStore] = useState<Nullable<StudyStore>>(null);
   const { storageEngine } = useStorageEngine();
+  const [searchParams] = useSearchParams();
   useEffect(() => {
     async function initializeUserStoreRouting() {
       // Check that we have a storage engine and active config (studyId is set for config, but typescript complains)
@@ -69,9 +70,8 @@ export function Shell({ globalConfig }: {
         await storageEngine.setSequenceArray(await generateSequenceArray(activeConfig));
       }
 
-
-        // If we don't have a user's session, we need to generate one
-      const participantSession = await storageEngine.initializeParticipantSession();
+      // Get or generate participant session
+      const participantSession = await storageEngine.initializeParticipantSession(searchParams);
 
       // Initialize the redux stores
       const store = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, participantSession.answers);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -71,8 +71,9 @@ export function Shell({ globalConfig }: {
       }
 
       // Get or generate participant session
-      const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) : undefined;
-      const participantSession = await storageEngine.initializeParticipantSession(searchParams, urlParticipantId);
+      const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) || undefined : undefined;
+      const searchParamsObject = Object.fromEntries(searchParams.entries());
+      const participantSession = await storageEngine.initializeParticipantSession(searchParamsObject, urlParticipantId);
 
       // Initialize the redux stores
       const store = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, participantSession.answers);
@@ -82,7 +83,7 @@ export function Shell({ globalConfig }: {
       setRoutes(generateStudiesRoutes(studyId, activeConfig, participantSession.sequence));
     }
     initializeUserStoreRouting();
-  }, [storageEngine, activeConfig, studyId]);
+  }, [storageEngine, activeConfig, studyId, searchParams]);
 
   const routing = useRoutes(routes);
   

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1237,7 +1237,7 @@
           "type": "string"
         },
         "urlParticipantIdParam": {
-          "description": "If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID).",
+          "description": "If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.",
           "type": "string"
         },
         "windowEventDebounceTime": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -55,7 +55,7 @@
           "type": "array"
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "prompt": {
@@ -115,7 +115,7 @@
           "type": "array"
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "placeholder": {
@@ -172,7 +172,7 @@
           "description": "Controls the response location. These might be the same for all responses, or differ across responses."
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "prompt": {
@@ -405,7 +405,7 @@
           "description": "Controls the response location. These might be the same for all responses, or differ across responses."
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "preset": {
@@ -466,7 +466,7 @@
           "description": "Controls the response location. These might be the same for all responses, or differ across responses."
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "placeholder": {
@@ -589,7 +589,7 @@
           "type": "number"
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "placeholder": {
@@ -768,7 +768,7 @@
           "type": "array"
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "prompt": {
@@ -927,7 +927,7 @@
           "description": "Controls the response location. These might be the same for all responses, or differ across responses."
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "placeholder": {
@@ -990,7 +990,7 @@
           "type": "array"
         },
         "paramCapture": {
-          "description": "Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used.",
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
           "type": "string"
         },
         "prompt": {
@@ -1234,6 +1234,10 @@
         },
         "studyEndMsg": {
           "description": "The message to display when the study ends.",
+          "type": "string"
+        },
+        "urlParticipantIdParam": {
+          "description": "If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID).",
           "type": "string"
         },
         "windowEventDebounceTime": {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -62,7 +62,7 @@ export interface UIConfig {
   /** Debounce time in milliseconds for automatically tracked window events. Defaults to 100. E.g 100 here means 1000ms / 100ms = 10 times a second, 200 here means 1000ms / 200ms = 5 times per second  */
   windowEventDebounceTime?: number;
   /**
-   * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID).
+   * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.
    */
   urlParticipantIdParam?: string;
 }

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -61,6 +61,10 @@ export interface UIConfig {
   sidebar: boolean;
   /** Debounce time in milliseconds for automatically tracked window events. Defaults to 100. E.g 100 here means 1000ms / 100ms = 10 times a second, 200 here means 1000ms / 200ms = 5 times per second  */
   windowEventDebounceTime?: number;
+  /**
+   * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID).
+   */
+  urlParticipantIdParam?: string;
 }
 
 /**
@@ -95,7 +99,7 @@ export interface BaseResponse {
   requiredValue?: unknown;
   /** You can provide a required label, which makes it so a participant has to answer with a response that matches label. */
   requiredLabel?: string;
-  /** Use to capture querystring parameters such as PROLIFIC_ID. See the examples for how this is used. */
+  /** Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID. */
   paramCapture?: string;
   /** Controls whether the response is hidden. */
   hidden?: boolean;

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -70,7 +70,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return await setDoc(configDoc, config);
   }
 
-  async initializeParticipantSession() {
+  async initializeParticipantSession(searchParams: URLSearchParams) {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -109,6 +109,7 @@ export class FirebaseStorageEngine extends StorageEngine {
         participantId: this.currentParticipantId,
         sequence: await this.getSequence(),
         answers: {},
+        searchParams,
       };
       await setDoc(participantDoc, participantData);
 

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -76,7 +76,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
 
     // Ensure that we have a participantId
-    await this.getCurrentParticipantId();
+    await this.getCurrentParticipantId(urlParticipantId);
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
@@ -118,11 +118,16 @@ export class FirebaseStorageEngine extends StorageEngine {
 
   }
 
-  async getCurrentParticipantId() {
+  async getCurrentParticipantId(urlParticipantId?: string) {
     // Get currentParticipantId from localForage
     const currentParticipantId = await this.localForage.getItem('currentParticipantId');
 
-    if (currentParticipantId) {
+    // Prioritize urlParticipantId, then currentParticipantId, then generate a new participantId
+    if (urlParticipantId) {
+      this.currentParticipantId = urlParticipantId;
+      await this.localForage.setItem('currentParticipantId', urlParticipantId);
+      return urlParticipantId;
+    } else if (currentParticipantId) {
       this.currentParticipantId = currentParticipantId as string;
       return currentParticipantId as string;
     } else {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -70,7 +70,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return await setDoc(configDoc, config);
   }
 
-  async initializeParticipantSession(searchParams: URLSearchParams) {
+  async initializeParticipantSession(searchParams: Record<string, string>, urlParticipantId?: string) {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -323,6 +323,7 @@ export class FirebaseStorageEngine extends StorageEngine {
         participantId: newParticipantId,
         sequence: await this.getSequence(),
         answers: {},
+        searchParams: {},
       };
       await setDoc(newParticipant, newParticipantData);
       participant = newParticipantData;

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -24,7 +24,7 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.setItem('config', config);
   }
 
-  async initializeParticipantSession(searchParams: URLSearchParams, urlParticipantId?: string) {
+  async initializeParticipantSession(searchParams: Record<string, string>, urlParticipantId?: string) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
@@ -194,6 +194,7 @@ export class LocalStorageEngine extends StorageEngine {
         participantId: newParticipantId,
         sequence: await this.getSequence(),
         answers: {},
+        searchParams: {},
       };
       await this.studyDatabase.setItem(newParticipantId, newParticipant);
       participant = newParticipant;

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -24,7 +24,7 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.setItem('config', config);
   }
 
-  async initializeParticipantSession() {
+  async initializeParticipantSession(searchParams: URLSearchParams) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
@@ -47,6 +47,7 @@ export class LocalStorageEngine extends StorageEngine {
       participantId: this.currentParticipantId,
       sequence: await this.getSequence(),
       answers: {},
+      searchParams,
     };
     await this.studyDatabase?.setItem(this.currentParticipantId, participantData);
 

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -24,13 +24,13 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.setItem('config', config);
   }
 
-  async initializeParticipantSession(searchParams: URLSearchParams) {
+  async initializeParticipantSession(searchParams: URLSearchParams, urlParticipantId?: string) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
 
     // Ensure participantId
-    await this.getCurrentParticipantId();
+    await this.getCurrentParticipantId(urlParticipantId);
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
@@ -54,13 +54,20 @@ export class LocalStorageEngine extends StorageEngine {
     return participantData;
   }
 
-  async getCurrentParticipantId() {
+  async getCurrentParticipantId(urlParticipantId?: string) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
 
+    // Check the database for a participantId
     const currentParticipantId = await this.studyDatabase.getItem('currentParticipant');
-    if (currentParticipantId) {
+
+    // Prioritize urlParticipantId, then currentParticipantId, then generate a new participantId
+    if (urlParticipantId) {
+      this.currentParticipantId = urlParticipantId;
+      await this.studyDatabase.setItem('currentParticipant', urlParticipantId);
+      return urlParticipantId;
+    } else if (currentParticipantId) {
       this.currentParticipantId = currentParticipantId as string;
       return currentParticipantId as string;
     } else {

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -23,9 +23,9 @@ export abstract class StorageEngine {
 
   abstract initializeStudyDb(studyId: string, config: object): Promise<void>;
 
-  abstract initializeParticipantSession(searchParams: URLSearchParams): Promise<ParticipantData>;
+  abstract initializeParticipantSession(searchParams: URLSearchParams, urlParticipantId?: string): Promise<ParticipantData>;
 
-  abstract getCurrentParticipantId(): Promise<string>;
+  abstract getCurrentParticipantId(urlParticipantId?: string): Promise<string>;
   abstract clearCurrentParticipantId(): Promise<void>;
 
   abstract saveAnswer(currentStep: string, answer: StoredAnswer): Promise<void>;

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -23,7 +23,7 @@ export abstract class StorageEngine {
 
   abstract initializeStudyDb(studyId: string, config: object): Promise<void>;
 
-  abstract initializeParticipantSession(searchParams: URLSearchParams, urlParticipantId?: string): Promise<ParticipantData>;
+  abstract initializeParticipantSession(searchParams: Record<string, string>, urlParticipantId?: string): Promise<ParticipantData>;
 
   abstract getCurrentParticipantId(urlParticipantId?: string): Promise<string>;
   abstract clearCurrentParticipantId(): Promise<void>;

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -23,7 +23,7 @@ export abstract class StorageEngine {
 
   abstract initializeStudyDb(studyId: string, config: object): Promise<void>;
 
-  abstract initializeParticipantSession(): Promise<ParticipantData>;
+  abstract initializeParticipantSession(searchParams: URLSearchParams): Promise<ParticipantData>;
 
   abstract getCurrentParticipantId(): Promise<string>;
   abstract clearCurrentParticipantId(): Promise<void>;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -4,5 +4,5 @@ export interface ParticipantData {
   participantId: string;
   sequence: string[],
   answers: Record<string, StoredAnswer>,
-  searchParams: URLSearchParams,
+  searchParams: Record<string, string>,
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -4,4 +4,5 @@ export interface ParticipantData {
   participantId: string;
   sequence: string[],
   answers: Record<string, StoredAnswer>,
+  searchParams: URLSearchParams,
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #237 
Closes #129

### Give a longer description of what this PR addresses and why it's needed
This PR makes revisit capture all the url search parameters from a user, and allows a study designer to specify if one of the fields in the search parameters should be used for participantID. This makes it so that we can find if users have errors with the study, and that if they change browsers, we can resume their session. Resuming the session is especially important in cases where the sequence a user sees is randomized.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation
- [ ] Test to verify this actually works as intended