### PR TITLE
Fixing analysis dashboard. Pulls participant data all at once 

### DIFF
--- a/src/analysis/dashboard/SummaryBlock.tsx
+++ b/src/analysis/dashboard/SummaryBlock.tsx
@@ -1,18 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Box, Grid, LoadingOverlay, Title,
 } from '@mantine/core';
 import { ParticipantData } from '../../storage/types';
 import { SummaryPanel } from './SummaryPanel';
 import { GlobalConfig, StudyConfig } from '../../parser/types';
-import { initializeStorageEngine } from '../../storage/initialize';
 import { getStudyConfig } from '../../utils/fetchConfig';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
+import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 
 export function SummaryBlock(props: { globalConfig: GlobalConfig; }) {
   const { globalConfig } = props;
   const [loading, setLoading] = useState(false);
   const [expData, setExpData] = useState<Record<string, ParticipantData[]>>({});
   const [expConfig, setExpConfig] = useState<Record<string, StudyConfig>>({});
+  const { storageEngine } = useStorageEngine();
   useEffect(() => {
     const init = async () => {
       setLoading(true);
@@ -20,12 +22,12 @@ export function SummaryBlock(props: { globalConfig: GlobalConfig; }) {
       const allConfig: Record<string, StudyConfig> = {};
 
       const fetchData = async (studyId: string) => {
-        const storageEngine = await initializeStorageEngine();
-        const config = await getStudyConfig(studyId, globalConfig);
-        if (config === null) return;
-        await storageEngine.initializeStudyDb(studyId, config as StudyConfig);
-        allData[studyId] = await storageEngine.getAllParticipantsData();
-        allConfig[studyId] = config;
+        if (storageEngine instanceof FirebaseStorageEngine) {
+          const config = await getStudyConfig(studyId, globalConfig);
+          allData[studyId] = await storageEngine.getAllParticipantsDataByStudy(studyId);
+          if (config === null) return;
+          allConfig[studyId] = config;
+        }
       };
 
       const fetchAllData = async () => {
@@ -43,7 +45,7 @@ export function SummaryBlock(props: { globalConfig: GlobalConfig; }) {
       await fetchAllData();
     };
     init();
-  }, []);
+  }, [storageEngine]);
 
   return (
     <Box>

--- a/src/analysis/dashboard/SummaryBlock.tsx
+++ b/src/analysis/dashboard/SummaryBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box, Grid, LoadingOverlay, Title,
 } from '@mantine/core';
@@ -7,7 +7,6 @@ import { SummaryPanel } from './SummaryPanel';
 import { GlobalConfig, StudyConfig } from '../../parser/types';
 import { getStudyConfig } from '../../utils/fetchConfig';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
-import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 
 export function SummaryBlock(props: { globalConfig: GlobalConfig; }) {
   const { globalConfig } = props;
@@ -45,7 +44,7 @@ export function SummaryBlock(props: { globalConfig: GlobalConfig; }) {
       await fetchAllData();
     };
     init();
-  }, [storageEngine]);
+  }, [globalConfig, storageEngine]);
 
   return (
     <Box>

--- a/src/analysis/dashboard/SummaryBlock.tsx
+++ b/src/analysis/dashboard/SummaryBlock.tsx
@@ -22,8 +22,8 @@ export function SummaryBlock(props: { globalConfig: GlobalConfig; }) {
       const allConfig: Record<string, StudyConfig> = {};
 
       const fetchData = async (studyId: string) => {
-        if (storageEngine instanceof FirebaseStorageEngine) {
-          const config = await getStudyConfig(studyId, globalConfig);
+        const config = await getStudyConfig(studyId, globalConfig);
+        if (storageEngine) {
           allData[studyId] = await storageEngine.getAllParticipantsDataByStudy(studyId);
           if (config === null) return;
           allConfig[studyId] = config;

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -463,6 +463,38 @@ export class FirebaseStorageEngine extends StorageEngine {
     return false;
   }
 
+  async getAllParticipantsDataByStudy(studyId:string) {
+    const currentCollection = collection(this.firestore, `${this.collectionPrefix}${studyId}`);
+
+    // Get all participants
+    const participants = await getDocs(currentCollection);
+    const participantData: ParticipantData[] = [];
+
+    // Iterate over the participants and add the provenance graph
+    const participantPulls = participants.docs.map(async (participant) => {
+      // Exclude the config doc and the sequenceArray doc
+      if (participant.id === 'config' || participant.id === 'sequenceArray') return;
+
+      const participantDataItem = participant.data() as ParticipantData;
+
+      const fullProvObj = await this._getFromFirebaseStorage(participantDataItem.participantId, 'provenance');
+      const fullWindowEventsObj = await this._getFromFirebaseStorage(participantDataItem.participantId, 'windowEvents');
+
+      // Rehydrate the provenance graphs
+      participantDataItem.answers = Object.fromEntries(Object.entries(participantDataItem.answers).map(([key, value]) => {
+        if (value === undefined) return [key, value];
+        const provenanceGraph = fullProvObj[key];
+        const windowEvents = fullWindowEventsObj[key];
+        return [key, { ...value, provenanceGraph, windowEvents }];
+      }));
+      participantData.push(participantDataItem);
+    });
+
+    await Promise.all(participantPulls);
+
+    return participantData;
+  }
+
   private _verifyStudyDatabase(db: CollectionReference<DocumentData, DocumentData> | undefined): db is CollectionReference<DocumentData, DocumentData> {
     return db !== undefined;
   }

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -181,7 +181,7 @@ export class LocalStorageEngine extends StorageEngine {
     return returnArray;
   }
 
-  async getAllParticipantsDataByStudy(studyId:string) {
+  async getAllParticipantsDataByStudy(studyId: string) {
     const currStudyDatabase = localforage.createInstance({
       name: studyId,
     });

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -170,6 +170,22 @@ export class LocalStorageEngine extends StorageEngine {
     return returnArray;
   }
 
+  async getAllParticipantsDataByStudy(studyId:string) {
+    const currStudyDatabase = localforage.createInstance({
+      name: studyId,
+    });
+
+    const returnArray: ParticipantData[] = [];
+
+    await currStudyDatabase.iterate((value, key) => {
+      if (key !== 'config' && key !== 'currentParticipant' && key !== 'sequenceArray' && key !== 'configs') {
+        returnArray.push(value as ParticipantData);
+      }
+    });
+
+    return returnArray;
+  }
+
   async getParticipantData() {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -41,6 +41,8 @@ export abstract class StorageEngine {
 
   abstract getAllParticipantsData(): Promise<ParticipantData[]>;
 
+  abstract getAllParticipantsDataByStudy(studyId:string): Promise<ParticipantData[]>;
+
   abstract getParticipantData(): Promise<ParticipantData | null>;
 
   abstract nextParticipant(config: StudyConfig): Promise<ParticipantData>;


### PR DESCRIPTION
Analysis dashboard not available with Firebase storage

### Give a longer description of what this PR addresses and why it's needed
Analysis dashboard was pulling in data for each study by initializing a storage engine for each one. We've changed this to pull participant data by the studyId that was given. Prevents issues trying to initialize too many firebase applications at once.

