### PR TITLE
Add config hash to ParticipantData allow multiple config versions

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -115,7 +115,7 @@ export function Shell({ globalConfig }: {
       // Get or generate participant session
       const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) || undefined : undefined;
       const searchParamsObject = Object.fromEntries(searchParams.entries());
-      const participantSession = await storageEngine.initializeParticipantSession(searchParamsObject, urlParticipantId);
+      const participantSession = await storageEngine.initializeParticipantSession(searchParamsObject, activeConfig, urlParticipantId);
 
       // Initialize the redux stores
       const newStore = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, participantSession.answers);

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -47,7 +47,7 @@ export default function AppHeader() {
   const studyId = useStudyId();
   const studyHref = useHref(`/${studyId}`);
   function getNewParticipant() {
-    storageEngine?.nextParticipant()
+    storageEngine?.nextParticipant(studyConfig)
       .then(() => {
         window.location.href = studyHref;
       })

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -12,6 +12,8 @@ import localforage from 'localforage';
 import { StorageEngine } from './StorageEngine';
 import { ParticipantData } from '../types';
 import { EventType, StoredAnswer, TrrackedProvenance } from '../../store/types';
+import { hash } from './utils';
+import { StudyConfig } from '../../parser/types';
 
 export class FirebaseStorageEngine extends StorageEngine {
   private RECAPTCHAV3TOKEN = '6LdjOd0lAAAAAASvFfDZFWgtbzFSS9Y3so8rHJth';
@@ -70,15 +72,21 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
-  async initializeStudyDb(studyId: string, config: object) {
+  async initializeStudyDb(studyId: string, config: StudyConfig) {
+    // Hash the config
+    const configHash = await hash(JSON.stringify(config));
+
     // Create or retrieve database for study
     this.studyCollection = collection(this.firestore, `${this.collectionPrefix}${studyId}`);
     this.studyId = studyId;
-    const configDoc = doc(this.studyCollection, 'config');
+    const configsDoc = doc(this.studyCollection, 'configs');
+    const configsCollection = collection(configsDoc, 'configs');
+    const configDoc = doc(configsCollection, configHash);
+
     return await setDoc(configDoc, config);
   }
 
-  async initializeParticipantSession(searchParams: Record<string, string>, urlParticipantId?: string) {
+  async initializeParticipantSession(searchParams: Record<string, string>, config: StudyConfig, urlParticipantId?: string) {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -113,8 +121,10 @@ export class FirebaseStorageEngine extends StorageEngine {
       return participant;
     }
     // Initialize participant
+    const participantConfigHash = await hash(JSON.stringify(config));
     const participantData: ParticipantData = {
       participantId: this.currentParticipantId,
+      participantConfigHash,
       sequence: await this.getSequence(),
       answers: {},
       searchParams,
@@ -302,7 +312,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return participant;
   }
 
-  async nextParticipant(): Promise<ParticipantData> {
+  async nextParticipant(config: StudyConfig): Promise<ParticipantData> {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -322,9 +332,11 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
 
     if (!participant) {
+      const participantConfigHash = await hash(JSON.stringify(config));
       // Generate a new participant
       const newParticipantData: ParticipantData = {
         participantId: newParticipantId,
+        participantConfigHash,
         sequence: await this.getSequence(),
         answers: {},
         searchParams: {},

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -1,3 +1,4 @@
+import { StudyConfig } from '../../parser/types';
 import { StoredAnswer } from '../../store/types';
 import { ParticipantData } from '../types';
 
@@ -22,9 +23,9 @@ export abstract class StorageEngine {
 
   abstract connect(): Promise<void>;
 
-  abstract initializeStudyDb(studyId: string, config: object): Promise<void>;
+  abstract initializeStudyDb(studyId: string, config: StudyConfig): Promise<void>;
 
-  abstract initializeParticipantSession(searchParams: Record<string, string>, urlParticipantId?: string): Promise<ParticipantData>;
+  abstract initializeParticipantSession(searchParams: Record<string, string>, config: StudyConfig, urlParticipantId?: string): Promise<ParticipantData>;
 
   abstract getCurrentParticipantId(urlParticipantId?: string): Promise<string>;
 
@@ -42,7 +43,7 @@ export abstract class StorageEngine {
 
   abstract getParticipantData(): Promise<ParticipantData | null>;
 
-  abstract nextParticipant(): Promise<ParticipantData>;
+  abstract nextParticipant(config: StudyConfig): Promise<ParticipantData>;
 
   abstract verifyCompletion(answers: Record<string, StoredAnswer>): Promise<boolean>;
 }

--- a/src/storage/engines/utils.ts
+++ b/src/storage/engines/utils.ts
@@ -1,0 +1,7 @@
+export async function hash(input: string) {
+  const msgUint8 = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  return hashHex;
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -2,6 +2,7 @@ import { StoredAnswer } from '../store/types';
 
 export interface ParticipantData {
   participantId: string;
+  participantConfigHash: string;
   sequence: string[],
   answers: Record<string, StoredAnswer>,
   searchParams: Record<string, string>,


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #236 

### Give a longer description of what this PR addresses and why it's needed
This saves the config version in the participant data so that we can figure out the config version a participant saw. This is useful if the config changes from pilot to study for example.

Currently, there is not a great way to download the configs, but we should add that in a follow up. Right now, this will work for our use case poking around in the database.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Make issue for downloading config versions (#246)