### PR TITLE
Participant data docs

### DIFF
--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,5 +1,6 @@
-// export type { ParticipantData } from '../storage/types';
-// export type { StoredAnswer, Sequence } from '../store/types';
+// eslint-disable-next-line import/no-cycle
+export type { ParticipantData } from '../storage/types';
+export type { StoredAnswer, Sequence } from '../store/types';
 /**
  * The GlobalConfig is used to generate the list of available studies in the UI.
  * This list is displayed on the landing page when running the app.

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,3 +1,5 @@
+// export type { ParticipantData } from '../storage/types';
+// export type { StoredAnswer, Sequence } from '../store/types';
 /**
  * The GlobalConfig is used to generate the list of available studies in the UI.
  * This list is displayed on the landing page when running the app.

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import { Sequence, StoredAnswer } from '../store/types';
 
 /**

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -33,12 +33,17 @@ Each key in answer will be labeled the same as the response component that it re
         },
         "startTime": 1711641174858,
         "endTime": 1711641178836,
+        "provenanceGraph":{
+          ...
+        },
         "windowEvents": [
           ...
         ]
       }
 ```
 The keys of this object are the names of the components with an additional underscore and number appended to the end. This is done so that the study creator can discern between not only the components but also between the various instances of the same component when necessary. All times are in **epoch milliseconds**.
+
+<div class="info-panel"><div class="info-text">The <code>"provenanceGraph"</code> key will only exist if the component is a React component and if it is utilizing Trrack. See <a href="/typedoc/interfaces/StoredAnswer.html">here</a> for more details.</div></div>
 
 We can see at a high level that we are given the answer that the user submitted, the start time for the component, and the end time. In addition to this, we have a list of window events. You can find more information about the StoredAnswer object [here](/typedoc/interfaces/StoredAnswer.html).
 */

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -22,7 +22,7 @@ Below we have an example of a participants data.
     }
 ]
 ```
-Each key in answer will be labeled the same as the response component that it refers to. The sequence shows the order that the participant saw each component (since these may be different for each participant if the configuration sequence has some randomization). This answer wil contain information such as the start time, the end time, and all of the window events. See the example below.
+Each key in answer will be labeled the same as the response component that it refers to. The sequence shows the order that the participant saw each component (since these may be different for each participant if the configuration sequence has some randomization). This answer will contain information such as the start time, the end time, and all of the window events. See the example below.
 
 ```JSON
      "bar-chart-1_1": {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,9 +1,55 @@
 import { Sequence, StoredAnswer } from '../store/types';
 
+/**
+The ParticipantData is a JSON object that contains all of the data for all of the participants in your study. It is structured as a list. Each element refers to a participants data or a configuration. While in many cases there is only one configuration per study, the study creator is allowed to change the configuration file after the study has already been completed by other participants. The data for each participant will have a "participantConfigHash" which refers to a particular configuration which is also in this list.
+
+Below we have an example of a participants data.
+``` JSON
+[
+    {
+        "participantId": <UUID4>,
+        "participantConfigHash": <CONFIG_ID>,
+        "sequence": {
+            ...
+        },
+        "answers": {
+            ...
+        },
+        "searchParameters": {
+            ...
+        }
+    }
+]
+```
+Each key in answer will be labeled the same as the response component that it refers to. The sequence shows the order that the participant saw each component (since these may be different for each participant if the configuration sequence has some randomization). This answer wil contain information such as the start time, the end time, and all of the window events. See the example below.
+
+```JSON
+     "bar-chart-1_1": {
+        "answer": {
+          "barChart": [
+            1.3
+          ]
+        },
+        "startTime": 1711641174858,
+        "endTime": 1711641178836,
+        "windowEvents": [
+          ...
+        ]
+      }
+```
+The keys of this object are the names of the components with an additional underscore and number appended to the end. This is done so that the study creator can discern between not only the components but also between the various instances of the same component when necessary. All times are in **epoch milliseconds**.
+
+We can see at a high level that we are given the answer that the user submitted, the start time for the component, and the end time. In addition to this, we have a list of window events. You can find more information about the StoredAnswer object [here](/typedoc/interfaces/StoredAnswer.html).
+*/
 export interface ParticipantData {
+  /** Unique ID  associated with the participant */
   participantId: string;
+  /** Unique ID corresponding to the Configuration that the participant received. */
   participantConfigHash: string;
+  /** Sequence of components that the participant received. */
   sequence: Sequence;
+  /** Object whose keys are the component names and values are StoredAnswer objects. */
   answers: Record<string, StoredAnswer>;
+  /** Query parameters of the URL used to enter the study. */
   searchParams: Record<string, string>;
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -27,11 +27,65 @@ export type TrialValidation = Record<
   }
 >;
 
+/**
+The StoredAnswer object is a data structure describing the participants interaction with an individual component. It is the data structure used as values of the `answers` object of [ParticipantData](/typedoc/interfaces/ParticipantData.html). The general structure for this is below:
+
+```JSON
+    {
+      "answer": {
+        "barChart": [
+          1.3
+        ]
+      },
+      "startTime": 1711641174858,
+      "endTime": 1711641178836,
+      "windowEvents": [
+        ...
+      ]
+    }
+```
+The `answer` object here uses the "id" in the [Response](/typedoc/interfaces/BaseResponse.html) list of the component in your [StudyConfiguration](/typedoc/interfaces/StudyConfig.html) as its keys. It then contains a list of the answers given. You are also given a start and end time for the participants interaction with the component. Lastly, a set of windowEvents is given. Below is an example of the windowEvents list.
+
+Each item in the window event is given a time, a position an event name, and some extra information for the event (for mouse events, this is the location).
+*/
 export interface StoredAnswer {
+  /** Object whose keys are the "id"s in the Response list of the component in the StudyConfiguration and whose value is the inputted value from the participant. */
   answer: Record<string, Record<string, unknown>>;
+  /** Time that the user began interacting with the component in epoch milliseconds. */
   startTime: number;
+  /** Time that the user ended interaction with the component in epoch milliseconds. */
   endTime: number;
   provenanceGraph?: TrrackedProvenance,
+  /** A list containing the time (in epoch milliseconds), the action (focus, input, kepress, mousedown, mouseup, mousemove, resize, scroll or visibility), and then either a coordinate pertaining to where the event took place on the screen or string related to such event. Below is an example of the windowEvents list.
+```JSON
+
+"windowEvents" :[
+  [
+    1711641174878,
+    "mousedown",
+    [ 1843, 286 ]
+  ],
+  [
+    1711641174878,
+    "focus",
+    "BUTTON"
+  ],
+  [
+    1711641174935,
+    "mouseup",
+    [ 1843, 286 ]
+  ],
+  .
+  .
+  .
+  [
+    1711641178706,
+    "mousemove",
+    [ 1868, 728 ]
+  ]
+]
+```
+   */
   windowEvents: EventType[];
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -56,6 +56,7 @@ export interface StoredAnswer {
   startTime: number;
   /** Time that the user ended interaction with the component in epoch milliseconds. */
   endTime: number;
+  /** The entire provenance graph exported from a Trrack instance from a React component. This will only be present if you are using React components and you're utilizing Trrack. */
   provenanceGraph?: TrrackedProvenance,
   /** A list containing the time (in epoch milliseconds), the action (focus, input, kepress, mousedown, mouseup, mousemove, resize, scroll or visibility), and then either a coordinate pertaining to where the event took place on the screen or string related to such event. Below is an example of the windowEvents list.
 ```JSON

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,4 +1,5 @@
 import { ProvenanceGraph } from '@trrack/core/graph/graph-slice';
+// eslint-disable-next-line import/no-cycle
 import { StudyConfig } from '../parser/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Adds ParticipantData documentation and the documentation for relevant sub types. 
Closes #281 

For this, decided to export the ParticipantDat, StoredAnswer, and Sequence interfaces in the parser/types.ts file so we could still have just one entry point for the tyepdoc.json file. Added the relevant eslint commands to disable errors on the circular imports that were caused.

