### PR TITLE
Add ability to define StringOption arrays as string arrays

### DIFF
--- a/public/demo-VLAT-full-randomized/config.json
+++ b/public/demo-VLAT-full-randomized/config.json
@@ -109,28 +109,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "$57.36",
-                            "value": "$57.36"
-                        },
-                        {
-                            "label": "$47.82",
-                            "value": "$47.82"
-                        },
-                        {
-                            "label": "$50.24",
-                            "value": "$50.24"
-                        },
-                        {
-                            "label": "$39.72",
-                            "value": "$39.72"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["57.36", "47.82", "50.24", "39.72", "Skip"]
                 }
             ]
         },
@@ -159,28 +138,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "March",
-                            "value": "March"
-                        },
-                        {
-                            "label": "May",
-                            "value": "May"
-                        },
-                        {
-                            "label": "July",
-                            "value": "July"
-                        },
-                        {
-                            "label": "December",
-                            "value": "December"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["March", "May", "July", "December", "Skip"]
                 }
             ]
         },
@@ -209,28 +167,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "$35 - $65",
-                            "value": "$35 - $65"
-                        },
-                        {
-                            "label": "$48.36 - $60.95",
-                            "value": "$48.36 - $60.95"
-                        },
-                        {
-                            "label": "$37.04 - $48.36",
-                            "value": "$37.04 - $48.36"
-                        },
-                        {
-                            "label": "$37.04 - $60.95",
-                            "value": "$37.04 - $60.95"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$35 - $65", "$48.36 - $60.95", "$37.04 - $48.36", "$37.04 - $60.95", "Skip"]
                 }
             ]
         },
@@ -259,24 +196,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Rising",
-                            "value": "Rising"
-                        },
-                        {
-                            "label": "Falling",
-                            "value": "Falling"
-                        },
-                        {
-                            "label": "Staying",
-                            "value": "Staying"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Rising", "Falling", "Staying", "Skip"]
                 }
             ]
         },
@@ -305,28 +225,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "$4",
-                            "value": "$4"
-                        },
-                        {
-                            "label": "$15",
-                            "value": "$15"
-                        },
-                        {
-                            "label": "$17",
-                            "value": "$17"
-                        },
-                        {
-                            "label": "$45",
-                            "value": "$45"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$4", "$15", "$17", "$45", "Skip"]
                 }
             ]
         },
@@ -355,28 +254,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "10 Mbps",
-                            "value": "10 Mbps"
-                        },
-                        {
-                            "label": "14 Mbps",
-                            "value": "14 Mbps"
-                        },
-                        {
-                            "label": "15 Mbps",
-                            "value": "15 Mbps"
-                        },
-                        {
-                            "label": "16 Mbps",
-                            "value": "16 Mbps"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["10 Mbps", "14 Mbps", "15 Mbps", "16 Mbps", "Skip"]
                 }
             ]
         },
@@ -405,27 +283,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "China",
-                            "value": "China"
-                        },
-                        {
-                            "label": "Hong Kong",
-                            "value": "Hong Kong"
-                        },
-                        {
-                            "label": "South Korea",
-                            "value": "South Korea"
-                        },
-                        {
-                            "label": "Vietnam",
-                            "value": "Vietnam"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
+                    "options": ["China", "Hong Kong", "South Korea", "Vietnam", "Skip"]
                     ]
                 }
             ]
@@ -455,28 +313,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "0 - 22 Mbps",
-                            "value": "0 - 22 Mbps"
-                        },
-                        {
-                            "label": " 2 - 20.5 Mbps",
-                            "value": " 2 - 20.5 Mbps"
-                        },
-                        {
-                            "label": "3 - 20 Mbps",
-                            "value": "3 - 20 Mbps"
-                        },
-                        {
-                            "label": "3.4 - 7.8 Mbps",
-                            "value": "3.4 - 7.8 Mbps"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["0 - 22 Mbps", "2 - 20.5 Mbps", "3 - 20 Mbps", "3.4 - 7.8 Mbps", "Skip"]
                 }
             ]
         },
@@ -505,28 +342,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "5 Countries",
-                            "value": "5 Countries"
-                        },
-                        {
-                            "label": " 6 Countries",
-                            "value": " 6 Countries"
-                        },
-                        {
-                            "label": "7 Countries",
-                            "value": "7 Countries"
-                        },
-                        {
-                            "label": "8 Countries",
-                            "value": "8 Countries"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["5 Countries", "6 Countries", "7 Countries", "8 Countries", "Skip"]
                 }
             ]
         },
@@ -555,28 +371,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "$12",
-                            "value": "$12"
-                        },
-                        {
-                            "label": " $16.7",
-                            "value": " $16.7"
-                        },
-                        {
-                            "label": "$23.4",
-                            "value": "$23.4"
-                        },
-                        {
-                            "label": "$35.4",
-                            "value": "$35.4"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$12", " $16.7", "$23.4", "$35.4", "Skip"]
                 }
             ]
         },
@@ -605,28 +400,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "1 to 10",
-                            "value": "1 to 10"
-                        },
-                        {
-                            "label": "2 to 10",
-                            "value": "2 to 10"
-                        },
-                        {
-                            "label": "4 to 10",
-                            "value": "4 to 10"
-                        },
-                        {
-                            "label": "6 to 10",
-                            "value": "6 to 10"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["1 to 10", "2 to 10", "4 to 10", "6 to 10", "Skip"]
                 }
             ]
         },
@@ -655,28 +429,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "New York City",
-                            "value": "New York City"
-                        },
-                        {
-                            "label": "Las Vegas",
-                            "value": "Las Vegas"
-                        },
-                        {
-                            "label": "Atlanta",
-                            "value": "Atlanta"
-                        },
-                        {
-                            "label": "Washington D.C.",
-                            "value": "Washington D.C."
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["New York City", "Las Vegas", "Atlanta", "Washington D.C.", "Skip"]
                 }
             ]
         },
@@ -705,20 +458,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -747,20 +487,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -789,28 +516,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "38%",
-                            "value": "38%"
-                        },
-                        {
-                            "label": "47%",
-                            "value": "47%"
-                        },
-                        {
-                            "label": "53%",
-                            "value": "53%"
-                        },
-                        {
-                            "label": "62%",
-                            "value": "62%"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["38%", "47%", "53%", "62%", "Skip"]
                 }
             ]
         },
@@ -839,28 +545,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "High School Graduate or Less",
-                            "value": "High School Graduate or Less"
-                        },
-                        {
-                            "label": "Some College Degree",
-                            "value": "Some College Degree"
-                        },
-                        {
-                            "label": "College Graduate",
-                            "value": "College Graduate"
-                        },
-                        {
-                            "label": "Postgraduate study",
-                            "value": "Postgraduate study"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["High School Graduate or Less", "Some College Degree", "College Graduate", "Postgraduate study", "Skip"]
                 }
             ]
         },
@@ -889,20 +574,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -931,28 +603,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "15%",
-                            "value": "15%"
-                        },
-                        {
-                            "label": "25%",
-                            "value": "25%"
-                        },
-                        {
-                            "label": "33%",
-                            "value": "33%"
-                        },
-                        {
-                            "label": "50%",
-                            "value": "50%"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["15%", "25%", "33%", "50%", "Skip"]
                 }
             ]
         },
@@ -981,28 +632,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Apple",
-                            "value": "Apple"
-                        },
-                        {
-                            "label": "Xiaomi",
-                            "value": "Xiaomi"
-                        },
-                        {
-                            "label": "Lenovo",
-                            "value": "Lenovo"
-                        },
-                        {
-                            "label": "Others",
-                            "value": "Others"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Apple", "Xiaomi", "Lenovo", "Others", "Skip"]
                 }
             ]
         },
@@ -1031,20 +661,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1073,28 +690,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "145",
-                            "value": "145"
-                        },
-                        {
-                            "label": "153",
-                            "value": "153"
-                        },
-                        {
-                            "label": "200",
-                            "value": "200"
-                        },
-                        {
-                            "label": "240",
-                            "value": "240"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["145", "153", "200", "240", "Skip"]
                 }
             ]
         },
@@ -1123,28 +719,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "4.2-4.4",
-                            "value": "4.2-4.4"
-                        },
-                        {
-                            "label": "4.4-4.6",
-                            "value": "4.4-4.6"
-                        },
-                        {
-                            "label": "4.6-4.8",
-                            "value": "4.6-4.8"
-                        },
-                        {
-                            "label": "4.8-5.0",
-                            "value": "4.8-5.0"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["4.2-4.4", "4.4-4.6", "4.6-4.8", "4.8-5.0", "Skip"]
                 }
             ]
         },
@@ -1173,20 +748,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1215,28 +777,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "53.9kg",
-                            "value": "53.9kg"
-                        },
-                        {
-                            "label": "67.7kg",
-                            "value": "67.7kg"
-                        },
-                        {
-                            "label": "70.5kg",
-                            "value": "70.5kg"
-                        },
-                        {
-                            "label": "82.7kg",
-                            "value": "82.7kg"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["53.9kg", "67.7kg", "70.5kg", "82.7kg", "Skip"]
                 }
             ]
         },
@@ -1265,28 +806,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "175.3cm",
-                            "value": "175.3cm"
-                        },
-                        {
-                            "label": "192cm",
-                            "value": "192cm"
-                        },
-                        {
-                            "label": "197.1cm",
-                            "value": "197.1cm"
-                        },
-                        {
-                            "label": "200cm",
-                            "value": "200cm"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["175.3cm", "192cm", "197.1cm", "200cm", "Skip"]
                 }
             ]
         },
@@ -1315,28 +835,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "40 - 130kg",
-                            "value": "40 - 130kg"
-                        },
-                        {
-                            "label": "62.3 - 90.9kg",
-                            "value": "62.3 - 90.9kg"
-                        },
-                        {
-                            "label": "53.9 - 102.3kg",
-                            "value": "53.9 - 102.3kg"
-                        },
-                        {
-                            "label": "53.9 - 123.6kg",
-                            "value": "53.9 - 123.6kg"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["40 - 130kg", "62.3 - 90.9kg", "53.9 - 102.3kg", "53.9 - 123.6kg", "Skip"]
                 }
             ]
         },
@@ -1365,28 +864,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "167.4cm",
-                            "value": "167.4cm"
-                        },
-                        {
-                            "label": "175.3cm",
-                            "value": "175.3cm"
-                        },
-                        {
-                            "label": "193cm",
-                            "value": "193cm"
-                        },
-                        {
-                            "label": "197.1cm",
-                            "value": "197.1cm"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["167.4cm", "175.3cm", "193cm", "197.1cm", "Skip"]
                 }
             ]
         },
@@ -1415,20 +893,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1457,20 +922,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1499,20 +951,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1541,28 +980,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "$4.9",
-                            "value": "$4.9"
-                        },
-                        {
-                            "label": "$5.0",
-                            "value": "$5.0"
-                        },
-                        {
-                            "label": "$5.1",
-                            "value": "$5.1"
-                        },
-                        {
-                            "label": "$5.2",
-                            "value": "$5.2"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$4.9", "$5.0", "$5.1", "$5.2", "Skip"]
                 }
             ]
         },

--- a/public/demo-VLAT-full-randomized/config.json
+++ b/public/demo-VLAT-full-randomized/config.json
@@ -1009,28 +1009,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "April 2013",
-                            "value": "April 2013"
-                        },
-                        {
-                            "label": "September 2013",
-                            "value": "September 2013"
-                        },
-                        {
-                            "label": "June 2014",
-                            "value": "June 2014"
-                        },
-                        {
-                            "label": "December 2014",
-                            "value": "December 2014"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["April 2013", "September 2013", "June 2014", "December 2014", "Skip"]
                 }
             ]
         },
@@ -1059,28 +1038,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "$4.4 - $6.2",
-                            "value": "$4.4 - $6.2"
-                        },
-                        {
-                            "label": "$4.6 - $5.9",
-                            "value": "$4.6 - $5.9"
-                        },
-                        {
-                            "label": "$4.6 - $6.0",
-                            "value": "$4.6 - $6.0"
-                        },
-                        {
-                            "label": "$4.6 - $6.1",
-                            "value": "$4.6 - $6.1"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$4.4 - $6.2", "$4.6 - $5.9", "$4.6 - $6.0", "$4.6 - $6.1", "Skip"]
                 }
             ]
         },
@@ -1109,24 +1067,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Rising",
-                            "value": "Rising"
-                        },
-                        {
-                            "label": "Falling",
-                            "value": "Falling"
-                        },
-                        {
-                            "label": "Staying",
-                            "value": "Staying"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Rising", "Falling", "Staying", "Skip"]
                 }
             ]
         },
@@ -1155,28 +1096,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "1500",
-                            "value": "1500"
-                        },
-                        {
-                            "label": "3800",
-                            "value": "3800"
-                        },
-                        {
-                            "label": "4200",
-                            "value": "4200"
-                        },
-                        {
-                            "label": "8000",
-                            "value": "8000"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["1500", "3800", "4200", "8000", "Skip"]
                 }
             ]
         },
@@ -1205,28 +1125,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "1 to 1",
-                            "value": "1 to 1"
-                        },
-                        {
-                            "label": "1 to 2",
-                            "value": "1 to 2"
-                        },
-                        {
-                            "label": "1 to 3",
-                            "value": "1 to 3"
-                        },
-                        {
-                            "label": "1 to 4",
-                            "value": "1 to 4"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["1 to 1", "1 to 2", "1 to 3", "1 to 4", "Skip"]
                 }
             ]
         },
@@ -1255,28 +1154,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "2009",
-                            "value": "2009"
-                        },
-                        {
-                            "label": "2011",
-                            "value": "2011"
-                        },
-                        {
-                            "label": "2012",
-                            "value": "2012"
-                        },
-                        {
-                            "label": "2014",
-                            "value": "2014"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["2009", "2011", "2012", "2014", "Skip"]
                 }
             ]
         },
@@ -1305,24 +1183,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Rising",
-                            "value": "Rising"
-                        },
-                        {
-                            "label": "Falling",
-                            "value": "Falling"
-                        },
-                        {
-                            "label": "Staying",
-                            "value": "Staying"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Rising", "Falling", "Staying", "Skip"]
                 }
             ]
         },
@@ -1351,20 +1212,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1393,20 +1241,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1435,28 +1270,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "330km",
-                            "value": "330km"
-                        },
-                        {
-                            "label": "400km",
-                            "value": "400km"
-                        },
-                        {
-                            "label": "530km",
-                            "value": "530km"
-                        },
-                        {
-                            "label": "560km",
-                            "value": "560km"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["330km", "400km", "530km", "560km", "Skip"]
                 }
             ]
         },
@@ -1485,28 +1299,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Seoul",
-                            "value": "Seoul"
-                        },
-                        {
-                            "label": "Beijing",
-                            "value": "Beijing"
-                        },
-                        {
-                            "label": "New York City",
-                            "value": "New York City"
-                        },
-                        {
-                            "label": "Shanghai",
-                            "value": "Shanghai"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Seoul", "Beijing", "New York City", "Shanghai", "Skip"]
                 }
             ]
         },
@@ -1535,28 +1328,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "150 - 600 km",
-                            "value": "150 - 600 km"
-                        },
-                        {
-                            "label": "240 - 380 km",
-                            "value": "240 - 380 km"
-                        },
-                        {
-                            "label": "240 - 560 km",
-                            "value": "240 - 560 km"
-                        },
-                        {
-                            "label": "180 - 560 km",
-                            "value": "180 - 560 km"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["150 - 600 km", "240 - 380 km", "240 - 560 km", "180 - 560 km", "Skip"]
                 }
             ]
         },
@@ -1585,28 +1357,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Tokyo",
-                            "value": "Tokyo"
-                        },
-                        {
-                            "label": "New York City",
-                            "value": "New York City"
-                        },
-                        {
-                            "label": "Beijing",
-                            "value": "Beijing"
-                        },
-                        {
-                            "label": "London",
-                            "value": "London"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Tokyo", "New York City", "Beijing", "London", "Skip"]
                 }
             ]
         },
@@ -1635,20 +1386,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1677,20 +1415,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1719,20 +1444,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1761,28 +1473,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "1.1 - 2.3%",
-                            "value": "1.1 - 2.3%"
-                        },
-                        {
-                            "label": "2.3 - 3.4%",
-                            "value": "2.3 - 3.4%"
-                        },
-                        {
-                            "label": "3.4 - 4.6%",
-                            "value": "3.4 - 4.6%"
-                        },
-                        {
-                            "label": "4.6 - 5.7%",
-                            "value": "4.6 - 5.7%"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["1.1 - 2.3%", "2.3 - 3.4%", "3.4 - 4.6%", "4.6 - 5.7%", "Skip"]
                 }
             ]
         },
@@ -1811,28 +1502,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Alaska (AK)",
-                            "value": "Alaska (AK)"
-                        },
-                        {
-                            "label": "New Mexico (NM)",
-                            "value": "New Mexico (NM)"
-                        },
-                        {
-                            "label": "Florida (FL)",
-                            "value": "Florida (FL)"
-                        },
-                        {
-                            "label": "New York (NY)",
-                            "value": "New York (NY)"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Alaska (AK)", "New Mexico (NM)", "Florida (FL)", "New York (NY)", "Skip"]
                 }
             ]
         },
@@ -1861,20 +1531,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1903,28 +1560,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "Facebook",
-                            "value": "Facebook"
-                        },
-                        {
-                            "label": "Amazon",
-                            "value": "Amazon"
-                        },
-                        {
-                            "label": "Bing",
-                            "value": "Bing"
-                        },
-                        {
-                            "label": "Google",
-                            "value": "Google"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Facebook", "Amazon", "Bing", "Google", "Skip"]
                 }
             ]
         },
@@ -1953,20 +1589,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         },
@@ -1995,20 +1618,7 @@
                     "prompt": "Your answer (do not skip more than 3 times)",
                     "required": true,
                     "location": "sidebar",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ]
         }

--- a/public/demo-VLAT-mini-randomized/config.json
+++ b/public/demo-VLAT-mini-randomized/config.json
@@ -104,20 +104,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -147,28 +134,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Great Britain",
-                            "value": "Great Britain"
-                        },
-                        {
-                            "label": "USA",
-                            "value": "USA"
-                        },
-                        {
-                            "label": "Japan",
-                            "value": "Japan"
-                        },
-                        {
-                            "label": "Australia",
-                            "value": "Australia"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Great Britain", "USA", "Japan", "Australia", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -198,28 +164,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "50 - 70km",
-                            "value": "50 - 70km"
-                        },
-                        {
-                            "label": "30 - 40km",
-                            "value": "30 - 40km"
-                        },
-                        {
-                            "label": "20 - 30km",
-                            "value": "20 - 30km"
-                        },
-                        {
-                            "label": "50 - 60km",
-                            "value": "50 - 60km"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["50-70km", "30-40km", "20-30km", "50-60km", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -249,20 +194,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -292,28 +224,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "17.6%",
-                            "value": "17.6%"
-                        },
-                        {
-                            "label": "25.3%",
-                            "value": "25.3%"
-                        },
-                        {
-                            "label": "10.9%",
-                            "value": "10.9%"
-                        },
-                        {
-                            "label": "35.2%",
-                            "value": "35.2%"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["17.6%", "25.3%", "10.9%", "35.2%", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -343,28 +254,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Beijing",
-                            "value": "Beijing"
-                        },
-                        {
-                            "label": "Shanghai",
-                            "value": "Shanghai"
-                        },
-                        {
-                            "label": "London",
-                            "value": "London"
-                        },
-                        {
-                            "label": "Seoul",
-                            "value": "Seoul"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["Beijing", "Shanghai", "London", "Seoul", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -394,28 +284,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "$5.2",
-                            "value": "$5.2"
-                        },
-                        {
-                            "label": "$6.1",
-                            "value": "$6.1"
-                        },
-                        {
-                            "label": "$7.5",
-                            "value": "$7.5"
-                        },
-                        {
-                            "label": "$4.5",
-                            "value": "$4.5"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$5.2", "$6.1", "$7.5", "$4.5", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -445,28 +314,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "$50.54",
-                            "value": "$50.54"
-                        },
-                        {
-                            "label": "$47.02",
-                            "value": "$47.02"
-                        },
-                        {
-                            "label": "$42.34",
-                            "value": "$42.34"
-                        },
-                        {
-                            "label": "$43.48",
-                            "value": "$43.48"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["$50.54", "$47.02", "$42.34", "$43.48", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -496,28 +344,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "42.30 Mbps",
-                            "value": "42.30 Mbps"
-                        },
-                        {
-                            "label": "40.51 Mbps",
-                            "value": "40.51 Mbps"
-                        },
-                        {
-                            "label": "35.25 Mbps",
-                            "value": "35.25 Mbps"
-                        },
-                        {
-                            "label": "16.16 Mbps",
-                            "value": "16.16 Mbps"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["42.30 Mbps", "40.51 Mbps", "35.25 Mbps", "16.16 Mbps", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -547,28 +374,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "$0.71",
-                            "value": "$0.71"
-                        },
-                        {
-                            "label": "$0.90",
-                            "value": "$0.90"
-                        },
-                        {
-                            "label": "$0.80",
-                            "value": "$0.80"
-                        },
-                        {
-                            "label": "$0.63",
-                            "value": "$0.63"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["0.71", "0.90", "0.80", "0.63", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -598,28 +404,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "1 to 1",
-                            "value": "1 to 1"
-                        },
-                        {
-                            "label": "1 to 2",
-                            "value": "1 to 2"
-                        },
-                        {
-                            "label": "1 to 3",
-                            "value": "1 to 3"
-                        },
-                        {
-                            "label": "1 to 4",
-                            "value": "1 to 4"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["1 to 1", "1 to 2", "1 to 3", "1 to 4", "Skip"]
                 }
             ],
             "correctAnswer": [
@@ -649,20 +434,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "True",
-                            "value": "True"
-                        },
-                        {
-                            "label": "False",
-                            "value": "False"
-                        },
-                        {
-                            "label": "Skip",
-                            "value": "Skip"
-                        }
-                    ]
+                    "options": ["True", "False", "Skip"]
                 }
             ],
             "correctAnswer": [

--- a/public/demo-brush-interactions/config.json
+++ b/public/demo-brush-interactions/config.json
@@ -136,20 +136,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "Europe",
-                            "value": "Europe"
-                        },
-                        {
-                            "label": "Japan",
-                            "value": "Japan"
-                        },
-                        {
-                            "label": "USA",
-                            "value": "USA"
-                        }
-                    ]
+                    "options": ["Europe", "Japan", "USA"]
                 },
                 {
                     "id": "min-response",
@@ -157,20 +144,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "Europe",
-                            "value": "Europe"
-                        },
-                        {
-                            "label": "Japan",
-                            "value": "Japan"
-                        },
-                        {
-                            "label": "USA",
-                            "value": "USA"
-                        }
-                    ]
+                    "options": ["Europe", "Japan", "USA"]
                 }
             ],
             "correctAnswer": [
@@ -233,24 +207,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "drizzle",
-                            "value": "drizzle"
-                        },
-                        {
-                            "label": "fog",
-                            "value": "fog"
-                        },
-                        {
-                            "label": "rain",
-                            "value": "rain"
-                        },
-                        {
-                            "label": "sun",
-                            "value": "sun"
-                        }
-                    ]
+                    "options": ["drizzle", "fog", "rain", "sun"]
                 },
                 {
                     "id": "min-response",
@@ -258,24 +215,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "drizzle",
-                            "value": "drizzle"
-                        },
-                        {
-                            "label": "fog",
-                            "value": "fog"
-                        },
-                        {
-                            "label": "rain",
-                            "value": "rain"
-                        },
-                        {
-                            "label": "sun",
-                            "value": "sun"
-                        }
-                    ]
+                    "options": ["drizzle", "fog", "rain", "sun"]
                 }
             ],
             "correctAnswer": [
@@ -336,20 +276,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "Adelie",
-                            "value": "Adelie"
-                        },
-                        {
-                            "label": "Chinstrap",
-                            "value": "Chinstrap"
-                        },
-                        {
-                            "label": "Gentoo",
-                            "value": "Gentoo"
-                        }
-                    ]
+                    "options": ["Adelie", "Chinstrap", "Gentoo"]
                 },
                 {
                     "id": "min-response",
@@ -357,20 +284,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "Adelie",
-                            "value": "Adelie"
-                        },
-                        {
-                            "label": "Chinstrap",
-                            "value": "Chinstrap"
-                        },
-                        {
-                            "label": "Gentoo",
-                            "value": "Gentoo"
-                        }
-                    ]
+                    "options": ["Adelie", "Chinstrap", "Gentoo"]
                 }
             ],
             "correctAnswer": [
@@ -431,24 +345,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "Action",
-                            "value": "Action"
-                        },
-                        {
-                            "label": "Adventure",
-                            "value": "Adventure"
-                        },
-                        {
-                            "label": "Comedy",
-                            "value": "Comedy"
-                        },
-                        {
-                            "label": "Drama",
-                            "value": "Drama"
-                        }
-                    ]
+                    "options": ["Action", "Adventure", "Comedy", "Drama"]
                 },
                 {
                     "id": "min-response",
@@ -456,24 +353,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "dropdown",
-                    "options": [
-                        {
-                            "label": "Action",
-                            "value": "Action"
-                        },
-                        {
-                            "label": "Adventure",
-                            "value": "Adventure"
-                        },
-                        {
-                            "label": "Comedy",
-                            "value": "Comedy"
-                        },
-                        {
-                            "label": "Drama",
-                            "value": "Drama"
-                        }
-                    ]
+                    "options": ["Action", "Adventure", "Comedy", "Drama"]
                 }
             ],
             "correctAnswer": [

--- a/public/demo-brush-interactions/config.json
+++ b/public/demo-brush-interactions/config.json
@@ -67,19 +67,10 @@
                     "id": "accept",
                     "prompt": "Do you consent to the study and wish to continue?",
                     "required": true,
-                    "requiredValue": "yes",
+                    "requiredValue": "Accept",
                     "location": "belowStimulus",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Decline",
-                            "value": "no"
-                        },
-                        {
-                            "label": "Accept",
-                            "value": "yes"
-                        }
-                    ]
+                    "options": ["Decline", "Accept"]
                 }
             ]
         },

--- a/public/demo-cleveland/config.json
+++ b/public/demo-cleveland/config.json
@@ -251,19 +251,10 @@
                     "id": "accept",
                     "prompt": "Do you consent to the study and wish to continue?",
                     "required": true,
-                    "requiredValue": "yes",
+                    "requiredValue": "Accept",
                     "location": "belowStimulus",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Decline",
-                            "value": "no"
-                        },
-                        {
-                            "label": "Accept",
-                            "value": "yes"
-                        }
-                    ]
+                    "options": ["Decline", "Accept"]
                 }
             ]
         },

--- a/public/demo-cleveland/config.json
+++ b/public/demo-cleveland/config.json
@@ -460,24 +460,7 @@
                     "location": "aboveStimulus",
                     "type": "dropdown",
                     "placeholder": "Enter your preference",
-                    "options": [
-                        {
-                            "label": "Bar",
-                            "value": "Bar"
-                        },
-                        {
-                            "label": "Stacked Bar",
-                            "value": "Stacked Bar"
-                        },
-                        {
-                            "label": "Bubble",
-                            "value": "Bubble"
-                        },
-                        {
-                            "label": "Pie",
-                            "value": "Pike"
-                        }
-                    ]
+                    "options": ["Bar", "Bubble", "Pie", "Stacked Bar"]
                 },
                 {
                     "id": "q2",

--- a/public/demo-image/config.json
+++ b/public/demo-image/config.json
@@ -49,16 +49,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Yes",
-                            "value": "1"
-                        },
-                        {
-                            "label": "No",
-                            "value": "2"
-                        }
-                    ]
+                    "options": ["Yes", "No"]
                 }
             ]
         },
@@ -83,16 +74,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Yes",
-                            "value": "1"
-                        },
-                        {
-                            "label": "No",
-                            "value": "2"
-                        }
-                    ]
+                    "options": ["Yes", "No"]
                 }
             ]
         },
@@ -117,16 +99,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Yes",
-                            "value": "1"
-                        },
-                        {
-                            "label": "No",
-                            "value": "2"
-                        }
-                    ]
+                    "options": ["Yes", "No"]
                 }
             ]
         }

--- a/public/demo-mvnv/config.json
+++ b/public/demo-mvnv/config.json
@@ -268,16 +268,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Mentions",
-                            "value": "Mentions"
-                        },
-                        {
-                            "label": "Retweets",
-                            "value": "Retweets"
-                        }
-                    ]
+                    "options": ["Mentions", "Retweets"]
                 },
                 {
                     "id": "task8-2",
@@ -385,24 +376,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "NA",
-                            "value": "NA"
-                        },
-                        {
-                            "label": "SA",
-                            "value": "SA"
-                        },
-                        {
-                            "label": "EU",
-                            "value": "EU"
-                        },
-                        {
-                            "label": "AS",
-                            "value": "AS"
-                        }
-                    ]
+                    "options": ["NA", "SA", "EU", "AS"]
                 }
             ]
         },
@@ -431,24 +405,7 @@
                     "required": true,
                     "location": "sidebar",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "NA",
-                            "value": "NA"
-                        },
-                        {
-                            "label": "SA",
-                            "value": "SA"
-                        },
-                        {
-                            "label": "EU",
-                            "value": "EU"
-                        },
-                        {
-                            "label": "AS",
-                            "value": "AS"
-                        }
-                    ]
+                    "options": ["NA", "SA", "EU", "AS"]
                 }
             ]
         },

--- a/public/demo-mvnv/config.json
+++ b/public/demo-mvnv/config.json
@@ -47,16 +47,7 @@
                     "required": true,
                     "location": "belowStimulus",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Decline",
-                            "value": "no"
-                        },
-                        {
-                            "label": "Accept",
-                            "value": "yes"
-                        }
-                    ]
+                    "options": ["Decline", "Accept"]
                 }
             ]
         },
@@ -208,16 +199,7 @@
                     "type": "radio",
                     "prompt": "Select Answer Below",
                     "required": true,
-                    "options": [
-                        {
-                            "label": "European",
-                            "value": "EU"
-                        },
-                        {
-                            "label": "North American",
-                            "value": "NA"
-                        }
-                    ],
+                    "options": ["European", "North American"],
                     "location": "sidebar"
                 },
                 {

--- a/public/demo-survey/config.json
+++ b/public/demo-survey/config.json
@@ -89,20 +89,7 @@
                     "maxSelections": 2,
                     "location": "aboveStimulus",
                     "type": "checkbox",
-                    "options": [
-                        {
-                            "label": "Option 1",
-                            "value": "opt-1"
-                        },
-                        {
-                            "label": "Option 2",
-                            "value": "opt-2"
-                        },
-                        {
-                            "label": "Option 3",
-                            "value": "opt-3"
-                        }
-                    ]
+                    "options": ["Option 1", "Option 2", "Option 3"]
                 },
                 {
                     "id": "q-radio",
@@ -110,16 +97,7 @@
                     "required": true,
                     "location": "aboveStimulus",
                     "type": "radio",
-                    "options": [
-                        {
-                            "label": "Option 1",
-                            "value": "opt-1"
-                        },
-                        {
-                            "label": "Option 2",
-                            "value": "opt-2"
-                        }
-                    ]
+                    "options": ["Option 1", "Option 2"]
                 },
                 {
                     "id": "q6",

--- a/public/demo-survey/config.json
+++ b/public/demo-survey/config.json
@@ -39,22 +39,10 @@
                     "type": "dropdown",
                     "placeholder": "Enter your preference",
                     "options": [
-                        {
-                            "label": "Bar",
-                            "value": "Bar"
-                        },
-                        {
-                            "label": "Bubble",
-                            "value": "Bubble"
-                        },
-                        {
-                            "label": "Pie",
-                            "value": "Pie"
-                        },
-                        {
-                            "label": "Stacked Bar",
-                            "value": "Stacked Bar"
-                        }
+                        "Bar",
+                        "Bubble",
+                        "Pie",
+                        "Stacked Bar"
                     ]
                 },
                 {

--- a/public/test-skip-logic/config.json
+++ b/public/test-skip-logic/config.json
@@ -30,7 +30,7 @@
           "prompt": "What is your favorite color?",
           "location": "belowStimulus",
           "required": true,
-          "options": [{"label": "Blue", "value": "Blue"}, {"label": "Red", "value": "Red"}, {"label": "Green", "value": "Green"}, {"label": "Yellow", "value": "Yellow"}]
+          "options": ["Blue", "Red", "Green", "Yellow"]
         },
         {
           "id": "q2",
@@ -38,7 +38,8 @@
           "prompt": "What is your favorite animal?",
           "location": "belowStimulus",
           "required": true,
-          "options": [{"label": "Dog", "value": "dog"}, {"label": "Cat", "value": "cat"}, {"label": "Bird", "value": "bird"}, {"label": "Fish", "value": "fish"}]}
+          "options": ["Dog", "Cat", "Bird", "Fish"]
+        }
       ],
       "nextButtonLocation": "belowStimulus",
       "instruction": "Please answer the following questions...",
@@ -69,10 +70,7 @@
           "prompt": "Are you paying attention?",
           "location": "belowStimulus",
           "required": true,
-          "options": [
-            {"label": "Yes", "value": "Yes"},
-            {"label": "No", "value": "No"}
-          ]
+          "options": ["Yes", "No"]
         }
       ],
       "correctAnswer": [

--- a/src/analysis/individualStudy/stats/AnswerPanel.tsx
+++ b/src/analysis/individualStudy/stats/AnswerPanel.tsx
@@ -41,7 +41,11 @@ export default function AnswerPanel({ data, config }: { data: Record<string, Rec
               }
             }
 
-            const categoryData:{option:string, count:number, correct:boolean}[] = (response as RadioResponse).options.map((op) => ({
+            const categoryData: { option: string, count: number, correct: boolean }[] = (response as RadioResponse).options.map((op) => (typeof op === 'string' ? {
+              option: op,
+              count: map.get(op as string) || 0,
+              correct: op === correctAnswer.find((ans) => ans.id === id)?.answer,
+            } : {
               option: op.value as string,
               count: map.get(op.value as string) || 0,
               correct: op.value === correctAnswer.find((ans) => ans.id === id)?.answer,

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -25,6 +25,8 @@ export default function CheckBoxInput({
     secondaryText,
   } = response;
 
+  const optionsAsStringOptions = options.map((option) => (typeof option === 'string' ? { value: option, label: option } : option));
+
   return (
     <Checkbox.Group
       label={(
@@ -37,11 +39,11 @@ export default function CheckBoxInput({
       )}
       description={secondaryText}
       {...answer}
-      error={generateErrorMessage(response, answer, options)}
+      error={generateErrorMessage(response, answer, optionsAsStringOptions)}
       style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
     >
       <Group mt="xs">
-        {options.map((option) => (
+        {optionsAsStringOptions.map((option) => (
           <Checkbox
             key={option.value}
             disabled={disabled}

--- a/src/components/response/DropdownInput.tsx
+++ b/src/components/response/DropdownInput.tsx
@@ -26,6 +26,8 @@ export default function DropdownInput({
     secondaryText,
   } = response;
 
+  const optionsAsStringOptions = options.map((option) => (typeof option === 'string' ? { value: option, label: option } : option));
+
   return (
     <Select
       disabled={disabled}
@@ -39,11 +41,11 @@ export default function DropdownInput({
       )}
       description={secondaryText}
       placeholder={placeholder}
-      data={options}
+      data={optionsAsStringOptions}
       radius="md"
       size="md"
       {...answer}
-      error={generateErrorMessage(response, answer, options)}
+      error={generateErrorMessage(response, answer, optionsAsStringOptions)}
     />
   );
 }

--- a/src/components/response/RadioInput.tsx
+++ b/src/components/response/RadioInput.tsx
@@ -27,6 +27,8 @@ export default function RadioInput({
     secondaryText,
   } = response;
 
+  const optionsAsStringOptions = options.map((option) => (typeof option === 'string' ? { value: option, label: option } : option));
+
   return (
     <Radio.Group
       name={`radioInput${response.id}`}
@@ -42,12 +44,12 @@ export default function RadioInput({
       key={response.id}
       {...answer}
         // This overrides the answers error. Which..is bad?
-      error={generateErrorMessage(response, answer, options)}
+      error={generateErrorMessage(response, answer, optionsAsStringOptions)}
       style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
     >
       <Group mt="xs">
         {leftLabel ? <Text style={{ textAlign: 'center' }}>{leftLabel}</Text> : null}
-        {options.map((radio) => (
+        {optionsAsStringOptions.map((radio) => (
           <Radio
             disabled={disabled}
             value={radio.value}

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -169,7 +169,14 @@
         "options": {
           "description": "The options that are displayed as checkboxes, provided as an array of objects, with label and value fields.",
           "items": {
-            "$ref": "#/definitions/StringOption"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/StringOption"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -343,7 +350,14 @@
         "options": {
           "description": "The options that are displayed in the dropdown.",
           "items": {
-            "$ref": "#/definitions/StringOption"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/StringOption"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -1105,7 +1119,14 @@
         "options": {
           "description": "The options that are displayed as checkboxes, provided as an array of objects, with label and value fields.",
           "items": {
-            "$ref": "#/definitions/StringOption"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/StringOption"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -314,7 +314,7 @@ export interface DropdownResponse extends BaseResponse {
   /** The placeholder text that is displayed in the input. */
   placeholder?: string;
   /** The options that are displayed in the dropdown. */
-  options: StringOption[];
+  options: (StringOption | string)[];
 }
 
 /**
@@ -382,7 +382,7 @@ export interface SliderResponse extends BaseResponse {
 export interface RadioResponse extends BaseResponse {
   type: 'radio';
   /** The options that are displayed as checkboxes, provided as an array of objects, with label and value fields. */
-  options: StringOption[];
+  options: (StringOption | string)[];
   /** The left label of the radio group. Used in Likert scales for example */
   leftLabel?: string;
   /** The right label of the radio group. Used in Likert scales for example */
@@ -420,7 +420,7 @@ export interface RadioResponse extends BaseResponse {
 export interface CheckboxResponse extends BaseResponse {
   type: 'checkbox';
   /** The options that are displayed as checkboxes, provided as an array of objects, with label and value fields. */
-  options: StringOption[];
+  options: (StringOption | string)[];
   /** The minimum number of selections that are required. */
   minSelections?: number;
   /** The maximum number of selections that are required. */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -294,16 +294,7 @@ export interface LikertResponse extends BaseResponse {
   "location": "aboveStimulus",
   "type": "dropdown",
   "placeholder": "Please choose your favorite color",
-  "options": [
-    {
-      "label": "Red",
-      "value": "red"
-    },
-    {
-      "label": "Blue",
-      "value": "blue"
-    }
-  ]
+  "options": ["Red", "Blue"]
 }
   ```
  *
@@ -365,16 +356,7 @@ export interface SliderResponse extends BaseResponse {
   "required": true,
   "location": "aboveStimulus",
   "type": "radio",
-  "options": [
-    {
-      "label": "Option 1",
-      "value": "opt-1"
-    },
-    {
-      "label": "Option 2",
-      "value": "opt-2"
-    }
-  ]
+  "options": ["Option 1", "Option 2"]
 }
 ```
  *
@@ -400,20 +382,7 @@ export interface RadioResponse extends BaseResponse {
   "required": false,
   "location": "aboveStimulus",
   "type": "checkbox",
-  "options": [
-    {
-      "label": "Option 1",
-      "value": "opt-1"
-    },
-    {
-      "label": "Option 2",
-      "value": "opt-2"
-    },
-    {
-      "label": "Option 3",
-      "value": "opt-3"
-    }
-  ]
+  "options": ["Option 1", "Option 2", "Option 3"]
 }
 ```
  */
@@ -682,25 +651,7 @@ export interface WebsiteComponent extends BaseIndividualComponent {
       "required": true,
       "location": "belowStimulus",
       "type": "checkbox",
-      "options": [
-        {
-          "label": "Man",
-          "value": "Man"
-        },
-        {
-          "label": "Woman",
-          "value": "Woman"
-        },
-        {
-          "label": "Genderqueer",
-          "value": "Genderqueer"
-        },
-        {
-          "label": "Third-gender",
-          "value": "Third-gender"
-        },
-        ... etc.
-      ]
+      "options": ["Man", "Woman", "Genderqueer", "Third-gender", ...]
     }
   ]
 }
@@ -1115,20 +1066,7 @@ export type InheritedComponent = (Partial<IndividualComponent> & { baseComponent
     "response": [
       {
         "id": "my-image-id",
-        "options": [
-          {
-            "label": "Europe",
-            "value": "Europe"
-          },
-          {
-            "label": "Japan",
-            "value": "Japan"
-          },
-          {
-            "label": "USA",
-            "value": "USA"
-          }
-        ],
+        "options": ["Europe", "Japan", "USA"],
         "prompt": "Your Selected Answer:",
         "type": "dropdown"
       }


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
Allows a simplification of the config, by allowing the options array to be defined using lists of strings instead of list of objects, e.g.:

```
"options": [
    "Bar",
    "Bubble",
    "Pie",
    "Stacked Bar"
]
```

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation
- [x] Check docs repo for updates (https://github.com/revisit-studies/reVISit-studies.github.io/pull/66)