### PR TITLE
Admin user fix

### DIFF
--- a/src/analysis/components/interface/AppHeader.tsx
+++ b/src/analysis/components/interface/AppHeader.tsx
@@ -126,7 +126,7 @@ export default function AppHeader({ studyIds }: { studyIds: string[] }) {
                           size="sm"
                           ml={10}
                           style={{ cursor: 'pointer' }}
-                          onClick={logout}
+                          onClick={() => { logout(); navigate('/login'); setNavOpen(false); }}
                         >
                           Logout
                         </Text>

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -400,9 +400,9 @@ export class FirebaseStorageEngine extends StorageEngine {
           if (isAdmin) {
             // Add UID to user in collection if not existent.
             if (user.user.email && adminUsersObject[user.user.email] === null) {
-              const adminUser = adminUsers.adminUsersList.find((u: StoredUser) => u.email === user.user!.email);
+              const adminUser: StoredUser | undefined = adminUsers.adminUsersList.find((u: StoredUser) => u.email === user.user!.email);
               if (adminUser) {
-                adminUser.user.uid = user.user.uid;
+                adminUser.uid = user.user.uid;
               }
               await setDoc(doc(this.firestore, 'user-management', 'adminUsers'), {
                 adminUsersList: adminUsers.adminUsersList,


### PR DESCRIPTION
### Does this PR close any open issues?
Fixes issue brought up in Core. Also added navigation to the Login screen whenever clicking 'logout'.

### Give a longer description of what this PR addresses and why it's needed
New users were not properly having their UID added to firestore, causing the application to crash.
For the 'logout' behavior, there is no necessity to navigate to the Login screen in general, but when you're on a protected route, this will happen automatically. Thus, for consistency, I decided to make it so that clicking logout navigates you to the login no matter what.
