### PR TITLE
Google auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>reVISit</title>
 
+    
     <!-- Required for react browser router on GitHub pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/public/global.json
+++ b/public/global.json
@@ -51,5 +51,8 @@
         "demo-image": {
             "path": "demo-image/config.json"
         }
-    }
+    },
+    "adminUsers":[
+        "briancbollen@gmail.com"
+    ]
 }

--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -8,7 +8,6 @@ import { AnalysisInterface } from './analysis/AnalysisInterface';
 import { PREFIX } from './utils/Prefix';
 import { ProtectedRoute } from './ProtectedRoute';
 import { Login } from './Login';
-import { StorageEngine } from './storage/engines/StorageEngine';
 import { AuthProvider } from './store/hooks/useAuth';
 
 async function fetchGlobalConfigArray() {
@@ -33,7 +32,7 @@ async function fetchStudyConfigs(globalConfig: GlobalConfig) {
   return studyConfigs;
 }
 
-export function GlobalConfigParser({ storageEngine } : { storageEngine:StorageEngine|undefined }) {
+export function GlobalConfigParser() {
   const [globalConfig, setGlobalConfig] = useState<Nullable<GlobalConfig>>(null);
   const [studyConfigs, setStudyConfigs] = useState<Record<string, StudyConfig>>({});
 
@@ -73,16 +72,20 @@ export function GlobalConfigParser({ storageEngine } : { storageEngine:StorageEn
             path="/:studyId/*"
             element={<Shell globalConfig={globalConfig} />}
           />
-
           <Route
             path="/analysis/:page"
-            element={<AnalysisInterface globalConfig={globalConfig} />}
+            element={(
+              <ProtectedRoute>
+                <AnalysisInterface
+                  globalConfig={globalConfig}
+                />
+              </ProtectedRoute>
+            )}
           />
           <Route
             path="/login"
             element={(
               <Login
-                storageEngine={storageEngine}
                 admins={globalConfig.adminUsers}
               />
             )}

--- a/src/GlobalInitializer.tsx
+++ b/src/GlobalInitializer.tsx
@@ -16,6 +16,6 @@ export function GlobalInitializer() {
     fn();
   }, [setStorageEngine, storageEngine]);
   return (
-    <GlobalConfigParser storageEngine={storageEngine} />
+    <GlobalConfigParser />
   );
 }

--- a/src/GlobalInitializer.tsx
+++ b/src/GlobalInitializer.tsx
@@ -15,8 +15,7 @@ export function GlobalInitializer() {
     }
     fn();
   }, [setStorageEngine, storageEngine]);
-
   return (
-    <GlobalConfigParser />
+    <GlobalConfigParser storageEngine={storageEngine} />
   );
 }

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -52,20 +52,15 @@ export function Login({ admins }:LoginProps) {
 
   useEffect(() => {
     const engine = storageEngine?.getEngine();
-    if (engine !== 'firebase' && !user) {
+    if (engine && engine !== 'firebase' && !user) {
       // If not using firebase as storage engine, authenticate the user with a fake user with admin privileges.
       const currUser: User = {
         name: 'localName',
         admin: false,
         email: 'localEmail@example.com',
       };
-      const admin = false;
-      if (!admin) {
-        setErrorMessage('You are not authorized as an admin on this application.');
-      } else {
-        login(currUser);
-        setErrorMessage(null);
-      }
+      login(currUser);
+      setErrorMessage(null);
     }
   }, []);
 

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { getAuth, signInWithPopup, GoogleAuthProvider } from '@firebase/auth';
+import { StorageEngine } from './storage/engines/StorageEngine';
+import { User } from './ProtectedRoute';
+
+const signInWithGoogle = async () => {
+  const provider = new GoogleAuthProvider();
+  const auth = getAuth();
+  signInWithPopup(auth, provider)
+    .then((result) => {
+      // This gives you a Google Access Token. You can use it to access the Google API.
+      const credential = GoogleAuthProvider.credentialFromResult(result);
+      if (credential !== null) {
+        const token = credential.accessToken;
+        // The signed-in user info.
+        const user = result.user;
+        // IdP data available using getAdditionalUserInfo(result)
+        // ...
+      }
+    }).catch((error) => {
+      // Handle Errors here.
+      const errorCode = error.code;
+      const errorMessage = error.message;
+      // The email of the user's account used.
+      const email = error.customData.email;
+      // The AuthCredential type that was used.
+      const credential = GoogleAuthProvider.credentialFromError(error);
+      // ...
+    });
+};
+
+interface LoginProps {
+  storageEngine: StorageEngine | undefined;
+  user: User | undefined;
+  setUser : React.Dispatch<React.SetStateAction<User|undefined>>;
+  isAuth : boolean;
+  setIsAuth: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function Login({
+  storageEngine, user, setUser, isAuth, setIsAuth,
+}:LoginProps) {
+  useEffect(() => {
+    if (storageEngine) {
+      if (storageEngine.getEngine() === 'firebase') {
+        const currUser: User = {
+          name: 'localName',
+          admin: true,
+          email: 'localEmail@example.com',
+        };
+        if (user && user.email !== currUser.email) {
+          setUser(currUser);
+        }
+        setIsAuth(true);
+      } else {
+        const currUser: User = {
+          name: 'localName',
+          admin: true,
+          email: 'localEmail@example.com',
+        };
+        if (user && user.email !== currUser.email) {
+          setUser(currUser);
+        }
+        setIsAuth(true);
+      }
+    } else {
+      if (user) {
+        setUser(undefined);
+      }
+      setIsAuth(false);
+    }
+  }, [storageEngine, isAuth, user]);
+
+  return isAuth ? <Navigate to="/" /> : <button type="button" onClick={signInWithGoogle}>CLICK TO LOGIN</button>;
+}

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,76 +1,49 @@
-import React, { useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
 import { getAuth, signInWithPopup, GoogleAuthProvider } from '@firebase/auth';
 import { StorageEngine } from './storage/engines/StorageEngine';
-import { User } from './ProtectedRoute';
-
-const signInWithGoogle = async () => {
-  const provider = new GoogleAuthProvider();
-  const auth = getAuth();
-  signInWithPopup(auth, provider)
-    .then((result) => {
-      // This gives you a Google Access Token. You can use it to access the Google API.
-      const credential = GoogleAuthProvider.credentialFromResult(result);
-      if (credential !== null) {
-        const token = credential.accessToken;
-        // The signed-in user info.
-        const user = result.user;
-        // IdP data available using getAdditionalUserInfo(result)
-        // ...
-      }
-    }).catch((error) => {
-      // Handle Errors here.
-      const errorCode = error.code;
-      const errorMessage = error.message;
-      // The email of the user's account used.
-      const email = error.customData.email;
-      // The AuthCredential type that was used.
-      const credential = GoogleAuthProvider.credentialFromError(error);
-      // ...
-    });
-};
+import { useAuth } from './store/hooks/useAuth';
 
 interface LoginProps {
   storageEngine: StorageEngine | undefined;
-  user: User | undefined;
-  setUser : React.Dispatch<React.SetStateAction<User|undefined>>;
-  isAuth : boolean;
-  setIsAuth: React.Dispatch<React.SetStateAction<boolean>>;
+  admins:string[];
 }
 
 export function Login({
-  storageEngine, user, setUser, isAuth, setIsAuth,
+  storageEngine, admins,
 }:LoginProps) {
-  useEffect(() => {
-    if (storageEngine) {
-      if (storageEngine.getEngine() === 'firebase') {
-        const currUser: User = {
-          name: 'localName',
-          admin: true,
-          email: 'localEmail@example.com',
-        };
-        if (user && user.email !== currUser.email) {
-          setUser(currUser);
-        }
-        setIsAuth(true);
-      } else {
-        const currUser: User = {
-          name: 'localName',
-          admin: true,
-          email: 'localEmail@example.com',
-        };
-        if (user && user.email !== currUser.email) {
-          setUser(currUser);
-        }
-        setIsAuth(true);
-      }
-    } else {
-      if (user) {
-        setUser(undefined);
-      }
-      setIsAuth(false);
-    }
-  }, [storageEngine, isAuth, user]);
+  const { login, logout } = useAuth();
 
-  return isAuth ? <Navigate to="/" /> : <button type="button" onClick={signInWithGoogle}>CLICK TO LOGIN</button>;
+  const signInWithGoogle = async () => {
+    const provider = new GoogleAuthProvider();
+    const auth = getAuth();
+    signInWithPopup(auth, provider)
+      .then((result) => {
+        // This gives you a Google Access Token. You can use it to access the Google API.
+        const credential = GoogleAuthProvider.credentialFromResult(result);
+        if (credential !== null) {
+          const token = credential.accessToken;
+          // The signed-in user info.
+          const googleUser = result.user;
+          // IdP data available using getAdditionalUserInfo(result)
+          // ...
+          login({
+            name: googleUser.displayName,
+            admin: true,
+            email: googleUser.email,
+          });
+        }
+      }).catch((error) => {
+        // Handle Errors here.
+        const errorCode = error.code;
+        const errorMessage = error.message;
+        // The email of the user's account used.
+        const email = error.customData.email;
+        // The AuthCredential type that was used.
+        const credential = GoogleAuthProvider.credentialFromError(error);
+        // ...
+        // Set authentication to false in this case.
+        logout();
+      });
+  };
+
+  return <button type="button" onClick={signInWithGoogle}>CLICK TO LOGIN</button>;
 }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,17 +1,30 @@
-import { useState, useEffect } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
-
-export interface User {
-  email: string;
-  admin: boolean;
-  name?: string;
-}
+import { ReactNode, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth, User } from './store/hooks/useAuth';
+import { useStorageEngine } from './store/storageEngineHooks';
 
 interface ProtectedRouteProps {
-  user: User | undefined;
-  isAuth: boolean;
+  children: ReactNode;
 }
 
-export function ProtectedRoute({ user, isAuth }: ProtectedRouteProps) {
-  return isAuth ? <Outlet /> : <Navigate to="/login" />;
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { user, login } = useAuth();
+  const { storageEngine } = useStorageEngine();
+
+  useEffect(() => {
+    if (storageEngine?.getEngine() !== 'firebase') {
+      // If not using firebase as storage engine, authenticate the user with a fake user with admin privileges.
+      const currUser: User = {
+        name: 'localName',
+        admin: true,
+        email: 'localEmail@example.com',
+      };
+      login(currUser);
+    }
+  }, []);
+
+  if (user && user.admin) {
+    return <div>{children}</div>;
+  }
+  return <Navigate to="/login" />;
 }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,27 +1,13 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAuth, User } from './store/hooks/useAuth';
-import { useStorageEngine } from './store/storageEngineHooks';
+import { useAuth } from './store/hooks/useAuth';
 
 interface ProtectedRouteProps {
   children: ReactNode;
 }
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { user, login } = useAuth();
-  const { storageEngine } = useStorageEngine();
-
-  useEffect(() => {
-    if (storageEngine?.getEngine() !== 'firebase') {
-      // If not using firebase as storage engine, authenticate the user with a fake user with admin privileges.
-      const currUser: User = {
-        name: 'localName',
-        admin: true,
-        email: 'localEmail@example.com',
-      };
-      login(currUser);
-    }
-  }, []);
+  const { user } = useAuth();
 
   if (user && user.admin) {
     return <div>{children}</div>;

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+export interface User {
+  email: string;
+  admin: boolean;
+  name?: string;
+}
+
+interface ProtectedRouteProps {
+  user: User | undefined;
+  isAuth: boolean;
+}
+
+export function ProtectedRoute({ user, isAuth }: ProtectedRouteProps) {
+  return isAuth ? <Outlet /> : <Navigate to="/login" />;
+}

--- a/src/parser/GlobalConfigSchema.json
+++ b/src/parser/GlobalConfigSchema.json
@@ -34,12 +34,20 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "adminUsers":{
+          "description":"A required property used to list emails of those who require admin access.",
+          "items":{
+            "type":"string"
+          },
+          "type":"array"
         }
       },
       "required": [
         "$schema",
         "configs",
-        "configsList"
+        "configsList",
+        "adminUsers"
       ],
       "type": "object"
     }

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -18,6 +18,8 @@ export interface GlobalConfig {
   };
   /** A required property that is used to generate the list of available studies in the UI. This list is displayed on the landing page when running the app. */
   configsList: string[];
+  /** A required property listing out the emails of users who require admin access. */
+  adminUsers: string[];
 }
 
 /**

--- a/src/store/hooks/useAuth.tsx
+++ b/src/store/hooks/useAuth.tsx
@@ -1,0 +1,49 @@
+import {
+  createContext, useContext, useMemo, useState, ReactNode,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export interface User {
+  name?: string|null;
+  email: string|null;
+  admin: boolean;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  login: (user: User) => void;
+  logout: () => void;
+  }
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  login: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  logout: () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children } : { children: ReactNode }) {
+  const [user, setUser] = useState<User|null>(null);
+  const navigate = useNavigate();
+
+  const login = async (currUser: User) => {
+    setUser(currUser);
+    navigate('/');
+  };
+
+  const logout = () => {
+    setUser(null);
+    navigate('/login');
+  };
+
+  const value = useMemo(() => ({
+    user,
+    login,
+    logout,
+  }), [user]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/src/store/hooks/useAuth.tsx
+++ b/src/store/hooks/useAuth.tsx
@@ -2,6 +2,7 @@ import {
   createContext, useContext, useMemo, useState, ReactNode,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useLocalStorage } from './useLocalStorage';
 
 export interface User {
   name?: string|null;
@@ -26,7 +27,7 @@ const AuthContext = createContext<AuthContextValue>({
 export const useAuth = () => useContext(AuthContext);
 
 export function AuthProvider({ children } : { children: ReactNode }) {
-  const [user, setUser] = useState<User|null>(null);
+  const [user, setUser] = useLocalStorage('user', null);
   const navigate = useNavigate();
 
   const login = async (currUser: User) => {

--- a/src/store/hooks/useLocalStorage.ts
+++ b/src/store/hooks/useLocalStorage.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useLocalStorage(keyName:string, defaultValue:any) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const value = window.localStorage.getItem(keyName);
+      if (value) {
+        return JSON.parse(value);
+      }
+      window.localStorage.setItem(keyName, JSON.stringify(defaultValue));
+      return defaultValue;
+    } catch (err) {
+      return defaultValue;
+    }
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const setValue = (newValue:any) => {
+    try {
+      window.localStorage.setItem(keyName, JSON.stringify(newValue));
+    } catch (err) {
+      console.error(err);
+    }
+    setStoredValue(newValue);
+  };
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #290 
Closes #292 

### Give a longer description of what this PR addresses and why it's needed
This PR sets up a Google SSO Authentication flow for users who are using Firebase as their storage engine. The analysis dashboard and the main page (displaying all the studies) are not behind protected routes which require login. This functionality is disabled whenever the storage engine is NOT firebase. The user provides a list of admins in the global.json in the key "adminUsers". These entries must be valid Google emails. The user info is stored in local storage so a login will persist through refreshes and restarting the server. The individual studies are not behind protected routes as they are meant to be used by completely anonymous users. Below we can see some simple functionality, including refreshing does not interfere with the user session, error codes for non-admin users (and other error codes such as a change in the debug token) are displayed on the login page properly. 

https://github.com/revisit-studies/study/assets/26078758/18e0024e-c6f3-4e12-9423-9260fca59cd1
https://github.com/revisit-studies/study/assets/26078758/21872986-8dae-408c-8008-3591e84736d2

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] #291 
- [ ] Develop and implement workflow for storing admin users in the Firebase store rather than in the global.json (best workflow might be adding the admin users to the JSON and letting the application store them directly in Firebase and then reading from Firebase in subsequent sessions). 