### PR TITLE
Adding public mode

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,5 @@ VITE_FIREBASE_CONFIG='
 '
 VITE_STORAGE_ENGINE="localStorage" # "firebase" or "localStorage" or your own custom storage engine
 VITE_RECAPTCHAV3TOKEN="6LdjOd0lAAAAAASvFfDZFWgtbzFSS9Y3so8rHJth" # recaptcha SITE KEY
+
+VITE_REVISIT_MODE="public"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   // Opt out of parallel tests on CI.
   workers: process.env.CI ? 1 : undefined,
-  timeout: 90000,
+  timeout: 180000,
   reporter: 'html',
 
   use: {

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -1,5 +1,7 @@
 import {
+  ActionIcon,
   Aside,
+  CloseButton,
   ScrollArea,
   Text,
 } from '@mantine/core';
@@ -7,7 +9,9 @@ import React, { useMemo } from 'react';
 import { DownloadPanel } from '../DownloadPanel';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
-import { useFlatSequence, useStoreSelector } from '../../store/store';
+import {
+  useFlatSequence, useStoreActions, useStoreDispatch, useStoreSelector,
+} from '../../store/store';
 import { useCurrentStep } from '../../routes/utils';
 import { deepCopy } from '../../utils/deepCopy';
 import { ComponentBlock } from '../../parser/types';
@@ -20,11 +24,13 @@ function addPathToComponentBlock(order: ComponentBlock | string, orderPath: stri
 }
 
 export default function AppAside() {
-  const { showAdmin, sequence } = useStoreSelector((state) => state);
+  const { showStudyBrowser, sequence } = useStoreSelector((state) => state);
+  const { toggleStudyBrowser } = useStoreActions();
 
   const currentStep = useCurrentStep();
   const currentComponent = useFlatSequence()[currentStep];
   const studyConfig = useStudyConfig();
+  const dispatch = useStoreDispatch();
 
   const fullOrder = useMemo(() => {
     let r = deepCopy(studyConfig.sequence) as ComponentBlockWithOrderPath;
@@ -33,8 +39,16 @@ export default function AppAside() {
     return r;
   }, [studyConfig.sequence]);
 
-  return showAdmin || (currentComponent === 'end' && studyConfig.uiConfig.autoDownloadStudy) ? (
+  return showStudyBrowser || (currentComponent === 'end' && studyConfig.uiConfig.autoDownloadStudy) ? (
     <Aside p="0" width={{ base: 300 }} style={{ zIndex: 0 }}>
+      <ActionIcon
+        style={{
+          position: 'absolute', right: '10px', top: '10px', zIndex: 5,
+        }}
+        onClick={() => dispatch(toggleStudyBrowser())}
+      >
+        <CloseButton />
+      </ActionIcon>
       <ScrollArea p="0">
         {currentComponent === 'end' && (
           <div
@@ -47,7 +61,7 @@ export default function AppAside() {
           </div>
         )}
         <Text size="md" p={10} weight="bold">
-          Study Sequence
+          Study Browser
         </Text>
         <StepsPanel configSequence={fullOrder} participantSequence={sequence} fullSequence={sequence} />
       </ScrollArea>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -1,14 +1,17 @@
 import {
   ActionIcon,
+  Badge,
   Button,
   Flex,
   Grid,
+  Group,
   Header,
   Image,
   Menu,
   Progress,
   Space,
   Title,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconDotsVertical,
@@ -41,9 +44,6 @@ export default function AppHeader() {
   const logoPath = studyConfig?.uiConfig.logoPath;
   const withProgressBar = studyConfig?.uiConfig.withProgressBar;
 
-  const [searchParams] = useState(new URLSearchParams(window.location.search));
-  const admin = searchParams.get('admin') || 'f';
-
   const studyId = useStudyId();
   const studyHref = useHref(`/${studyId}`);
   function getNewParticipant() {
@@ -74,7 +74,8 @@ export default function AppHeader() {
         </Grid.Col>
 
         <Grid.Col span={4}>
-          <Flex align="center" justify="flex-end">
+          <Group noWrap position="right">
+            {import.meta.env.VITE_REVISIT_MODE === 'public' ? <Tooltip multiline withArrow arrowSize={6} width={300} label="This is a demo version of the study, we’re not collecting any data. Navigate the study via the Study Navigitor on the right."><Badge size="lg" color="orange">Demo Mode</Badge></Tooltip> : null}
             {studyConfig?.uiConfig.helpTextPath !== undefined && (
               <Button
                 variant="outline"
@@ -84,9 +85,7 @@ export default function AppHeader() {
               </Button>
             )}
 
-            <Space w="md" />
-
-            {(import.meta.env.DEV || admin === 't') && (
+            {(import.meta.env.DEV || import.meta.env.VITE_REVISIT_MODE === 'public') && (
               <Menu
                 shadow="md"
                 width={200}
@@ -104,7 +103,7 @@ export default function AppHeader() {
                     icon={<IconSchema size={14} />}
                     onClick={() => storeDispatch(toggleShowAdmin())}
                   >
-                    Admin Mode
+                    Sequence Navigator
                   </Menu.Item>
 
                   <Menu.Item
@@ -128,7 +127,7 @@ export default function AppHeader() {
                 </Menu.Dropdown>
               </Menu>
             )}
-          </Flex>
+          </Group>
         </Grid.Col>
       </Grid>
     </Header>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -94,7 +94,7 @@ export default function AppHeader() {
                 onChange={setMenuOpened}
               >
                 <Menu.Target>
-                  <ActionIcon size="lg">
+                  <ActionIcon size="lg" className="studyBrowserMenuDropdown">
                     <IconDotsVertical />
                   </ActionIcon>
                 </Menu.Target>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -31,7 +31,7 @@ export default function AppHeader() {
   const { config: studyConfig } = useStoreSelector((state) => state);
   const flatSequence = useFlatSequence();
   const storeDispatch = useStoreDispatch();
-  const { toggleShowHelpText, toggleShowAdmin } = useStoreActions();
+  const { toggleShowHelpText, toggleStudyBrowser } = useStoreActions();
   const { storageEngine } = useStorageEngine();
 
   const currentStep = useCurrentStep();
@@ -75,7 +75,7 @@ export default function AppHeader() {
 
         <Grid.Col span={4}>
           <Group noWrap position="right">
-            {import.meta.env.VITE_REVISIT_MODE === 'public' ? <Tooltip multiline withArrow arrowSize={6} width={300} label="This is a demo version of the study, we’re not collecting any data. Navigate the study via the Study Navigitor on the right."><Badge size="lg" color="orange">Demo Mode</Badge></Tooltip> : null}
+            {import.meta.env.VITE_REVISIT_MODE === 'public' ? <Tooltip multiline withArrow arrowSize={6} width={300} label="This is a demo version of the study, we’re not collecting any data. Navigate the study via the study browser on the right."><Badge size="lg" color="orange">Demo Mode</Badge></Tooltip> : null}
             {studyConfig?.uiConfig.helpTextPath !== undefined && (
               <Button
                 variant="outline"
@@ -101,9 +101,9 @@ export default function AppHeader() {
                 <Menu.Dropdown>
                   <Menu.Item
                     icon={<IconSchema size={14} />}
-                    onClick={() => storeDispatch(toggleShowAdmin())}
+                    onClick={() => storeDispatch(toggleStudyBrowser())}
                   >
-                    Sequence Navigator
+                    Study Browser
                   </Menu.Item>
 
                   <Menu.Item

--- a/src/storage/initialize.ts
+++ b/src/storage/initialize.ts
@@ -6,7 +6,7 @@ export async function initializeStorageEngine() {
   let storageEngine: StorageEngine | undefined;
   let fallback = false;
 
-  const storageEngineName: string = import.meta.env.VITE_REVISIT_MODE ? 'localStorage' : import.meta.env.VITE_STORAGE_ENGINE;
+  const storageEngineName: string = import.meta.env.VITE_REVISIT_MODE === 'public' ? 'localStorage' : import.meta.env.VITE_STORAGE_ENGINE;
 
   if (storageEngineName === 'firebase') {
     const firebaseStorageEngine = new FirebaseStorageEngine();

--- a/src/storage/initialize.ts
+++ b/src/storage/initialize.ts
@@ -6,7 +6,7 @@ export async function initializeStorageEngine() {
   let storageEngine: StorageEngine | undefined;
   let fallback = false;
 
-  const storageEngineName: string = import.meta.env.VITE_STORAGE_ENGINE;
+  const storageEngineName: string = import.meta.env.VITE_REVISIT_MODE ? 'localStorage' : import.meta.env.VITE_STORAGE_ENGINE;
 
   if (storageEngineName === 'firebase') {
     const firebaseStorageEngine = new FirebaseStorageEngine();

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -34,7 +34,7 @@ export async function studyStoreCreator(
     answers: answers || emptyAnswers,
     sequence,
     config,
-    showAdmin: false,
+    showStudyBrowser: import.meta.env.VITE_REVISIT_MODE === 'public',
     showHelpText: false,
     alertModal: { show: false, message: '' },
     trialValidation: answers ? allValid : emptyValidation,
@@ -48,8 +48,8 @@ export async function studyStoreCreator(
       setConfig(state, payload: PayloadAction<StudyConfig>) {
         state.config = payload.payload;
       },
-      toggleShowAdmin: (state) => {
-        state.showAdmin = !state.showAdmin;
+      toggleStudyBrowser: (state) => {
+        state.showStudyBrowser = !state.showStudyBrowser;
       },
       toggleShowHelpText: (state) => {
         state.showHelpText = !state.showHelpText;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -109,7 +109,7 @@ export interface StoreState {
   answers: Record<string, StoredAnswer>;
   sequence: Sequence;
   config: StudyConfig;
-  showAdmin: boolean;
+  showStudyBrowser: boolean;
   showHelpText: boolean;
   alertModal: { show: boolean, message: string };
   trialValidation: TrialValidation;

--- a/src/utils/useDisableBrowserBack.tsx
+++ b/src/utils/useDisableBrowserBack.tsx
@@ -13,7 +13,7 @@ export function useDisableBrowserBack() {
     const searchParams = new URLSearchParams(window.location.search);
     const isAdmin = (searchParams.get('admin') || 'f') === 't';
 
-    if (import.meta.env.PROD && !isAdmin) {
+    if (import.meta.env.PROD && !isAdmin && import.meta.env.VITE_REVISIT_MODE !== 'public') {
       window.history.pushState(null, '', window.location.href);
       window.onpopstate = () => {
         window.history.pushState(null, '', window.location.href);

--- a/tests/test-randomization.spec.ts
+++ b/tests/test-randomization.spec.ts
@@ -134,7 +134,7 @@ test('test', async ({ page }) => {
   expect(globalOcurrences.trial20).toBe(500);
 
   // Check to make sure that the admin panel renders with such a complex sequence
-  await page.locator('#mantine-r1-target').click();
+  await page.locator('.studyBrowserMenuDropdown').click();
   await page.getByRole('menuitem', { name: 'Admin Mode' }).click();
 
   const sequenceHeader = await page.getByText('Study Browser');

--- a/tests/test-randomization.spec.ts
+++ b/tests/test-randomization.spec.ts
@@ -135,7 +135,7 @@ test('test', async ({ page }) => {
 
   // Check to make sure that the admin panel renders with such a complex sequence
   await page.locator('.studyBrowserMenuDropdown').click();
-  await page.getByRole('menuitem', { name: 'Admin Mode' }).click();
+  await page.getByRole('menuitem', { name: 'Study Browser' }).click();
 
   const sequenceHeader = await page.getByText('Study Browser');
   await expect(sequenceHeader).toBeVisible();

--- a/tests/test-randomization.spec.ts
+++ b/tests/test-randomization.spec.ts
@@ -137,6 +137,6 @@ test('test', async ({ page }) => {
   await page.locator('#mantine-r1-target').click();
   await page.getByRole('menuitem', { name: 'Admin Mode' }).click();
 
-  const sequenceHeader = await page.getByText('Study Sequence');
+  const sequenceHeader = await page.getByText('Study Browser');
   await expect(sequenceHeader).toBeVisible();
 });

--- a/tests/test-skip-logic.spec.ts
+++ b/tests/test-skip-logic.spec.ts
@@ -53,7 +53,7 @@ async function verifyStudyEnd(page) {
 }
 
 async function getNextParticipant(page) {
-  await page.locator('#mantine-r1-target').click();
+  await page.locator('.studyBrowserMenuDropdown').click();
   await page.getByRole('menuitem', { name: 'Next Participant' }).click();
 }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #316 
Closes #317 
Closes #318

### Give a longer description of what this PR addresses and why it's needed
Adds a public mode, set via the env variable 'VITE_REVISIT_MODE', checking if it is 'public'. 

If it is, does a few things 

- Sets the storage engine to localStorage, so that nothing is tracked
- Adds a banner telling people we are in public mode, and they arent being tracked
- Gives access to the study browser dropdown/sidebar, and opens the study browser by default. 
