### PR TITLE
Allow retrying training questions, disabling continuation if the answers are wrong

### DIFF
--- a/public/demo-cleveland/config.json
+++ b/public/demo-cleveland/config.json
@@ -282,6 +282,7 @@
                 ]
             },
             "provideFeedback": true,
+            "allowFailedTraining": false,
             "correctAnswer": [
                 {
                     "id": "cm-response",

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -6,24 +6,21 @@ type Props = {
   label?: string;
   disabled?: boolean;
   onClick?: null | (() => void | Promise<void>);
-  setCheckClicked: (arg: boolean) => void | null
 };
 
 export function NextButton({
   label = 'Next',
   disabled = false,
-  setCheckClicked = () => {},
   onClick,
 }: Props) {
   const { isNextDisabled, goToNextStep } = useNextStep();
 
   const handleClick = useCallback(() => {
-    setCheckClicked(false);
     if (onClick) {
       onClick();
     }
     goToNextStep();
-  }, [goToNextStep, onClick, setCheckClicked]);
+  }, [goToNextStep, onClick]);
 
   return (
     <Button

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import { Alert, Button, Group } from '@mantine/core';
 
 import React, { useEffect, useMemo, useState } from 'react';
@@ -29,6 +30,8 @@ export default function ResponseBlock({
   status,
   style,
 }: Props) {
+  const storeDispatch = useStoreDispatch();
+  const { updateResponseBlockValidation } = useStoreActions();
   const currentStep = useCurrentStep();
   const currentComponent = useCurrentComponent();
   const storedAnswer = status?.answer;
@@ -37,13 +40,15 @@ export default function ResponseBlock({
 
   const responses = useMemo(() => configInUse?.response?.filter((r) => (r.location ? r.location === location : location === 'belowStimulus')) || [], [configInUse?.response, location]);
 
-  const storeDispatch = useStoreDispatch();
-  const { updateResponseBlockValidation } = useStoreActions();
   const answerValidator = useAnswerField(responses, currentStep, storedAnswer || {});
   const [provenanceGraph, setProvenanceGraph] = useState<TrrackedProvenance | undefined>(undefined);
-  const [checkClicked, setCheckClicked] = useState(false);
   const { iframeAnswers, iframeProvenance } = useStoreSelector((state) => state);
+
   const hasCorrectAnswerFeedback = configInUse?.provideFeedback && ((configInUse?.correctAnswer?.length || 0) > 0);
+  const allowFailedTraining = configInUse?.allowFailedTraining === undefined ? true : configInUse.allowFailedTraining;
+  const [attemptsUsed, setAttemptsUsed] = useState(0);
+  const trainingAttempts = configInUse?.trainingAttempts || 2;
+  const [enableNextButton, setEnableNextButton] = useState(false);
 
   const showNextBtn = location === (configInUse?.nextButtonLocation || 'belowStimulus');
 
@@ -74,39 +79,92 @@ export default function ResponseBlock({
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answerValidator.values, currentComponent, currentStep, location, storeDispatch, updateResponseBlockValidation, provenanceGraph]);
+  const [alertConfig, setAlertConfig] = useState({
+    visible: false,
+    title: 'Correct Answer',
+    message: 'The correct answer is: ',
+    color: 'green',
+  });
+  const checkAnswerProvideFeedback = () => {
+    const newAttemptsUsed = attemptsUsed + 1;
+    setAttemptsUsed(newAttemptsUsed);
+
+    const correctAnswers = responses.every((response) => {
+      const configCorrectAnswer = configInUse.correctAnswer?.find((answer) => answer.id === response.id)?.answer;
+      const suppliedAnswer = answerValidator.getInputProps(response.id, {
+        type: response.type === 'checkbox' ? 'checkbox' : 'input',
+      }).value;
+      return configCorrectAnswer === suppliedAnswer;
+    });
+
+    if (hasCorrectAnswerFeedback) {
+      if (correctAnswers && !alertConfig.message.includes('You\'ve failed to answer this question correctly')) {
+        setAlertConfig({
+          visible: true,
+          title: 'Correct Answer',
+          message: 'You have answered the question correctly.',
+          color: 'green',
+        });
+      } else {
+        let message = '';
+        if (newAttemptsUsed >= trainingAttempts) {
+          message = `You've failed to answer this question correctly after ${trainingAttempts} attempts. ${allowFailedTraining ? 'You can continue to the next question.' : 'Unfortunately you have not met the criteria for continuing this study.'}`;
+        } else if (trainingAttempts - newAttemptsUsed === 1) {
+          message = 'Please try again. You have 1 attempt left. Please read the help text carefully.';
+        } else {
+          message = `Please try again. You have ${trainingAttempts - newAttemptsUsed} attempts left.`;
+        }
+        setAlertConfig({
+          visible: true,
+          title: 'Incorrect Answer',
+          message,
+          color: 'red',
+        });
+      }
+    }
+
+    setEnableNextButton((allowFailedTraining && newAttemptsUsed >= trainingAttempts) || (correctAnswers && newAttemptsUsed <= trainingAttempts));
+  };
 
   return (
     <div style={style}>
-      {responses.map((response, index) => (
-        <React.Fragment key={`${response.id}-${currentStep}`}>
-          {response.hidden ? (
-            ''
-          ) : (
-            <>
-              <ResponseSwitcher
-                storedAnswer={storedAnswer ? storedAnswer[response.id] : undefined}
-                answer={{
-                  ...answerValidator.getInputProps(response.id, {
-                    type: response.type === 'checkbox' ? 'checkbox' : 'input',
-                  }),
-                }}
-                response={response}
-                index={index + 1}
-              />
-              {hasCorrectAnswerFeedback && checkClicked && (
-                <Alert mb="md" title="Correct Answer">
-                  {`The correct answer is: ${configInUse.correctAnswer?.find((answer) => answer.id === response.id)?.answer}`}
-                </Alert>
-              )}
-            </>
-          )}
-        </React.Fragment>
-      ))}
+      {responses.map((response, index) => {
+        const configCorrectAnswer = configInUse.correctAnswer?.find((answer) => answer.id === response.id)?.answer;
+
+        return (
+          <React.Fragment key={`${response.id}-${currentStep}`}>
+            {response.hidden ? (
+              ''
+            ) : (
+              <>
+                <ResponseSwitcher
+                  storedAnswer={storedAnswer ? storedAnswer[response.id] : undefined}
+                  answer={{
+                    ...answerValidator.getInputProps(response.id, {
+                      type: response.type === 'checkbox' ? 'checkbox' : 'input',
+                    }),
+                  }}
+                  response={response}
+                  index={index + 1}
+                />
+                {alertConfig.visible && (
+                  <Alert mb="md" title={alertConfig.title} color={alertConfig.color}>
+                    {alertConfig.message}
+                    <br />
+                    <br />
+                    {attemptsUsed >= trainingAttempts && configCorrectAnswer && ` The correct answer was: ${configCorrectAnswer}.`}
+                  </Alert>
+                )}
+              </>
+            )}
+          </React.Fragment>
+        );
+      })}
 
       <Group justify="right" gap="xs">
         {hasCorrectAnswerFeedback && showNextBtn && (
           <Button
-            onClick={() => setCheckClicked(true)}
+            onClick={() => checkAnswerProvideFeedback()}
             disabled={!answerValidator.isValid()}
           >
             Check Answer
@@ -114,8 +172,7 @@ export default function ResponseBlock({
         )}
         {showNextBtn && (
           <NextButton
-            disabled={hasCorrectAnswerFeedback && !checkClicked}
-            setCheckClicked={setCheckClicked}
+            disabled={(hasCorrectAnswerFeedback && !enableNextButton) || !answerValidator.isValid()}
             label={configInUse.nextButtonText || 'Next'}
           />
         )}

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -32,6 +32,10 @@
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
+          "allowFailedTraining": {
+            "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+            "type": "boolean"
+          },
           "correctAnswer": {
             "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
             "items": {
@@ -119,7 +123,7 @@
             "type": "object"
           },
           "trainingAttempts": {
-            "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+            "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
             "type": "number"
           },
           "type": {
@@ -440,6 +444,10 @@
       "additionalProperties": false,
       "description": "The ImageComponent interface is used to define the properties of an image component. This component is used to render an image with optional styling.\n\nFor example, to render an image with a path of `path/to/study/assets/image.jpg` and a max width of 50%, you would use the following snippet: ```js { \"type\": \"image\", \"path\": \"<study-name>/assets/image.jpg\", \"style\": { \"maxWidth\": \"50%\" } } ```",
       "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
         "correctAnswer": {
           "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
           "items": {
@@ -495,7 +503,7 @@
           "type": "object"
         },
         "trainingAttempts": {
-          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
           "type": "number"
         },
         "type": {
@@ -605,6 +613,10 @@
       "additionalProperties": false,
       "description": "An InheritedComponent is a component that inherits properties from a baseComponent. This is used to avoid repeating properties in components. This also means that components in the baseComponents object can be partially defined, while components in the components object can inherit from them and must be fully defined and include all properties (after potentially merging with a base component).",
       "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
         "baseComponent": {
           "type": "string"
         },
@@ -695,7 +707,7 @@
           "type": "object"
         },
         "trainingAttempts": {
-          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
           "type": "number"
         },
         "type": {
@@ -854,6 +866,10 @@
       "additionalProperties": false,
       "description": "The MarkdownComponent interface is used to define the properties of a markdown component. The components can be used to render many different things, such as consent forms, instructions, and debriefs. Additionally, you can use the markdown component to render images, videos, and other media, with supporting text. Markdown components can have responses (e.g. in a consent form), or no responses (e.g. in a help text file). Here's an example with no responses for a simple help text file:\n\n```js { \"type\": \"markdown\", \"path\": \"<study-name>/assets/help.md\", \"response\": [] } ```",
       "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
         "correctAnswer": {
           "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
           "items": {
@@ -902,7 +918,7 @@
           "type": "array"
         },
         "trainingAttempts": {
-          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
           "type": "number"
         },
         "type": {
@@ -1004,6 +1020,10 @@
       "additionalProperties": false,
       "description": "A QuestionnaireComponent is used to render simple questions that require a response. The main use case of this component type is to ask participants questions when you don't need to render a stimulus. Please note, that even though we're not using a stimulus, the responses still require a `location`. For example this could be used to collect demographic information from a participant using the following snippet:\n\n```js { \"type\": \"questionnaire\", \"response\": [  {    \"id\": \"gender\",    \"prompt\": \"Gender:\",    \"required\": true,    \"location\": \"belowStimulus\",    \"type\": \"checkbox\",    \"options\": [      {        \"label\": \"Man\",        \"value\": \"Man\"      },      {        \"label\": \"Woman\",        \"value\": \"Woman\"      },      {        \"label\": \"Genderqueer\",        \"value\": \"Genderqueer\"      },      {        \"label\": \"Third-gender\",        \"value\": \"Third-gender\"      },      ... etc.    ]  } ] } ```",
       "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
         "correctAnswer": {
           "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
           "items": {
@@ -1048,7 +1068,7 @@
           "type": "array"
         },
         "trainingAttempts": {
-          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
           "type": "number"
         },
         "type": {
@@ -1162,6 +1182,10 @@
       "additionalProperties": false,
       "description": "The ReactComponent interface is used to define the properties of a react component. This component is used to render react code with certain parameters. These parameters can be used within your react code to render different things.\n\nUnlike other types of components, the path for a React component is relative to the `src/public/` folder. Similar to our standard assets, we suggest creating a folder named `src/public/{studyName}/assets` to house all of the React component assets for a particular study. Your React component which you link to in the path must be default exported from its file.\n\nReact components created this way have a generic prop type passed to the component on render, `<StimulusParams<T>>`, which has the following types.\n\n```ts { parameters: T; setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: Record<string, any> }) => void } ```\n\nparameters is the same object passed in from the ReactComponent type below, allowing you to pass options in from the config to your component. setAnswer is a callback function allowing the creator of the ReactComponent to programmatically set the answer, as well as the provenance graph. This can be useful if you don't use the default answer interface, and instead have something more unique.\n\nSo, for example, if I had the following ReactComponent in my config ```js { type: 'react-component'; path: 'my_study/CoolComponent.tsx'; parameters: {  name: 'Zach';  age: 26; } } ```\n\nMy react component, CoolComponent.tsx, would exist in src/public/my_study/assets, and look something like this\n\n```ts export default function CoolComponent({ parameters, setAnswer }: StimulusParams<{name: string, age: number}>) { // render something } ```\n\nFor in depth examples, see the following studies, and their associated codebases. https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/v1.0.1/src/public/demo-click-accuracy-test/assets) https://revisit.dev/study/demo-brush-interactions (https://github.com/revisit-studies/study/tree/v1.0.1/src/public/demo-brush-interactions/assets)",
       "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
         "correctAnswer": {
           "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
           "items": {
@@ -1215,7 +1239,7 @@
           "type": "array"
         },
         "trainingAttempts": {
-          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
           "type": "number"
         },
         "type": {
@@ -1625,6 +1649,10 @@
       "additionalProperties": false,
       "description": "The WebsiteComponent interface is used to define the properties of a website component. A WebsiteComponent is used to render an iframe with a website inside of it. This can be used to display an external website or an html file that is located in the public folder.\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/assets/website.html\", } ```\n\nTo pass a data from the config to the website, you can use the `parameters` field as below:\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/website.html\", \"parameters\": {  \"barData\": [0.32, 0.01, 1.2, 1.3, 0.82, 0.4, 0.3] } \"response\": [  {    \"id\": \"barChart\",    \"prompt\": \"Your selected answer:\",    \"required\": true,    \"location\": \"belowStimulus\",    \"type\": \"iframe\"  } ], } ``` In the `website.html` file, by including `revisit-communicate.js`, you can use the `Revisit.onDataReceive` method to retrieve the data, and `Revisit.postAnswers` to send the user's responses back to the reVISit as shown in the example below:\n\n```html <script src=\"../../revisitUtilities/revisit-communicate.js\"></script> <script> Revisit.onDataReceive((data) => {  const barData = data['barData'];  ... });\n\n// Call out that 'barChart' needs to match ID in 'response' object Revisit.postAnswers({ barChart: userAnswer }); </script> ```\n\n If the html website implements Trrack library for provenance tracking, you can send the provenance graph back to reVISit by calling `Revisit.postProvenanceGraph` as shown in the example below. You need to call this each time the Trrack state is updated so that reVISit is kept aware of the changes in the provenance graph.\n\n```js const trrack = initializeTrrack({ initialState, registry });\n\n... Revisit.postProvenance(trrack.graph.backend); ```",
       "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
         "correctAnswer": {
           "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
           "items": {
@@ -1678,7 +1706,7 @@
           "type": "array"
         },
         "trainingAttempts": {
-          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
           "type": "number"
         },
         "type": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -118,6 +118,10 @@
             "description": "The style of the image. This is an object with css properties as keys and css values as values.",
             "type": "object"
           },
+          "trainingAttempts": {
+            "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+            "type": "number"
+          },
           "type": {
             "enum": [
               "markdown",
@@ -490,6 +494,10 @@
           "description": "The style of the image. This is an object with css properties as keys and css values as values.",
           "type": "object"
         },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "type": "number"
+        },
         "type": {
           "const": "image",
           "type": "string"
@@ -685,6 +693,10 @@
           },
           "description": "The style of the image. This is an object with css properties as keys and css values as values.",
           "type": "object"
+        },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "type": "number"
         },
         "type": {
           "enum": [
@@ -889,6 +901,10 @@
           },
           "type": "array"
         },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "type": "number"
+        },
         "type": {
           "const": "markdown",
           "type": "string"
@@ -1030,6 +1046,10 @@
             "$ref": "#/definitions/Response"
           },
           "type": "array"
+        },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "type": "number"
         },
         "type": {
           "const": "questionnaire",
@@ -1193,6 +1213,10 @@
             "$ref": "#/definitions/Response"
           },
           "type": "array"
+        },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "type": "number"
         },
         "type": {
           "const": "react-component",
@@ -1652,6 +1676,10 @@
             "$ref": "#/definitions/Response"
           },
           "type": "array"
+        },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and will not show the correct answer ot the user.",
+          "type": "number"
         },
         "type": {
           "const": "website",

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -503,6 +503,8 @@ export interface BaseIndividualComponent {
   provideFeedback?: boolean;
   /** The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.  */
   trainingAttempts?: number;
+  /** Controls whether the component should allow failed training. If not provided, the default is true. */
+  allowFailedTraining?: boolean;
   /** The meta data for the component. This is used to identify and provide additional information for the component in the admin panel. */
   meta?: Record<string, unknown>;
   /** The description of the component. This is used to identify and provide additional information for the component in the admin panel. */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -501,6 +501,8 @@ export interface BaseIndividualComponent {
   correctAnswer?: Answer[];
   /** Controls whether the component should provide feedback to the participant, such as in a training trial. If not provided, the default is false. */
   provideFeedback?: boolean;
+  /** The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.  */
+  trainingAttempts?: number;
   /** The meta data for the component. This is used to identify and provide additional information for the component in the admin panel. */
   meta?: Record<string, unknown>;
   /** The description of the component. This is used to identify and provide additional information for the component in the admin panel. */

--- a/tests/demo-cleveland.spec.ts
+++ b/tests/demo-cleveland.spec.ts
@@ -54,7 +54,7 @@ test('test', async ({ page }) => {
     await page.getByRole('button', { name: 'Check Answer' }).click();
 
     // Check that the correct answer is shown
-    const correctAnswer = await page.getByText('The correct answer is: 66');
+    const correctAnswer = await page.getByText('You have answered the question correctly.');
     await expect(correctAnswer).toBeVisible();
 
     // Click on the next button

--- a/tests/test-training-feeback.spec.ts
+++ b/tests/test-training-feeback.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+async function goToTraining(page) {
+  // Check that the page contains the introduction text
+  const introText = await page.getByText('Welcome to our study. This is a more complex example to show how to embed React.js');
+  await expect(introText).toBeVisible();
+
+  // Click on the next button
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // Check the page contains consent form
+  const consent = await page.getByRole('heading', { name: 'Consent' });
+  await expect(consent).toBeVisible();
+
+  // Fill the consent form
+  await page.getByPlaceholder('Please provide your signature').click();
+  await page.getByPlaceholder('Please provide your signature').fill('test');
+  await page.getByLabel('Accept').check();
+
+  // Click on the next button
+  await page.getByRole('button', { name: 'Agree' }).click();
+
+  // Check the page contains the training image
+  const trainingImg = await page.getByRole('main').getByRole('img');
+  await expect(trainingImg).toBeVisible();
+
+  // Click on the next button
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+}
+
+test('test', async ({ page }) => {
+  await page.goto('/');
+
+  // Click on cleveland
+  await page.getByRole('button', { name: 'Dynamic React.js Stimuli: A Graphical Perception Experiment' }).click();
+
+  await goToTraining(page);
+
+  // Answer the training question incorrectly
+  await page.getByPlaceholder('0-100').fill('50');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  const incorrectAnswer = await page.getByText('Incorrect Answer');
+  await expect(incorrectAnswer).toBeVisible();
+
+  // Answer the training question incorrectly again
+  await page.getByPlaceholder('0-100').fill('51');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  const incorrectAnswer2 = await page.getByText('Incorrect Answer');
+  await expect(incorrectAnswer2).toBeVisible();
+
+  // Answer the training question incorrectly again
+  await page.getByPlaceholder('0-100').fill('52');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  const incorrectAnswer3 = await page.getByText('You\'ve failed to answer this question correctly after 2 attempts. Unfortunately you have not met the criteria for continuing this study.');
+  await expect(incorrectAnswer3).toBeVisible();
+
+  // Expect the next button to be disabled
+  const nextButton = await page.getByRole('button', { name: 'Next', exact: true });
+  await expect(nextButton).toBeDisabled();
+
+  // Answer the training question correctly and expect the next button to be disabled still
+  await page.getByPlaceholder('0-100').fill('66');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  await expect(nextButton).toBeDisabled();
+
+  // Click next participant
+  await page.getByRole('button', { name: 'Next Participant' }).click();
+
+  await goToTraining(page);
+
+  // Answer the training question correctly and expect the next button to be enabled
+  await page.getByPlaceholder('0-100').fill('66');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  await expect(nextButton).toBeEnabled();
+});


### PR DESCRIPTION
### Does this PR close any open issues?
No issue for this

### Give a longer description of what this PR addresses and why it's needed
Adds the ability to retry training questions up to a maximum amount where it's possible to prevent the participant from continuing using the next button.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="286" alt="Screenshot 2024-08-09 at 4 40 11 PM" src="https://github.com/user-attachments/assets/1758b8ae-53bc-4848-a612-ab3397649da1">
<img width="281" alt="Screenshot 2024-08-09 at 4 40 20 PM" src="https://github.com/user-attachments/assets/a1bc1988-2cc0-473e-949f-e9aa7d3e8655">


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Add issue to make a tutorial for this