### PR TITLE
Fix the issues with the auto download functionality

### DIFF
--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -32,7 +32,7 @@ export default function AppAside() {
     id: task,
   }));
 
-  return showAdmin ? (
+  return showAdmin || (currentStep === 'end' && studyConfig.uiConfig.autoDownloadStudy) ? (
     <Aside p="0" width={{ base: 300 }} style={{ zIndex: 0 }}>
       <ScrollArea p="0">
         <Aside.Section grow component={ScrollArea} px="xs" my="lg">


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #143

### Give a longer description of what this PR addresses and why it's needed
This fixes the issues with auto download. Now, the admin panel is rendered if auto download is selected and we're at study end. Also, the auto download functionality was broken, so I fixed it up using a `useCallback` hook.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No