### PR TITLE
Enable a reviewer mode in the study browser

### DIFF
--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -2,15 +2,16 @@ import {
   Aside,
   CloseButton,
   ScrollArea,
+  Switch,
   Text,
 } from '@mantine/core';
 import React, { useMemo } from 'react';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import {
-  useFlatSequence, useStoreActions, useStoreDispatch, useStoreSelector,
+  useStoreActions, useStoreDispatch, useStoreSelector,
 } from '../../store/store';
-import { useCurrentStep } from '../../routes/utils';
+import { useCurrentComponent } from '../../routes/utils';
 import { deepCopy } from '../../utils/deepCopy';
 import { ComponentBlock } from '../../parser/types';
 
@@ -25,10 +26,11 @@ export default function AppAside() {
   const { showStudyBrowser, sequence } = useStoreSelector((state) => state);
   const { toggleStudyBrowser } = useStoreActions();
 
-  const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
   const studyConfig = useStudyConfig();
   const dispatch = useStoreDispatch();
+
+  const [participantView, setParticipantView] = React.useState(true);
 
   const fullOrder = useMemo(() => {
     let r = deepCopy(studyConfig.sequence) as ComponentBlockWithOrderPath;
@@ -38,21 +40,30 @@ export default function AppAside() {
   }, [studyConfig.sequence]);
 
   return showStudyBrowser || (currentComponent === 'end' && studyConfig.uiConfig.autoDownloadStudy) ? (
-    <Aside p="0" width={{ base: 300 }} style={{ zIndex: 0 }}>
-      <Aside.Section>
+    <Aside p="0" width={{ base: 360 }} style={{ zIndex: 0 }}>
+      <Aside.Section sx={(theme) => ({ borderBottom: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2]}` })}>
         <CloseButton
           style={{
             position: 'absolute', right: '10px', top: '10px', zIndex: 5,
           }}
           onClick={() => dispatch(toggleStudyBrowser())}
         />
-        <Text size="md" p={10} weight="bold">
+        <Text size="md" p="sm" pb={2} weight="bold">
           Study Browser
         </Text>
+        <Switch
+          checked={participantView}
+          onChange={(event) => setParticipantView(event.currentTarget.checked)}
+          size="xs"
+          pt={0}
+          pb="sm"
+          label="Participant View"
+        />
+
       </Aside.Section>
 
-      <Aside.Section grow component={ScrollArea}>
-        <StepsPanel configSequence={fullOrder} participantSequence={sequence} fullSequence={sequence} />
+      <Aside.Section grow component={ScrollArea} p="xs">
+        <StepsPanel configSequence={fullOrder} participantSequence={sequence} fullSequence={sequence} participantView={participantView} />
       </Aside.Section>
     </Aside>
   ) : null;

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -40,7 +40,7 @@ export default function AppHeader() {
   const auth = useAuth();
 
   const progressBarMax = flatSequence.length - 1;
-  const progressPercent = (currentStep / progressBarMax) * 100;
+  const progressPercent = typeof currentStep === 'number' ? (currentStep / progressBarMax) * 100 : 0;
 
   const [menuOpened, setMenuOpened] = useState(false);
 

--- a/src/components/interface/AppNavBar.tsx
+++ b/src/components/interface/AppNavBar.tsx
@@ -5,10 +5,9 @@ import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import { useStoredAnswer } from '../../store/hooks/useStoredAnswer';
 import ResponseBlock from '../response/ResponseBlock';
-import { useCurrentStep } from '../../routes/utils';
+import { useCurrentComponent } from '../../routes/utils';
 import { IndividualComponent } from '../../parser/types';
 import { isInheritedComponent } from '../../parser/parser';
-import { useFlatSequence } from '../../store/store';
 
 export default function AppNavBar() {
   const trialHasSideBar = useStudyConfig()?.uiConfig.sidebar;
@@ -16,8 +15,7 @@ export default function AppNavBar() {
 
   // Get the config for the current step
   const studyConfig = useStudyConfig();
-  const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
   const stepConfig = studyConfig.components[currentComponent];
 
   const currentConfig = useMemo(() => {

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -110,7 +110,8 @@ function StepItem({
   const task = step in studyConfig.components && studyConfig.components[step];
 
   const stepIndex = subSequence && subSequence.components.slice(startIndex).includes(step) ? findTaskIndexInSequence(fullSequence, step, startIndex, subSequence.orderPath) : -1;
-  const active = currentStep === stepIndex;
+
+  const active = participantView ? currentStep === stepIndex : currentStep === `reviewer-${step}`;
 
   return (
     <Popover position="left" withArrow arrowSize={10} shadow="md" opened={opened} offset={20}>
@@ -131,7 +132,7 @@ function StepItem({
                 {active ? <strong>{step}</strong> : step}
               </div>
             )}
-            onClick={() => navigate(`/${studyId}/${stepIndex}`)}
+            onClick={() => (participantView ? navigate(`/${studyId}/${stepIndex}`) : navigate(`/${studyId}/reviewer-${step}`))}
             disabled={disabled}
           />
         </div>
@@ -224,6 +225,12 @@ export function StepsPanel({
                   opacity: sequenceStepsLength > 0 ? 1 : 0.5,
                 }}
               >
+                <Text display="inline">
+                  {step.order}
+                </Text>
+                {step.order === 'random' || step.order === 'latinSquare' ? (
+                  <IconArrowsShuffle size="15" opacity={0.5} style={{ marginLeft: '5px', verticalAlign: 'middle' }} />
+                ) : null}
                 {participantView && (
                 <Badge ml={5}>
                   {sequenceStepsLength}
@@ -236,12 +243,6 @@ export function StepsPanel({
                   {participantSubSequence?.components.filter((s) => typeof s === 'string' && step.interruptions?.flatMap((i) => i.components).includes(s)).length || 0}
                 </Badge>
                 )}
-                <Text c="dimmed" display="inline" mr={5} ml={5}>
-                  {step.order}
-                </Text>
-                {step.order === 'random' || step.order === 'latinSquare' ? (
-                  <IconArrowsShuffle size="15" opacity={0.5} style={{ marginLeft: '5px', verticalAlign: 'middle' }} />
-                ) : null}
               </div>
             )}
             defaultOpened

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -5,9 +5,9 @@ import {
   IndividualComponent,
   ResponseBlockLocation,
 } from '../../parser/types';
-import { useCurrentStep } from '../../routes/utils';
+import { useCurrentComponent, useCurrentStep } from '../../routes/utils';
 import {
-  useStoreDispatch, useStoreSelector, useStoreActions, useFlatSequence,
+  useStoreDispatch, useStoreSelector, useStoreActions,
 } from '../../store/store';
 
 import { deepCopy } from '../../utils/deepCopy';
@@ -30,7 +30,7 @@ export default function ResponseBlock({
   style,
 }: Props) {
   const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
   const storedAnswer = status?.answer;
 
   const configInUse = config as IndividualComponent;

--- a/src/components/response/utils.ts
+++ b/src/components/response/utils.ts
@@ -55,8 +55,8 @@ const generateValidation = (responses: Response[]) => {
   return validateObj;
 };
 
-export function useAnswerField(responses: Response[], currentStep: number, storedAnswer: StoredAnswer['answer']) {
-  const [_id, setId] = useState<number | null>(null);
+export function useAnswerField(responses: Response[], currentStep: string | number, storedAnswer: StoredAnswer['answer']) {
+  const [_id, setId] = useState<string | number | null>(null);
 
   const answerField = useForm({
     initialValues: generateInitFields(responses, storedAnswer),

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -6,14 +6,14 @@ import ImageController from './ImageController';
 import ReactComponentController from './ReactComponentController';
 import MarkdownController from './MarkdownController';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
-import { useCurrentStep } from '../routes/utils';
+import { useCurrentComponent, useCurrentStep } from '../routes/utils';
 import { useStoredAnswer } from '../store/hooks/useStoredAnswer';
 import ReactMarkdownWrapper from '../components/ReactMarkdownWrapper';
 import { isInheritedComponent } from '../parser/parser';
 import { IndividualComponent } from '../parser/types';
 import { useDisableBrowserBack } from '../utils/useDisableBrowserBack';
 import { useStorageEngine } from '../storage/storageEngineHooks';
-import { useFlatSequence, useStoreActions, useStoreDispatch } from '../store/store';
+import { useStoreActions, useStoreDispatch } from '../store/store';
 import { StudyEnd } from '../components/StudyEnd';
 import ResourceNotFound from '../ResourceNotFound';
 
@@ -22,7 +22,7 @@ export default function ComponentController() {
   // Get the config for the current step
   const studyConfig = useStudyConfig();
   const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep] || 'Notfound';
+  const currentComponent = useCurrentComponent() || 'Notfound';
   const stepConfig = studyConfig.components[currentComponent];
 
   // If we have a trial, use that config to render the right component else use the step

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -36,7 +36,7 @@ export default function ComponentController() {
   const storeDispatch = useStoreDispatch();
   const { setAlertModal } = useStoreActions();
   useEffect(() => {
-    if (storageEngine?.getEngine() !== import.meta.env.VITE_STORAGE_ENGINE) {
+    if (storageEngine?.getEngine() !== import.meta.env.VITE_STORAGE_ENGINE && import.meta.env.VITE_REVISIT_MODE !== 'public') {
       storeDispatch(setAlertModal({
         show: true,
         message: `There was an issue connecting to the ${import.meta.env.VITE_STORAGE_ENGINE} database. This could be caused by a network issue or your adblocker. If you are using an adblocker, please disable it for this website and refresh.`,

--- a/src/controllers/IframeController.tsx
+++ b/src/controllers/IframeController.tsx
@@ -3,8 +3,8 @@ import {
 } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { useCurrentStep } from '../routes/utils';
-import { useStoreDispatch, useStoreActions, useFlatSequence } from '../store/store';
+import { useCurrentComponent } from '../routes/utils';
+import { useStoreDispatch, useStoreActions } from '../store/store';
 import { WebsiteComponent } from '../parser/types';
 import { PREFIX as BASE_PREFIX } from '../utils/Prefix';
 
@@ -29,8 +29,7 @@ export default function IframeController({ currentConfig }: { currentConfig: Web
   );
 
   // navigation
-  const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
   const navigate = useNavigate();
 
   const sendMessage = useCallback(
@@ -78,7 +77,7 @@ export default function IframeController({ currentConfig }: { currentConfig: Web
     window.addEventListener('message', handler);
 
     return () => window.removeEventListener('message', handler);
-  }, [storeDispatch, currentStep, dispatch, iframeId, navigate, currentConfig, sendMessage, setIframeAnswers, setIframeProvenance]);
+  }, [storeDispatch, dispatch, iframeId, navigate, currentConfig, sendMessage, setIframeAnswers, setIframeProvenance]);
 
   return (
     <iframe

--- a/src/controllers/ReactComponentController.tsx
+++ b/src/controllers/ReactComponentController.tsx
@@ -2,9 +2,9 @@ import { Suspense } from 'react';
 import { ModuleNamespace } from 'vite/types/hot';
 import { ReactComponent } from '../parser/types';
 import { StimulusParams } from '../store/types';
-import { useStoreDispatch, useStoreActions, useFlatSequence } from '../store/store';
-import { useCurrentStep } from '../routes/utils';
 import ResourceNotFound from '../ResourceNotFound';
+import { useStoreDispatch, useStoreActions } from '../store/store';
+import { useCurrentComponent, useCurrentStep } from '../routes/utils';
 
 const modules = import.meta.glob(
   '../public/**/*.{mjs,js,mts,ts,jsx,tsx}',
@@ -13,7 +13,7 @@ const modules = import.meta.glob(
 
 function ReactComponentController({ currentConfig }: { currentConfig: ReactComponent; }) {
   const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
 
   const reactPath = `../public/${currentConfig.path}`;
   const StimulusComponent = reactPath in modules ? (modules[reactPath] as ModuleNamespace).default : null;

--- a/src/public/demo-fairness-jnd/assets/FairnessJND.tsx
+++ b/src/public/demo-fairness-jnd/assets/FairnessJND.tsx
@@ -5,9 +5,8 @@ import { Button, Grid } from '@mantine/core';
 import { IconCircleCheck } from '@tabler/icons-react';
 import { getHotkeyHandler } from '@mantine/hooks';
 import { StimulusParams } from '../../../store/types';
-import { useCurrentStep } from '../../../routes/utils';
+import { useCurrentComponent } from '../../../routes/utils';
 import { useNextStep } from '../../../store/hooks/useNextStep';
-import { useFlatSequence } from '../../../store/store';
 
 function Ranking({ rankings }: { rankings: number[] }) {
   return (
@@ -37,8 +36,7 @@ function FairnessJND({
 }: StimulusParams<{
   data: { r1: number[]; r2: number[]; r1ARP: string; r2ARP: string };
 }>) {
-  const currentStep = useCurrentStep();
-  const id = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
   const [userChoice, setUserChoice] = useState('');
 
   const { goToNextStep, isNextDisabled } = useNextStep();
@@ -57,18 +55,18 @@ function FairnessJND({
       setAnswer({
         status: true,
         answers: {
-          [`${id}/leftARP`]:
+          [`${currentComponent}/leftARP`]:
             left === 'r1' ? parameters.data.r1ARP : parameters.data.r2ARP,
-          [`${id}/rightARP`]:
+          [`${currentComponent}/rightARP`]:
             left === 'r2' ? parameters.data.r1ARP : parameters.data.r2ARP,
-          [`${id}/leftRanking`]: JSON.stringify(
+          [`${currentComponent}/leftRanking`]: JSON.stringify(
             left === 'r1' ? parameters.data.r1 : parameters.data.r2,
           ),
-          [`${id}/rightRanking`]: JSON.stringify(
+          [`${currentComponent}/rightRanking`]: JSON.stringify(
             left === 'r2' ? parameters.data.r1 : parameters.data.r2,
           ),
-          [`${id}/choice`]: choice,
-          [`${id}/correctChoice`]:
+          [`${currentComponent}/choice`]: choice,
+          [`${currentComponent}/correctChoice`]:
             left === 'r1'
             && parseFloat(parameters.data.r1ARP)
               < parseFloat(parameters.data.r2ARP)
@@ -77,7 +75,7 @@ function FairnessJND({
         },
       });
     },
-    [id, left, parameters.data, setAnswer],
+    [currentComponent, left, parameters.data, setAnswer],
   );
 
   const handleNextStimuli = useCallback(() => {

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom';
+import { useFlatSequence } from '../store/store';
 
 export function useStudyId(): string {
   const { studyId } = useParams();
@@ -6,8 +7,16 @@ export function useStudyId(): string {
   return `${studyId}`;
 }
 
-export function useCurrentStep(): number {
+export function useCurrentStep(): string | number {
   const { index } = useParams();
 
-  return parseInt(index || '0', 10);
+  const indexOrStep = parseInt(index || '0', 10);
+
+  return Number.isNaN(indexOrStep) ? index as string : indexOrStep;
+}
+
+export function useCurrentComponent(): string {
+  const currentStep = useCurrentStep();
+  const flatSequence = useFlatSequence();
+  return typeof currentStep === 'number' ? flatSequence[currentStep] : currentStep.replace('reviewer-', '');
 }

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -7,7 +7,7 @@ import {
   useAreResponsesValid,
   useFlatSequence,
 } from '../store';
-import { useCurrentStep, useStudyId } from '../../routes/utils';
+import { useCurrentComponent, useCurrentStep, useStudyId } from '../../routes/utils';
 
 import { deepCopy } from '../../utils/deepCopy';
 import { StoredAnswer, ValidationStatus } from '../types';
@@ -42,7 +42,7 @@ function checkAllAnswersCorrect(answers: Record<string, Answer>, componentId: st
 export function useNextStep() {
   const currentStep = useCurrentStep();
   const participantSequence = useFlatSequence();
-  const currentComponent = participantSequence[currentStep];
+  const currentComponent = useCurrentComponent();
   const identifier = `${currentComponent}_${currentStep}`;
 
   const { trialValidation, sequence, answers } = useStoreSelector((state) => state);
@@ -54,7 +54,7 @@ export function useNextStep() {
   const areResponsesValid = useAreResponsesValid(identifier);
 
   // Status of the next button. If false, the next button should be disabled
-  const isNextDisabled = !areResponsesValid;
+  const isNextDisabled = typeof currentStep !== 'number' || !areResponsesValid;
 
   const storedAnswer = useStoredAnswer();
 
@@ -68,6 +68,9 @@ export function useNextStep() {
 
   const windowEvents = useWindowEvents();
   const goToNextStep = useCallback(() => {
+    if (typeof currentStep !== 'number') {
+      return;
+    }
     // Get answer from across the 3 response blocks and the provenance graph
     const trialValidationCopy = deepCopy(trialValidation[identifier]);
     const answer = Object.values(trialValidationCopy).reduce((acc, curr) => {

--- a/src/store/hooks/useStoredAnswer.ts
+++ b/src/store/hooks/useStoredAnswer.ts
@@ -1,10 +1,10 @@
-import { useFlatSequence, useStoreSelector } from '../store';
-import { useCurrentStep } from '../../routes/utils';
+import { useStoreSelector } from '../store';
+import { useCurrentComponent, useCurrentStep } from '../../routes/utils';
 
 export function useStoredAnswer() {
   const { answers } = useStoreSelector((state) => state);
   const currentStep = useCurrentStep();
-  const currentComponent = useFlatSequence()[currentStep];
+  const currentComponent = useCurrentComponent();
   const identifier = `${currentComponent}_${currentStep}`;
   return answers[identifier];
 }

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -139,6 +139,10 @@ export const useStoreSelector: TypedUseSelectorHook<StoreState> = useSelector;
 
 export function useAreResponsesValid(id: string) {
   return useStoreSelector((state) => {
+    if (id.includes('reviewer-')) {
+      return true;
+    }
+
     const valid = Object.values(state.trialValidation[id]).every((x) => {
       if (typeof x === 'object' && 'valid' in x) {
         return x.valid;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #319 

### Give a longer description of what this PR addresses and why it's needed
This adds the ability for a reviewer to navigate to any component in the study config order, even if it is not included in a participant's sequence.

### Provide pictures/videos of the behavior before and after these changes (optional)
Participant view
<img width="363" alt="Screenshot 2024-06-05 at 10 46 53 AM" src="https://github.com/revisit-studies/study/assets/36867477/7c140bb5-166b-442e-bb6c-df7b3d48022e">

Reviewer view
<img width="362" alt="Screenshot 2024-06-05 at 10 46 45 AM" src="https://github.com/revisit-studies/study/assets/36867477/8b053e58-7a6b-4e88-ac5c-c857ac176839">

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] Decide if this should only be available in demo mode