### PR TITLE
UI cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>reVISit</title>
 
+    <link rel="stylesheet" href="/revisitAssets/cssOverrides.css" />
+
     <!-- Required for react browser router on GitHub pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/public/revisitAssets/cssOverrides.css
+++ b/public/revisitAssets/cssOverrides.css
@@ -1,0 +1,3 @@
+.mantine-InputWrapper-label * {
+  padding: 0;
+}

--- a/public/revisitAssets/cssOverrides.css
+++ b/public/revisitAssets/cssOverrides.css
@@ -1,3 +1,15 @@
-.mantine-InputWrapper-label * {
-  padding: 0;
+.no-last-child-bottom-padding > div:last-child,
+.no-last-child-bottom-padding > a:last-child,
+.no-last-child-bottom-padding > p:last-child,
+.no-last-child-bottom-padding > h1:last-child,
+.no-last-child-bottom-padding > h2:last-child,
+.no-last-child-bottom-padding > h3:last-child,
+.no-last-child-bottom-padding > h4:last-child,
+.no-last-child-bottom-padding > h5:last-child,
+.no-last-child-bottom-padding > h6:last-child,
+.no-last-child-bottom-padding > ul:last-child,
+.no-last-child-bottom-padding > ol:last-child,
+.no-last-child-bottom-padding > img:last-child
+{
+  padding-bottom: 0;
 }

--- a/src/components/ReactMarkdownWrapper.tsx
+++ b/src/components/ReactMarkdownWrapper.tsx
@@ -6,7 +6,6 @@ import {
 } from '@mantine/core';
 import { ReactNode } from 'react';
 import rehypeRaw from 'rehype-raw';
-import { IconAsterisk } from '@tabler/icons-react';
 
 export default function ReactMarkdownWrapper({ text, required }: { text: string; required?: boolean }) {
   const components = {
@@ -23,12 +22,12 @@ export default function ReactMarkdownWrapper({ text, required }: { text: string;
     ol: ({ node, ...props }: { node: unknown; children: ReactNode; }) => <List type="ordered" withPadding {...props} pb={8} />,
   };
 
-  const asteriskIcon = ('<span style="color: #fa5252">*</span>');
+  const asteriskIcon = ('<span style="color: #fa5252; margin-left: 4px">*</span>');
 
   return (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     <ReactMarkdown components={components} rehypePlugins={[rehypeRaw] as any}>
-      {text + (required ? ` ${asteriskIcon}` : '')}
+      {text + (required ? `${asteriskIcon}` : '')}
     </ReactMarkdown>
   );
 }

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -1,19 +1,27 @@
 import {
   Aside,
+  Box,
+  Button,
   CloseButton,
+  Flex,
   ScrollArea,
-  Switch,
+  Tabs,
   Text,
+  Tooltip,
 } from '@mantine/core';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import { IconInfoCircle, IconUserPlus } from '@tabler/icons-react';
+import { useHref } from 'react-router-dom';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import {
   useStoreActions, useStoreDispatch, useStoreSelector,
 } from '../../store/store';
-import { useCurrentComponent } from '../../routes/utils';
+import { useCurrentComponent, useStudyId } from '../../routes/utils';
 import { deepCopy } from '../../utils/deepCopy';
 import { ComponentBlock } from '../../parser/types';
+import { getNewParticipant } from '../../utils/nextParticipant';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
 
 function addPathToComponentBlock(order: ComponentBlock | string, orderPath: string): (ComponentBlock & { orderPath: string }) | string {
   if (typeof order === 'string') {
@@ -22,15 +30,27 @@ function addPathToComponentBlock(order: ComponentBlock | string, orderPath: stri
   return { ...order, orderPath, components: order.components.map((o, i) => addPathToComponentBlock(o, `${orderPath}-${i}`)) };
 }
 
+// eslint-disable-next-line react/display-name
+function InfoHover({ text }: { text: string }) {
+  return (
+    <Tooltip label={text} multiline width={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom">
+      <IconInfoCircle size={16} style={{ marginBottom: -3, marginLeft: 4 }} />
+    </Tooltip>
+  );
+}
+
 export default function AppAside() {
-  const { showStudyBrowser, sequence } = useStoreSelector((state) => state);
+  const { showStudyBrowser, sequence, metadata } = useStoreSelector((state) => state);
   const { toggleStudyBrowser } = useStoreActions();
 
   const currentComponent = useCurrentComponent();
   const studyConfig = useStudyConfig();
   const dispatch = useStoreDispatch();
 
-  const [participantView, setParticipantView] = React.useState(true);
+  const studyId = useStudyId();
+  const studyHref = useHref(`/${studyId}`);
+
+  const { storageEngine } = useStorageEngine();
 
   const fullOrder = useMemo(() => {
     let r = deepCopy(studyConfig.sequence) as ComponentBlockWithOrderPath;
@@ -39,31 +59,58 @@ export default function AppAside() {
     return r;
   }, [studyConfig.sequence]);
 
+  const [activeTab, setActiveTab] = useState<string | null>('participant');
+
   return showStudyBrowser || (currentComponent === 'end' && studyConfig.uiConfig.autoDownloadStudy) ? (
     <Aside p="0" width={{ base: 360 }} style={{ zIndex: 0 }}>
-      <Aside.Section sx={(theme) => ({ borderBottom: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[2]}` })}>
-        <CloseButton
-          style={{
-            position: 'absolute', right: '10px', top: '10px', zIndex: 5,
-          }}
-          onClick={() => dispatch(toggleStudyBrowser())}
-        />
-        <Text size="md" p="sm" pb={2} weight="bold">
-          Study Browser
-        </Text>
-        <Switch
-          checked={participantView}
-          onChange={(event) => setParticipantView(event.currentTarget.checked)}
-          size="xs"
-          pt={0}
-          pb="sm"
-          label="Participant View"
-        />
-
+      <Aside.Section>
+        <Flex direction="row" p="sm" justify="space-between" pb="xs">
+          <Text size="md" weight="bold" pt={3}>
+            Study Browser
+          </Text>
+          <Button
+            variant="light"
+            leftIcon={<IconUserPlus size={14} />}
+            onClick={() => getNewParticipant(storageEngine, studyConfig, metadata, studyHref)}
+            size="xs"
+          >
+            Next Participant
+          </Button>
+          <CloseButton
+            onClick={() => dispatch(toggleStudyBrowser())}
+            mt={1}
+          />
+        </Flex>
       </Aside.Section>
 
-      <Aside.Section grow component={ScrollArea} p="xs">
-        <StepsPanel configSequence={fullOrder} participantSequence={sequence} fullSequence={sequence} participantView={participantView} />
+      <Aside.Section grow component={ScrollArea} p="xs" pt={0}>
+        <Tabs value={activeTab} onTabChange={setActiveTab}>
+          <Box style={{
+            position: 'sticky',
+            top: 0,
+            backgroundColor: 'white',
+            zIndex: 1,
+          }}
+          >
+            <Tabs.List grow>
+              <Tabs.Tab value="participant">
+                Participant View
+                <InfoHover text="The Participants View shows items just as a participants would see them, considering randomization, omissions, etc. You can navigate between multiple participants using the next participant button." />
+              </Tabs.Tab>
+              <Tabs.Tab value="allTrials">
+                All Trials View
+                <InfoHover text="The All Trials View shows all items in the order defined in the config." />
+              </Tabs.Tab>
+            </Tabs.List>
+          </Box>
+
+          <Tabs.Panel value="participant">
+            <StepsPanel configSequence={fullOrder} participantSequence={sequence} fullSequence={sequence} participantView />
+          </Tabs.Panel>
+          <Tabs.Panel value="allTrials">
+            <StepsPanel configSequence={fullOrder} participantSequence={sequence} fullSequence={sequence} participantView={false} />
+          </Tabs.Panel>
+        </Tabs>
       </Aside.Section>
     </Aside>
   ) : null;

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -28,6 +28,7 @@ import {
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { PREFIX } from '../../utils/Prefix';
 import { useAuth } from '../../store/hooks/useAuth';
+import { getNewParticipant } from '../../utils/nextParticipant';
 
 export default function AppHeader() {
   const { config: studyConfig, metadata } = useStoreSelector((state) => state);
@@ -50,16 +51,6 @@ export default function AppHeader() {
 
   const studyId = useStudyId();
   const studyHref = useHref(`/${studyId}`);
-
-  function getNewParticipant() {
-    storageEngine?.nextParticipant(studyConfig, metadata)
-      .then(() => {
-        window.location.href = studyHref;
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-  }
 
   const titleRef = useRef<HTMLHeadingElement | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
@@ -142,7 +133,7 @@ export default function AppHeader() {
 
                   <Menu.Item
                     icon={<IconUserPlus size={14} />}
-                    onClick={() => getNewParticipant()}
+                    onClick={() => getNewParticipant(storageEngine, studyConfig, metadata, studyHref)}
                   >
                     Next Participant
                   </Menu.Item>

--- a/src/components/interface/AppNavBar.tsx
+++ b/src/components/interface/AppNavBar.tsx
@@ -18,6 +18,8 @@ export default function AppNavBar() {
   const currentComponent = useCurrentComponent();
   const stepConfig = studyConfig.components[currentComponent];
 
+  const sidebarWidth = useMemo(() => studyConfig.uiConfig.sidebarWidth ?? 300, [studyConfig.uiConfig.sidebarWidth]);
+
   const currentConfig = useMemo(() => {
     if (stepConfig) {
       return isInheritedComponent(stepConfig) && studyConfig.baseComponents
@@ -39,7 +41,7 @@ export default function AppNavBar() {
     || currentConfig?.instructionLocation === undefined;
 
   return trialHasSideBar && currentConfig ? (
-    <Navbar bg="gray.1" display="block" width={{ base: 300 }} style={{ zIndex: 0, overflowY: 'scroll' }}>
+    <Navbar bg="gray.1" display="block" width={{ base: sidebarWidth }} style={{ zIndex: 0, overflowY: 'scroll' }}>
       {instructionInSideBar && instruction !== '' && (
         <Navbar.Section
           bg="gray.3"

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -250,8 +250,6 @@ export function StepsPanel({
             style={{
               lineHeight: '32px',
               height: '32px',
-              position: 'sticky',
-              backgroundColor: '#fff',
             }}
           >
             <div style={{ borderLeft: '1px solid #e9ecef' }}>

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -16,7 +16,12 @@ export default function CheckBoxInput({
   index: number;
   enumerateQuestions: boolean;
 }) {
-  const { prompt, required, options } = response;
+  const {
+    prompt,
+    required,
+    options,
+    secondaryText,
+  } = response;
 
   return (
     <Checkbox.Group
@@ -26,6 +31,7 @@ export default function CheckBoxInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       {...answer}
       error={generateErrorMessage(response, answer, options)}
       size="md"

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -28,7 +28,7 @@ export default function CheckBoxInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <Box style={{ display: 'block' }}>
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
             <ReactMarkdownWrapper text={prompt} required={required} />
           </Box>
         </Flex>

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -1,24 +1,31 @@
-import { Checkbox } from '@mantine/core';
+import { Box, Checkbox, Flex } from '@mantine/core';
 import { CheckboxResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
-
-type inputProps = {
-  response: CheckboxResponse;
-  disabled: boolean;
-  answer: object;
-};
 
 export default function CheckBoxInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: CheckboxResponse;
+  disabled: boolean;
+  answer: object;
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const { prompt, required, options } = response;
 
   return (
     <Checkbox.Group
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       {...answer}
       error={generateErrorMessage(response, answer, options)}
       size="md"

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -28,7 +28,9 @@ export default function CheckBoxInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }}>
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/DropdownInput.tsx
+++ b/src/components/response/DropdownInput.tsx
@@ -1,19 +1,23 @@
-import { Select, SelectItem } from '@mantine/core';
+import {
+  Box, Flex, Select, SelectItem,
+} from '@mantine/core';
 import { DropdownResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
-
-type inputProps = {
-  response: DropdownResponse;
-  disabled: boolean;
-  answer: object;
-};
 
 export default function DropdownInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: DropdownResponse;
+  disabled: boolean;
+  answer: object;
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const {
     placeholder, prompt, required, options,
   } = response;
@@ -21,7 +25,12 @@ export default function DropdownInput({
   return (
     <Select
       disabled={disabled}
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       placeholder={placeholder}
       data={options as SelectItem[]}
       radius="md"

--- a/src/components/response/DropdownInput.tsx
+++ b/src/components/response/DropdownInput.tsx
@@ -32,7 +32,9 @@ export default function DropdownInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/DropdownInput.tsx
+++ b/src/components/response/DropdownInput.tsx
@@ -19,7 +19,11 @@ export default function DropdownInput({
   enumerateQuestions: boolean;
 }) {
   const {
-    placeholder, prompt, required, options,
+    placeholder,
+    prompt,
+    required,
+    options,
+    secondaryText,
   } = response;
 
   return (
@@ -31,6 +35,7 @@ export default function DropdownInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       placeholder={placeholder}
       data={options as SelectItem[]}
       radius="md"

--- a/src/components/response/IframeInput.tsx
+++ b/src/components/response/IframeInput.tsx
@@ -22,7 +22,9 @@ export default function IframeInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/IframeInput.tsx
+++ b/src/components/response/IframeInput.tsx
@@ -1,4 +1,6 @@
-import { List, Text } from '@mantine/core';
+import {
+  Box, Flex, Input, List, Text,
+} from '@mantine/core';
 import { IFrameResponse } from '../../parser/types';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
 
@@ -13,18 +15,23 @@ export default function IframeInput({
   index: number;
   enumerateQuestions: boolean;
 }) {
-  const { prompt, required } = response;
+  const { prompt, required, secondaryText } = response;
 
   return (
-    <>
-      <>
-        {enumerateQuestions ? `${index}. ` : ''}
-        <ReactMarkdownWrapper text={prompt} required={required} />
-      </>
+    <Input.Wrapper
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
+      description={secondaryText}
+      size="md"
+    >
 
       <List>
         {Array.isArray(answer.value) ? (answer.value).map((item) => <List.Item key={item}>{item}</List.Item>) : <List.Item>{answer.value}</List.Item>}
       </List>
-    </>
+    </Input.Wrapper>
   );
 }

--- a/src/components/response/IframeInput.tsx
+++ b/src/components/response/IframeInput.tsx
@@ -2,21 +2,25 @@ import { List, Text } from '@mantine/core';
 import { IFrameResponse } from '../../parser/types';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
 
-type inputProps = {
-  response: IFrameResponse;
-  answer: { value?: string[] };
-};
 export default function IframeInput({
   response,
   answer,
-}: inputProps) {
-  const { prompt } = response;
+  index,
+  enumerateQuestions,
+}: {
+  response: IFrameResponse;
+  answer: { value?: string[] };
+  index: number;
+  enumerateQuestions: boolean;
+}) {
+  const { prompt, required } = response;
 
   return (
     <>
-      <Text fz="md" fw={500}>
-        <ReactMarkdownWrapper text={prompt} />
-      </Text>
+      <>
+        {enumerateQuestions ? `${index}. ` : ''}
+        <ReactMarkdownWrapper text={prompt} required={required} />
+      </>
 
       <List>
         {Array.isArray(answer.value) ? (answer.value).map((item) => <List.Item key={item}>{item}</List.Item>) : <List.Item>{answer.value}</List.Item>}

--- a/src/components/response/LikertInput.tsx
+++ b/src/components/response/LikertInput.tsx
@@ -1,17 +1,19 @@
 import { LikertResponse, RadioResponse } from '../../parser/types';
 import RadioInput from './RadioInput';
 
-type inputProps = {
-  response: LikertResponse;
-  disabled: boolean;
-  answer: object;
-};
-
 export default function LikertInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: LikertResponse;
+  disabled: boolean;
+  answer: object;
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const { preset } = response;
 
   const options = [];
@@ -31,6 +33,8 @@ export default function LikertInput({
       disabled={disabled}
       response={radioResponse}
       answer={answer}
+      index={index}
+      enumerateQuestions={enumerateQuestions}
     />
   );
 }

--- a/src/components/response/NumericInput.tsx
+++ b/src/components/response/NumericInput.tsx
@@ -1,18 +1,21 @@
-import { NumberInput } from '@mantine/core';
+import { Box, Flex, NumberInput } from '@mantine/core';
 import { NumericalResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
 
-type inputProps = {
-  response: NumericalResponse;
-  disabled: boolean;
-  answer: object;
-};
 export default function NumericInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: NumericalResponse;
+  disabled: boolean;
+  answer: object;
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const {
     prompt, required, min, max, placeholder,
   } = response;
@@ -21,7 +24,12 @@ export default function NumericInput({
     <NumberInput
       disabled={disabled}
       placeholder={placeholder}
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       radius="md"
       size="md"
       min={min}

--- a/src/components/response/NumericInput.tsx
+++ b/src/components/response/NumericInput.tsx
@@ -17,7 +17,12 @@ export default function NumericInput({
   enumerateQuestions: boolean;
 }) {
   const {
-    prompt, required, min, max, placeholder,
+    prompt,
+    required,
+    min,
+    max,
+    placeholder,
+    secondaryText,
   } = response;
 
   return (
@@ -30,6 +35,7 @@ export default function NumericInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       radius="md"
       size="md"
       min={min}

--- a/src/components/response/NumericInput.tsx
+++ b/src/components/response/NumericInput.tsx
@@ -32,7 +32,9 @@ export default function NumericInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/RadioInput.tsx
+++ b/src/components/response/RadioInput.tsx
@@ -1,19 +1,23 @@
-import { Radio, Text } from '@mantine/core';
+import {
+  Box, Flex, Radio, Text,
+} from '@mantine/core';
 import { RadioResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
-
-type inputProps = {
-  response: RadioResponse;
-  disabled: boolean;
-  answer: object;
-};
 
 export default function RadioInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: RadioResponse;
+  disabled: boolean;
+  answer: object;
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const {
     prompt, required, options, leftLabel, rightLabel,
   } = response;
@@ -21,7 +25,12 @@ export default function RadioInput({
   return (
     <Radio.Group
       name={`radioInput${response.id}`}
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       size="md"
       key={response.id}
       {...answer}

--- a/src/components/response/RadioInput.tsx
+++ b/src/components/response/RadioInput.tsx
@@ -19,7 +19,12 @@ export default function RadioInput({
   enumerateQuestions: boolean;
 }) {
   const {
-    prompt, required, options, leftLabel, rightLabel,
+    prompt,
+    required,
+    options,
+    leftLabel,
+    rightLabel,
+    secondaryText,
   } = response;
 
   return (
@@ -31,6 +36,7 @@ export default function RadioInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       size="md"
       key={response.id}
       {...answer}

--- a/src/components/response/RadioInput.tsx
+++ b/src/components/response/RadioInput.tsx
@@ -33,7 +33,9 @@ export default function RadioInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -77,7 +77,7 @@ export default function ResponseBlock({
 
   return (
     <div style={style}>
-      {responses.map((response) => (
+      {responses.map((response, index) => (
         <React.Fragment key={`${response.id}-${currentStep}`}>
           {response.hidden ? (
             ''
@@ -91,6 +91,7 @@ export default function ResponseBlock({
                   }),
                 }}
                 response={response}
+                index={index + 1}
               />
               {hasCorrectAnswerFeedback && checkClicked && (
                 <Text>

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -11,23 +11,27 @@ import RadioInput from './RadioInput';
 import SliderInput from './SliderInput';
 import StringInput from './StringInput';
 import TextAreaInput from './TextAreaInput';
-
-type Props = {
-  response: Response;
-  answer: { value?: object };
-  storedAnswer?: Record<string, unknown>;
-};
+import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 
 export default function ResponseSwitcher({
   response,
   answer,
   storedAnswer,
-}: Props) {
+  index,
+}: {
+  response: Response;
+  answer: { value?: object };
+  storedAnswer?: Record<string, unknown>;
+  index: number;
+}) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ans: { value?: any } = (storedAnswer ? { value: storedAnswer } : answer) || { value: undefined };
   const disabled = !!storedAnswer;
 
   const [searchParams] = useSearchParams();
+
+  const studyConfig = useStudyConfig();
+  const enumerateQuestions = studyConfig.uiConfig.enumerateQuestions ?? false;
 
   const isDisabled = useMemo(() => {
     if (response.paramCapture) {
@@ -45,43 +49,80 @@ export default function ResponseSwitcher({
         response={response}
         disabled={isDisabled}
         answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
       />
       )}
       {response.type === 'shortText' && (
-      <StringInput response={response} disabled={isDisabled} answer={ans} />
+      <StringInput
+        response={response}
+        disabled={isDisabled}
+        answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
+      />
       )}
       {response.type === 'longText' && (
       <TextAreaInput
         response={response}
         disabled={isDisabled}
         answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
       />
       )}
       {response.type === 'likert' && (
-      <LikertInput response={response} disabled={isDisabled} answer={ans} />
+      <LikertInput
+        response={response}
+        disabled={isDisabled}
+        answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
+      />
       )}
       {response.type === 'dropdown' && (
       <DropdownInput
         response={response}
         disabled={isDisabled}
         answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
       />
       )}
       {response.type === 'slider' && (
-      <SliderInput response={response} disabled={isDisabled} answer={ans} />
+      <SliderInput
+        response={response}
+        disabled={isDisabled}
+        answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
+      />
       )}
       {response.type === 'radio' && (
-      <RadioInput response={response} disabled={isDisabled} answer={ans} />
+      <RadioInput
+        response={response}
+        disabled={isDisabled}
+        answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
+      />
       )}
       {response.type === 'checkbox' && (
       <CheckBoxInput
         response={response}
         disabled={isDisabled}
         answer={ans}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
       />
       )}
       {response.type === 'iframe' && (
-      <IframeInput response={response} answer={ans as { value: string[] }} />
+      <IframeInput
+        response={response}
+        answer={ans as { value: string[] }}
+        index={index}
+        enumerateQuestions={enumerateQuestions}
+      />
       )}
     </Box>
   );

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -1,27 +1,36 @@
 import {
+  Box,
+  Flex,
   Input, Slider, SliderProps,
 } from '@mantine/core';
 import { SliderResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
 
-type inputProps = {
-  response: SliderResponse;
-  disabled: boolean;
-  answer: object;
-};
-
 export default function SliderInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: SliderResponse;
+  disabled: boolean;
+  answer: object;
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const { prompt, required, options } = response;
 
   const errorMessage = generateErrorMessage(response, answer);
   return (
     <Input.Wrapper
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       error={errorMessage}
       size="md"
     >

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -20,7 +20,12 @@ export default function SliderInput({
   index: number;
   enumerateQuestions: boolean;
 }) {
-  const { prompt, required, options } = response;
+  const {
+    prompt,
+    required,
+    options,
+    secondaryText,
+  } = response;
 
   const errorMessage = generateErrorMessage(response, answer);
   return (
@@ -31,6 +36,7 @@ export default function SliderInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       error={errorMessage}
       size="md"
     >

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -33,7 +33,9 @@ export default function SliderInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/StringInput.tsx
+++ b/src/components/response/StringInput.tsx
@@ -16,7 +16,12 @@ export default function StringInput({
   index: number;
   enumerateQuestions: boolean;
 }) {
-  const { placeholder, prompt, required } = response;
+  const {
+    placeholder,
+    prompt,
+    required,
+    secondaryText,
+  } = response;
 
   return (
     <TextInput
@@ -28,6 +33,7 @@ export default function StringInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       radius="md"
       size="md"
       {...answer}

--- a/src/components/response/StringInput.tsx
+++ b/src/components/response/StringInput.tsx
@@ -1,26 +1,33 @@
-import { TextInput } from '@mantine/core';
+import { Box, Flex, TextInput } from '@mantine/core';
 import { ShortTextResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
-
-type inputProps = {
-  response: ShortTextResponse;
-  disabled: boolean;
-  answer: { value?: string };
-};
 
 export default function StringInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: ShortTextResponse;
+  disabled: boolean;
+  answer: { value?: string };
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const { placeholder, prompt, required } = response;
 
   return (
     <TextInput
       disabled={disabled}
       placeholder={placeholder}
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       radius="md"
       size="md"
       {...answer}

--- a/src/components/response/StringInput.tsx
+++ b/src/components/response/StringInput.tsx
@@ -30,7 +30,9 @@ export default function StringInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/components/response/TextAreaInput.tsx
+++ b/src/components/response/TextAreaInput.tsx
@@ -1,26 +1,33 @@
-import { Textarea } from '@mantine/core';
+import { Box, Flex, Textarea } from '@mantine/core';
 import { LongTextResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import ReactMarkdownWrapper from '../ReactMarkdownWrapper';
-
-type inputProps = {
-  response: LongTextResponse;
-  disabled: boolean;
-  answer: { value?: string };
-};
 
 export default function TextAreaInput({
   response,
   disabled,
   answer,
-}: inputProps) {
+  index,
+  enumerateQuestions,
+}: {
+  response: LongTextResponse;
+  disabled: boolean;
+  answer: { value?: string };
+  index: number;
+  enumerateQuestions: boolean;
+}) {
   const { placeholder, prompt, required } = response;
 
   return (
     <Textarea
       disabled={disabled}
       placeholder={placeholder}
-      label={<ReactMarkdownWrapper text={prompt} required={required} />}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
+          <ReactMarkdownWrapper text={prompt} required={required} />
+        </Flex>
+      )}
       radius="md"
       size="md"
       {...answer}

--- a/src/components/response/TextAreaInput.tsx
+++ b/src/components/response/TextAreaInput.tsx
@@ -16,7 +16,12 @@ export default function TextAreaInput({
   index: number;
   enumerateQuestions: boolean;
 }) {
-  const { placeholder, prompt, required } = response;
+  const {
+    placeholder,
+    prompt,
+    required,
+    secondaryText,
+  } = response;
 
   return (
     <Textarea
@@ -28,6 +33,7 @@ export default function TextAreaInput({
           <ReactMarkdownWrapper text={prompt} required={required} />
         </Flex>
       )}
+      description={secondaryText}
       radius="md"
       size="md"
       {...answer}

--- a/src/components/response/TextAreaInput.tsx
+++ b/src/components/response/TextAreaInput.tsx
@@ -30,7 +30,9 @@ export default function TextAreaInput({
       label={(
         <Flex direction="row" wrap="nowrap" gap={4}>
           {enumerateQuestions && <Box style={{ minWidth: 'fit-content' }}>{`${index}. `}</Box>}
-          <ReactMarkdownWrapper text={prompt} required={required} />
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
         </Flex>
       )}
       description={secondaryText}

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1454,6 +1454,10 @@
           "description": "The email address that used during the study if a participant clicks contact.",
           "type": "string"
         },
+        "enumerateQuestions": {
+          "description": "Whether to prepend questions with their index (+ 1). This should only be used when all questions are in the same location, e.g. all are in the side bar.",
+          "type": "boolean"
+        },
         "helpTextPath": {
           "description": "The path to the help text file. This is displayed when a participant clicks help. Markdown is supported.",
           "type": "string"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1510,6 +1510,10 @@
           "description": "Controls whether the left sidebar is rendered at all. Required to be true if your response's location is set to sidebar for any question.",
           "type": "boolean"
         },
+        "sidebarWidth": {
+          "description": "The width of the left sidebar. Defaults to 300.",
+          "type": "number"
+        },
         "studyEndMsg": {
           "description": "The message to display when the study ends.",
           "type": "string"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -70,6 +70,10 @@
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
         },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
+        },
         "type": {
           "const": "checkbox",
           "type": "string"
@@ -245,6 +249,10 @@
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
         },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
+        },
         "type": {
           "const": "dropdown",
           "type": "string"
@@ -294,6 +302,10 @@
         },
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
         },
         "type": {
           "const": "iframe",
@@ -615,6 +627,10 @@
           "description": "The right label of the likert scale. E.g Strongly Agree",
           "type": "string"
         },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
+        },
         "type": {
           "const": "likert",
           "type": "string"
@@ -668,6 +684,10 @@
         },
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
         },
         "type": {
           "const": "longText",
@@ -792,6 +812,10 @@
         },
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
         },
         "type": {
           "const": "numerical",
@@ -932,6 +956,10 @@
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
         },
         "rightLabel": {
+          "type": "string"
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
           "type": "string"
         },
         "type": {
@@ -1162,6 +1190,10 @@
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
         },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
+        },
         "type": {
           "const": "shortText",
           "type": "string"
@@ -1237,6 +1269,10 @@
         },
         "requiredValue": {
           "description": "You can provide a required value, which makes it so a participant has to answer with that value."
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
         },
         "type": {
           "const": "slider",

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -110,6 +110,10 @@ export interface UIConfig {
    * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.
    */
   numSequences?: number;
+  /**
+   * Whether to prepend questions with their index (+ 1). This should only be used when all questions are in the same location, e.g. all are in the side bar.
+   */
+  enumerateQuestions?: boolean;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -100,6 +100,8 @@ export interface UIConfig {
   studyEndMsg?: string;
   /** Controls whether the left sidebar is rendered at all. Required to be true if your response's location is set to sidebar for any question. */
   sidebar: boolean;
+  /** The width of the left sidebar. Defaults to 300. */
+  sidebarWidth?: number;
   /** Debounce time in milliseconds for automatically tracked window events. Defaults to 100. E.g 100 here means 1000ms / 100ms = 10 times a second, 200 here means 1000ms / 200ms = 5 times per second  */
   windowEventDebounceTime?: number;
   /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -151,6 +151,8 @@ export interface BaseResponse {
   id: string;
   /** The prompt that is displayed to the participant. You can use markdown here to render images, links, etc. */
   prompt: string;
+  /** The secondary text that is displayed to the participant under the prompt. This does not accept markdown. */
+  secondaryText?: string;
   /** Controls whether the response is required to be answered. */
   required: boolean;
   /** Controls the response location. These might be the same for all responses, or differ across responses. */

--- a/src/utils/nextParticipant.ts
+++ b/src/utils/nextParticipant.ts
@@ -1,0 +1,13 @@
+import { StudyConfig } from '../parser/types';
+import { StorageEngine } from '../storage/engines/StorageEngine';
+import { ParticipantMetadata } from '../store/types';
+
+export function getNewParticipant(storageEngine: StorageEngine | undefined, studyConfig: StudyConfig, metadata: ParticipantMetadata, studyHref: string) {
+  storageEngine?.nextParticipant(studyConfig, metadata)
+    .then(() => {
+      window.location.href = studyHref;
+    })
+    .catch((err) => {
+      console.error(err);
+    });
+}

--- a/tests/demo-cleveland.spec.ts
+++ b/tests/demo-cleveland.spec.ts
@@ -12,7 +12,7 @@ test('test', async ({ page }) => {
   await expect(introText).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains consent form
   const consent = await page.getByRole('heading', { name: 'Consent' });
@@ -31,7 +31,7 @@ test('test', async ({ page }) => {
   await expect(trainingImg).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check for each practice question
   const questionArray = new Array(4).fill(null).map((val, idx) => idx);
@@ -58,7 +58,7 @@ test('test', async ({ page }) => {
     await expect(correctAnswer).toBeVisible();
 
     // Click on the next button
-    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
   }
 
   // Check that the next question does not have a check answer button
@@ -82,7 +82,7 @@ test('test', async ({ page }) => {
     await page.getByPlaceholder('0-100').fill('66');
 
     // Click on the next button
-    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
   }
 
   // Check for the post study survey and fill it out
@@ -91,7 +91,7 @@ test('test', async ({ page }) => {
   await page.getByPlaceholder('Enter your age here, range from 0 - 100').fill('25');
   await page.getByLabel('5').check();
   await page.getByPlaceholder('Enter your comments here').fill('Test Test');
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the end of study text renders
   const endText = await page.getByText('Please wait while your answers are uploaded.');

--- a/tests/demo-click-accuracy-test.spec.ts
+++ b/tests/demo-click-accuracy-test.spec.ts
@@ -7,7 +7,7 @@ test('test', async ({ page }) => {
   // Check for introduction page
   const introText = await page.getByRole('heading', { name: 'Introduction' });
   await expect(introText).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check click accuracy test
   const questionText = await page.getByText('Task:');
@@ -21,7 +21,7 @@ test('test', async ({ page }) => {
   const oneAnswer = await page.getByRole('listitem');
   await expect(await oneAnswer.count()).toEqual(1);
 
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the thank you message is displayed
   await page.getByText('Please wait while your answers are uploaded.').click();

--- a/tests/demo-html-input.spec.ts
+++ b/tests/demo-html-input.spec.ts
@@ -11,7 +11,7 @@ test('test', async ({ page }) => {
   await expect(introText).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains the question
   const questionText = await page.getByText('Click on the largest bar');
@@ -29,7 +29,7 @@ test('test', async ({ page }) => {
   await expect(responseValue).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains the question
   const questionText2 = await page.getByText('Click on the smallest bar');
@@ -47,7 +47,7 @@ test('test', async ({ page }) => {
   await expect(responseValue2).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the end of study text renders
   const endText = await page.getByText('Please wait while your answers are uploaded.');

--- a/tests/demo-html.spec.ts
+++ b/tests/demo-html.spec.ts
@@ -11,7 +11,7 @@ test('html demo works as intended', async ({ page }) => {
   await expect(introText).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains the question
   const questionText = await page.getByText('How many bars have a value greater than 1?');
@@ -27,7 +27,7 @@ test('html demo works as intended', async ({ page }) => {
   await input.fill('2');
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the end of study text renders
   const endText = await page.getByText('Please wait while your answers are uploaded.');

--- a/tests/demo-image.spec.ts
+++ b/tests/demo-image.spec.ts
@@ -11,7 +11,7 @@ test('test', async ({ page }) => {
   await expect(introText).toBeVisible();
 
   // Click on the next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains the question
   const question1Text = await page.getByText('Will you issue blankets to the alpacas?');
@@ -23,7 +23,7 @@ test('test', async ({ page }) => {
 
   // Select a response and click next
   await page.getByLabel('Yes').check();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains the question
   const question2Text = await page.getByText('Will you issue blankets to the alpacas?');
@@ -35,7 +35,7 @@ test('test', async ({ page }) => {
 
   // Select a response and click next
   await page.getByLabel('No').check();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check the page contains the question
   const question3Text = await page.getByText('Will you issue blankets to the alpacas?');
@@ -47,7 +47,7 @@ test('test', async ({ page }) => {
 
   // Select a response and click next
   await page.getByLabel('Yes').check();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the end of study text renders
   const endText = await page.getByText('Please wait while your answers are uploaded.');

--- a/tests/demo-mvnv.spec.ts
+++ b/tests/demo-mvnv.spec.ts
@@ -12,7 +12,7 @@ test('test', async ({ page }) => {
   await expect(introText).toBeVisible();
 
   // Click on next button
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check for consent page
   const consentText = await page.getByRole('heading', { name: 'Consent' });
@@ -30,7 +30,7 @@ test('test', async ({ page }) => {
   await expect(trainingText).toBeVisible();
   const trainingVideo = await page.frameLocator('#root iframe').locator('video');
   await expect(trainingVideo).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < 16; i++) {
@@ -83,14 +83,14 @@ test('test', async ({ page }) => {
     }
 
     try {
-      const input = await page.getByLabel('Enter Findings Below *');
+      const input = await page.getByLabel('Enter Findings Below*');
       await expect(input).toBeVisible({ timeout: 100 });
       await input.fill('test');
     } catch (e) {
       // eslint-disable-next-line no-empty
     }
 
-    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
   }
 
   // Check that the thank you message is displayed

--- a/tests/demo-survey.spec.ts
+++ b/tests/demo-survey.spec.ts
@@ -7,7 +7,7 @@ test('test', async ({ page }) => {
   // Check for introduction page
   const introText = await page.getByText('Welcome to our study. This is an example survey study. It asks basic questions o');
   await expect(introText).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Fill the survey
   await page.getByPlaceholder('Enter your preference').click();
@@ -18,7 +18,7 @@ test('test', async ({ page }) => {
   await page.getByPlaceholder('Enter your long comments here').fill('asdf');
   await page.locator('.mantine-Slider-track').click();
   await page.getByRole('checkbox', { name: 'Option 2' }).click();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the thank you message is displayed
   const endText = await page.getByText('Please wait while your answers are uploaded.');

--- a/tests/demo-vlat.spec.ts
+++ b/tests/demo-vlat.spec.ts
@@ -5,10 +5,10 @@ test('test', async ({ page }) => {
   await page.goto('/demo-VLAT-full-randomized?PROLIFIC_ID=test');
 
   await page.getByRole('heading', { name: 'What is VLAT?' }).click();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   await page.getByPlaceholder('Your Initials').fill('test');
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   const questionArray = new Array(53).fill(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -18,14 +18,14 @@ test('test', async ({ page }) => {
     const img = await page.getByRole('main').getByRole('img');
     await expect(img).toBeVisible();
     await page.locator('input[type="radio"]').nth(0).click();
-    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
   }
 
   await page.getByPlaceholder('Enter your answer here.').click();
   await page.getByPlaceholder('Enter your answer here.').fill('no');
-  await page.getByLabel('Did anything not render or display properly? *').fill('no');
-  await page.getByLabel('Any other issues or anything you would like to tell us? *').fill('no');
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByLabel('Did anything not render or display properly?*').fill('no');
+  await page.getByLabel('Any other issues or anything you would like to tell us?*').fill('no');
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   await page.getByText('Please wait while your answers are uploaded.').click();
 });

--- a/tests/test-skip-logic.spec.ts
+++ b/tests/test-skip-logic.spec.ts
@@ -4,12 +4,12 @@ import { test, expect } from '@playwright/test';
 async function answerTrial1(page, q1, q2) {
   await page.getByLabel(q1).check();
   await page.getByLabel(q2).check();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 }
 
 async function answerAttentionCheck(page, q1) {
   await page.getByLabel(q1).check();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 }
 
 async function answerAttentionCheckBlock(page, numIncorrect) {
@@ -34,17 +34,17 @@ async function answerAttentionCheckBlock(page, numIncorrect) {
 
 async function verifyContinuingComponent(page) {
   await expect(page.getByText('This component exists to show that we didn\'t get skipped over.')).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 }
 
 async function verifyTargetComponent(page) {
   await expect(page.getByText('This component exists to show that we can choose where to skip to.')).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 }
 
 async function verifyTargetBlockComponent(page) {
   await expect(page.getByText('This component exists to show that we can choose a block to skip to.')).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
 }
 
 async function verifyStudyEnd(page) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #397 

### Give a longer description of what this PR addresses and why it's needed
Improves a bunch of our UI, including enumerating questions, adding secondary text to inputs, custom sidebar width, and using tabs in the study browser.

### Provide pictures/videos of the behavior before and after these changes (optional)
Enumerating questions:
![image](https://github.com/revisit-studies/study/assets/36867477/6cee5400-fab0-46e5-b825-ac0536f1fb12)

Secondary text:
![image](https://github.com/revisit-studies/study/assets/36867477/39875037-0cf4-483a-b504-4c44bc938477)

Custom sidebar width:
![image](https://github.com/revisit-studies/study/assets/36867477/b1d7088e-2154-4666-bfb9-81e45f34d0b2)

Tabs:
![image](https://github.com/revisit-studies/study/assets/36867477/44fdfe19-3a86-4446-a599-2b0893b21587)


### Are there any additional TODOs before this PR is ready to go?
No