### PR TITLE
Reject participants on failed training, add rejection reason, fix redux state getters, add cleaned duration to csv export and table view

### DIFF
--- a/src/analysis/dashboard/StudyCard.tsx
+++ b/src/analysis/dashboard/StudyCard.tsx
@@ -14,7 +14,7 @@ import { ParticipantStatusBadges } from '../interface/ParticipantStatusBadges';
 import { PREFIX } from '../../utils/Prefix';
 
 function isWithinRange(answers: Record<string, StoredAnswer>, rangeTime: [Date | null, Date | null]) {
-  const timeStamps = Object.values(answers).map((ans) => [ans.startTime, ans.endTime]).flat();
+  const timeStamps = Object.values(answers).map((ans) => [ans.startTime, ans.endTime]).flat().filter((time) => time !== -1);
   if (rangeTime[0] === null || rangeTime[1] === null) {
     return false;
   }
@@ -27,7 +27,7 @@ export function StudyCard({ studyId, allParticipants }: { studyId: string; allPa
 
   const completionTimes = allParticipants
     .filter((d) => d.completed)
-    .map((d) => Math.max(...Object.values(d.answers).map((ans) => ans.endTime).filter((time) => time !== undefined)))
+    .map((d) => Math.max(...Object.values(d.answers).map((ans) => ans.endTime).filter((time) => time !== -1)))
     .filter((d) => Number.isFinite(d));
   const [rangeTime, setRangeTime] = useState<[Date | null, Date | null]>([
     new Date(new Date(Math.min(...(completionTimes.length > 0 ? completionTimes : [new Date().getTime()]))).setHours(0, 0, 0, 0)),
@@ -47,7 +47,7 @@ export function StudyCard({ studyId, allParticipants }: { studyId: string; allPa
         { Date: rangeTime[0]?.getTime(), Participants: 0 },
         ...completedInTime
           .map((participant) => Math.max(
-            ...Object.values(participant.answers).map((ans) => ans.endTime).flat(),
+            ...Object.values(participant.answers).map((ans) => ans.endTime).flat().filter((time) => time !== -1),
           ))
           .sort((a, b) => a - b)
           .map((time, idx) => ({

--- a/src/analysis/individualStudy/stats/InfoPanel.tsx
+++ b/src/analysis/individualStudy/stats/InfoPanel.tsx
@@ -44,6 +44,11 @@ export default function InfoPanel(props: { data: Record<string, StoredAnswer>, t
       const durationAry:number[] = [];
       Object.entries(data).forEach(([pid, answers]) => {
         const duration = answers.endTime - answers.startTime;
+
+        if (duration < 0) {
+          return;
+        }
+
         sum += duration;
         durationAry.push(duration);
         if (duration > max) {

--- a/src/analysis/individualStudy/stats/ResponseVisualization.tsx
+++ b/src/analysis/individualStudy/stats/ResponseVisualization.tsx
@@ -55,7 +55,7 @@ export function ResponseVisualization({
     if (response.type === 'metadata') {
       const timingData = participantData
         .map((p) => Object.entries(p.answers).filter(([key]) => key.slice(0, key.lastIndexOf('_')) === trialId))
-        .map((p) => p.map(([_, value]) => (value.endTime - value.startTime) / 1000))
+        .map((p) => p.filter(([_, value]) => value.endTime !== -1).map(([_, value]) => (value.endTime - value.startTime) / 1000))
         .flat();
 
       // Histogram of completion times

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Spoiler, Stack, Table, Text, Flex, Checkbox, Button, Tooltip, LoadingOverlay, Group, Select, Space,
+  Box, Spoiler, Stack, Table, Text, Flex, Checkbox, Button, Tooltip, LoadingOverlay, Group, Select, Space, Modal, TextInput,
 } from '@mantine/core';
 import {
   IconCheck, IconProgress,
@@ -8,7 +8,6 @@ import {
 } from '@tabler/icons-react';
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { openConfirmModal } from '@mantine/modals';
 import { ParticipantData, StoredAnswer, StudyConfig } from '../../../parser/types';
 import { ParticipantMetadata } from '../../../store/types';
 import { configSequenceToUniqueTrials, findBlockForStep, getSequenceFlatMap } from '../../../utils/getSequenceFlatMap';
@@ -94,10 +93,11 @@ export function TableView({
   const { storageEngine } = useStorageEngine();
   const { studyId } = useParams();
   const { user } = useAuth();
-  const rejectParticipant = async (participantId: string) => {
+  const rejectParticipant = async (participantId: string, reason: string) => {
     if (storageEngine && studyId) {
       if (user.isAdmin) {
-        await storageEngine.rejectParticipant(studyId, participantId);
+        const finalReason = reason === '' ? 'Rejected by admin' : reason;
+        await storageEngine.rejectParticipant(studyId, participantId, finalReason);
         await refresh();
       } else {
         console.warn('You are not authorized to perform this action.');
@@ -106,29 +106,18 @@ export function TableView({
   };
   const [checked, setChecked] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
-  const openModal = () => openConfirmModal({
-    title: 'Confirm rejecting participants',
-    children: (
-      <Text size="sm">
-        Are you sure you want to reject the selected participants? This action is
-        {' '}
-        <Text span fw={700} td="underline" inherit>irreversible</Text>
-        , and will return the participants&apos; sequences to the beginning of the sequence array.
-      </Text>
-    ),
-    labels: { confirm: 'Reject Participants', cancel: 'Cancel' },
-    confirmProps: { color: 'red' },
-    cancelProps: { variant: 'subtle', color: 'dark' },
-    onCancel: () => {},
-    onConfirm: async () => {
-      setLoading(true);
-      const promises = checked.map(async (participantId) => await rejectParticipant(participantId));
-      await Promise.all(promises);
-      setChecked([]);
-      await refresh();
-      setLoading(false);
-    },
-  });
+  const [modalRejectParticipantsOpened, setModalRejectParticipantsOpened] = useState<boolean>(false);
+  const [rejectParticipantsMessage, setRejectParticipantsMessage] = useState<string>('');
+
+  const handleRejectParticipants = async () => {
+    setLoading(true);
+    setModalRejectParticipantsOpened(false);
+    const promises = checked.map(async (participantId) => await rejectParticipant(participantId, rejectParticipantsMessage));
+    await Promise.all(promises);
+    setChecked([]);
+    await refresh();
+    setLoading(false);
+  };
 
   const allParticipants = useMemo(() => [...completed, ...inProgress, ...rejected], [completed, inProgress, rejected]);
 
@@ -177,19 +166,26 @@ export function TableView({
         {record.participantId}
       </Table.Td>
       <Table.Td>
-        <Flex direction="row" align="center">
-          {
-          // eslint-disable-next-line no-nested-ternary
-          record.rejected ? <Tooltip label="Rejected"><IconX size={16} color="red" style={{ marginBottom: -3 }} /></Tooltip>
-            : record.completed
-              ? <Tooltip label="Completed"><IconCheck size={16} color="teal" style={{ marginBottom: -3 }} /></Tooltip>
-              : <Tooltip label="In Progress"><IconProgress size={16} color="orange" style={{ marginBottom: -3 }} /></Tooltip>
-        }
-          {(!record.completed) && (
-          <Text size="sm" mb={-1} ml={4}>
-            {((Object.entries(record.answers).filter(([_, entry]) => entry.endTime !== undefined).length / (getSequenceFlatMap(record.sequence).length - 1)) * 100).toFixed(2)}
-            %
-          </Text>
+        <Flex direction="column" miw={100}>
+          <Flex direction="row" align="center">
+            {
+              // eslint-disable-next-line no-nested-ternary
+              record.rejected ? <Tooltip label="Rejected"><IconX size={16} color="red" style={{ marginBottom: -3 }} /></Tooltip>
+                : record.completed
+                  ? <Tooltip label="Completed"><IconCheck size={16} color="teal" style={{ marginBottom: -3 }} /></Tooltip>
+                  : <Tooltip label="In Progress"><IconProgress size={16} color="orange" style={{ marginBottom: -3 }} /></Tooltip>
+            }
+            {(!record.completed) && (
+            <Text size="sm" mb={-1} ml={4}>
+              {((Object.entries(record.answers).filter(([_, entry]) => entry.endTime !== undefined).length / (getSequenceFlatMap(record.sequence).length - 1)) * 100).toFixed(2)}
+              %
+            </Text>
+            )}
+          </Flex>
+          {record.rejected && (
+            <Text mt={5} fz={10}>
+              {record.rejected.reason}
+            </Text>
           )}
         </Flex>
       </Table.Td>
@@ -249,8 +245,12 @@ export function TableView({
             />
           </Group>
           <Group>
-            <DownloadButtons allParticipants={[...completed, ...inProgress]} studyId={studyId || ''} />
-            <Button disabled={checked.length === 0 || !user.isAdmin} onClick={openModal} color="red">Reject Participants</Button>
+            <DownloadButtons allParticipants={allParticipants} studyId={studyId || ''} />
+            <Button disabled={checked.length === 0 || !user.isAdmin} onClick={() => setModalRejectParticipantsOpened(true)} color="red">
+              Reject Participants (
+              {checked.length}
+              )
+            </Button>
           </Group>
         </Flex>
         <Flex direction="column" style={{ width: '100%', overflow: 'auto' }}>
@@ -261,7 +261,32 @@ export function TableView({
             <Table.Tbody>{rows}</Table.Tbody>
           </Table>
         </Flex>
+        <Modal
+          opened={modalRejectParticipantsOpened}
+          onClose={() => setModalRejectParticipantsOpened(false)}
+          title={(
+            <Text>
+              Reject Participants (
+              {checked.length}
+              )
+            </Text>
+)}
+        >
+          <TextInput
+            label="Please enter the reason for rejection."
+            onChange={(event) => setRejectParticipantsMessage(event.target.value)}
+          />
+          <Flex mt="sm" justify="right">
+            <Button mr={5} variant="subtle" color="dark" onClick={() => { setModalRejectParticipantsOpened(false); setRejectParticipantsMessage(''); }}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={() => handleRejectParticipants()}>
+              Reject Participants
+            </Button>
+          </Flex>
+        </Modal>
       </>
+
     ) : (
       <>
         <Space h="xl" />

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -193,7 +193,7 @@ export function TableView({
             }
             {(!record.completed) && (
             <Text size="sm" mb={-1} ml={4}>
-              {((Object.entries(record.answers).filter(([_, entry]) => entry.endTime !== -1).length / (getSequenceFlatMap(record.sequence).length - 1)) * 100).toFixed(2)}
+              {((Object.entries(record.answers).filter(([_, entry]) => entry.endTime !== -1 && entry.endTime !== undefined).length / (getSequenceFlatMap(record.sequence).length - 1)) * 100).toFixed(2)}
               %
             </Text>
             )}
@@ -233,8 +233,8 @@ export function TableView({
       })}
       <DurationCell
         cellData={{
-          startTime: Math.min(...Object.values(record.answers).filter((a) => a.endTime !== -1).map((a) => a.startTime)),
-          endTime: Math.max(...Object.values(record.answers).filter((a) => a.endTime !== -1).map((a) => a.endTime)),
+          startTime: Math.min(...Object.values(record.answers).filter((a) => a.endTime !== -1 && a.endTime !== undefined).map((a) => a.startTime)),
+          endTime: Math.max(...Object.values(record.answers).filter((a) => a.endTime !== -1 && a.endTime !== undefined).map((a) => a.endTime)),
           answer: {},
           windowEvents: Object.values(record.answers).flatMap((a) => a.windowEvents),
         }}

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -14,7 +14,7 @@ import { useStudyId } from '../routes/utils';
 export function StudyEnd() {
   const studyConfig = useStudyConfig();
   const { storageEngine } = useStorageEngine();
-  const { answers } = useStoreSelector((state) => state);
+  const answers = useStoreSelector((state) => state.answers);
 
   const [completed, setCompleted] = useState(false);
   useEffect(() => {

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -28,6 +28,8 @@ import { useAsync } from '../../store/hooks/useAsync';
 
 export const OPTIONAL_COMMON_PROPS = [
   'status',
+  'rejectReason',
+  'rejectTime',
   'percentComplete',
   'description',
   'instruction',
@@ -94,6 +96,12 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
       if (properties.includes('status')) {
         // eslint-disable-next-line no-nested-ternary
         tidyRow.status = participant.rejected ? 'rejected' : (participant.completed ? 'completed' : 'in progress');
+      }
+      if (properties.includes('rejectReason')) {
+        tidyRow.rejectReason = participant.rejected ? participant.rejected.reason : undefined;
+      }
+      if (properties.includes('rejectTime')) {
+        tidyRow.rejectTime = participant.rejected ? new Date(participant.rejected.timestamp).toISOString() : undefined;
       }
       if (properties.includes('configHash')) {
         // eslint-disable-next-line no-nested-ternary

--- a/src/components/interface/AlertModal.tsx
+++ b/src/components/interface/AlertModal.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useStoreActions, useStoreDispatch, useStoreSelector } from '../../store/store';
 
 export function AlertModal() {
-  const { alertModal } = useStoreSelector((state) => state);
+  const alertModal = useStoreSelector((state) => state.alertModal);
   const { setAlertModal } = useStoreActions();
   const storeDispatch = useStoreDispatch();
 

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -33,7 +33,8 @@ function InfoHover({ text }: { text: string }) {
 }
 
 export default function AppAside() {
-  const { sequence, metadata } = useStoreSelector((state) => state);
+  const sequence = useStoreSelector((state) => state.sequence);
+  const metadata = useStoreSelector((state) => state.metadata);
   const { toggleStudyBrowser } = useStoreActions();
 
   const studyConfig = useStudyConfig();

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -30,7 +30,9 @@ import { PREFIX } from '../../utils/Prefix';
 import { getNewParticipant } from '../../utils/nextParticipant';
 
 export default function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled }: { studyNavigatorEnabled: boolean; dataCollectionEnabled: boolean }) {
-  const { config: studyConfig, metadata } = useStoreSelector((state) => state);
+  const studyConfig = useStoreSelector((state) => state.config);
+  const metadata = useStoreSelector((state) => state.metadata);
+
   const flatSequence = useFlatSequence();
   const storeDispatch = useStoreDispatch();
   const { toggleShowHelpText, toggleStudyBrowser } = useStoreActions();

--- a/src/components/interface/HelpModal.tsx
+++ b/src/components/interface/HelpModal.tsx
@@ -7,7 +7,8 @@ import ResourceNotFound from '../../ResourceNotFound';
 
 export default function HelpModal() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { showHelpText, config } = useStoreSelector((state: any) => state);
+  const showHelpText = useStoreSelector((state) => state.showHelpText);
+  const config = useStoreSelector((state) => state.config);
 
   const storeDispatch = useStoreDispatch();
   const { toggleShowHelpText } = useStoreActions();
@@ -16,7 +17,11 @@ export default function HelpModal() {
 
   const [loading, setLoading] = useState(true);
   useEffect(() => {
-    async function fetchImage() {
+    async function fetchText() {
+      if (!config.uiConfig.helpTextPath) {
+        setLoading(false);
+        return;
+      }
       const asset = await getStaticAssetByPath(config.uiConfig.helpTextPath);
       if (asset !== undefined) {
         setHelpText(asset);
@@ -24,7 +29,7 @@ export default function HelpModal() {
       setLoading(false);
     }
 
-    fetchImage();
+    fetchText();
   }, [config.uiConfig.helpTextPath]);
 
   return (

--- a/src/components/response/IframeInput.tsx
+++ b/src/components/response/IframeInput.tsx
@@ -30,10 +30,11 @@ export default function IframeInput({
       description={secondaryText}
       size="md"
     >
-
+      {answer.value && (
       <List>
         {Array.isArray(answer.value) ? (answer.value).map((item) => <List.Item key={item}>{item}</List.Item>) : <List.Item>{answer.value}</List.Item>}
       </List>
+      )}
     </Input.Wrapper>
   );
 }

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -133,7 +133,7 @@ export default function ResponseBlock({
 
             // If the user has failed the training, wait 5 seconds and redirect to a fail page
             if (!allowFailedTraining && storageEngine) {
-              storageEngine.rejectCurrentParticipant(studyId)
+              storageEngine.rejectCurrentParticipant(studyId, 'Failed training')
                 .then(() => {
                   setTimeout(() => {
                     navigate('./__trainingFailed');

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -9,7 +9,7 @@ import {
   IndividualComponent,
   ResponseBlockLocation,
 } from '../../parser/types';
-import { useCurrentComponent, useCurrentStep } from '../../routes/utils';
+import { useCurrentComponent, useCurrentStep, useStudyId } from '../../routes/utils';
 import {
   useStoreDispatch, useStoreSelector, useStoreActions,
 } from '../../store/store';
@@ -19,6 +19,7 @@ import { NextButton } from '../NextButton';
 import { useAnswerField } from './utils';
 import ResponseSwitcher from './ResponseSwitcher';
 import { StoredAnswer, TrrackedProvenance } from '../../store/types';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
 
 type Props = {
   status?: StoredAnswer;
@@ -33,11 +34,14 @@ export default function ResponseBlock({
   status,
   style,
 }: Props) {
+  const { storageEngine } = useStorageEngine();
   const storeDispatch = useStoreDispatch();
   const { updateResponseBlockValidation, toggleShowHelpText } = useStoreActions();
   const currentStep = useCurrentStep();
   const currentComponent = useCurrentComponent();
   const storedAnswer = status?.answer;
+
+  const studyId = useStudyId();
 
   const navigate = useNavigate();
 
@@ -128,10 +132,19 @@ export default function ResponseBlock({
             message = `You didn't answer this question correctly after ${trainingAttempts} attempts. ${allowFailedTraining ? 'You can continue to the next question.' : 'Unfortunately you have not met the criteria for continuing this study.'}`;
 
             // If the user has failed the training, wait 5 seconds and redirect to a fail page
-            if (!allowFailedTraining) {
-              setTimeout(() => {
-                navigate('./__trainingFailed');
-              }, 5000);
+            if (!allowFailedTraining && storageEngine) {
+              storageEngine.rejectCurrentParticipant(studyId)
+                .then(() => {
+                  setTimeout(() => {
+                    navigate('./__trainingFailed');
+                  }, 5000);
+                })
+                .catch(() => {
+                  console.error('Failed to reject participant who failed training');
+                  setTimeout(() => {
+                    navigate('./__trainingFailed');
+                  }, 5000);
+                });
             }
           } else if (trainingAttempts - newAttemptsUsed === 1) {
             message = 'Please try again. You have 1 attempt left.';
@@ -195,7 +208,7 @@ export default function ResponseBlock({
         {hasCorrectAnswerFeedback && showNextBtn && (
           <Button
             onClick={() => checkAnswerProvideFeedback()}
-            disabled={!answerValidator.isValid()}
+            disabled={!answerValidator.isValid() || attemptsUsed >= trainingAttempts}
           >
             Check Answer
           </Button>

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -51,7 +51,8 @@ export default function ResponseBlock({
 
   const answerValidator = useAnswerField(responses, currentStep, storedAnswer || {});
   const [provenanceGraph, setProvenanceGraph] = useState<TrrackedProvenance | undefined>(undefined);
-  const { iframeAnswers, iframeProvenance } = useStoreSelector((state) => state);
+  const iframeAnswers = useStoreSelector((state) => state.iframeAnswers);
+  const iframeProvenance = useStoreSelector((state) => state.iframeProvenance);
 
   const hasCorrectAnswerFeedback = configInUse?.provideFeedback && ((configInUse?.correctAnswer?.length || 0) > 0);
   const allowFailedTraining = configInUse?.allowFailedTraining === undefined ? true : configInUse.allowFailedTraining;

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -714,6 +714,14 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
+  async rejectCurrentParticipant(studyId: string) {
+    if (!this.currentParticipantId) {
+      throw new Error('Participant not initialized');
+    }
+
+    return await this.rejectParticipant(studyId, this.currentParticipantId);
+  }
+
   async setMode(studyId: string, mode: REVISIT_MODE, value: boolean) {
     const revisitModesDoc = doc(
       this.firestore,

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -666,7 +666,7 @@ export class FirebaseStorageEngine extends StorageEngine {
     return participantsData;
   }
 
-  async rejectParticipant(studyId: string, participantId: string) {
+  async rejectParticipant(studyId: string, participantId: string, reason: string) {
     const studyCollection = collection(
       this.firestore,
       `${this.collectionPrefix}${studyId}`,
@@ -691,7 +691,10 @@ export class FirebaseStorageEngine extends StorageEngine {
       }
 
       // set reject flag
-      participant.rejected = true;
+      participant.rejected = {
+        reason,
+        timestamp: new Date().getTime(),
+      };
       await this._pushToFirebaseStorageByRef(
         participantRef,
         'participantData',
@@ -714,12 +717,12 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
   }
 
-  async rejectCurrentParticipant(studyId: string) {
+  async rejectCurrentParticipant(studyId: string, reason: string) {
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
 
-    return await this.rejectParticipant(studyId, this.currentParticipantId);
+    return await this.rejectParticipant(studyId, this.currentParticipantId, reason);
   }
 
   async setMode(studyId: string, mode: REVISIT_MODE, value: boolean) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -284,7 +284,7 @@ export class LocalStorageEngine extends StorageEngine {
     return true;
   }
 
-  async rejectParticipant(studyId:string, participantId: string) {
+  async rejectParticipant(studyId: string, participantId: string) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
@@ -313,6 +313,18 @@ export class LocalStorageEngine extends StorageEngine {
 
     // Save the user
     await this.studyDatabase.setItem(participantId, participant);
+  }
+
+  async rejectCurrentParticipant(studyId: string) {
+    if (!this._verifyStudyDatabase(this.studyDatabase)) {
+      throw new Error('Study database not initialized');
+    }
+
+    if (!this.currentParticipantId) {
+      throw new Error('Participant not initialized');
+    }
+
+    await this.rejectParticipant(studyId, this.currentParticipantId);
   }
 
   async setMode(studyId: string, key: REVISIT_MODE, value: boolean) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -284,7 +284,7 @@ export class LocalStorageEngine extends StorageEngine {
     return true;
   }
 
-  async rejectParticipant(studyId: string, participantId: string) {
+  async rejectParticipant(studyId: string, participantId: string, reason: string) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
@@ -302,7 +302,10 @@ export class LocalStorageEngine extends StorageEngine {
     }
 
     // Set the user as rejected
-    participant.rejected = true;
+    participant.rejected = {
+      reason,
+      timestamp: new Date().getTime(),
+    };
 
     // Return the user's sequence to the pool
     const sequenceArray = await this.studyDatabase.getItem('sequenceArray') as Sequence[] | null;
@@ -315,7 +318,7 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.setItem(participantId, participant);
   }
 
-  async rejectCurrentParticipant(studyId: string) {
+  async rejectCurrentParticipant(studyId: string, reason: string) {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');
     }
@@ -324,7 +327,7 @@ export class LocalStorageEngine extends StorageEngine {
       throw new Error('Participant not initialized');
     }
 
-    await this.rejectParticipant(studyId, this.currentParticipantId);
+    await this.rejectParticipant(studyId, this.currentParticipantId, reason);
   }
 
   async setMode(studyId: string, key: REVISIT_MODE, value: boolean) {

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -78,9 +78,9 @@ export abstract class StorageEngine {
 
   abstract validateUser(user: UserWrapped | null): Promise<boolean>;
 
-  abstract rejectParticipant(studyId: string, participantID: string): Promise<void>;
+  abstract rejectParticipant(studyId: string, participantID: string, reason: string): Promise<void>;
 
-  abstract rejectCurrentParticipant(studyId: string): Promise<void>;
+  abstract rejectCurrentParticipant(studyId: string, reason: string): Promise<void>;
 
   abstract setMode(studyId: string, mode: REVISIT_MODE, value: boolean): Promise<void>;
 

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -80,6 +80,8 @@ export abstract class StorageEngine {
 
   abstract rejectParticipant(studyId: string, participantID: string): Promise<void>;
 
+  abstract rejectCurrentParticipant(studyId: string): Promise<void>;
+
   abstract setMode(studyId: string, mode: REVISIT_MODE, value: boolean): Promise<void>;
 
   abstract getModes(studyId: string): Promise<Record<REVISIT_MODE, boolean>>;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -64,6 +64,9 @@ export interface ParticipantData {
   metadata: ParticipantMetadata
   /** Whether the participant has completed the study. */
   completed: boolean;
-  /** Whether the participant has been rejected. */
-  rejected: boolean;
+  /** Whether the participant has been rejected and the reason. */
+  rejected: {
+    reason: string;
+    timestamp: number;
+  } | false;
 }

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -100,7 +100,7 @@ export function useNextStep() {
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
-    if (dataCollectionEnabled && !storedAnswer?.endTime) {
+    if (dataCollectionEnabled && storedAnswer.endTime === -1) { // === -1 means the answer has not been saved yet
       storeDispatch(
         saveTrialAnswer({
           identifier,

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -47,7 +47,9 @@ export function useNextStep() {
   const currentComponent = useCurrentComponent();
   const identifier = `${currentComponent}_${currentStep}`;
 
-  const { trialValidation, sequence, answers } = useStoreSelector((state) => state);
+  const trialValidation = useStoreSelector((state) => state.trialValidation);
+  const sequence = useStoreSelector((state) => state.sequence);
+  const answers = useStoreSelector((state) => state.answers);
 
   const storeDispatch = useStoreDispatch();
   const { saveTrialAnswer, setIframeAnswers } = useStoreActions();

--- a/src/store/hooks/useStoredAnswer.ts
+++ b/src/store/hooks/useStoredAnswer.ts
@@ -1,11 +1,10 @@
 import { useStoreSelector } from '../store';
 import { useCurrentComponent, useCurrentStep } from '../../routes/utils';
-import { StoredAnswer } from '../types';
 
 export function useStoredAnswer() {
-  const { answers } = useStoreSelector((state) => state);
   const currentStep = useCurrentStep();
   const currentComponent = useCurrentComponent();
   const identifier = `${currentComponent}_${currentStep}`;
-  return answers[identifier] as StoredAnswer | undefined;
+  const answers = useStoreSelector((state) => state.answers[identifier]);
+  return answers;
 }

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -1,4 +1,6 @@
-import { createSlice, configureStore, type PayloadAction } from '@reduxjs/toolkit';
+import {
+  createSlice, configureStore, type PayloadAction, createSelector,
+} from '@reduxjs/toolkit';
 import { createContext, useContext } from 'react';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { ResponseBlockLocation, StudyConfig } from '../parser/types';
@@ -155,6 +157,11 @@ export function useAreResponsesValid(id: string) {
   });
 }
 
-export function useFlatSequence(): string[] {
-  return useStoreSelector((state) => getSequenceFlatMap(state.sequence));
+const flatSequenceSelector = createSelector(
+  (state) => state.sequence,
+  (sequence) => getSequenceFlatMap(sequence),
+);
+
+export function useFlatSequence() {
+  return useStoreSelector(flatSequenceSelector);
 }

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -18,7 +18,13 @@ export async function studyStoreCreator(
 ) {
   const flatSequence = getSequenceFlatMap(sequence);
 
-  const emptyAnswers = Object.fromEntries(flatSequence.filter((id) => id !== 'end').map((id, idx) => [`${id}_${idx}`, { answer: {} }])) as Record<string, StoredAnswer>;
+  const emptyAnswers: Record<string, StoredAnswer> = Object.fromEntries(flatSequence.filter((id) => id !== 'end')
+    .map((id, idx) => [
+      `${id}_${idx}`,
+      {
+        answer: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [],
+      },
+    ]));
   const emptyValidation: TrialValidation = Object.assign(
     {},
     ...flatSequence.map((id, idx) => ({ [`${id}_${idx}`]: { aboveStimulus: { valid: false, values: {} }, belowStimulus: { valid: false, values: {} }, sidebar: { valid: false, values: {} } } })),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -74,7 +74,7 @@ export interface StoredAnswer {
   provenanceGraph?: TrrackedProvenance,
   /** A list containing the time (in epoch milliseconds), the action (focus, input, kepress, mousedown, mouseup, mousemove, resize, scroll or visibility), and then either a coordinate pertaining to where the event took place on the screen or string related to such event. Below is an example of the windowEvents list.
 ```js
-"windowEvents" :[
+"windowEvents": [
   [
     1711641174878,
     "mousedown",

--- a/src/utils/getCleanedDuration.ts
+++ b/src/utils/getCleanedDuration.ts
@@ -1,0 +1,23 @@
+import { StoredAnswer } from '../store/types';
+
+export function getCleanedDuration(answer: StoredAnswer) {
+  const duration = answer.endTime === -1 ? undefined : answer.endTime - answer.startTime;
+  const visibilityEvents = (answer.windowEvents || [])
+    .filter(([_, type, __]) => type === 'visibility');
+  let timeNavigatedAway = 0;
+  let i = 0;
+  while (i < visibilityEvents.length - 1) {
+    if (visibilityEvents[i][2] === 'hidden') {
+      for (let j = i + 1; j < visibilityEvents.length; j += 1) {
+        if (visibilityEvents[j][2] === 'visible') {
+          timeNavigatedAway += visibilityEvents[j][0] - visibilityEvents[i][0];
+          i = j;
+          break;
+        }
+      }
+    }
+    i += 1;
+  }
+  const cleanedDuration = duration ? duration - timeNavigatedAway : undefined;
+  return cleanedDuration;
+}

--- a/src/utils/getCleanedDuration.ts
+++ b/src/utils/getCleanedDuration.ts
@@ -3,6 +3,7 @@ import { StoredAnswer } from '../store/types';
 export function getCleanedDuration(answer: StoredAnswer) {
   const duration = answer.endTime === -1 ? undefined : answer.endTime - answer.startTime;
   const visibilityEvents = (answer.windowEvents || [])
+    .filter((event) => event !== undefined)
     .filter(([_, type, __]) => type === 'visibility');
   let timeNavigatedAway = 0;
   let i = 0;

--- a/tests/test-training-feeback.spec.ts
+++ b/tests/test-training-feeback.spec.ts
@@ -43,12 +43,6 @@ test('test', async ({ page }) => {
   await expect(incorrectAnswer).toBeVisible();
 
   // Answer the training question incorrectly again
-  await page.getByPlaceholder('0-100').fill('51');
-  await page.getByRole('button', { name: 'Check Answer' }).click();
-  const incorrectAnswer2 = await page.getByText('Incorrect Answer');
-  await expect(incorrectAnswer2).toBeVisible();
-
-  // Answer the training question incorrectly again
   await page.getByPlaceholder('0-100').fill('52');
   await page.getByRole('button', { name: 'Check Answer' }).click();
   const incorrectAnswer3 = await page.getByText('You didn\'t answer this question correctly after 2 attempts. Unfortunately you have not met the criteria for continuing this study.');
@@ -60,7 +54,6 @@ test('test', async ({ page }) => {
 
   // Answer the training question correctly and expect the next button to be disabled still
   await page.getByPlaceholder('0-100').fill('66');
-  await page.getByRole('button', { name: 'Check Answer' }).click();
   await expect(nextButton).toBeDisabled();
 
   // Click next participant


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #461 
Closes #450
Closes #216 

### Give a longer description of what this PR addresses and why it's needed
Added multiple features/fixes:
- Reject participants on failed training
  -  With rejection reason, "failed training"
- add rejection reason
  - Identifies why people were rejected (optional)
  - In this refactor, added number to the button so you can see how many people will be rejected
- fix redux state getters
  - Addressed a console error here
- add cleaned duration to csv export and table view
  - Automatically handles the window events for visibility so that an analyst can see how long participants were looking at the tab.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="571" alt="Screenshot 2024-09-09 at 3 41 44 PM" src="https://github.com/user-attachments/assets/9d98b50c-d4eb-4618-8a6c-d97ffd0d7592">

### Are there any additional TODOs before this PR is ready to go?
No