### PR TITLE
Fix sequence array size limitations and data races

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
             cache_dir: ~/.cache/ms-playwright
 
           - project: webkit
-            os: macos-latest
+            os: macos-14
             cache_dir: ~/Library/Caches/ms-playwright
     steps:
       - uses: actions/checkout@v3

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1228,6 +1228,10 @@
           "description": "The path to the logo image. This is displayed on the landing page and the header.",
           "type": "string"
         },
+        "numSequences": {
+          "description": "The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.",
+          "type": "number"
+        },
         "sidebar": {
           "description": "Controls whether the left sidebar is rendered at all. Required to be true if your response's location is set to sidebar for any question.",
           "type": "boolean"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -65,6 +65,10 @@ export interface UIConfig {
    * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.
    */
   urlParticipantIdParam?: string;
+  /**
+   * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.
+   */
+  numSequences?: number;
 }
 
 /**

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -81,11 +81,13 @@ function generateLatinSquare(config: StudyConfig, path: string) {
   return newSquare;
 }
 
-export function generateSequenceArray(config: StudyConfig, numSequences = 1000) {
+export function generateSequenceArray(config: StudyConfig) {
   const paths = createRandomOrders(config.sequence);
   const latinSquareObject: Record<string, string[][]> = paths
     .map((p) => ({ [p]: generateLatinSquare(config, p) }))
     .reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+  const numSequences = config.uiConfig.numSequences || 1000;
 
   const sequenceArray: string[][] = [];
   Array.from({ length: numSequences }).forEach(() => {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #176 
Closes #250 

### Give a longer description of what this PR addresses and why it's needed
This fixes the issues with the sequence array:
1. The sequence array could be too large. I fixed this by using storage, which has no real size limitation.
2. Race conditions when pulling a sequence. I fixed this in 2 ways. The first fix is to not modify the sequence array, thus we can just get an index and take the sequence at that index as our sequence. Second, I made the firebase database track a timestamp of a participants intent to get a sequence, which can then be used to find the order in which people state their intent. We can use these 2 fixes together to avoid any race conditions.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation (number of sequences generated)
- [x] Make the number of sequences generated modifiable through the config
- [x] What do we do if the intent array is messy? That might ruin some of the guarantees (#255)