### PR TITLE
Adding download snapshots

### DIFF
--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,5 +1,5 @@
 import {
-  Badge, Button, Card, Text, Container, Flex, Image, LoadingOverlay,
+  Button, Card, Text, Container, Flex, Image, LoadingOverlay,
 } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import {
@@ -12,19 +12,21 @@ import { useAuth } from './store/hooks/useAuth';
 import { useStorageEngine } from './storage/storageEngineHooks';
 import { FirebaseStorageEngine } from './storage/engines/FirebaseStorageEngine';
 import { StorageEngine } from './storage/engines/StorageEngine';
+import { showNotification } from './utils/notifications';
 
-export async function signInWithGoogle(storageEngine: StorageEngine | undefined, setLoading: (val: boolean) => void, setErrorMessage?: (val: string) => void) {
+export async function signInWithGoogle(storageEngine: StorageEngine | undefined, setLoading: (val: boolean) => void) {
   if (storageEngine instanceof FirebaseStorageEngine) {
     setLoading(true);
     const provider = new GoogleAuthProvider();
     const auth = getAuth();
     try {
       await signInWithPopup(auth, provider, browserPopupRedirectResolver);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      if (setErrorMessage) {
-        setErrorMessage(error.message);
-      }
+      showNotification({ title: 'Error', message: error.message, color: 'red' });
+      // if (setErrorMessage) {
+      //   setErrorMessage(error.message);
+      // }
     } finally {
       setLoading(false);
     }
@@ -35,13 +37,13 @@ export async function signInWithGoogle(storageEngine: StorageEngine | undefined,
 
 export function Login() {
   const { user } = useAuth();
-  const [errorMessage, setErrorMessage] = useState<string|null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const { storageEngine } = useStorageEngine();
 
   useEffect(() => {
     if (!user.determiningStatus && !user.isAdmin && user.adminVerification) {
-      setErrorMessage('You are not authorized to use this application.');
+      // setErrorMessage('You are not authorized to use this application.');
+      showNotification({ title: 'Unauthorized', message: 'You are not authorized to use this application.', color: 'red' });
     }
   }, [user.adminVerification]);
 
@@ -56,9 +58,8 @@ export function Login() {
           <Image maw={200} mt={50} mb={100} src={`${PREFIX}revisitAssets/revisitLogoSquare.svg`} alt="Revisit Logo" />
           <>
             <Text mb={20}>To access admin settings, please sign in using your Google account.</Text>
-            <Button onClick={() => signInWithGoogle(storageEngine, setLoading, setErrorMessage)} leftSection={<IconBrandGoogleFilled />} variant="filled">Sign In With Google</Button>
+            <Button onClick={() => signInWithGoogle(storageEngine, setLoading)} leftSection={<IconBrandGoogleFilled />} variant="filled">Sign In With Google</Button>
           </>
-          {errorMessage ? <Badge size="lg" color="red" mt={30}>{errorMessage}</Badge> : null}
           <LoadingOverlay visible={loading} />
         </Flex>
       </Card>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -24,9 +24,6 @@ export async function signInWithGoogle(storageEngine: StorageEngine | undefined,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       showNotification({ title: 'Error', message: error.message, color: 'red' });
-      // if (setErrorMessage) {
-      //   setErrorMessage(error.message);
-      // }
     } finally {
       setLoading(false);
     }
@@ -42,7 +39,6 @@ export function Login() {
 
   useEffect(() => {
     if (!user.determiningStatus && !user.isAdmin && user.adminVerification) {
-      // setErrorMessage('You are not authorized to use this application.');
       showNotification({ title: 'Unauthorized', message: 'You are not authorized to use this application.', color: 'red' });
     }
   }, [user.adminVerification]);

--- a/src/analysis/dashboard/StudyCard.tsx
+++ b/src/analysis/dashboard/StudyCard.tsx
@@ -1,11 +1,11 @@
 import {
-  Box, Button, Card, Center, Text, Title, Container, Flex, Group, Popover,
+  Box, Button, Card, Center, Text, Title, Container, Flex, Group, Tooltip,
 } from '@mantine/core';
 import React, { useMemo, useState } from 'react';
 import { IconChartHistogram } from '@tabler/icons-react';
 import { DatePickerInput } from '@mantine/dates';
 import { VegaLite } from 'react-vega';
-import { useDisclosure, useResizeObserver } from '@mantine/hooks';
+import { useResizeObserver } from '@mantine/hooks';
 import { useNavigate } from 'react-router-dom';
 import { ParticipantData } from '../../storage/types';
 import { StoredAnswer } from '../../parser/types';
@@ -76,8 +76,6 @@ export function StudyCard({ studyId, allParticipants }: { studyId: string; allPa
     data: { values: completedStatsData },
   }), [dms.width, rangeTime, completedStatsData]);
 
-  const [checkOpened, { close: closeCheck, open: openCheck }] = useDisclosure(false);
-
   return (
     <Container>
       <Card ref={ref} padding="lg" shadow="md" withBorder>
@@ -88,24 +86,16 @@ export function StudyCard({ studyId, allParticipants }: { studyId: string; allPa
           </Flex>
           <Group>
             <DownloadButtons allParticipants={allParticipants} studyId={studyId} />
-
-            <Popover opened={checkOpened}>
-              <Popover.Target>
-                <Button
-                  onClick={(event) => { if (!event.ctrlKey && !event.metaKey) { event.preventDefault(); navigate(`/analysis/stats/${studyId}`); } }}
-                  onMouseEnter={openCheck}
-                  onMouseLeave={closeCheck}
-                  px={4}
-                  component="a"
-                  href={`${PREFIX}analysis/stats/${studyId}`}
-                >
-                  <IconChartHistogram />
-                </Button>
-              </Popover.Target>
-              <Popover.Dropdown>
-                <Text>Analyze and manage study data</Text>
-              </Popover.Dropdown>
-            </Popover>
+            <Tooltip label="Analyze and manage study data">
+              <Button
+                onClick={(event) => { if (!event.ctrlKey && !event.metaKey) { event.preventDefault(); navigate(`/analysis/stats/${studyId}`); } }}
+                px={4}
+                component="a"
+                href={`${PREFIX}analysis/stats/${studyId}`}
+              >
+                <IconChartHistogram />
+              </Button>
+            </Tooltip>
           </Group>
         </Flex>
 

--- a/src/analysis/individualStudy/management/DataManagementAccordionItem.tsx
+++ b/src/analysis/individualStudy/management/DataManagementAccordionItem.tsx
@@ -10,7 +10,6 @@ import { DownloadButtons } from '../../../components/downloader/DownloadButtons'
 import {
   FirebaseStorageEngine, FirebaseActionResponse, SnapshotNameItem,
 } from '../../../storage/engines/FirebaseStorageEngine';
-import { ParticipantData } from '../../../storage/types';
 
 export function DataManagementAccordionItem({ studyId, refresh }: { studyId: string, refresh: () => Promise<void> }) {
   const [modalArchiveOpened, setModalArchiveOpened] = useState<boolean>(false);

--- a/src/analysis/individualStudy/management/DataManagementAccordionItem.tsx
+++ b/src/analysis/individualStudy/management/DataManagementAccordionItem.tsx
@@ -134,10 +134,9 @@ export function DataManagementAccordionItem({ studyId, refresh }: { studyId: str
     return null;
   };
 
-  const fetchParticipants = async (snapshotName: string): Promise<ParticipantData[]> => {
+  const fetchParticipants = async (snapshotName: string) => {
     const strippedFilename = snapshotName.slice(snapshotName.indexOf('-') + 1);
-    const participants = await storageEngine.getAllParticipantsDataByStudy(strippedFilename);
-    return participants;
+    return await storageEngine.getAllParticipantsDataByStudy(strippedFilename);
   };
   return (
     <>

--- a/src/analysis/individualStudy/management/DataManagementAccordionItem.tsx
+++ b/src/analysis/individualStudy/management/DataManagementAccordionItem.tsx
@@ -1,14 +1,16 @@
 import {
-  Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, ActionIcon, Space, Table,
+  Text, LoadingOverlay, Box, Title, Flex, Modal, TextInput, Button, Tooltip, Space, Table,
 } from '@mantine/core';
 import { useCallback, useEffect, useState } from 'react';
 import { IconTrashX, IconRefresh, IconPencil } from '@tabler/icons-react';
 import { openConfirmModal } from '@mantine/modals';
 import { useStorageEngine } from '../../../storage/storageEngineHooks';
 import { showNotification, RevisitNotification } from '../../../utils/notifications';
+import { DownloadButtons } from '../../../components/downloader/DownloadButtons';
 import {
   FirebaseStorageEngine, FirebaseActionResponse, SnapshotNameItem,
 } from '../../../storage/engines/FirebaseStorageEngine';
+import { ParticipantData } from '../../../storage/types';
 
 export function DataManagementAccordionItem({ studyId, refresh }: { studyId: string, refresh: () => Promise<void> }) {
   const [modalArchiveOpened, setModalArchiveOpened] = useState<boolean>(false);
@@ -131,6 +133,12 @@ export function DataManagementAccordionItem({ studyId, refresh }: { studyId: str
     }
     return null;
   };
+
+  const fetchParticipants = async (snapshotName: string): Promise<ParticipantData[]> => {
+    const strippedFilename = snapshotName.slice(snapshotName.indexOf('-') + 1);
+    const participants = await storageEngine.getAllParticipantsDataByStudy(strippedFilename);
+    return participants;
+  };
   return (
     <>
       <LoadingOverlay visible={loading} />
@@ -226,37 +234,43 @@ export function DataManagementAccordionItem({ studyId, refresh }: { studyId: str
                         <Table.Td>{snapshotItem.alternateName}</Table.Td>
                         <Table.Td>{getDateFromSnapshotName(snapshotItem.originalName)}</Table.Td>
                         <Table.Td>
-                          <Tooltip label="Rename">
-                            <ActionIcon
-                              color="green"
-                              variant="subtle"
-                              style={{ margin: '0px 5px 0px 0px' }}
-                              onClick={() => { setModalRenameSnapshotOpened(true); setCurrentSnapshot(snapshotItem.originalName); }}
-                            >
-                              <IconPencil />
-                            </ActionIcon>
-                          </Tooltip>
-                          <Tooltip label="Restore Snapshot">
-                            <ActionIcon
-                              color="blue"
-                              variant="subtle"
-                              style={{ margin: '0px 5px' }}
-                              onClick={() => { openRestoreSnapshotModal(snapshotItem.originalName); }}
-                            >
-                              <IconRefresh />
-                            </ActionIcon>
-                          </Tooltip>
+                          <Flex>
+                            <Tooltip label="Rename">
+                              <Button
+                                color="green"
+                                variant="light"
+                                px={4}
+                                style={{ margin: '0px 5px' }}
+                                onClick={() => { setModalRenameSnapshotOpened(true); setCurrentSnapshot(snapshotItem.originalName); }}
+                              >
+                                <IconPencil />
+                              </Button>
+                            </Tooltip>
+                            <Tooltip label="Restore Snapshot">
+                              <Button
+                                color="blue"
+                                variant="light"
+                                px={4}
+                                style={{ margin: '0px 5px' }}
+                                onClick={() => { openRestoreSnapshotModal(snapshotItem.originalName); }}
+                              >
+                                <IconRefresh />
+                              </Button>
+                            </Tooltip>
 
-                          <Tooltip label="Delete Snapshot">
-                            <ActionIcon
-                              color="red"
-                              variant="subtle"
-                              style={{ margin: '0px 5px' }}
-                              onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(snapshotItem.originalName); }}
-                            >
-                              <IconTrashX />
-                            </ActionIcon>
-                          </Tooltip>
+                            <Tooltip label="Delete Snapshot">
+                              <Button
+                                color="red"
+                                px={4}
+                                variant="light"
+                                style={{ margin: '0px 10px 0px 5px' }}
+                                onClick={() => { setModalDeleteSnapshotOpened(true); setCurrentSnapshot(snapshotItem.originalName); }}
+                              >
+                                <IconTrashX />
+                              </Button>
+                            </Tooltip>
+                            <DownloadButtons allParticipants={() => fetchParticipants(snapshotItem.originalName)} studyId={studyId} gap="10px" fileName={snapshotItem.alternateName} />
+                          </Flex>
                         </Table.Td>
                       </Table.Tr>
                     ),

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -1,5 +1,5 @@
 import {
-  Popover, Button, Text, Group,
+  Button, Group, Tooltip,
 } from '@mantine/core';
 import { IconDatabaseExport, IconTableExport } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -12,8 +12,8 @@ type ParticipantDataFetcher = ParticipantData[] | (() => Promise<ParticipantData
 export function DownloadButtons({
   allParticipants, studyId, gap, fileName,
 }: { allParticipants: ParticipantDataFetcher; studyId: string, gap?: string, fileName?: string }) {
-  const [jsonOpened, { close: closeJson, open: openJson }] = useDisclosure(false);
-  const [csvOpened, { close: closeCsv, open: openCsv }] = useDisclosure(false);
+  // const [jsonOpened, { close: closeJson, open: openJson }] = useDisclosure(false);
+  // const [csvOpened, { close: closeCsv, open: openCsv }] = useDisclosure(false);
   const [openDownload, { open, close }] = useDisclosure(false);
   const [participants, setParticipants] = useState<ParticipantData[]>([]);
 
@@ -37,40 +37,44 @@ export function DownloadButtons({
   return (
     <>
       <Group style={{ gap }}>
-        <Popover opened={jsonOpened}>
-          <Popover.Target>
-            <Button
-              variant="light"
-              disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
-              onClick={handleDownloadJSON}
-              onMouseEnter={openJson}
-              onMouseLeave={closeJson}
-              px={4}
-            >
-              <IconDatabaseExport />
-            </Button>
-          </Popover.Target>
+        {/* <Popover opened={jsonOpened}>
+          <Popover.Target> */}
+        <Tooltip label="Download all participants data as JSON">
+          <Button
+            variant="light"
+            disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
+            onClick={handleDownloadJSON}
+            // onMouseEnter={openJson}
+            // onMouseLeave={closeJson}
+            px={4}
+          >
+            <IconDatabaseExport />
+          </Button>
+        </Tooltip>
+        {/* </Popover.Target>
           <Popover.Dropdown>
             <Text>Download all participants data as JSON</Text>
           </Popover.Dropdown>
-        </Popover>
-        <Popover opened={csvOpened}>
-          <Popover.Target>
-            <Button
-              variant="light"
-              disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
-              onClick={handleOpenTidy}
-              onMouseEnter={openCsv}
-              onMouseLeave={closeCsv}
-              px={4}
-            >
-              <IconTableExport />
-            </Button>
-          </Popover.Target>
+        </Popover> */}
+        {/* <Popover opened={csvOpened}>
+          <Popover.Target> */}
+        <Tooltip label="Download all participants data as a tidy CSV">
+          <Button
+            variant="light"
+            disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
+            onClick={handleOpenTidy}
+            // onMouseEnter={openCsv}
+            // onMouseLeave={closeCsv}
+            px={4}
+          >
+            <IconTableExport />
+          </Button>
+        </Tooltip>
+        {/* </Popover.Target>
           <Popover.Dropdown>
             <Text>Download all participants data as a tidy CSV</Text>
           </Popover.Dropdown>
-        </Popover>
+        </Popover> */}
       </Group>
 
       {openDownload && participants.length > 0 && (

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -12,8 +12,6 @@ type ParticipantDataFetcher = ParticipantData[] | (() => Promise<ParticipantData
 export function DownloadButtons({
   allParticipants, studyId, gap, fileName,
 }: { allParticipants: ParticipantDataFetcher; studyId: string, gap?: string, fileName?: string }) {
-  // const [jsonOpened, { close: closeJson, open: openJson }] = useDisclosure(false);
-  // const [csvOpened, { close: closeCsv, open: openCsv }] = useDisclosure(false);
   const [openDownload, { open, close }] = useDisclosure(false);
   const [participants, setParticipants] = useState<ParticipantData[]>([]);
 
@@ -37,44 +35,26 @@ export function DownloadButtons({
   return (
     <>
       <Group style={{ gap }}>
-        {/* <Popover opened={jsonOpened}>
-          <Popover.Target> */}
         <Tooltip label="Download all participants data as JSON">
           <Button
             variant="light"
             disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
             onClick={handleDownloadJSON}
-            // onMouseEnter={openJson}
-            // onMouseLeave={closeJson}
             px={4}
           >
             <IconDatabaseExport />
           </Button>
         </Tooltip>
-        {/* </Popover.Target>
-          <Popover.Dropdown>
-            <Text>Download all participants data as JSON</Text>
-          </Popover.Dropdown>
-        </Popover> */}
-        {/* <Popover opened={csvOpened}>
-          <Popover.Target> */}
         <Tooltip label="Download all participants data as a tidy CSV">
           <Button
             variant="light"
             disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
             onClick={handleOpenTidy}
-            // onMouseEnter={openCsv}
-            // onMouseLeave={closeCsv}
             px={4}
           >
             <IconTableExport />
           </Button>
         </Tooltip>
-        {/* </Popover.Target>
-          <Popover.Dropdown>
-            <Text>Download all participants data as a tidy CSV</Text>
-          </Popover.Dropdown>
-        </Popover> */}
       </Group>
 
       {openDownload && participants.length > 0 && (

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -2,26 +2,47 @@ import {
   Popover, Button, Text, Group,
 } from '@mantine/core';
 import { IconDatabaseExport, IconTableExport } from '@tabler/icons-react';
+import { useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { DownloadTidy, download } from './DownloadTidy';
 import { ParticipantData } from '../../storage/types';
 
-export function DownloadButtons({ allParticipants, studyId }: { allParticipants: ParticipantData[]; studyId: string }) {
+type ParticipantDataFetcher = ParticipantData[] | (() => Promise<ParticipantData[]>);
+
+export function DownloadButtons({
+  allParticipants, studyId, gap, fileName,
+}: { allParticipants: ParticipantDataFetcher; studyId: string, gap?: string, fileName?: string }) {
   const [jsonOpened, { close: closeJson, open: openJson }] = useDisclosure(false);
   const [csvOpened, { close: closeCsv, open: openCsv }] = useDisclosure(false);
   const [openDownload, { open, close }] = useDisclosure(false);
+  const [participants, setParticipants] = useState<ParticipantData[]>([]);
+
+  const fetchParticipants = async () => {
+    const currParticipants = typeof allParticipants === 'function' ? await allParticipants() : allParticipants;
+    return currParticipants;
+  };
+
+  const handleDownloadJSON = async () => {
+    const currParticipants = await fetchParticipants();
+    const currFileName = fileName ? `${fileName}.json` : `${studyId}_all.json`;
+    download(JSON.stringify(currParticipants, null, 2), currFileName);
+  };
+
+  const handleOpenTidy = async () => {
+    const currParticipants = await fetchParticipants();
+    setParticipants(currParticipants);
+    open();
+  };
 
   return (
     <>
-      <Group>
+      <Group style={{ gap }}>
         <Popover opened={jsonOpened}>
           <Popover.Target>
             <Button
               variant="light"
-              disabled={allParticipants.length === 0}
-              onClick={() => {
-                download(JSON.stringify(allParticipants, null, 2), `${studyId}_all.json`);
-              }}
+              disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
+              onClick={handleDownloadJSON}
               onMouseEnter={openJson}
               onMouseLeave={closeJson}
               px={4}
@@ -37,8 +58,8 @@ export function DownloadButtons({ allParticipants, studyId }: { allParticipants:
           <Popover.Target>
             <Button
               variant="light"
-              disabled={allParticipants.length === 0}
-              onClick={open}
+              disabled={allParticipants.length === 0 && typeof allParticipants !== 'function'}
+              onClick={handleOpenTidy}
               onMouseEnter={openCsv}
               onMouseLeave={closeCsv}
               px={4}
@@ -52,14 +73,14 @@ export function DownloadButtons({ allParticipants, studyId }: { allParticipants:
         </Popover>
       </Group>
 
-      {openDownload && (
-      <DownloadTidy
-        opened={openDownload}
-        close={close}
-        filename={`${studyId}_all_tidy.csv`}
-        data={allParticipants}
-        studyId={studyId}
-      />
+      {openDownload && participants.length > 0 && (
+        <DownloadTidy
+          opened={openDownload}
+          close={close}
+          filename={fileName ? `${fileName}_tidy.csv` : `${studyId}_all_tidy.csv`}
+          data={participants}
+          studyId={studyId}
+        />
       )}
     </>
   );


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #451 

### Give a longer description of what this PR addresses and why it's needed
Added download buttons to each snapshot. When clicked, the data is labeled with the snapshot name (the alternate name, so if it was renamed, it will use the renamed value).

To do this, the download buttons component needed to be adjusted to take in a list of participants data (like originally done) OR a function which fetches that data. It also takes in a couple other optional attributes for styling and file naming. 

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1707" alt="Screenshot 2024-08-09 at 8 37 56 AM" src="https://github.com/user-attachments/assets/79013d2a-0ef3-45be-beef-b5354fe92e18">