### PR TITLE
Fix bug with nested latinSquares

### DIFF
--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -18,8 +18,8 @@ function _orderObjectToSequence(
   } else if (order.order === 'latinSquare' && latinSquareObject) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     computedComponents = latinSquareObject[path].pop()!.map((o) => {
-      if (o.startsWith('_componentBlock')) {
-        return order.components[+o.slice('_componentBlock'.length)];
+      if (o.startsWith('_orderObj')) {
+        return order.components[+o.slice('_orderObj'.length)];
       }
 
       return o;

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -9,30 +9,32 @@ function _orderObjectToSequence(
   latinSquareObject: Record<string, string[][]>,
   path: string,
 ): Sequence {
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < order.components.length; i++) {
-    const curr = order.components[i];
-    if (typeof curr !== 'string') {
-      order.components[i] = _orderObjectToSequence(curr, latinSquareObject, `${path}-${i}`) as unknown as OrderObject;
-    }
-  }
+  let computedComponents: (string | OrderObject | string[])[] = order.components;
 
   if (order.order === 'random') {
     const randomArr = order.components.sort(() => 0.5 - Math.random());
 
-    order.components = randomArr;
+    computedComponents = randomArr;
   } else if (order.order === 'latinSquare' && latinSquareObject) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    order.components = latinSquareObject[path].pop()!.map((o) => {
-      if (o.startsWith('_orderObj')) {
-        return order.components[+o.slice(9)];
+    computedComponents = latinSquareObject[path].pop()!.map((o) => {
+      if (o.startsWith('_componentBlock')) {
+        return order.components[+o.slice('_componentBlock'.length)];
       }
 
       return o;
     });
   }
 
-  let computedComponents: (string | OrderObject | string[])[] = order.components.slice(0, order.numSamples !== undefined ? order.numSamples : undefined).flat();
+  computedComponents = computedComponents.slice(0, order.numSamples);
+
+  for (let i = 0; i < computedComponents.length; i += 1) {
+    const curr = computedComponents[i];
+    if (typeof curr !== 'string' && !Array.isArray(curr)) {
+      const index = order.components.indexOf(curr);
+      computedComponents[i] = _orderObjectToSequence(curr, latinSquareObject, `${path}-${index}`) as unknown as OrderObject;
+    }
+  }
 
   // If we have a break, insert it into the sequence at the correct intervals
   if (order.interruptions) {

--- a/tests/randomization-test.spec.ts
+++ b/tests/randomization-test.spec.ts
@@ -122,6 +122,17 @@ test('test', async ({ page }) => {
   expect(globalOcurrences.trial9).toBe(500);
   expect(globalOcurrences.trial10).toBe(500);
 
+  expect(globalOcurrences.trial11).toBe(500);
+  expect(globalOcurrences.trial12).toBe(500);
+  expect(globalOcurrences.trial13).toBe(500);
+  expect(globalOcurrences.trial14).toBe(500);
+  expect(globalOcurrences.trial15).toBe(500);
+  expect(globalOcurrences.trial16).toBe(500);
+  expect(globalOcurrences.trial17).toBe(500);
+  expect(globalOcurrences.trial18).toBe(500);
+  expect(globalOcurrences.trial19).toBe(500);
+  expect(globalOcurrences.trial20).toBe(500);
+
   // Check to make sure that the admin panel renders with such a complex sequence
   await page.locator('#mantine-r1-target').click();
   await page.getByRole('menuitem', { name: 'Admin Mode' }).click();


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
There was an issue with nested latin squares where we would pop a randomization and not use it. This led to imbalanced randomization, but was easily fixed by modifying the sequence generation logic. We needed to randomize first, prune using numSteps, then recurse.

I updated the test to check that the behavior is as we expect.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No