### PR TITLE
Add error reporting for studies with configuration file errors

### DIFF
--- a/public/demo-html/config.json
+++ b/public/demo-html/config.json
@@ -57,7 +57,6 @@
         "components": [
             "introduction",
             "barChart"
-        ],
-        "test":123,
+        ]
     }
 }

--- a/public/demo-html/config.json
+++ b/public/demo-html/config.json
@@ -57,6 +57,7 @@
         "components": [
             "introduction",
             "barChart"
-        ]
+        ],
+        "test":123,
     }
 }

--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -17,17 +17,17 @@ async function fetchGlobalConfigArray() {
 }
 
 async function fetchStudyConfigs(globalConfig: GlobalConfig) {
-  const studyConfigs: { [key: string]: StudyConfig } = {};
+  const studyConfigs: Record<string, StudyConfig> = {};
   const urls = globalConfig.configsList.map(
     (configId) => `${PREFIX}${globalConfig.configs[configId].path}`,
   );
 
-  const res = await Promise.all(urls.map((u) => fetch(u)))
-    .then((responses) => Promise.all(responses.map((_res) => _res.text())))
-    .then((responses) => Promise.all(responses.map((_res, idx) => parseStudyConfig(_res, globalConfig.configsList[idx]))));
+  const res = await Promise.all(urls.map((u) => fetch(u)));
+  const responses = await Promise.all(res.map((_res) => _res.text()));
+  const configs = await Promise.all(responses.map((_res, idx) => parseStudyConfig(_res, globalConfig.configsList[idx])));
 
   globalConfig.configsList.forEach((configId, idx) => {
-    studyConfigs[configId] = res[idx];
+    studyConfigs[configId] = configs[idx];
   });
   return studyConfigs;
 }

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -9,6 +9,7 @@ import { sanitizeStringForUrl } from '../utils/sanitizeStringForUrl';
 import { PREFIX } from '../utils/Prefix';
 import { useAuth } from '../store/hooks/useAuth';
 import { useStorageEngine } from '../storage/storageEngineHooks';
+import { ErrorLoadingConfig } from './ErrorLoadingConfig';
 
 const REVISIT_GITHUB_PUBLIC = 'https://github.com/revisit-studies/study/tree/main/public/';
 
@@ -68,23 +69,7 @@ function ConfigSwitcher({ globalConfig, studyConfigs }: Props) {
                       <IconAlertTriangle color="red" />
                       <Text fw="bold" ml={8}>{configName}</Text>
                     </Flex>
-                    <Text>Errors when loading config:</Text>
-                    <List>
-                      {config.errors.map((error) => (
-                        <List.Item key={error.message} c="red">
-                          You have an error at
-                          {' '}
-                          {error.instancePath || 'root'}
-                          :
-                          {' '}
-                          {error.message}
-                          {' '}
-                          -
-                          {' '}
-                          {JSON.stringify(error.params)}
-                        </List.Item>
-                      ))}
-                    </List>
+                    <ErrorLoadingConfig errors={config.errors} />
                   </>
                 )
                 : (

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -67,7 +67,7 @@ function ConfigSwitcher({ globalConfig, studyConfigs }: Props) {
                   <>
                     <Flex align="center" direction="row">
                       <IconAlertTriangle color="red" />
-                      <Text fw="bold" ml={8}>{configName}</Text>
+                      <Text fw="bold" ml={8} color="red">{configName}</Text>
                     </Flex>
                     <ErrorLoadingConfig errors={config.errors} />
                   </>

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -1,7 +1,9 @@
 import {
-  Anchor, Card, Container, Image, Text, UnstyledButton,
+  Anchor, Card, Container, Flex, Image, List, Text, UnstyledButton,
 } from '@mantine/core';
 import { useNavigate } from 'react-router-dom';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { ErrorObject } from 'ajv';
 import { GlobalConfig, StudyConfig } from '../parser/types';
 import { sanitizeStringForUrl } from '../utils/sanitizeStringForUrl';
 import { PREFIX } from '../utils/Prefix';
@@ -12,7 +14,7 @@ const REVISIT_GITHUB_PUBLIC = 'https://github.com/revisit-studies/study/tree/mai
 
 type Props = {
   globalConfig: GlobalConfig;
-  studyConfigs: {[key: string]: StudyConfig};
+  studyConfigs: {[key: string]: StudyConfig & { errors?: ErrorObject<string, Record<string, unknown>, unknown>[] }};
 };
 
 function ConfigSwitcher({ globalConfig, studyConfigs }: Props) {
@@ -59,23 +61,53 @@ function ConfigSwitcher({ globalConfig, studyConfigs }: Props) {
             style={{ width: '100%' }}
           >
             <Card shadow="sm" radius="md" withBorder>
-              <Text fw="bold">{config.studyMetadata.title}</Text>
-              <Text c="dimmed">
-                Authors:
-                {config.studyMetadata.authors}
-              </Text>
-              <Text c="dimmed">{config.studyMetadata.description}</Text>
-              <Text c="dimmed" ta="right" style={{ paddingRight: 5 }}>
-                <Anchor
-                  target="_blank"
-                  onClick={(e) => e.stopPropagation()}
-                  href={`${REVISIT_GITHUB_PUBLIC}${url}`}
-                >
-                  View source:
-                  {' '}
-                  {url}
-                </Anchor>
-              </Text>
+              {config.errors
+                ? (
+                  <>
+                    <Flex align="center" direction="row">
+                      <IconAlertTriangle color="red" />
+                      <Text fw="bold" ml={8}>{configName}</Text>
+                    </Flex>
+                    <Text>Errors when loading config:</Text>
+                    <List>
+                      {config.errors.map((error) => (
+                        <List.Item key={error.message} c="red">
+                          You have an error at
+                          {' '}
+                          {error.instancePath || 'root'}
+                          :
+                          {' '}
+                          {error.message}
+                          {' '}
+                          -
+                          {' '}
+                          {JSON.stringify(error.params)}
+                        </List.Item>
+                      ))}
+                    </List>
+                  </>
+                )
+                : (
+                  <>
+                    <Text fw="bold">{config.studyMetadata.title}</Text>
+                    <Text c="dimmed">
+                      Authors:
+                      {config.studyMetadata.authors}
+                    </Text>
+                    <Text c="dimmed">{config.studyMetadata.description}</Text>
+                    <Text c="dimmed" ta="right" style={{ paddingRight: 5 }}>
+                      <Anchor
+                        target="_blank"
+                        onClick={(e) => e.stopPropagation()}
+                        href={`${REVISIT_GITHUB_PUBLIC}${url}`}
+                      >
+                        View source:
+                        {' '}
+                        {url}
+                      </Anchor>
+                    </Text>
+                  </>
+                )}
             </Card>
           </UnstyledButton>
         );

--- a/src/components/ErrorLoadingConfig.tsx
+++ b/src/components/ErrorLoadingConfig.tsx
@@ -1,0 +1,14 @@
+import { ErrorObject } from 'ajv';
+import ReactMarkdownWrapper from './ReactMarkdownWrapper';
+
+export function ErrorLoadingConfig({ errors }: {errors: ErrorObject<string, Record<string, unknown>, unknown>[]}) {
+  const text = `
+      ## Error loading config
+      There was an issue loading the study config. Please check the following errors:  
+
+      ${errors.map((error) => `- You have an error at ${error.instancePath || 'root'}: ${error.message} - ${JSON.stringify(error.params)}  `).join('\n')}
+    `.replace(/\n\s+/g, '\n');
+  return (
+    <ReactMarkdownWrapper text={text} />
+  );
+}

--- a/src/components/ErrorLoadingConfig.tsx
+++ b/src/components/ErrorLoadingConfig.tsx
@@ -3,7 +3,6 @@ import ReactMarkdownWrapper from './ReactMarkdownWrapper';
 
 export function ErrorLoadingConfig({ errors }: {errors: ErrorObject<string, Record<string, unknown>, unknown>[]}) {
   const text = `
-      ## Error loading config
       There was an issue loading the study config. Please check the following errors:  
 
       ${errors.map((error) => `- You have an error at ${error.instancePath || 'root'}: ${error.message} - ${JSON.stringify(error.params)}  `).join('\n')}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -7,6 +7,7 @@ import {
   RouteObject, useRoutes, useSearchParams,
 } from 'react-router-dom';
 import { Box, Center, Loader } from '@mantine/core';
+import { ErrorObject } from 'ajv';
 import {
   GlobalConfig,
   Nullable,
@@ -26,6 +27,7 @@ import { StepRenderer } from './StepRenderer';
 import { useStorageEngine } from '../storage/storageEngineHooks';
 import { generateSequenceArray } from '../utils/handleRandomSequences';
 import { getStudyConfig } from '../utils/fetchConfig';
+import { ErrorLoadingConfig } from './ErrorLoadingConfig';
 
 export function Shell({ globalConfig }: {
   globalConfig: GlobalConfig;
@@ -35,7 +37,7 @@ export function Shell({ globalConfig }: {
   if (!studyId || !globalConfig.configsList.find((c) => sanitizeStringForUrl(c))) {
     throw new Error('Study id invalid');
   }
-  const [activeConfig, setActiveConfig] = useState<Nullable<StudyConfig>>(null);
+  const [activeConfig, setActiveConfig] = useState<Nullable<StudyConfig & { errors?: ErrorObject<string, Record<string, unknown>, unknown>[] }>>(null);
   useEffect(() => {
     getStudyConfig(studyId, globalConfig).then((config) => {
       setActiveConfig(config);
@@ -77,7 +79,7 @@ export function Shell({ globalConfig }: {
           },
           {
             path: '/:index',
-            element: <ComponentController />,
+            element: activeConfig.errors ? <ErrorLoadingConfig errors={activeConfig.errors} /> : <ComponentController />,
           },
         ],
       }]);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -6,7 +6,9 @@ import { Provider } from 'react-redux';
 import {
   RouteObject, useRoutes, useSearchParams,
 } from 'react-router-dom';
-import { Box, Center, Loader } from '@mantine/core';
+import {
+  Box, Center, Loader, Title,
+} from '@mantine/core';
 import { ErrorObject } from 'ajv';
 import {
   GlobalConfig,
@@ -79,7 +81,12 @@ export function Shell({ globalConfig }: {
           },
           {
             path: '/:index',
-            element: activeConfig.errors ? <ErrorLoadingConfig errors={activeConfig.errors} /> : <ComponentController />,
+            element: activeConfig.errors ? (
+              <>
+                <Title order={2} mb={8}>Error loading config</Title>
+                <ErrorLoadingConfig errors={activeConfig.errors} />
+              </>
+            ) : <ComponentController />,
           },
         ],
       }]);

--- a/src/utils/fetchConfig.ts
+++ b/src/utils/fetchConfig.ts
@@ -8,7 +8,7 @@ export async function fetchStudyConfig(configLocation: string, configKey: string
   return parseStudyConfig(config, configKey);
 }
 
-export async function getStudyConfig(studyId:string, globalConfig:GlobalConfig) {
+export async function getStudyConfig(studyId: string, globalConfig: GlobalConfig) {
   const configKey = globalConfig.configsList.find(
     (c) => sanitizeStringForUrl(c) === studyId,
   );


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #178 

### Give a longer description of what this PR addresses and why it's needed
This adds feedback for configuration errors to the main application in the config switcher, and the study itself.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1624" alt="Screenshot 2024-04-26 at 2 12 31 PM" src="https://github.com/revisit-studies/study/assets/36867477/d56bfa86-3169-4ade-9291-ee443989c5d7">

<img width="1624" alt="Screenshot 2024-04-26 at 2 01 17 PM" src="https://github.com/revisit-studies/study/assets/36867477/8d5151a1-63d5-4e07-9b26-e7d18adb93b6">

### Are there any additional TODOs before this PR is ready to go?
No