### PR TITLE
Clear database feature

### DIFF
--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -3,7 +3,7 @@ import {
 } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import {
-  getAuth, signInWithPopup, GoogleAuthProvider,
+  getAuth, signInWithPopup, GoogleAuthProvider, browserPopupRedirectResolver,
 } from '@firebase/auth';
 import { IconBrandGoogle } from '@tabler/icons-react';
 import { Navigate } from 'react-router-dom';
@@ -19,7 +19,7 @@ export async function signInWithGoogle(storageEngine: StorageEngine | undefined,
     const provider = new GoogleAuthProvider();
     const auth = getAuth();
     try {
-      await signInWithPopup(auth, provider);
+      await signInWithPopup(auth, provider, browserPopupRedirectResolver);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (setErrorMessage) {

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -59,7 +59,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             <Tabs.Tab value="table" icon={<IconTable size={16} />}>Table View</Tabs.Tab>
             <Tabs.Tab value="stats" icon={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
             <Tabs.Tab value="replay" icon={<IconPlayerPlay size={16} />}>Individual Replay</Tabs.Tab>
-            { import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine ? <Tabs.Tab value="settings" icon={<IconSettings size={16} />}>Manage</Tabs.Tab> : null}
+            { import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine ? <Tabs.Tab value="manage" icon={<IconSettings size={16} />}>Manage</Tabs.Tab> : null}
           </Tabs.List>
           <Tabs.Panel value="table" pt="xs" style={{ height: 'calc(100% - 38px - 10px)', width: '100%', overflow: 'scroll' }}>
             {studyConfig && <TableView completed={completed} inProgress={inProgress} studyConfig={studyConfig} refresh={getData} />}
@@ -71,8 +71,8 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
           <Tabs.Panel value="replay" pt="xs">
             Replay Tab Content
           </Tabs.Panel>
-          <Tabs.Panel value="settings" pt="xs">
-            {studyId && import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine && <DataManagementBoard studyId={studyId} />}
+          <Tabs.Panel value="manage" pt="xs">
+            {studyId && import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine && <DataManagementBoard studyId={studyId} refresh={getData} />}
           </Tabs.Panel>
         </Tabs>
       </Container>

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -14,6 +14,7 @@ import { getStudyConfig } from '../utils/fetchConfig';
 import { TableView } from './stats/TableView';
 import { useStorageEngine } from '../storage/storageEngineHooks';
 import { DataManagementBoard } from './management/DataManagementBoard';
+import { FirebaseStorageEngine } from '../storage/engines/FirebaseStorageEngine';
 
 export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
   const { globalConfig } = props;
@@ -58,7 +59,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             <Tabs.Tab value="table" icon={<IconTable size={16} />}>Table View</Tabs.Tab>
             <Tabs.Tab value="stats" icon={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
             <Tabs.Tab value="replay" icon={<IconPlayerPlay size={16} />}>Individual Replay</Tabs.Tab>
-            <Tabs.Tab value="settings" icon={<IconSettings size={16} />}>Manage</Tabs.Tab>
+            { import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine ? <Tabs.Tab value="settings" icon={<IconSettings size={16} />}>Manage</Tabs.Tab> : null}
           </Tabs.List>
           <Tabs.Panel value="table" pt="xs" style={{ height: 'calc(100% - 38px - 10px)', width: '100%', overflow: 'scroll' }}>
             {studyConfig && <TableView completed={completed} inProgress={inProgress} studyConfig={studyConfig} refresh={getData} />}
@@ -71,7 +72,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             Replay Tab Content
           </Tabs.Panel>
           <Tabs.Panel value="settings" pt="xs">
-            {studyId && <DataManagementBoard studyId={studyId} />}
+            {studyId && import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine && <DataManagementBoard studyId={studyId} />}
           </Tabs.Panel>
         </Tabs>
       </Container>

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -59,7 +59,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             <Tabs.Tab value="table" icon={<IconTable size={16} />}>Table View</Tabs.Tab>
             <Tabs.Tab value="stats" icon={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
             <Tabs.Tab value="replay" icon={<IconPlayerPlay size={16} />}>Individual Replay</Tabs.Tab>
-            { import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine ? <Tabs.Tab value="manage" icon={<IconSettings size={16} />}>Manage</Tabs.Tab> : null}
+            <Tabs.Tab value="manage" icon={<IconSettings size={16} />} disabled={import.meta.env.VITE_REVISIT_MODE === 'public' || !(storageEngine instanceof FirebaseStorageEngine)}>Manage</Tabs.Tab>
           </Tabs.List>
           <Tabs.Panel value="table" pt="xs" style={{ height: 'calc(100% - 38px - 10px)', width: '100%', overflow: 'scroll' }}>
             {studyConfig && <TableView completed={completed} inProgress={inProgress} studyConfig={studyConfig} refresh={getData} />}

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -71,7 +71,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             Replay Tab Content
           </Tabs.Panel>
           <Tabs.Panel value="settings" pt="xs">
-            {studyConfig && studyId && <DataManagementBoard studyConfig={studyConfig} studyId={studyId} />}
+            {studyId && <DataManagementBoard studyId={studyId} />}
           </Tabs.Panel>
         </Tabs>
       </Container>

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -49,6 +49,8 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
     return [comp, prog];
   }, [expData]);
 
+  const showManage = import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine;
+
   return (
     <AppShell>
       <AppHeader studyIds={props.globalConfig.configsList} />
@@ -59,7 +61,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             <Tabs.Tab value="table" icon={<IconTable size={16} />}>Table View</Tabs.Tab>
             <Tabs.Tab value="stats" icon={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
             <Tabs.Tab value="replay" icon={<IconPlayerPlay size={16} />}>Individual Replay</Tabs.Tab>
-            <Tabs.Tab value="manage" icon={<IconSettings size={16} />} disabled={import.meta.env.VITE_REVISIT_MODE === 'public' || !(storageEngine instanceof FirebaseStorageEngine)}>Manage</Tabs.Tab>
+            <Tabs.Tab value="manage" icon={<IconSettings size={16} />} disabled={!showManage}>Manage</Tabs.Tab>
           </Tabs.List>
           <Tabs.Panel value="table" pt="xs" style={{ height: 'calc(100% - 38px - 10px)', width: '100%', overflow: 'scroll' }}>
             {studyConfig && <TableView completed={completed} inProgress={inProgress} studyConfig={studyConfig} refresh={getData} />}
@@ -72,7 +74,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
             Replay Tab Content
           </Tabs.Panel>
           <Tabs.Panel value="manage" pt="xs">
-            {studyId && import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine && <DataManagementBoard studyId={studyId} refresh={getData} />}
+            {studyId && showManage && <DataManagementBoard studyId={studyId} refresh={getData} />}
           </Tabs.Panel>
         </Tabs>
       </Container>

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -3,7 +3,7 @@ import {
 } from '@mantine/core';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
-  IconChartDonut2, IconPlayerPlay, IconTable,
+  IconChartDonut2, IconPlayerPlay, IconTable, IconSettings,
 } from '@tabler/icons-react';
 import React, {
   useCallback, useEffect, useMemo, useState,
@@ -13,6 +13,7 @@ import { GlobalConfig, ParticipantData, StudyConfig } from '../parser/types';
 import { getStudyConfig } from '../utils/fetchConfig';
 import { TableView } from './stats/TableView';
 import { useStorageEngine } from '../storage/storageEngineHooks';
+import { DataManagementBoard } from './management/DataManagementBoard';
 
 export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
   const { globalConfig } = props;
@@ -56,7 +57,8 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
           <Tabs.List>
             <Tabs.Tab value="table" icon={<IconTable size={16} />}>Table View</Tabs.Tab>
             <Tabs.Tab value="stats" icon={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
-            <Tabs.Tab value="settings" icon={<IconPlayerPlay size={16} />}>Individual Replay</Tabs.Tab>
+            <Tabs.Tab value="replay" icon={<IconPlayerPlay size={16} />}>Individual Replay</Tabs.Tab>
+            <Tabs.Tab value="settings" icon={<IconSettings size={16} />}>Manage</Tabs.Tab>
           </Tabs.List>
           <Tabs.Panel value="table" pt="xs" style={{ height: 'calc(100% - 38px - 10px)', width: '100%', overflow: 'scroll' }}>
             {studyConfig && <TableView completed={completed} inProgress={inProgress} studyConfig={studyConfig} refresh={getData} />}
@@ -65,9 +67,11 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
           <Tabs.Panel value="stats" pt="xs">
             statsboard
           </Tabs.Panel>
-
+          <Tabs.Panel value="replay" pt="xs">
+            Replay Tab Content
+          </Tabs.Panel>
           <Tabs.Panel value="settings" pt="xs">
-            Settings tab content
+            {studyConfig && studyId && <DataManagementBoard studyConfig={studyConfig} studyId={studyId} />}
           </Tabs.Panel>
         </Tabs>
       </Container>

--- a/src/analysis/dashboard/SummaryPanel.tsx
+++ b/src/analysis/dashboard/SummaryPanel.tsx
@@ -150,7 +150,7 @@ export function SummaryPanel(props: { studyId: string; allParticipants: Particip
                 </Button>
               </Popover.Target>
               <Popover.Dropdown>
-                <Text>Analyze study data</Text>
+                <Text>Analyze and manage study data</Text>
               </Popover.Dropdown>
             </Popover>
           </Group>

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -1,5 +1,5 @@
 import {
-  Card, Container, Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, ActionIcon,
+  Card, Container, Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip,
 } from '@mantine/core';
 import { useForm, isEmail } from '@mantine/form';
 import { useEffect, useMemo, useState } from 'react';
@@ -14,8 +14,20 @@ import { StudyConfig } from '../../parser/types';
 export function DataManagementBoard({ studyConfig, studyId }:{studyConfig:StudyConfig, studyId:string}) {
   const [modalDeleteOpened, setModalDeleteOpened] = useState<boolean>(false);
   const [deleteValue, setDeleteValue] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const { storageEngine } = useStorageEngine();
+
+  const handleCopyCollection = async () => {
+    setLoading(true);
+    if (storageEngine instanceof FirebaseStorageEngine) {
+      await storageEngine.copyCollection(studyId);
+      setLoading(false);
+    }
+  };
+
   return (
     <>
+      <LoadingOverlay visible={loading} />
       <Container>
         <Card withBorder style={{ backgroundColor: '#FAFAFA', justifySelf: 'left' }}>
           <Title mb={20} order={3}>Data Management</Title>
@@ -51,7 +63,7 @@ export function DataManagementBoard({ studyConfig, studyId }:{studyConfig:StudyC
             <Button mr={5} variant="subtle" color="red" onClick={() => setModalDeleteOpened(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={deleteValue !== studyId}>
+            <Button onClick={() => handleCopyCollection()} disabled={deleteValue !== studyId}>
               Delete
             </Button>
           </Flex>

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -20,15 +20,14 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
   const [loading, setLoading] = useState<boolean>(false);
   const [snapshotListLoading, setSnapshotListLoading] = useState<boolean>(false);
 
-  const { storageEngine } = useStorageEngine();
+  const { storageEngine: storageEngineBadType } = useStorageEngine();
+  const storageEngine = storageEngineBadType as FirebaseStorageEngine; // We're guaranteed to have a FirebaseStorageEngine here
 
   // Used to fetch archived datasets
   const refreshSnapshots = useCallback(async () => {
     setSnapshotListLoading(true);
-    if (storageEngine instanceof FirebaseStorageEngine) {
-      const currSnapshots = await storageEngine.getSnapshots(studyId);
-      setSnapshots(currSnapshots);
-    }
+    const currSnapshots = await storageEngine.getSnapshots(studyId);
+    setSnapshots(currSnapshots);
     setSnapshotListLoading(false);
   }, [storageEngine, studyId]);
 
@@ -38,9 +37,7 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
 
   const handleCreateSnapshot = async () => {
     setLoading(true);
-    if (storageEngine instanceof FirebaseStorageEngine) {
-      await storageEngine.createSnapshot(studyId, false);
-    }
+    await storageEngine.createSnapshot(studyId, false);
     refreshSnapshots();
     setLoading(false);
     await refresh();
@@ -49,10 +46,8 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
   const handleArchiveData = async () => {
     setLoading(true);
     setDeleteValue('');
-    if (storageEngine instanceof FirebaseStorageEngine) {
-      setModalArchiveOpened(false);
-      await storageEngine.createSnapshot(studyId, true);
-    }
+    setModalArchiveOpened(false);
+    await storageEngine.createSnapshot(studyId, true);
     refreshSnapshots();
     setLoading(false);
     await refresh();
@@ -60,9 +55,7 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
 
   const handleRestoreSnapshot = async (snapshot: string) => {
     setLoading(true);
-    if (storageEngine instanceof FirebaseStorageEngine) {
-      await storageEngine.restoreSnapshot(studyId, snapshot);
-    }
+    await storageEngine.restoreSnapshot(studyId, snapshot);
     refreshSnapshots();
     setLoading(false);
     await refresh();
@@ -71,10 +64,8 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
   const handleDeleteSnapshot = async () => {
     setLoading(true);
     setDeleteValue('');
-    if (storageEngine instanceof FirebaseStorageEngine) {
-      setModalDeleteSnapshotOpened(false);
-      await storageEngine.removeSnapshotOrLive(currentSnapshot, true);
-    }
+    setModalDeleteSnapshotOpened(false);
+    await storageEngine.removeSnapshotOrLive(currentSnapshot, true);
     refreshSnapshots();
     setLoading(false);
     await refresh();
@@ -83,10 +74,8 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
   const handleDeleteLive = async () => {
     setLoading(true);
     setDeleteValue('');
-    if (storageEngine instanceof FirebaseStorageEngine) {
-      setModalDeleteLiveOpened(false);
-      await storageEngine.removeSnapshotOrLive(studyId, true);
-    }
+    setModalDeleteLiveOpened(false);
+    await storageEngine.removeSnapshotOrLive(studyId, true);
     refreshSnapshots();
     setLoading(false);
     await refresh();

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -29,8 +29,8 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
     async function fetchData() {
       setSnapshotListLoading(true);
       if (storageEngine instanceof FirebaseStorageEngine) {
-        const currArchivedCollections = await storageEngine.getSnapshots(studyId);
-        setSnapshots(currArchivedCollections);
+        const currSnapshots = await storageEngine.getSnapshots(studyId);
+        setSnapshots(currSnapshots);
       }
       setSnapshotListLoading(false);
     }
@@ -87,35 +87,41 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
           <Title mb={30} order={2}>Data Management</Title>
           <Flex mb={50} justify="space-between" align="center">
             <Box style={{ width: '70%' }}>
-              <Title order={4}>Archive and study data</Title>
+              <Title order={4}>Create a Snapshot</Title>
               <Text>
-                This wil create an archived dataset of the
-                <span style={{ fontWeight: 'bold' }}>{studyId}</span>
+                This wil create a snapshot of the current
+                <span style={{ fontWeight: 'bold' }}>
+                  {' '}
+                  {studyId}
+                </span>
                 {' '}
                 data. It will
-                <span style={{ fontStyle: 'italic', fontWeight: 'bold' }}>not</span>
+                <span style={{ fontStyle: 'italic', fontWeight: 'bold' }}> not</span>
                 {' '}
-                remove this data from the current dataset.
+                remove this data from the current dataset. The current study data can be restored to a snapshot at any time.
               </Text>
             </Box>
-            <Tooltip label="Archive and Delete study data">
+            <Tooltip label="Create a snapshot">
               <Button
                 color="red"
                 sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
                 onClick={() => setModalCreateSnapshotOpened(true)}
               >
-                Snapshot Data
+                Create a Snapshot
               </Button>
             </Tooltip>
           </Flex>
           <Flex justify="space-between" align="center">
             <Box style={{ width: '70%' }}>
-              <Title order={4}>Take a snapshot and delete data</Title>
+              <Title order={4}>Archive Data</Title>
               <Text>
                 This wil create a snapshot of the current
-                <span style={{ fontWeight: 'bold' }}>{studyId}</span>
-                {' '}
-                data. It will then remove this data from the current dataset. The current data can be restored to a snapshot at any time.
+                <span style={{ fontWeight: 'bold' }}>
+                  {' '}
+                  {studyId}
+                  {' '}
+                </span>
+                data. It will then remove this data from the current dataset. The current study data can be restored to a snapshot at any time.
               </Text>
             </Box>
             <Tooltip label="Snapshot and Delete Data">
@@ -124,7 +130,7 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
                 sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
                 onClick={() => setModalArchiveOpened(true)}
               >
-                Snapshot and Delete
+                Archive Data
               </Button>
             </Tooltip>
           </Flex>
@@ -139,10 +145,10 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
                   <Flex key={datasetName} justify="space-between" mb={10}>
                     <Text>{datasetName}</Text>
                     <Flex direction="row" gap={10}>
-                      <Tooltip label="Restore Archive">
+                      <Tooltip label="Restore Snapshot">
                         <ActionIcon variant="subtle" onClick={() => { setModalRestoreOpened(true); setCurrentSnapshot(datasetName); }}><IconRefresh color="green" /></ActionIcon>
                       </Tooltip>
-                      <Tooltip label="Delete Archive">
+                      <Tooltip label="Delete Snapshot">
                         <ActionIcon variant="subtle" onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(datasetName); }}><IconTrashX color="red" /></ActionIcon>
                       </Tooltip>
                     </Flex>
@@ -158,10 +164,10 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       <Modal
         opened={modalArchiveOpened}
         onClose={() => { setModalArchiveOpened(false); setDeleteValue(''); }}
-        title="Archive and Delete. This will create a separate archive of the dataset and then delete the existing data from this collection."
+        title={<Title order={4}>Archive Data</Title>}
       >
         <Box>
-          <Text mb={30}>This will create and archive and then delete all of the current study data.</Text>
+          <Text mb={30}>This will create a snapshot of the current dataset and then delete the current dataset.</Text>
           <TextInput
             label="To delete this data, please enter the name of the study."
             placeholder={studyId}
@@ -181,16 +187,16 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       <Modal
         opened={modalCreateSnapshotOpened}
         onClose={() => setModalCreateSnapshotOpened(false)}
-        title={<Title order={4}>Archive Current Data</Title>}
+        title={<Title order={4}>Create A Snapshot</Title>}
       >
         <Box>
-          <Text mb={30}>This will create an archive of the current study data and remove the current study data. An archive can be restored at any time.</Text>
+          <Text mb={30}>This will create a snapshot of the current dataset. The current study data can be restored to a snapshot at any time.</Text>
           <Flex mt={30} justify="right">
             <Button mr={5} variant="subtle" color="red" onClick={() => setModalCreateSnapshotOpened(false)}>
               Cancel
             </Button>
             <Button onClick={() => handleCreateSnapshot()}>
-              Take a Snapshot
+              Create a Snapshot
             </Button>
           </Flex>
         </Box>
@@ -199,10 +205,10 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       <Modal
         opened={modalRestoreOpened}
         onClose={() => setModalRestoreOpened(false)}
-        title={<Title order={4}>Restore Archive</Title>}
+        title={<Title order={4}>Restore Snapshot</Title>}
       >
         <Box>
-          <Text mb={30}>This will archive the current study data into a new archive and then copy the this archive back into the current study data. This archive will then be removed.</Text>
+          <Text mb={30}>This will create a snapshot of the current study data into a new snapshot and then copy the this snapshot back into the current study data. This snapshot will then be removed.</Text>
           <Flex mt={30} justify="right">
             <Button mr={5} variant="subtle" color="red" onClick={() => setModalRestoreOpened(false)}>
               Cancel
@@ -220,9 +226,9 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
         title={<Title order={4}>Delete Snapshot</Title>}
       >
         <Box>
-          <Text mb={30}>This will permanently remove this archive.</Text>
+          <Text mb={30}>This will permanently remove this snapshot.</Text>
           <TextInput
-            label="To delete this archive, please 'delete' in the box below."
+            label="To delete this snapshot, please 'delete' in the box below."
             placeholder="delete"
             onChange={(event) => setDeleteValue(event.target.value)}
           />
@@ -231,7 +237,7 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
               Cancel
             </Button>
             <Button onClick={() => handleDeleteSnapshot()} disabled={deleteValue !== 'delete'}>
-              Delete Archive
+              Delete Snapshot
             </Button>
           </Flex>
         </Box>

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -109,28 +109,27 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
     <>
       <LoadingOverlay visible={loading} />
       <Container>
-        <Card withBorder style={{ backgroundColor: '#FAFAFA', justifySelf: 'left' }}>
-          <Title mb="lg" order={3}>Data Management</Title>
+        <Card withBorder style={{ backgroundColor: '#FAFAFA' }}>
+          <Title mb="lg" order={4}>Data Management</Title>
+
           <Flex justify="space-between" align="center">
             <Box style={{ width: '70%' }}>
               <Title order={5}>Create a Snapshot</Title>
               <Text>
                 This will create a snapshot of the live
-                <span style={{ fontWeight: 'bold' }}>
-                  {' '}
-                  {studyId}
-                </span>
+                {' '}
+                <Text span fw={700}>{studyId}</Text>
                 {' '}
                 database. It will
-                <span style={{ fontStyle: 'italic', fontWeight: 'bold' }}> not</span>
+                {' '}
+                <Text span fw={700} fs="italic">not</Text>
                 {' '}
                 remove this data from the live database. The current study data can be restored from a snapshot at any time.
               </Text>
             </Box>
+
             <Tooltip label="Create a snapshot">
-              <Button
-                onClick={openCreateSnapshotModal}
-              >
+              <Button onClick={openCreateSnapshotModal}>
                 Snapshot
               </Button>
             </Tooltip>
@@ -143,20 +142,15 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
               <Title order={5}>Archive Data</Title>
               <Text>
                 This will create a snapshot of the live
-                <span style={{ fontWeight: 'bold' }}>
-                  {' '}
-                  {studyId}
-                  {' '}
-                </span>
+                {' '}
+                <Text span fw={700}>{studyId}</Text>
+                {' '}
                 database. It will then remove this data from the live database. The current study data can be restored from a snapshot at any time.
               </Text>
             </Box>
+
             <Tooltip label="Snapshot and Delete Data">
-              <Button
-                color="red"
-                sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
-                onClick={() => setModalArchiveOpened(true)}
-              >
+              <Button color="red" onClick={() => setModalArchiveOpened(true)}>
                 Archive
               </Button>
             </Tooltip>
@@ -169,47 +163,60 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
               <Title order={5}>Delete Data</Title>
               <Text>
                 This will delete the live
-                <span style={{ fontWeight: 'bold' }}>
-                  {' '}
-                  {studyId}
-                  {' '}
-                </span>
+                {' '}
+                <Text span fw={700}>{studyId}</Text>
+                {' '}
                 database. Since this does not create a snapshot the data will be permanently deleted and cannot be restored.
               </Text>
             </Box>
+
             <Tooltip label="Delete Data">
-              <Button
-                color="red"
-                sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
-                onClick={() => setModalDeleteLiveOpened(true)}
-              >
+              <Button color="red" onClick={() => setModalDeleteLiveOpened(true)}>
                 Delete
               </Button>
             </Tooltip>
           </Flex>
 
-          <Flex mt={40} direction="column">
-            <Flex style={{ borderBottom: '1px solid #dedede' }} direction="row" justify="space-between" mb={15} pb={15}>
+          <Space h="xl" />
+
+          <Flex direction="column">
+            <Flex style={{ borderBottom: '1px solid #dedede' }} direction="row" justify="space-between" mb="xs" pb="sm">
               <Title order={5}>Snapshots</Title>
             </Flex>
-            <div style={{ position: 'relative' }}>
+
+            {/* Position relative keeps the loading overlay only on the list */}
+            <Box style={{ position: 'relative' }}>
               <LoadingOverlay visible={snapshotListLoading} />
-              { snapshots.length > 0 ? snapshots.map(
-                (datasetName: string) => (
-                  <Flex key={datasetName} justify="space-between" mb={10}>
-                    <Text>{datasetName}</Text>
-                    <Flex direction="row" gap={10}>
-                      <Tooltip label="Restore Snapshot">
-                        <ActionIcon color="blue" variant="subtle" onClick={() => { openRestoreSnapshotModal(datasetName); }}><IconRefresh /></ActionIcon>
-                      </Tooltip>
-                      <Tooltip label="Delete Snapshot">
-                        <ActionIcon color="red" variant="subtle" onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(datasetName); }}><IconTrashX /></ActionIcon>
-                      </Tooltip>
+              { snapshots.length > 0
+                ? snapshots.map(
+                  (datasetName: string) => (
+                    <Flex key={datasetName} justify="space-between" mb="xs">
+                      <Text>{datasetName}</Text>
+                      <Flex direction="row" gap="xs">
+                        <Tooltip label="Restore Snapshot">
+                          <ActionIcon
+                            color="blue"
+                            variant="subtle"
+                            onClick={() => { openRestoreSnapshotModal(datasetName); }}
+                          >
+                            <IconRefresh />
+                          </ActionIcon>
+                        </Tooltip>
+                        <Tooltip label="Delete Snapshot">
+                          <ActionIcon
+                            color="red"
+                            variant="subtle"
+                            onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(datasetName); }}
+                          >
+                            <IconTrashX />
+                          </ActionIcon>
+                        </Tooltip>
+                      </Flex>
                     </Flex>
-                  </Flex>
-                ),
-              ) : <Text>No snapshots.</Text>}
-            </div>
+                  ),
+                )
+                : <Text>No snapshots.</Text>}
+            </Box>
           </Flex>
 
         </Card>
@@ -220,22 +227,22 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
         onClose={() => { setModalArchiveOpened(false); setDeleteValue(''); }}
         title={<Text>Archive Data</Text>}
       >
-        <Box>
-          <Text mb={30}>This will create a snapshot of the live database and remove the data from the live database.</Text>
-          <TextInput
-            label="To archive this data, please enter the name of the study."
-            placeholder={studyId}
-            onChange={(event) => setDeleteValue(event.target.value)}
-          />
-          <Flex mt={30} justify="right">
-            <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalArchiveOpened(false); setDeleteValue(''); }}>
-              Cancel
-            </Button>
-            <Button color="red" onClick={() => handleArchiveData()} disabled={deleteValue !== studyId}>
-              Archive
-            </Button>
-          </Flex>
-        </Box>
+        <Text mb="sm">This will create a snapshot of the live database and remove the data from the live database.</Text>
+
+        <TextInput
+          label="To archive this data, please enter the name of the study."
+          placeholder={studyId}
+          onChange={(event) => setDeleteValue(event.target.value)}
+        />
+
+        <Flex mt="sm" justify="right">
+          <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalArchiveOpened(false); setDeleteValue(''); }}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={handleArchiveData} disabled={deleteValue !== studyId}>
+            Archive
+          </Button>
+        </Flex>
       </Modal>
 
       <Modal
@@ -243,27 +250,27 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
         onClose={() => { setModalDeleteSnapshotOpened(false); setDeleteValue(''); }}
         title={<Text>Delete Snapshot</Text>}
       >
-        <Box>
-          <Text mb={30}>
-            This will permanently remove this snapshot. This action is
-            {' '}
-            <Text span fw={700}>irreversible</Text>
-            .
-          </Text>
-          <TextInput
-            label="To delete this snapshot, please enter the name of the study."
-            placeholder={studyId}
-            onChange={(event) => setDeleteValue(event.target.value)}
-          />
-          <Flex mt={30} justify="right">
-            <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalDeleteSnapshotOpened(false); setDeleteValue(''); }}>
-              Cancel
-            </Button>
-            <Button color="red" onClick={() => handleDeleteSnapshot()} disabled={deleteValue !== studyId}>
-              Delete
-            </Button>
-          </Flex>
-        </Box>
+        <Text mb="sm">
+          This will permanently remove this snapshot. This action is
+          {' '}
+          <Text span fw={700}>irreversible</Text>
+          .
+        </Text>
+
+        <TextInput
+          label="To delete this snapshot, please enter the name of the study."
+          placeholder={studyId}
+          onChange={(event) => setDeleteValue(event.target.value)}
+        />
+
+        <Flex mt="sm" justify="right">
+          <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalDeleteSnapshotOpened(false); setDeleteValue(''); }}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={handleDeleteSnapshot} disabled={deleteValue !== studyId}>
+            Delete
+          </Button>
+        </Flex>
       </Modal>
 
       <Modal
@@ -271,33 +278,31 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
         onClose={() => { setModalDeleteLiveOpened(false); setDeleteValue(''); }}
         title={<Text>Delete Live Data</Text>}
       >
-        <Box>
-          <Text mb={30}>
-            This will permanently delete the live
-            <span style={{ fontWeight: 'bold' }}>
-              {' '}
-              {studyId}
-              {' '}
-            </span>
-            data. This action is
-            {' '}
-            <Text span fw={700}>irreversible</Text>
-            . Please consider using archive data to create a snapshot of the live data before deleting.
-          </Text>
-          <TextInput
-            label="To delete this live data, please enter the name of the study."
-            placeholder={studyId}
-            onChange={(event) => setDeleteValue(event.target.value)}
-          />
-          <Flex mt={30} justify="right">
-            <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalDeleteLiveOpened(false); setDeleteValue(''); }}>
-              Cancel
-            </Button>
-            <Button color="red" onClick={() => handleDeleteLive()} disabled={deleteValue !== studyId}>
-              Delete
-            </Button>
-          </Flex>
-        </Box>
+        <Text mb="sm">
+          This will permanently delete the live
+          {' '}
+          <Text span fw={700}>{studyId}</Text>
+          {' '}
+          data. This action is
+          {' '}
+          <Text span fw={700}>irreversible</Text>
+          . Please consider using archive data to create a snapshot of the live data before deleting.
+        </Text>
+
+        <TextInput
+          label="To delete this live data, please enter the name of the study."
+          placeholder={studyId}
+          onChange={(event) => setDeleteValue(event.target.value)}
+        />
+
+        <Flex mt="sm" justify="right">
+          <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalDeleteLiveOpened(false); setDeleteValue(''); }}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={handleDeleteLive} disabled={deleteValue !== studyId}>
+            Delete
+          </Button>
+        </Flex>
       </Modal>
     </>
   );

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -80,7 +80,7 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
   const openCreateSnapshotModal = () => openConfirmModal({
     title: 'Create a Snapshot',
     children: (
-      <Text mb={30}>This will create a snapshot of the current dataset. The current study data can be restored to a snapshot at any time.</Text>
+      <Text mb={30}>This will create a snapshot of the live database. The current study data can be restored to a snapshot at any time.</Text>
     ),
     labels: { confirm: 'Create', cancel: 'Cancel' },
     // confirmProps: { color: 'blue' },
@@ -111,16 +111,16 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
             <Box style={{ width: '70%' }}>
               <Title order={4}>Create a Snapshot</Title>
               <Text>
-                This wil create a snapshot of the current
+                This wil create a snapshot of the live
                 <span style={{ fontWeight: 'bold' }}>
                   {' '}
                   {studyId}
                 </span>
                 {' '}
-                data. It will
+                database. It will
                 <span style={{ fontStyle: 'italic', fontWeight: 'bold' }}> not</span>
                 {' '}
-                remove this data from the current dataset. The current study data can be restored to a snapshot at any time.
+                remove this data from the live database. The current study data can be restored from a snapshot at any time.
               </Text>
             </Box>
             <Tooltip label="Create a snapshot">
@@ -135,13 +135,13 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
             <Box style={{ width: '70%' }}>
               <Title order={4}>Archive Data</Title>
               <Text>
-                This wil create a snapshot of the current
+                This wil create a snapshot of the live
                 <span style={{ fontWeight: 'bold' }}>
                   {' '}
                   {studyId}
                   {' '}
                 </span>
-                data. It will then remove this data from the current dataset. The current study data can be restored to a snapshot at any time.
+                database. It will then remove this data from the live database. The current study data can be restored from a snapshot at any time.
               </Text>
             </Box>
             <Tooltip label="Snapshot and Delete Data">
@@ -161,7 +161,7 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
             <div style={{ position: 'relative' }}>
               <LoadingOverlay visible={snapshotListLoading} />
               { snapshots.length > 0 ? snapshots.map(
-                (datasetName:string) => (
+                (datasetName: string) => (
                   <Flex key={datasetName} justify="space-between" mb={10}>
                     <Text>{datasetName}</Text>
                     <Flex direction="row" gap={10}>
@@ -187,9 +187,9 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
         title={<Title order={4}>Archive Data</Title>}
       >
         <Box>
-          <Text mb={30}>This will create a snapshot of the current dataset and then delete the current dataset.</Text>
+          <Text mb={30}>This will create a snapshot of the live database and clear all data out of the live database.</Text>
           <TextInput
-            label="To delete this data, please enter the name of the study."
+            label="To archive this data, please enter the name of the study."
             placeholder={studyId}
             onChange={(event) => setDeleteValue(event.target.value)}
           />
@@ -212,15 +212,15 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
         <Box>
           <Text mb={30}>This will permanently remove this snapshot.</Text>
           <TextInput
-            label="To delete this snapshot, please 'delete' in the box below."
-            placeholder="delete"
+            label="To delete this snapshot, please enter the name of the study."
+            placeholder={studyId}
             onChange={(event) => setDeleteValue(event.target.value)}
           />
           <Flex mt={30} justify="right">
             <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalDeleteSnapshotOpened(false); setDeleteValue(''); }}>
               Cancel
             </Button>
-            <Button color="red" onClick={() => handleDeleteSnapshot()} disabled={deleteValue !== 'delete'}>
+            <Button color="red" onClick={() => handleDeleteSnapshot()} disabled={deleteValue !== studyId}>
               Delete Snapshot
             </Button>
           </Flex>

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -17,19 +17,25 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
   const [archivedDatasets, setArchivedDatasets] = useState<string[]>([]);
 
   const [deleteValue, setDeleteValue] = useState<string>('');
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [archiveListLoading, setArchiveListLoading] = useState<boolean>(false);
+
+  const [archiveActionFlag, setArchiveActionFlag] = useState<boolean>(false);
+
   const { storageEngine } = useStorageEngine();
 
   // Used to fetch archived datasets
   useEffect(() => {
     async function fetchData() {
+      setArchiveListLoading(true);
       if (storageEngine instanceof FirebaseStorageEngine) {
         const currArchivedCollections = await storageEngine.getArchives(studyId);
         setArchivedDatasets(currArchivedCollections);
       }
+      setArchiveListLoading(false);
     }
     fetchData();
-  }, []);
+  }, [archiveActionFlag]);
 
   const handleArchiveData = async () => {
     setLoading(true);
@@ -37,6 +43,7 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       await storageEngine.archiveStudyData(studyId, false);
       setModalArchiveOpened(false);
     }
+    setArchiveActionFlag((prev) => !prev);
     setLoading(false);
   };
 
@@ -47,6 +54,7 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       await storageEngine.archiveStudyData(studyId, true);
       setModalDeleteOpened(false);
     }
+    setArchiveActionFlag((prev) => !prev);
     setLoading(false);
   };
 
@@ -57,6 +65,7 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       await storageEngine.removeArchive(currentArchive);
       setModalDeleteArchiveOpened(false);
     }
+    setArchiveActionFlag((prev) => !prev);
     setLoading(false);
   };
 
@@ -66,6 +75,7 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
       await storageEngine.restoreArchive(studyId, currentArchive);
       setModalRestoreOpened(false);
     }
+    setArchiveActionFlag((prev) => !prev);
     setLoading(false);
   };
 
@@ -122,21 +132,24 @@ export function DataManagementBoard({ studyId }:{ studyId:string}) {
             <Flex style={{ borderBottom: '1px solid #dedede' }} direction="row" justify="space-between" mb={15} pb={15}>
               <Title order={4}>Archived Datasets</Title>
             </Flex>
-            { archivedDatasets.length > 0 ? archivedDatasets.map(
-              (datasetName:string) => (
-                <Flex key={datasetName} justify="space-between" mb={10}>
-                  <Text>{datasetName}</Text>
-                  <Flex direction="row" gap={10}>
-                    <Tooltip label="Restore Archive">
-                      <ActionIcon variant="subtle" onClick={() => { setModalRestoreOpened(true); setCurrentArchive(datasetName); }}><IconRefresh color="green" /></ActionIcon>
-                    </Tooltip>
-                    <Tooltip label="Delete Archive">
-                      <ActionIcon variant="subtle" onClick={() => { setModalDeleteArchiveOpened(true); setCurrentArchive(datasetName); }}><IconTrashX color="red" /></ActionIcon>
-                    </Tooltip>
+            <div style={{ position: 'relative' }}>
+              <LoadingOverlay visible={archiveListLoading} />
+              { archivedDatasets.length > 0 ? archivedDatasets.map(
+                (datasetName:string) => (
+                  <Flex key={datasetName} justify="space-between" mb={10}>
+                    <Text>{datasetName}</Text>
+                    <Flex direction="row" gap={10}>
+                      <Tooltip label="Restore Archive">
+                        <ActionIcon variant="subtle" onClick={() => { setModalRestoreOpened(true); setCurrentArchive(datasetName); }}><IconRefresh color="green" /></ActionIcon>
+                      </Tooltip>
+                      <Tooltip label="Delete Archive">
+                        <ActionIcon variant="subtle" onClick={() => { setModalDeleteArchiveOpened(true); setCurrentArchive(datasetName); }}><IconTrashX color="red" /></ActionIcon>
+                      </Tooltip>
+                    </Flex>
                   </Flex>
-                </Flex>
-              ),
-            ) : <Text>No archived datasets.</Text>}
+                ),
+              ) : <Text>No archived datasets.</Text>}
+            </div>
           </Flex>
 
         </Card>

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -1,28 +1,72 @@
 import {
-  Card, Container, Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip,
+  Card, Container, Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, ActionIcon,
 } from '@mantine/core';
-import { useForm, isEmail } from '@mantine/form';
-import { useEffect, useMemo, useState } from 'react';
-import { IconUserPlus, IconAt, IconTrashX } from '@tabler/icons-react';
-import { useAuth } from '../../store/hooks/useAuth';
+import { useEffect, useState } from 'react';
+import { IconTrashX, IconRefresh } from '@tabler/icons-react';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
-import { StoredUser } from '../../storage/engines/StorageEngine';
-import { signInWithGoogle } from '../../Login';
-import { StudyConfig } from '../../parser/types';
 
-export function DataManagementBoard({ studyConfig, studyId }:{studyConfig:StudyConfig, studyId:string}) {
+export function DataManagementBoard({ studyId }:{ studyId:string}) {
   const [modalDeleteOpened, setModalDeleteOpened] = useState<boolean>(false);
+  const [modalArchiveOpened, setModalArchiveOpened] = useState<boolean>(false);
+  const [modalRestoreOpened, setModalRestoreOpened] = useState<boolean>(false);
+  const [modalDeleteArchiveOpened, setModalDeleteArchiveOpened] = useState<boolean>(false);
+
+  const [currentArchive, setCurrentArchive] = useState<string>('');
+
+  const [archivedDatasets, setArchivedDatasets] = useState<string[]>([]);
+
   const [deleteValue, setDeleteValue] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const { storageEngine } = useStorageEngine();
 
-  const handleCopyCollection = async () => {
+  // Used to fetch archived datasets
+  useEffect(() => {
+    async function fetchData() {
+      if (storageEngine instanceof FirebaseStorageEngine) {
+        const currArchivedCollections = await storageEngine.getArchives(studyId);
+        setArchivedDatasets(currArchivedCollections);
+      }
+    }
+    fetchData();
+  }, []);
+
+  const handleArchiveData = async () => {
     setLoading(true);
     if (storageEngine instanceof FirebaseStorageEngine) {
-      await storageEngine.copyCollection(studyId);
-      setLoading(false);
+      await storageEngine.archiveStudyData(studyId, false);
+      setModalArchiveOpened(false);
     }
+    setLoading(false);
+  };
+
+  const handleArchiveAndDeleteData = async () => {
+    setLoading(true);
+    setDeleteValue('');
+    if (storageEngine instanceof FirebaseStorageEngine) {
+      await storageEngine.archiveStudyData(studyId, true);
+      setModalDeleteOpened(false);
+    }
+    setLoading(false);
+  };
+
+  const handleDeleteArchive = async () => {
+    setLoading(true);
+    setDeleteValue('');
+    if (storageEngine instanceof FirebaseStorageEngine) {
+      await storageEngine.removeArchive(currentArchive);
+      setModalDeleteArchiveOpened(false);
+    }
+    setLoading(false);
+  };
+
+  const handleRestoreArchive = async () => {
+    setLoading(true);
+    if (storageEngine instanceof FirebaseStorageEngine) {
+      await storageEngine.restoreArchive(studyId, currentArchive);
+      setModalRestoreOpened(false);
+    }
+    setLoading(false);
   };
 
   return (
@@ -30,45 +74,156 @@ export function DataManagementBoard({ studyConfig, studyId }:{studyConfig:StudyC
       <LoadingOverlay visible={loading} />
       <Container>
         <Card withBorder style={{ backgroundColor: '#FAFAFA', justifySelf: 'left' }}>
-          <Title mb={20} order={3}>Data Management</Title>
-          <Flex justify="space-between">
-            <Box>
-              <Text>Delete Study Data</Text>
+          <Title mb={30} order={2}>Data Management</Title>
+          <Flex mb={50} justify="space-between" align="center">
+            <Box style={{ width: '70%' }}>
+              <Title order={4}>Archive and study data</Title>
+              <Text>
+                This wil create an archived dataset of the
+                <span style={{ fontWeight: 'bold' }}>{studyId}</span>
+                {' '}
+                data. It will
+                <span style={{ fontStyle: 'italic', fontWeight: 'bold' }}>not</span>
+                {' '}
+                remove this data from the current dataset.
+              </Text>
             </Box>
-            <Tooltip label="Archive all study data">
+            <Tooltip label="Archive and Delete study data">
+              <Button
+                color="red"
+                sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
+                onClick={() => setModalArchiveOpened(true)}
+              >
+                Archive Only
+              </Button>
+            </Tooltip>
+          </Flex>
+          <Flex justify="space-between" align="center">
+            <Box style={{ width: '70%' }}>
+              <Title order={4}>Archive and delete study data</Title>
+              <Text>
+                This wil create an archived dataset of the
+                <span style={{ fontWeight: 'bold' }}>{studyId}</span>
+                {' '}
+                data. It will then remove this data from the current dataset. Archived datasets can be restored at any time.
+              </Text>
+            </Box>
+            <Tooltip label="Archive and Delete study data">
               <Button
                 color="red"
                 sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
                 onClick={() => setModalDeleteOpened(true)}
               >
-                Delete Study Data
+                Archive and Delete
               </Button>
             </Tooltip>
           </Flex>
+          <Flex mt={40} direction="column">
+            <Flex style={{ borderBottom: '1px solid #dedede' }} direction="row" justify="space-between" mb={15} pb={15}>
+              <Title order={4}>Archived Datasets</Title>
+            </Flex>
+            { archivedDatasets.length > 0 ? archivedDatasets.map(
+              (datasetName:string) => (
+                <Flex key={datasetName} justify="space-between" mb={10}>
+                  <Text>{datasetName}</Text>
+                  <Flex direction="row" gap={10}>
+                    <Tooltip label="Restore Archive">
+                      <ActionIcon variant="subtle" onClick={() => { setModalRestoreOpened(true); setCurrentArchive(datasetName); }}><IconRefresh color="green" /></ActionIcon>
+                    </Tooltip>
+                    <Tooltip label="Delete Archive">
+                      <ActionIcon variant="subtle" onClick={() => { setModalDeleteArchiveOpened(true); setCurrentArchive(datasetName); }}><IconTrashX color="red" /></ActionIcon>
+                    </Tooltip>
+                  </Flex>
+                </Flex>
+              ),
+            ) : <Text>No archived datasets.</Text>}
+          </Flex>
+
         </Card>
       </Container>
+
       <Modal
         opened={modalDeleteOpened}
-        onClose={() => setModalDeleteOpened(false)}
-        title="Delete All User Data For This Study"
+        onClose={() => { setModalDeleteOpened(false); setDeleteValue(''); }}
+        title="Archive and Delete. This will create a separate archive of the dataset and then delete the existing data from this collection."
       >
-        <Box component="form">
-          <Text mb={30}>This will delete all user data for this individual study.</Text>
+        <Box>
+          <Text mb={30}>This will create and archive and then delete all of the current study data.</Text>
           <TextInput
             label="To delete this data, please enter the name of the study."
             placeholder={studyId}
             onChange={(event) => setDeleteValue(event.target.value)}
           />
           <Flex mt={30} justify="right">
-            <Button mr={5} variant="subtle" color="red" onClick={() => setModalDeleteOpened(false)}>
+            <Button mr={5} variant="subtle" color="red" onClick={() => { setModalDeleteOpened(false); setDeleteValue(''); }}>
               Cancel
             </Button>
-            <Button onClick={() => handleCopyCollection()} disabled={deleteValue !== studyId}>
-              Delete
+            <Button onClick={() => handleArchiveAndDeleteData()} disabled={deleteValue !== studyId}>
+              Archive and Delete
             </Button>
           </Flex>
         </Box>
       </Modal>
+
+      <Modal
+        opened={modalArchiveOpened}
+        onClose={() => setModalArchiveOpened(false)}
+        title={<Title order={4}>Archive Current Data</Title>}
+      >
+        <Box>
+          <Text mb={30}>This will create an archive of the current study data and remove the current study data. An archive can be restored at any time.</Text>
+          <Flex mt={30} justify="right">
+            <Button mr={5} variant="subtle" color="red" onClick={() => setModalArchiveOpened(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => handleArchiveData()}>
+              Archive
+            </Button>
+          </Flex>
+        </Box>
+      </Modal>
+
+      <Modal
+        opened={modalRestoreOpened}
+        onClose={() => setModalRestoreOpened(false)}
+        title={<Title order={4}>Restore Archive</Title>}
+      >
+        <Box>
+          <Text mb={30}>This will archive the current study data into a new archive and then copy the this archive back into the current study data. This archive will then be removed.</Text>
+          <Flex mt={30} justify="right">
+            <Button mr={5} variant="subtle" color="red" onClick={() => setModalRestoreOpened(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => handleRestoreArchive()}>
+              Restore
+            </Button>
+          </Flex>
+        </Box>
+      </Modal>
+
+      <Modal
+        opened={modalDeleteArchiveOpened}
+        onClose={() => { setModalDeleteArchiveOpened(false); setDeleteValue(''); }}
+        title={<Title order={4}>Delete Archive</Title>}
+      >
+        <Box>
+          <Text mb={30}>This will permanently remove this archive.</Text>
+          <TextInput
+            label="To delete this archive, please 'delete' in the box below."
+            placeholder="delete"
+            onChange={(event) => setDeleteValue(event.target.value)}
+          />
+          <Flex mt={30} justify="right">
+            <Button mr={5} variant="subtle" color="red" onClick={() => { setModalDeleteArchiveOpened(false); setDeleteValue(''); }}>
+              Cancel
+            </Button>
+            <Button onClick={() => handleDeleteArchive()} disabled={deleteValue !== 'delete'}>
+              Delete Archive
+            </Button>
+          </Flex>
+        </Box>
+      </Modal>
+
     </>
   );
 }

--- a/src/analysis/management/DataManagementBoard.tsx
+++ b/src/analysis/management/DataManagementBoard.tsx
@@ -1,0 +1,62 @@
+import {
+  Card, Container, Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, ActionIcon,
+} from '@mantine/core';
+import { useForm, isEmail } from '@mantine/form';
+import { useEffect, useMemo, useState } from 'react';
+import { IconUserPlus, IconAt, IconTrashX } from '@tabler/icons-react';
+import { useAuth } from '../../store/hooks/useAuth';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
+import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
+import { StoredUser } from '../../storage/engines/StorageEngine';
+import { signInWithGoogle } from '../../Login';
+import { StudyConfig } from '../../parser/types';
+
+export function DataManagementBoard({ studyConfig, studyId }:{studyConfig:StudyConfig, studyId:string}) {
+  const [modalDeleteOpened, setModalDeleteOpened] = useState<boolean>(false);
+  const [deleteValue, setDeleteValue] = useState<string>('');
+  return (
+    <>
+      <Container>
+        <Card withBorder style={{ backgroundColor: '#FAFAFA', justifySelf: 'left' }}>
+          <Title mb={20} order={3}>Data Management</Title>
+          <Flex justify="space-between">
+            <Box>
+              <Text>Delete Study Data</Text>
+            </Box>
+            <Tooltip label="Archive all study data">
+              <Button
+                color="red"
+                sx={{ '&[data-disabled]': { pointerEvents: 'all' } }}
+                onClick={() => setModalDeleteOpened(true)}
+              >
+                Delete Study Data
+              </Button>
+            </Tooltip>
+          </Flex>
+        </Card>
+      </Container>
+      <Modal
+        opened={modalDeleteOpened}
+        onClose={() => setModalDeleteOpened(false)}
+        title="Delete All User Data For This Study"
+      >
+        <Box component="form">
+          <Text mb={30}>This will delete all user data for this individual study.</Text>
+          <TextInput
+            label="To delete this data, please enter the name of the study."
+            placeholder={studyId}
+            onChange={(event) => setDeleteValue(event.target.value)}
+          />
+          <Flex mt={30} justify="right">
+            <Button mr={5} variant="subtle" color="red" onClick={() => setModalDeleteOpened(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={deleteValue !== studyId}>
+              Delete
+            </Button>
+          </Flex>
+        </Box>
+      </Modal>
+    </>
+  );
+}

--- a/src/analysis/stats/TableView.tsx
+++ b/src/analysis/stats/TableView.tsx
@@ -92,14 +92,14 @@ export function TableView({
   completed: ParticipantData[];
   inProgress: ParticipantData[];
   studyConfig: StudyConfig;
-  refresh: ()=> void;
+  refresh: () => Promise<void>;
 }) {
   const { storageEngine } = useStorageEngine();
   const { studyId } = useParams();
   const rejectParticipant = async (participantId: string) => {
     if (storageEngine && studyId) {
       await storageEngine.rejectParticipant(studyId, participantId);
-      refresh();
+      await refresh();
     }
   };
   const [checked, setChecked] = useState<string[]>([]);
@@ -123,7 +123,7 @@ export function TableView({
       const promises = checked.map(async (participantId) => await rejectParticipant(participantId));
       await Promise.all(promises);
       setChecked([]);
-      refresh();
+      await refresh();
       setLoading(false);
     },
   });

--- a/src/analysis/stats/TableView.tsx
+++ b/src/analysis/stats/TableView.tsx
@@ -183,7 +183,7 @@ export function TableView({
         }
           {(!record.completed) && (
           <Text size="sm" mb={-1} ml={4}>
-            {(Object.entries(record.answers).length / (getSequenceFlatMap(record.sequence).length - 1)) * 100}
+            {((Object.entries(record.answers).filter(([id, entry]) => entry.endTime !== undefined).length / (getSequenceFlatMap(record.sequence).length - 1)) * 100).toFixed(2)}
             %
           </Text>
           )}

--- a/src/components/DownloadTidy.tsx
+++ b/src/components/DownloadTidy.tsx
@@ -63,7 +63,7 @@ export function download(graph: string, filename: string) {
 }
 
 function participantDataToRows(participant: ParticipantData, studyConfig: StudyConfig, properties: Property[]): TidyRow[] {
-  const percentComplete = ((Object.entries(participant.answers).length / (getSequenceFlatMap(participant.sequence).length - 1)) * 100).toFixed(2);
+  const percentComplete = ((Object.entries(participant.answers).filter(([id, entry]) => entry.endTime !== undefined).length / (getSequenceFlatMap(participant.sequence).length - 1)) * 100).toFixed(2);
   return Object.entries(participant.answers).map(([trialIdentifier, trialAnswer]) => {
     // Get the whole component, including the base component if there is inheritance
     const trialId = trialIdentifier.split('_').slice(0, -1).join('_');

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -535,6 +535,8 @@ export class FirebaseStorageEngine extends StorageEngine {
   }
 
   async removeSnapshot(targetName:string) {
+    await this._deleteDirectory(`${targetName}/configs`);
+    await this._deleteDirectory(`${targetName}/participants`);
     await this._deleteDirectory(targetName);
     await this._deleteCollection(targetName);
     await this._removeNameFromMetadata(targetName);

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -499,7 +499,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
-  async createSnapshot(studyId:string, deleteData:boolean) {
+  async createSnapshot(studyId: string, deleteData: boolean) {
     const sourceName = `${this.collectionPrefix}${studyId}`;
 
     if (!await this._directoryExists(sourceName)) {
@@ -515,7 +515,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     const minutes = today.getUTCMinutes().toString().padStart(2, '0');
     const seconds = today.getUTCSeconds().toString().padStart(2, '0');
 
-    const formattedDate = `${year}${month}${date}${hours}${minutes}${seconds}`;
+    const formattedDate = `${year}-${month}-${date}T${hours}:${minutes}:${seconds}`;
 
     const targetName = `${this.collectionPrefix}${studyId}-snapshot-${formattedDate}`;
 
@@ -551,7 +551,7 @@ export class FirebaseStorageEngine extends StorageEngine {
         const collections = metadataSnapshot.data();
         const matchingCollections = Object.keys(collections)
           .filter((directoryName) => directoryName.startsWith(`${this.collectionPrefix}${studyId}-snapshot`));
-        return matchingCollections;
+        return matchingCollections.sort().reverse();
       }
       return [];
     } catch (error) {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -556,7 +556,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
-  async archiveStudyData(studyId:string, deleteData:boolean) {
+  async createSnapshot(studyId:string, deleteData:boolean) {
     const sourceDirectoryName = `${this.collectionPrefix}${studyId}`;
 
     if (!await this._directoryExists(sourceDirectoryName)) {
@@ -574,7 +574,7 @@ export class FirebaseStorageEngine extends StorageEngine {
 
     const formattedDate = `${year}${month}${date}${hours}${minutes}${seconds}`;
 
-    const targetDirectoryName = `${this.collectionPrefix}${studyId}-archive-${formattedDate}`;
+    const targetDirectoryName = `${this.collectionPrefix}${studyId}-snapshot-${formattedDate}`;
 
     await this._copyDirectory(sourceDirectoryName, targetDirectoryName);
     await this._addDirectoryNameToMetadata(targetDirectoryName);
@@ -585,12 +585,12 @@ export class FirebaseStorageEngine extends StorageEngine {
     return true;
   }
 
-  async removeArchive(directoryName:string) {
+  async removeSnapshot(directoryName:string) {
     await this._deleteDirectory(directoryName);
     await this._removeDirectoryNameFromMetadata(directoryName);
   }
 
-  async getArchives(studyId:string) {
+  async getSnapshots(studyId:string) {
     try {
       const metadataDoc = doc(this.firestore, 'metadata', 'collections');
       const metadataSnapshot = await getDoc(metadataDoc);
@@ -598,7 +598,7 @@ export class FirebaseStorageEngine extends StorageEngine {
       if (metadataSnapshot.exists()) {
         const collections = metadataSnapshot.data();
         const matchingCollections = Object.keys(collections)
-          .filter((directoryName) => directoryName.startsWith(`${this.collectionPrefix}${studyId}-archive`));
+          .filter((directoryName) => directoryName.startsWith(`${this.collectionPrefix}${studyId}-snapshot`));
         return matchingCollections;
       }
       return [];
@@ -608,14 +608,14 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
-  async restoreArchive(studyId:string, archivedDirectoryName:string) {
+  async restoreSnapshot(studyId:string, snapshotDirectoryName:string) {
     const originalDirectoryName = `${this.collectionPrefix}${studyId}`;
-    // Archive current collection
-    await this.archiveStudyData(studyId, true);
+    // Snapshot current collection
+    await this.createSnapshot(studyId, true);
 
-    await this._copyDirectory(archivedDirectoryName, originalDirectoryName);
-    await this._deleteDirectory(archivedDirectoryName);
-    await this._removeDirectoryNameFromMetadata(archivedDirectoryName);
+    await this._copyDirectory(snapshotDirectoryName, originalDirectoryName);
+    await this._deleteDirectory(snapshotDirectoryName);
+    await this._removeDirectoryNameFromMetadata(snapshotDirectoryName);
   }
 
   // Function to add collection name to metadata

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -115,7 +115,7 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.removeItem('currentParticipant');
   }
 
-  async saveAnswer(identifier: string, answer: StoredAnswer) {
+  async saveAnswers(answers: Record<string, StoredAnswer>) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
@@ -131,7 +131,7 @@ export class LocalStorageEngine extends StorageEngine {
     }
 
     // Save answer
-    participant.answers[identifier] = answer;
+    participant.answers = answers;
     await this.studyDatabase.setItem(this.currentParticipantId, participant);
   }
 

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -54,7 +54,7 @@ export abstract class StorageEngine {
 
   abstract clearCurrentParticipantId(): Promise<void>;
 
-  abstract saveAnswer(identifier: string, answer: StoredAnswer): Promise<void>;
+  abstract saveAnswers(answers: Record<string, StoredAnswer>): Promise<void>;
 
   abstract setSequenceArray(latinSquare: Sequence[]): Promise<void>;
 

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -47,8 +47,6 @@ export function useNextStep() {
 
   const { trialValidation, sequence, answers } = useStoreSelector((state) => state);
 
-  const status = useStoredAnswer();
-
   const storeDispatch = useStoreDispatch();
   const { saveTrialAnswer, setIframeAnswers } = useStoreActions();
   const { storageEngine } = useStorageEngine();
@@ -58,7 +56,7 @@ export function useNextStep() {
   // Status of the next button. If false, the next button should be disabled
   const isNextDisabled = !areResponsesValid;
 
-  const storedAnswer = status?.answer;
+  const storedAnswer = useStoredAnswer();
 
   const navigate = useNavigate();
 
@@ -84,7 +82,7 @@ export function useNextStep() {
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
-    if (Object.keys(storedAnswer || {}).length === 0) {
+    if (!storedAnswer.endTime) {
       storeDispatch(
         saveTrialAnswer({
           identifier,
@@ -97,14 +95,12 @@ export function useNextStep() {
       );
       // Update database
       if (storageEngine) {
-        storageEngine.saveAnswer(
-          identifier,
+        storageEngine.saveAnswers(
           {
-            answer,
-            startTime,
-            endTime,
-            provenanceGraph,
-            windowEvents: currentWindowEvents,
+            ...answers,
+            [identifier]: {
+              answer, startTime, endTime, provenanceGraph, windowEvents: currentWindowEvents,
+            },
           },
         );
       }

--- a/src/store/hooks/useStoredAnswer.ts
+++ b/src/store/hooks/useStoredAnswer.ts
@@ -1,12 +1,6 @@
 import { useFlatSequence, useStoreSelector } from '../store';
 import { useCurrentStep } from '../../routes/utils';
 
-/**
- *
- * @param trialId Trial id for which to get status
- * @returns StoredAnswer object with complete status and any answer if present
- */
-
 export function useStoredAnswer() {
   const { answers } = useStoreSelector((state) => state);
   const currentStep = useCurrentStep();

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -17,7 +17,7 @@ export async function studyStoreCreator(
 ) {
   const flatSequence = getSequenceFlatMap(sequence);
 
-  const emptyAnswers = { ...flatSequence.map((id) => ({ [id]: {} })) };
+  const emptyAnswers = Object.fromEntries(flatSequence.filter((id) => id !== 'end').map((id, idx) => [`${id}_${idx}`, { answer: {} }])) as Record<string, StoredAnswer>;
   const emptyValidation: TrialValidation = Object.assign(
     {},
     ...flatSequence.map((id, idx) => ({ [`${id}_${idx}`]: { aboveStimulus: { valid: false, values: {} }, belowStimulus: { valid: false, values: {} }, sidebar: { valid: false, values: {} } } })),
@@ -33,7 +33,7 @@ export async function studyStoreCreator(
 
   const initialState: StoreState = {
     studyId,
-    answers: answers || emptyAnswers,
+    answers: Object.keys(answers).length > 0 ? answers : emptyAnswers,
     sequence,
     config,
     showStudyBrowser: import.meta.env.VITE_REVISIT_MODE === 'public' || isAdmin,


### PR DESCRIPTION
### Does this PR close any open issues?
Closes https://github.com/revisit-studies/study/issues/266
Closes https://github.com/revisit-studies/study/issues/253
Closes #334 
Closes #386 
Closes #384 

### Give a longer description of what this PR addresses and why it's needed
This allows for better data management when using Firebase. What created an additional tab in the individual analysis views which is meant for data management. The functionality is as follows:

1. A user can "archive" a dataset. When you archive the data, it is copied to a separate directory in storage labeled exactly the same as the study with an additional "-archive-YYYYMMDDhhmmss" suffix. 
2. A user can "archive and delete" a dataset. This will not only archive the data, but will clear out the current study data as well. We can think of this as a "reset" and we can think of just archiving as a "snapshot".
3. A user can "restore" any archive. When you restore an archive, it will first archive the current study data if it exists. Then, it will copy all data from the archive to be restored into the current study data. The archive that is restored will then be removed. 
4. A user can delete any archive. The list of archives is on the same page.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1718" alt="Screenshot 2024-06-03 at 1 05 03 PM (2)" src="https://github.com/revisit-studies/study/assets/26078758/3fe3a6ac-29fa-4243-b223-ec3c07c0a68b">


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [x] Change to 'confirm modals'