### PR TITLE
Add revisit modes in analysis interface

### DIFF
--- a/.env
+++ b/.env
@@ -11,5 +11,3 @@ VITE_FIREBASE_CONFIG='
 '
 VITE_STORAGE_ENGINE="localStorage" # "firebase" or "localStorage" or your own custom storage engine
 VITE_RECAPTCHAV3TOKEN="6LdjOd0lAAAAAASvFfDZFWgtbzFSS9Y3so8rHJth" # recaptcha SITE KEY
-
-VITE_REVISIT_MODE="public"

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -19,9 +19,20 @@ export function ProtectedRoute({ children, paramToCheck, paramCallback }: Protec
 
   useEffect(() => {
     const verifyUser = async () => {
-      if (paramToCheck && paramCallback && params[paramToCheck] && isEnabled === false) {
-        const currIsEnabled = await paramCallback(params[paramToCheck]!);
-        setIsEnabled(currIsEnabled);
+      // If isEnabled is false, re-check. Additional rechecking is required becasue this effect needs to trigger whenever there is manipulation from an unwanted user.
+      if (isEnabled === false) {
+        // If we paramToCheck and paramCallback (meaning checking enabling the protected route is necessary), check
+        if (paramToCheck && paramCallback && params[paramToCheck]) {
+          // Get the current enabling feature
+          const currIsEnabled = await paramCallback(params[paramToCheck]!);
+          // If it should be enabled, set to true. Otherwise, leave as false.
+          if (currIsEnabled) {
+            setIsEnabled(currIsEnabled);
+          }
+        // Otherwise, isEnabled was set to false by external user state manipulation
+        } else {
+          setIsEnabled(true);
+        }
       }
       if (isEnabled) {
         try {

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,42 +1,53 @@
 import { LoadingOverlay } from '@mantine/core';
-import { ReactNode, useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
+import { ReactNode, useEffect, useState } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
 import { useAuth } from './store/hooks/useAuth';
 import { useStorageEngine } from './storage/storageEngineHooks';
 
 interface ProtectedRouteProps {
   children: ReactNode;
+  paramToCheck?: string;
+  paramCallback?: (paramToCheck:string) => Promise<boolean>;
 }
 
 // Wrapper component which only allows users who are authenticated and admins to access its child components.
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
+export function ProtectedRoute({ children, paramToCheck, paramCallback }: ProtectedRouteProps) {
   const { user, verifyAdminStatus, logout } = useAuth();
   const { storageEngine } = useStorageEngine();
+  const [isEnabled, setIsEnabled] = useState<boolean>(false);
+  const params = useParams();
 
   useEffect(() => {
     const verifyUser = async () => {
-      try {
-        if (user) {
-          const isAdmin = await verifyAdminStatus(user);
-          if (!isAdmin) {
+      if (paramToCheck && paramCallback && params[paramToCheck] && isEnabled === false) {
+        const currIsEnabled = await paramCallback(params[paramToCheck]!);
+        setIsEnabled(currIsEnabled);
+      }
+      if (isEnabled) {
+        try {
+          if (user) {
+            const isAdmin = await verifyAdminStatus(user);
+            if (!isAdmin) {
+              logout();
+            }
+          } else {
             logout();
           }
-        } else {
+        } catch (error) {
           logout();
+          console.warn(error);
         }
-      } catch (error) {
-        logout();
-        console.warn(error);
       }
     };
+
     verifyUser();
-  }, [user.isAdmin]);
+  }, [user.isAdmin, isEnabled]);
 
   if (user.determiningStatus || !storageEngine) {
     return <LoadingOverlay visible={user.determiningStatus || !storageEngine?.getEngine()} />;
   }
 
-  if (!user.isAdmin && !user.determiningStatus) {
+  if (isEnabled && !user.isAdmin && !user.determiningStatus) {
     return <Navigate to="/login" />;
   }
   // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/analysis/AnalysisInterface.tsx
+++ b/src/analysis/AnalysisInterface.tsx
@@ -15,9 +15,8 @@ import { GlobalConfig, ParticipantData, StudyConfig } from '../parser/types';
 import { getStudyConfig } from '../utils/fetchConfig';
 import { TableView } from './table/TableView';
 import { useStorageEngine } from '../storage/storageEngineHooks';
-import { DataManagementBoard } from './management/DataManagementBoard';
-import { FirebaseStorageEngine } from '../storage/engines/FirebaseStorageEngine';
 import { ParticipantStatusBadges } from './components/interface/ParticipantStatusBadges';
+import ManageAccordion from './management/ManageAccordion';
 
 export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
   const { globalConfig } = props;
@@ -53,8 +52,6 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
     return [comp, prog, rej];
   }, [expData]);
 
-  const showManage = import.meta.env.VITE_REVISIT_MODE !== 'public' && storageEngine instanceof FirebaseStorageEngine;
-
   return (
     <>
       <AppHeader studyIds={props.globalConfig.configsList} />
@@ -78,15 +75,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
               <Tooltip label="Coming soon" position="bottom">
                 <Tabs.Tab value="replay" leftSection={<IconPlayerPlay size={16} />} disabled>Participant Replay</Tabs.Tab>
               </Tooltip>
-              {
-                showManage
-                  ? <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />}>Manage</Tabs.Tab>
-                  : (
-                    <Tooltip label="Management is currently only available for Firebase studies" position="bottom">
-                      <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled>Manage</Tabs.Tab>
-                    </Tooltip>
-                  )
-}
+              <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />}>Manage</Tabs.Tab>
             </Tabs.List>
             <Tabs.Panel value="table" pt="xs">
               {studyConfig && <TableView completed={completed} inProgress={inProgress} studyConfig={studyConfig} refresh={getData} />}
@@ -99,7 +88,7 @@ export function AnalysisInterface(props: { globalConfig: GlobalConfig; }) {
               Replay Tab Content
             </Tabs.Panel>
             <Tabs.Panel value="manage" pt="xs">
-              {studyId && showManage && <DataManagementBoard studyId={studyId} refresh={getData} />}
+              {studyId && <ManageAccordion studyId={studyId} refresh={getData} />}
             </Tabs.Panel>
           </Tabs>
         </Container>

--- a/src/analysis/components/interface/AppHeader.tsx
+++ b/src/analysis/components/interface/AppHeader.tsx
@@ -40,7 +40,7 @@ export default function AppHeader({ studyIds }: { studyIds: string[] }) {
       name: 'Analysis',
       leftIcon: <IconChartBar />,
       href: '/analysis/dashboard',
-      needAdmin: true,
+      needAdmin: false,
     },
     {
       name: 'Settings',

--- a/src/analysis/dashboard/GlobalSettings.tsx
+++ b/src/analysis/dashboard/GlobalSettings.tsx
@@ -129,7 +129,7 @@ export function GlobalSettings() {
                     onClick={(event) => (!storageEngineIsFirebase ? event.preventDefault() : handleEnableAuth())}
                     color="green"
                     data-disabled={!storageEngineIsFirebase ? true : undefined}
-                    style={{ '&[data-disabled]': { pointerEvents: 'all' } }}
+                    style={{ '&[dataDisabled]': { pointerEvents: 'all' } }}
                   >
                     Enable Authentication
                   </Button>

--- a/src/analysis/management/DataManagementAccordionItem.tsx
+++ b/src/analysis/management/DataManagementAccordionItem.tsx
@@ -1,5 +1,5 @@
 import {
-  Card, Container, Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, ActionIcon, Space,
+  Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, ActionIcon, Space,
 } from '@mantine/core';
 import { useCallback, useEffect, useState } from 'react';
 import { IconTrashX, IconRefresh } from '@tabler/icons-react';
@@ -7,7 +7,7 @@ import { openConfirmModal } from '@mantine/modals';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 
-export function DataManagementBoard({ studyId, refresh }: { studyId: string, refresh: () => Promise<void> }) {
+export function DataManagementAccordionItem({ studyId, refresh }: { studyId: string, refresh: () => Promise<void> }) {
   const [modalArchiveOpened, setModalArchiveOpened] = useState<boolean>(false);
   const [modalDeleteSnapshotOpened, setModalDeleteSnapshotOpened] = useState<boolean>(false);
   const [modalDeleteLiveOpened, setModalDeleteLiveOpened] = useState<boolean>(false);
@@ -108,119 +108,112 @@ export function DataManagementBoard({ studyId, refresh }: { studyId: string, ref
   return (
     <>
       <LoadingOverlay visible={loading} />
-      <Container>
-        <Card withBorder style={{ backgroundColor: '#FAFAFA' }}>
-          <Title mb="lg" order={4}>Data Management</Title>
+      <Flex justify="space-between" align="center">
+        <Box style={{ width: '70%' }}>
+          <Title order={5}>Create a Snapshot</Title>
+          <Text>
+            This will create a snapshot of the live
+            {' '}
+            <Text span fw={700}>{studyId}</Text>
+            {' '}
+            database. It will
+            {' '}
+            <Text span fw={700} fs="italic">not</Text>
+            {' '}
+            remove this data from the live database. The current study data can be restored from a snapshot at any time.
+          </Text>
+        </Box>
 
-          <Flex justify="space-between" align="center">
-            <Box style={{ width: '70%' }}>
-              <Title order={5}>Create a Snapshot</Title>
-              <Text>
-                This will create a snapshot of the live
-                {' '}
-                <Text span fw={700}>{studyId}</Text>
-                {' '}
-                database. It will
-                {' '}
-                <Text span fw={700} fs="italic">not</Text>
-                {' '}
-                remove this data from the live database. The current study data can be restored from a snapshot at any time.
-              </Text>
-            </Box>
+        <Tooltip label="Create a snapshot">
+          <Button onClick={openCreateSnapshotModal}>
+            Snapshot
+          </Button>
+        </Tooltip>
+      </Flex>
 
-            <Tooltip label="Create a snapshot">
-              <Button onClick={openCreateSnapshotModal}>
-                Snapshot
-              </Button>
-            </Tooltip>
-          </Flex>
+      <Space h="lg" />
 
-          <Space h="lg" />
+      <Flex justify="space-between" align="center">
+        <Box style={{ width: '70%' }}>
+          <Title order={5}>Archive Data</Title>
+          <Text>
+            This will create a snapshot of the live
+            {' '}
+            <Text span fw={700}>{studyId}</Text>
+            {' '}
+            database. It will then remove this data from the live database. The current study data can be restored from a snapshot at any time.
+          </Text>
+        </Box>
 
-          <Flex justify="space-between" align="center">
-            <Box style={{ width: '70%' }}>
-              <Title order={5}>Archive Data</Title>
-              <Text>
-                This will create a snapshot of the live
-                {' '}
-                <Text span fw={700}>{studyId}</Text>
-                {' '}
-                database. It will then remove this data from the live database. The current study data can be restored from a snapshot at any time.
-              </Text>
-            </Box>
+        <Tooltip label="Snapshot and Delete Data">
+          <Button color="red" onClick={() => setModalArchiveOpened(true)}>
+            Archive
+          </Button>
+        </Tooltip>
+      </Flex>
 
-            <Tooltip label="Snapshot and Delete Data">
-              <Button color="red" onClick={() => setModalArchiveOpened(true)}>
-                Archive
-              </Button>
-            </Tooltip>
-          </Flex>
+      <Space h="lg" />
 
-          <Space h="lg" />
+      <Flex justify="space-between" align="center">
+        <Box style={{ width: '70%' }}>
+          <Title order={5}>Delete Data</Title>
+          <Text>
+            This will delete the live
+            {' '}
+            <Text span fw={700}>{studyId}</Text>
+            {' '}
+            database. Since this does not create a snapshot the data will be permanently deleted and cannot be restored.
+          </Text>
+        </Box>
 
-          <Flex justify="space-between" align="center">
-            <Box style={{ width: '70%' }}>
-              <Title order={5}>Delete Data</Title>
-              <Text>
-                This will delete the live
-                {' '}
-                <Text span fw={700}>{studyId}</Text>
-                {' '}
-                database. Since this does not create a snapshot the data will be permanently deleted and cannot be restored.
-              </Text>
-            </Box>
+        <Tooltip label="Delete Data">
+          <Button color="red" onClick={() => setModalDeleteLiveOpened(true)}>
+            Delete
+          </Button>
+        </Tooltip>
+      </Flex>
 
-            <Tooltip label="Delete Data">
-              <Button color="red" onClick={() => setModalDeleteLiveOpened(true)}>
-                Delete
-              </Button>
-            </Tooltip>
-          </Flex>
+      <Space h="xl" />
 
-          <Space h="xl" />
+      <Flex direction="column">
+        <Flex style={{ borderBottom: '1px solid #dedede' }} direction="row" justify="space-between" mb="xs" pb="sm">
+          <Title order={5}>Snapshots</Title>
+        </Flex>
 
-          <Flex direction="column">
-            <Flex style={{ borderBottom: '1px solid #dedede' }} direction="row" justify="space-between" mb="xs" pb="sm">
-              <Title order={5}>Snapshots</Title>
-            </Flex>
-
-            {/* Position relative keeps the loading overlay only on the list */}
-            <Box style={{ position: 'relative' }}>
-              <LoadingOverlay visible={snapshotListLoading} />
-              { snapshots.length > 0
-                ? snapshots.map(
-                  (datasetName: string) => (
-                    <Flex key={datasetName} justify="space-between" mb="xs">
-                      <Text>{datasetName}</Text>
-                      <Flex direction="row" gap="xs">
-                        <Tooltip label="Restore Snapshot">
-                          <ActionIcon
-                            color="blue"
-                            variant="subtle"
-                            onClick={() => { openRestoreSnapshotModal(datasetName); }}
-                          >
-                            <IconRefresh />
-                          </ActionIcon>
-                        </Tooltip>
-                        <Tooltip label="Delete Snapshot">
-                          <ActionIcon
-                            color="red"
-                            variant="subtle"
-                            onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(datasetName); }}
-                          >
-                            <IconTrashX />
-                          </ActionIcon>
-                        </Tooltip>
-                      </Flex>
-                    </Flex>
-                  ),
-                )
-                : <Text>No snapshots.</Text>}
-            </Box>
-          </Flex>
-
-        </Card>
-      </Container>
+        {/* Position relative keeps the loading overlay only on the list */}
+        <Box style={{ position: 'relative' }}>
+          <LoadingOverlay visible={snapshotListLoading} />
+          { snapshots.length > 0
+            ? snapshots.map(
+              (datasetName: string) => (
+                <Flex key={datasetName} justify="space-between" mb="xs">
+                  <Text>{datasetName}</Text>
+                  <Flex direction="row" gap="xs">
+                    <Tooltip label="Restore Snapshot">
+                      <ActionIcon
+                        color="blue"
+                        variant="subtle"
+                        onClick={() => { openRestoreSnapshotModal(datasetName); }}
+                      >
+                        <IconRefresh />
+                      </ActionIcon>
+                    </Tooltip>
+                    <Tooltip label="Delete Snapshot">
+                      <ActionIcon
+                        color="red"
+                        variant="subtle"
+                        onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(datasetName); }}
+                      >
+                        <IconTrashX />
+                      </ActionIcon>
+                    </Tooltip>
+                  </Flex>
+                </Flex>
+              ),
+            )
+            : <Text>No snapshots.</Text>}
+        </Box>
+      </Flex>
 
       <Modal
         opened={modalArchiveOpened}

--- a/src/analysis/management/ManageAccordion.tsx
+++ b/src/analysis/management/ManageAccordion.tsx
@@ -1,0 +1,28 @@
+import { Accordion, Container, Title } from '@mantine/core';
+import { DataManagementAccordionItem } from './DataManagementAccordionItem';
+import { RevisitModesAccordionItem } from './RevisitModesAccordionItem';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
+
+export default function ManageAccordion({ studyId, refresh }: { studyId: string, refresh: () => Promise<void> }) {
+  const { storageEngine } = useStorageEngine();
+
+  return (
+    <Container>
+      <Accordion
+        multiple
+        variant="contained"
+      >
+        <Accordion.Item key="modes" value="ReVISit Modes">
+          <Accordion.Control><Title order={5}>ReVISit Modes</Title></Accordion.Control>
+          <Accordion.Panel><RevisitModesAccordionItem studyId={studyId} /></Accordion.Panel>
+        </Accordion.Item>
+        <Accordion.Item key="dataManagement" value="Data Management">
+          <Accordion.Control disabled={storageEngine?.getEngine() === 'localStorage'}><Title order={5}>Data Management</Title></Accordion.Control>
+          <Accordion.Panel>
+            {storageEngine?.getEngine() !== 'localStorage' && <DataManagementAccordionItem studyId={studyId} refresh={refresh} />}
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+    </Container>
+  );
+}

--- a/src/analysis/management/RevisitModesAccordionItem.tsx
+++ b/src/analysis/management/RevisitModesAccordionItem.tsx
@@ -1,0 +1,61 @@
+import { Stack, Switch } from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
+
+export function RevisitModesAccordionItem({ studyId }: { studyId: string }) {
+  const { storageEngine } = useStorageEngine();
+
+  const [asyncStatus, setAsyncStatus] = useState(false);
+  const [dataCollectionEnabled, setDataCollectionEnabled] = useState(false);
+  const [studyNavigatorEnabled, setStudyNavigatorEnabled] = useState(false);
+  const [analyticsInterfacePubliclyAccessible, setAnalyticsInterfacePubliclyAccessible] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (storageEngine) {
+        const modes = await storageEngine.getModes(studyId);
+        setDataCollectionEnabled(modes.dataCollectionEnabled);
+        setStudyNavigatorEnabled(modes.studyNavigatorEnabled);
+        setAnalyticsInterfacePubliclyAccessible(modes.analyticsInterfacePubliclyAccessible);
+        setAsyncStatus(true);
+      }
+    };
+    fetchData();
+  }, [storageEngine, studyId]);
+
+  const handleSwitch = async (key: 'dataCollectionEnabled' | 'studyNavigatorEnabled' | 'analyticsInterfacePubliclyAccessible', value: boolean) => {
+    if (storageEngine) {
+      await storageEngine.setMode(studyId, key, value);
+
+      if (key === 'dataCollectionEnabled') {
+        setDataCollectionEnabled(value);
+      } else if (key === 'studyNavigatorEnabled') {
+        setStudyNavigatorEnabled(value);
+      } else if (key === 'analyticsInterfacePubliclyAccessible') {
+        setAnalyticsInterfacePubliclyAccessible(value);
+      }
+    }
+  };
+
+  return (
+    asyncStatus && (
+      <Stack>
+        <Switch
+          label="Data Collection Enabled"
+          checked={dataCollectionEnabled}
+          onChange={(event) => handleSwitch('dataCollectionEnabled', event.currentTarget.checked)}
+        />
+        <Switch
+          label="Study Navigator Enabled"
+          checked={studyNavigatorEnabled}
+          onChange={(event) => handleSwitch('studyNavigatorEnabled', event.currentTarget.checked)}
+        />
+        <Switch
+          label="Analytics Interface Publicly Accessible"
+          checked={analyticsInterfacePubliclyAccessible}
+          onChange={(event) => handleSwitch('analyticsInterfacePubliclyAccessible', event.currentTarget.checked)}
+        />
+      </Stack>
+    )
+  );
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -76,7 +76,7 @@ export function Shell({ globalConfig }: {
         ip: ip.ip,
       };
 
-      const participantSession = await storageEngine.initializeParticipantSession(searchParamsObject, activeConfig, metadata, urlParticipantId);
+      const participantSession = await storageEngine.initializeParticipantSession(studyId, searchParamsObject, activeConfig, metadata, urlParticipantId);
 
       // Initialize the redux stores
       const newStore = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, metadata, participantSession.answers);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -29,7 +29,6 @@ import { getStudyConfig } from '../utils/fetchConfig';
 import { ParticipantMetadata } from '../store/types';
 import { ErrorLoadingConfig } from './ErrorLoadingConfig';
 import ResourceNotFound from '../ResourceNotFound';
-import { useAuth } from '../store/hooks/useAuth';
 
 export function Shell({ globalConfig }: {
   globalConfig: GlobalConfig;
@@ -38,8 +37,6 @@ export function Shell({ globalConfig }: {
   const studyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedStudyConfig | null>(null);
   const isValidStudyId = globalConfig.configsList.includes(studyId);
-
-  const auth = useAuth();
 
   useEffect(() => {
     getStudyConfig(studyId, globalConfig).then((config) => {
@@ -82,7 +79,7 @@ export function Shell({ globalConfig }: {
       const participantSession = await storageEngine.initializeParticipantSession(searchParamsObject, activeConfig, metadata, urlParticipantId);
 
       // Initialize the redux stores
-      const newStore = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, metadata, participantSession.answers, auth.user.isAdmin);
+      const newStore = await studyStoreCreator(studyId, activeConfig, participantSession.sequence, metadata, participantSession.answers);
       setStore(newStore);
 
       // Initialize the routing
@@ -106,7 +103,7 @@ export function Shell({ globalConfig }: {
       }]);
     }
     initializeUserStoreRouting();
-  }, [storageEngine, activeConfig, studyId, searchParams, auth.user.isAdmin]);
+  }, [storageEngine, activeConfig, studyId, searchParams]);
 
   const routing = useRoutes(routes);
 

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -1,7 +1,7 @@
 import { AppShell } from '@mantine/core';
 import { Outlet } from 'react-router-dom';
 import {
-  useEffect, useRef,
+  useEffect, useMemo, useRef, useState,
 } from 'react';
 import debounce from 'lodash.debounce';
 import AppAside from './interface/AppAside';
@@ -13,6 +13,8 @@ import { EventType } from '../store/types';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
 import { WindowEventsContext } from '../store/hooks/useWindowEvents';
 import { useStoreSelector } from '../store/store';
+import { useStorageEngine } from '../storage/storageEngineHooks';
+import { useStudyId } from '../routes/utils';
 
 export function StepRenderer() {
   const windowEvents = useRef<EventType[]>([]);
@@ -20,7 +22,7 @@ export function StepRenderer() {
   const studyConfig = useStudyConfig();
   const windowEventDebounceTime = studyConfig.uiConfig.windowEventDebounceTime ?? 100;
 
-  const asideOpen = useStoreSelector((state) => state.showStudyBrowser);
+  const showStudyBrowser = useStoreSelector((state) => state.showStudyBrowser);
 
   // Attach event listeners
   useEffect(() => {
@@ -94,6 +96,21 @@ export function StepRenderer() {
 
   const sidebarWidth = studyConfig.uiConfig.sidebarWidth ?? 300;
 
+  const { storageEngine } = useStorageEngine();
+  const studyId = useStudyId();
+  const [studyNavigatorEnabled, setStudyNavigatorEnabled] = useState(false);
+  useEffect(() => {
+    const checkStudyNavigatorEnabled = async () => {
+      if (storageEngine) {
+        const modes = await storageEngine.getModes(studyId);
+        setStudyNavigatorEnabled(modes.studyNavigatorEnabled);
+      }
+    };
+    checkStudyNavigatorEnabled();
+  }, [storageEngine, studyId]);
+
+  const asideOpen = useMemo(() => studyNavigatorEnabled && showStudyBrowser, [studyNavigatorEnabled, showStudyBrowser]);
+
   return (
     <WindowEventsContext.Provider value={windowEvents}>
       <AppShell
@@ -104,7 +121,7 @@ export function StepRenderer() {
       >
         <AppNavBar />
         <AppAside />
-        <AppHeader />
+        <AppHeader studyNavigatorEnabled={studyNavigatorEnabled} />
         <HelpModal />
         <AlertModal />
         <AppShell.Main>

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -99,11 +99,13 @@ export function StepRenderer() {
   const { storageEngine } = useStorageEngine();
   const studyId = useStudyId();
   const [studyNavigatorEnabled, setStudyNavigatorEnabled] = useState(false);
+  const [dataCollectionEnabled, setDataCollectionEnabled] = useState(false);
   useEffect(() => {
     const checkStudyNavigatorEnabled = async () => {
       if (storageEngine) {
         const modes = await storageEngine.getModes(studyId);
         setStudyNavigatorEnabled(modes.studyNavigatorEnabled);
+        setDataCollectionEnabled(modes.dataCollectionEnabled);
       }
     };
     checkStudyNavigatorEnabled();
@@ -121,7 +123,7 @@ export function StepRenderer() {
       >
         <AppNavBar />
         <AppAside />
-        <AppHeader studyNavigatorEnabled={studyNavigatorEnabled} />
+        <AppHeader studyNavigatorEnabled={studyNavigatorEnabled} dataCollectionEnabled={dataCollectionEnabled} />
         <HelpModal />
         <AlertModal />
         <AppShell.Main>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -9,6 +9,7 @@ import { useStorageEngine } from '../storage/storageEngineHooks';
 import { useStoreSelector } from '../store/store';
 import { ParticipantData } from '../storage/types';
 import { download } from './downloader/DownloadTidy';
+import { useStudyId } from '../routes/utils';
 
 export function StudyEnd() {
   const studyConfig = useStudyConfig();
@@ -78,10 +79,22 @@ export function StudyEnd() {
     return () => {};
   }, [autoDownload, completed, delayCounter, downloadParticipant]);
 
+  const studyId = useStudyId();
+  const [dataCollectionEnabled, setDataCollectionEnabled] = useState(false);
+  useEffect(() => {
+    const checkStudyNavigatorEnabled = async () => {
+      if (storageEngine) {
+        const modes = await storageEngine.getModes(studyId);
+        setDataCollectionEnabled(modes.dataCollectionEnabled);
+      }
+    };
+    checkStudyNavigatorEnabled();
+  }, [storageEngine, studyId]);
+
   return (
     <Center style={{ height: '100%' }}>
       <Flex direction="column">
-        {completed
+        {completed || !dataCollectionEnabled
           ? (
             <Text size="xl" display="block">
               {studyConfig.uiConfig.studyEndMsg

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -40,10 +40,9 @@ function InfoHover({ text }: { text: string }) {
 }
 
 export default function AppAside() {
-  const { showStudyBrowser, sequence, metadata } = useStoreSelector((state) => state);
+  const { sequence, metadata } = useStoreSelector((state) => state);
   const { toggleStudyBrowser } = useStoreActions();
 
-  const currentComponent = useCurrentComponent();
   const studyConfig = useStudyConfig();
   const dispatch = useStoreDispatch();
 
@@ -61,7 +60,7 @@ export default function AppAside() {
 
   const [activeTab, setActiveTab] = useState<string | null>('participant');
 
-  return showStudyBrowser || (currentComponent === 'end' && studyConfig.uiConfig.autoDownloadStudy) ? (
+  return (
     <AppShell.Aside p="0">
       <AppShell.Section>
         <Flex direction="row" p="sm" justify="space-between" pb="xs">
@@ -114,5 +113,5 @@ export default function AppAside() {
         </Tabs>
       </AppShell.Section>
     </AppShell.Aside>
-  ) : null;
+  );
 }

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -98,52 +98,50 @@ export default function AppHeader({ studyNavigatorEnabled }: { studyNavigatorEna
               </Button>
             )}
 
-            {(import.meta.env.DEV || import.meta.env.VITE_REVISIT_MODE === 'public' || auth.user.isAdmin) && (
-              <Menu
-                shadow="md"
-                width={200}
-                withinPortal
-                opened={menuOpened}
-                onChange={setMenuOpened}
-              >
-                <Menu.Target>
-                  <ActionIcon size="lg" className="studyBrowserMenuDropdown" variant="subtle" color="gray">
-                    <IconDotsVertical />
-                  </ActionIcon>
-                </Menu.Target>
-                <Menu.Dropdown>
-                  {studyNavigatorEnabled && (
+            <Menu
+              shadow="md"
+              width={200}
+              withinPortal
+              opened={menuOpened}
+              onChange={setMenuOpened}
+            >
+              <Menu.Target>
+                <ActionIcon size="lg" className="studyBrowserMenuDropdown" variant="subtle" color="gray">
+                  <IconDotsVertical />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>
+                {studyNavigatorEnabled && (
                   <Menu.Item
                     leftSection={<IconSchema size={14} />}
                     onClick={() => storeDispatch(toggleStudyBrowser())}
                   >
                     Study Browser
                   </Menu.Item>
-                  )}
+                )}
 
-                  <Menu.Item
-                    component="a"
-                    href={
+                <Menu.Item
+                  component="a"
+                  href={
                       studyConfig !== null
                         ? `mailto:${studyConfig.uiConfig.contactEmail}`
                         : undefined
                     }
-                    leftSection={<IconMail size={14} />}
-                  >
-                    Contact
-                  </Menu.Item>
+                  leftSection={<IconMail size={14} />}
+                >
+                  Contact
+                </Menu.Item>
 
-                  {studyNavigatorEnabled && (
+                {studyNavigatorEnabled && (
                   <Menu.Item
                     leftSection={<IconUserPlus size={14} />}
                     onClick={() => getNewParticipant(storageEngine, studyConfig, metadata, studyHref)}
                   >
                     Next Participant
                   </Menu.Item>
-                  )}
-                </Menu.Dropdown>
-              </Menu>
-            )}
+                )}
+              </Menu.Dropdown>
+            </Menu>
           </Group>
         </Grid.Col>
       </Grid>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -27,10 +27,9 @@ import {
 } from '../../store/store';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { PREFIX } from '../../utils/Prefix';
-import { useAuth } from '../../store/hooks/useAuth';
 import { getNewParticipant } from '../../utils/nextParticipant';
 
-export default function AppHeader({ studyNavigatorEnabled }: { studyNavigatorEnabled: boolean }) {
+export default function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled }: { studyNavigatorEnabled: boolean; dataCollectionEnabled: boolean }) {
   const { config: studyConfig, metadata } = useStoreSelector((state) => state);
   const flatSequence = useFlatSequence();
   const storeDispatch = useStoreDispatch();
@@ -38,8 +37,6 @@ export default function AppHeader({ studyNavigatorEnabled }: { studyNavigatorEna
   const { storageEngine } = useStorageEngine();
 
   const currentStep = useCurrentStep();
-
-  const auth = useAuth();
 
   const progressBarMax = flatSequence.length - 1;
   const progressPercent = typeof currentStep === 'number' ? (currentStep / progressBarMax) * 100 : 0;
@@ -88,7 +85,7 @@ export default function AppHeader({ studyNavigatorEnabled }: { studyNavigatorEna
 
         <Grid.Col span={4}>
           <Group wrap="nowrap" justify="right">
-            {import.meta.env.VITE_REVISIT_MODE === 'public' ? <Tooltip multiline withArrow arrowSize={6} w={300} label="This is a demo version of the study, we’re not collecting any data. Navigate the study via the study browser on the right."><Badge size="lg" color="orange">Demo Mode</Badge></Tooltip> : null}
+            {!dataCollectionEnabled && <Tooltip multiline withArrow arrowSize={6} w={300} label="This is a demo version of the study, we’re not collecting any data."><Badge size="lg" color="orange">Demo Mode</Badge></Tooltip>}
             {studyConfig?.uiConfig.helpTextPath !== undefined && (
               <Button
                 variant="outline"

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -30,7 +30,7 @@ import { PREFIX } from '../../utils/Prefix';
 import { useAuth } from '../../store/hooks/useAuth';
 import { getNewParticipant } from '../../utils/nextParticipant';
 
-export default function AppHeader() {
+export default function AppHeader({ studyNavigatorEnabled }: { studyNavigatorEnabled: boolean }) {
   const { config: studyConfig, metadata } = useStoreSelector((state) => state);
   const flatSequence = useFlatSequence();
   const storeDispatch = useStoreDispatch();
@@ -112,12 +112,14 @@ export default function AppHeader() {
                   </ActionIcon>
                 </Menu.Target>
                 <Menu.Dropdown>
+                  {studyNavigatorEnabled && (
                   <Menu.Item
                     leftSection={<IconSchema size={14} />}
                     onClick={() => storeDispatch(toggleStudyBrowser())}
                   >
                     Study Browser
                   </Menu.Item>
+                  )}
 
                   <Menu.Item
                     component="a"
@@ -131,12 +133,14 @@ export default function AppHeader() {
                     Contact
                   </Menu.Item>
 
+                  {studyNavigatorEnabled && (
                   <Menu.Item
                     leftSection={<IconUserPlus size={14} />}
                     onClick={() => getNewParticipant(storageEngine, studyConfig, metadata, studyHref)}
                   >
                     Next Participant
                   </Menu.Item>
+                  )}
                 </Menu.Dropdown>
               </Menu>
             )}

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -36,7 +36,7 @@ export default function ComponentController() {
   const storeDispatch = useStoreDispatch();
   const { setAlertModal } = useStoreActions();
   useEffect(() => {
-    if (storageEngine?.getEngine() !== import.meta.env.VITE_STORAGE_ENGINE && import.meta.env.VITE_REVISIT_MODE !== 'public') {
+    if (storageEngine?.getEngine() !== import.meta.env.VITE_STORAGE_ENGINE) {
       storeDispatch(setAlertModal({
         show: true,
         message: `There was an issue connecting to the ${import.meta.env.VITE_STORAGE_ENGINE} database. This could be caused by a network issue or your adblocker. If you are using an adblocker, please disable it for this website and refresh.`,

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -83,12 +83,6 @@ export class FirebaseStorageEngine extends StorageEngine {
     try {
       await enableNetwork(this.firestore);
 
-      const auth = getAuth();
-      if (!auth.currentUser) {
-        await signInAnonymously(auth);
-        if (!auth.currentUser) throw new Error('Login failed with firebase');
-      }
-
       this.connected = true;
     } catch (e) {
       console.warn('Failed to connect to Firebase');
@@ -97,6 +91,12 @@ export class FirebaseStorageEngine extends StorageEngine {
 
   async initializeStudyDb(studyId: string, config: StudyConfig) {
     try {
+      const auth = getAuth();
+      if (!auth.currentUser) {
+        await signInAnonymously(auth);
+        if (!auth.currentUser) throw new Error('Login failed with firebase');
+      }
+
       const currentConfigHash = await this.getCurrentConfigHash();
       // Hash the config
       const configHash = await hash(JSON.stringify(config));

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -127,7 +127,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
-  async initializeParticipantSession(searchParams: Record<string, string>, config: StudyConfig, metadata: ParticipantMetadata, urlParticipantId?: string) {
+  async initializeParticipantSession(studyId: string, searchParams: Record<string, string>, config: StudyConfig, metadata: ParticipantMetadata, urlParticipantId?: string) {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -140,6 +140,9 @@ export class FirebaseStorageEngine extends StorageEngine {
 
     // Check if the participant has already been initialized
     const participant = await this._getFromFirebaseStorage(`participants/${this.currentParticipantId}`, 'participantData');
+
+    // Get modes
+    const modes = await this.getModes(studyId);
 
     if (isParticipantData(participant)) {
       // Participant already initialized
@@ -158,7 +161,10 @@ export class FirebaseStorageEngine extends StorageEngine {
       completed: false,
       rejected: false,
     };
-    await this._pushToFirebaseStorage(`participants/${this.currentParticipantId}`, 'participantData', this.participantData);
+
+    if (modes.dataCollectionEnabled) {
+      await this._pushToFirebaseStorage(`participants/${this.currentParticipantId}`, 'participantData', this.participantData);
+    }
 
     return this.participantData;
   }
@@ -250,6 +256,9 @@ export class FirebaseStorageEngine extends StorageEngine {
       throw new Error('Latin square not initialized');
     }
 
+    // Get modes
+    const modes = await this.getModes(this.studyId);
+
     // Note intent to get a sequence in the sequenceAssignment collection
     const sequenceAssignmentDoc = doc(this.studyCollection, 'sequenceAssignment');
     // Initializes document
@@ -262,9 +271,11 @@ export class FirebaseStorageEngine extends StorageEngine {
     if (rejectedDocs.docs.length > 0) {
       const firstReject = rejectedDocs.docs[0];
       const firstRejectTime = firstReject.data().timestamp;
-      await deleteDoc(firstReject.ref);
-      await setDoc(participantSequenceAssignmentDoc, { participantId: this.currentParticipantId, timestamp: firstRejectTime });
-    } else {
+      if (modes.dataCollectionEnabled) {
+        await deleteDoc(firstReject.ref);
+        await setDoc(participantSequenceAssignmentDoc, { participantId: this.currentParticipantId, timestamp: firstRejectTime });
+      }
+    } else if (modes.dataCollectionEnabled) {
       await setDoc(participantSequenceAssignmentDoc, { participantId: this.currentParticipantId, timestamp: serverTimestamp() });
     }
 
@@ -274,8 +285,9 @@ export class FirebaseStorageEngine extends StorageEngine {
     const intents = intentDocs.docs.map((intent) => intent.data());
 
     // Get the current row
-    const intentIndex = intents.findIndex((intent) => intent.participantId === this.currentParticipantId);
-    const currentRow = sequenceArray[intentIndex % sequenceArray.length];
+    const intentIndex = intents.findIndex((intent) => intent.participantId === this.currentParticipantId) % sequenceArray.length;
+    const selectedIndex = intentIndex === -1 ? Math.floor(Math.random() * sequenceArray.length - 1) : intentIndex;
+    const currentRow = sequenceArray[selectedIndex];
 
     if (!currentRow) {
       throw new Error('Latin square is empty');
@@ -321,7 +333,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return isParticipantData(participantData) ? participantData : null;
   }
 
-  async nextParticipant(config: StudyConfig, metadata: ParticipantMetadata): Promise<ParticipantData> {
+  async nextParticipant() {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -331,23 +343,6 @@ export class FirebaseStorageEngine extends StorageEngine {
 
     // Set current participant id
     await this.localForage.setItem('currentParticipantId', newParticipantId);
-    this.currentParticipantId = newParticipantId;
-
-    const participantConfigHash = await hash(JSON.stringify(config));
-    // Generate a new participant
-    const newParticipantData: ParticipantData = {
-      participantId: newParticipantId,
-      participantConfigHash,
-      sequence: await this.getSequence(),
-      answers: {},
-      searchParams: {},
-      metadata,
-      completed: false,
-      rejected: false,
-    };
-    await this._pushToFirebaseStorage(`participants/${newParticipantId}`, 'participantData', newParticipantData);
-
-    return newParticipantData;
   }
 
   async verifyCompletion() {
@@ -365,8 +360,13 @@ export class FirebaseStorageEngine extends StorageEngine {
       throw new Error('Participant not initialized');
     }
 
+    // Get modes
+    const modes = await this.getModes(this.studyId);
+
     this.participantData.completed = true;
-    await this._pushToFirebaseStorage(`participants/${this.currentParticipantId}`, 'participantData', this.participantData);
+    if (modes.dataCollectionEnabled) {
+      await this._pushToFirebaseStorage(`participants/${this.currentParticipantId}`, 'participantData', this.participantData);
+    }
 
     return true;
   }

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -48,7 +48,7 @@ export abstract class StorageEngine {
 
   abstract initializeStudyDb(studyId: string, config: StudyConfig): Promise<void>;
 
-  abstract initializeParticipantSession(searchParams: Record<string, string>, config: StudyConfig, metadata: ParticipantMetadata, urlParticipantId?: string): Promise<ParticipantData>;
+  abstract initializeParticipantSession(studyId: string, searchParams: Record<string, string>, config: StudyConfig, metadata: ParticipantMetadata, urlParticipantId?: string): Promise<ParticipantData>;
 
   abstract getCurrentConfigHash(): Promise<string>;
 
@@ -70,7 +70,7 @@ export abstract class StorageEngine {
 
   abstract getParticipantData(): Promise<ParticipantData | null>;
 
-  abstract nextParticipant(config: StudyConfig, metadata: ParticipantMetadata): Promise<ParticipantData>;
+  abstract nextParticipant(): Promise<void>;
 
   abstract verifyCompletion(answers: Record<string, StoredAnswer>): Promise<boolean>;
 

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -23,6 +23,8 @@ export interface UserWrapped {
   adminVerification:boolean
 }
 
+export type REVISIT_MODE = 'dataCollectionEnabled' | 'studyNavigatorEnabled' | 'analyticsInterfacePubliclyAccessible';
+
 export abstract class StorageEngine {
   protected engine: string;
 
@@ -75,4 +77,8 @@ export abstract class StorageEngine {
   abstract validateUser(user: UserWrapped | null): Promise<boolean>;
 
   abstract rejectParticipant(studyId: string, participantID: string): Promise<void>;
+
+  abstract setMode(studyId: string, mode: REVISIT_MODE, value: boolean): Promise<void>;
+
+  abstract getModes(studyId: string): Promise<Record<REVISIT_MODE, boolean>>;
 }

--- a/src/storage/initialize.ts
+++ b/src/storage/initialize.ts
@@ -6,7 +6,7 @@ export async function initializeStorageEngine() {
   let storageEngine: StorageEngine | undefined;
   let fallback = false;
 
-  const storageEngineName: string = import.meta.env.VITE_REVISIT_MODE === 'public' ? 'localStorage' : import.meta.env.VITE_STORAGE_ENGINE;
+  const storageEngineName: string = import.meta.env.VITE_STORAGE_ENGINE;
 
   if (storageEngineName === 'firebase') {
     const firebaseStorageEngine = new FirebaseStorageEngine();

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -1,4 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import {
+  useCallback, useEffect, useMemo, useState,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   useStoreSelector,
@@ -51,6 +53,19 @@ export function useNextStep() {
   const { saveTrialAnswer, setIframeAnswers } = useStoreActions();
   const { storageEngine } = useStorageEngine();
 
+  const studyId = useStudyId();
+
+  const [dataCollectionEnabled, setDataCollectionEnabled] = useState(true);
+  useEffect(() => {
+    const checkStudyNavigatorEnabled = async () => {
+      if (storageEngine) {
+        const modes = await storageEngine.getModes(studyId);
+        setDataCollectionEnabled(modes.dataCollectionEnabled);
+      }
+    };
+    checkStudyNavigatorEnabled();
+  }, [storageEngine, studyId]);
+
   const areResponsesValid = useAreResponsesValid(identifier);
 
   // Status of the next button. If false, the next button should be disabled
@@ -61,8 +76,6 @@ export function useNextStep() {
   const navigate = useNavigate();
 
   const studyConfig = useStudyConfig();
-
-  const studyId = useStudyId();
 
   const startTime = useMemo(() => Date.now(), []);
 
@@ -85,7 +98,7 @@ export function useNextStep() {
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
-    if (!storedAnswer.endTime) {
+    if (dataCollectionEnabled && !storedAnswer.endTime) {
       storeDispatch(
         saveTrialAnswer({
           identifier,

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -13,7 +13,6 @@ export async function studyStoreCreator(
   sequence: Sequence,
   metadata: ParticipantMetadata,
   answers: Record<string, StoredAnswer>,
-  isAdmin: boolean,
 ) {
   const flatSequence = getSequenceFlatMap(sequence);
 
@@ -36,7 +35,7 @@ export async function studyStoreCreator(
     answers: Object.keys(answers).length > 0 ? answers : emptyAnswers,
     sequence,
     config,
-    showStudyBrowser: import.meta.env.VITE_REVISIT_MODE === 'public' || isAdmin,
+    showStudyBrowser: true,
     showHelpText: false,
     alertModal: { show: false, message: '' },
     trialValidation: answers ? allValid : emptyValidation,

--- a/src/utils/nextParticipant.ts
+++ b/src/utils/nextParticipant.ts
@@ -3,7 +3,7 @@ import { StorageEngine } from '../storage/engines/StorageEngine';
 import { ParticipantMetadata } from '../store/types';
 
 export function getNewParticipant(storageEngine: StorageEngine | undefined, studyConfig: StudyConfig, metadata: ParticipantMetadata, studyHref: string) {
-  storageEngine?.nextParticipant(studyConfig, metadata)
+  storageEngine?.nextParticipant()
     .then(() => {
       window.location.href = studyHref;
     })

--- a/src/utils/useDisableBrowserBack.tsx
+++ b/src/utils/useDisableBrowserBack.tsx
@@ -10,10 +10,7 @@ export function useDisableBrowserBack() {
   const storeDispatch = useStoreDispatch();
 
   useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const isAdmin = (searchParams.get('admin') || 'f') === 't';
-
-    if (import.meta.env.PROD && !isAdmin && import.meta.env.VITE_REVISIT_MODE !== 'public') {
+    if (import.meta.env.PROD) {
       window.history.pushState(null, '', window.location.href);
       window.onpopstate = () => {
         window.history.pushState(null, '', window.location.href);

--- a/tests/test-randomization.spec.ts
+++ b/tests/test-randomization.spec.ts
@@ -137,6 +137,6 @@ test('test', async ({ page }) => {
   await page.locator('.studyBrowserMenuDropdown').click();
   await page.getByRole('menuitem', { name: 'Study Browser' }).click();
 
-  const sequenceHeader = await page.getByText('Study Browser');
+  const sequenceHeader = await page.locator('#root').getByText('Study Browser');
   await expect(sequenceHeader).toBeVisible();
 });


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #407 

### Give a longer description of what this PR addresses and why it's needed
This adds revisit modes for dataCollectionEnabled, studyBrowser, and analysisPublic. This allows us to toggle the settings from the firebase/UI and let's the application react according for debugging, etc.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1624" alt="Screenshot 2024-06-20 at 2 14 49 PM" src="https://github.com/revisit-studies/study/assets/36867477/c18022fd-30f5-4e52-a911-450eabf8307a">


### Are there any additional TODOs before this PR is ready to go?
No