### PR TITLE
Add next button wait and timeout

### DIFF
--- a/public/demo-image/config.json
+++ b/public/demo-image/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v1.0.5/src/parser/StudyConfigSchema.json",
+  "$schema": "file:///Users/jwilburn/Projects/revisit-study/src/parser/StudyConfigSchema.json",
   "studyMetadata": {
     "title": "Simple Images as Stimuli: Decision-Making with Uncertainty Visualizations",
     "version": "pilot",
@@ -54,7 +54,9 @@
             "No"
           ]
         }
-      ]
+      ],
+      "nextButtonEnableTime": 3000,
+      "nextButtonDisableTime": 15000
     },
     "dotplot-medium": {
       "meta": {

--- a/public/demo-image/config.json
+++ b/public/demo-image/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "file:///Users/jwilburn/Projects/revisit-study/src/parser/StudyConfigSchema.json",
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/time-to-next/src/parser/StudyConfigSchema.json",
   "studyMetadata": {
     "title": "Simple Images as Stimuli: Decision-Making with Uncertainty Visualizations",
     "version": "pilot",

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -20,17 +20,19 @@ function AnswerCell({ cellData }: { cellData: StoredAnswer }) {
   return Number.isFinite(cellData.endTime) && Number.isFinite(cellData.startTime) ? (
     <Table.Td>
       <Stack miw={100}>
-        {Object.entries(cellData.answer).map(([key, storedAnswer]) => (
-          <Box key={`cell-${key}`}>
-            <Text fw={700} span>
-              {' '}
-              {`${key}: `}
-            </Text>
-            <Text span>
-              {`${storedAnswer}`}
-            </Text>
-          </Box>
-        ))}
+        {cellData.timedOut
+          ? <Text>Timed out</Text>
+          : Object.entries(cellData.answer).map(([key, storedAnswer]) => (
+            <Box key={`cell-${key}`}>
+              <Text fw={700} span>
+                {' '}
+                {`${key}: `}
+              </Text>
+              <Text span>
+                {`${storedAnswer}`}
+              </Text>
+            </Box>
+          ))}
       </Stack>
     </Table.Td>
   ) : (
@@ -237,6 +239,7 @@ export function TableView({
           endTime: Math.max(...Object.values(record.answers).filter((a) => a.endTime !== -1 && a.endTime !== undefined).map((a) => a.endTime)),
           answer: {},
           windowEvents: Object.values(record.answers).flatMap((a) => a.windowEvents),
+          timedOut: false, // not used
         }}
         key={`cell-${record.participantId}-total-duration`}
       />

--- a/src/components/TimedOut.tsx
+++ b/src/components/TimedOut.tsx
@@ -1,0 +1,9 @@
+import { Text } from '@mantine/core';
+
+export function TimedOut() {
+  return (
+    <Text>
+      Thank you for participating. Unfortunately you have didn&apos;t answer the questions in time and you are not eligible to participate in the study. You may close this window now.
+    </Text>
+  );
+}

--- a/src/components/TimedOut.tsx
+++ b/src/components/TimedOut.tsx
@@ -3,7 +3,7 @@ import { Text } from '@mantine/core';
 export function TimedOut() {
   return (
     <Text>
-      Thank you for participating. Unfortunately you have didn&apos;t answer the questions in time and you are not eligible to participate in the study. You may close this window now.
+      Thank you for participating. Unfortunately, you have not answered the questions within the given time limit. Because of this, you are no longer eligible to participate in the study. You may close this window now.
     </Text>
   );
 }

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -181,8 +181,9 @@ export default function ResponseBlock({
       });
 
       setEnableNextButton(
-        (allowFailedTraining && newAttemptsUsed >= trainingAttempts)
-        || (
+      (
+          allowFailedTraining && newAttemptsUsed >= trainingAttempts
+       ) || (
           Object.values(correctAnswers).every((isCorrect) => isCorrect)
           && newAttemptsUsed <= trainingAttempts
         ),

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -75,7 +75,7 @@ export default function ResponseBlock({
     const interval = setInterval(() => {
       time += 100;
       setTimer(time);
-    }, 100);
+    }, 500);
     return () => {
       clearInterval(interval);
     };
@@ -181,9 +181,9 @@ export default function ResponseBlock({
       });
 
       setEnableNextButton(
-      (
+        (
           allowFailedTraining && newAttemptsUsed >= trainingAttempts
-       ) || (
+        ) || (
           Object.values(correctAnswers).every((isCorrect) => isCorrect)
           && newAttemptsUsed <= trainingAttempts
         ),

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -17,6 +17,7 @@ import { useStoreActions, useStoreDispatch } from '../store/store';
 import { StudyEnd } from '../components/StudyEnd';
 import { TrainingFailed } from '../components/TrainingFailed';
 import ResourceNotFound from '../ResourceNotFound';
+import { TimedOut } from '../components/TimedOut';
 
 // current active stimuli presented to the user
 export default function ComponentController() {
@@ -54,6 +55,11 @@ export default function ComponentController() {
   // Handle failed training
   if (currentComponent === '__trainingFailed') {
     return <TrainingFailed />;
+  }
+
+  // Handle timed out participants
+  if (currentComponent === '__timedOut') {
+    return <TimedOut />;
   }
 
   if (currentComponent === 'Notfound') {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -61,11 +61,11 @@
             "type": "object"
           },
           "nextButtonDisableTime": {
-            "description": "A timeout after which the next button will be disabled.",
+            "description": "A timeout (in ms) after which the next button will be disabled.",
             "type": "number"
           },
           "nextButtonEnableTime": {
-            "description": "A timer after which the next button will be enabled.",
+            "description": "A timer (in ms) after which the next button will be enabled.",
             "type": "number"
           },
           "nextButtonLocation": {
@@ -495,11 +495,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -675,11 +675,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -974,11 +974,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -1136,11 +1136,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -1313,11 +1313,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -1630,11 +1630,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -60,6 +60,14 @@
             "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "object"
           },
+          "nextButtonDisableTime": {
+            "description": "A timeout after which the next button will be disabled.",
+            "type": "number"
+          },
+          "nextButtonEnableTime": {
+            "description": "A timer after which the next button will be enabled.",
+            "type": "number"
+          },
           "nextButtonLocation": {
             "$ref": "#/definitions/ResponseBlockLocation",
             "description": "The location of the next button."
@@ -486,6 +494,14 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
           "description": "The location of the next button."
@@ -657,6 +673,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
@@ -949,6 +973,14 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
           "description": "The location of the next button."
@@ -1102,6 +1134,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
@@ -1271,6 +1311,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
@@ -1580,6 +1628,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -61,11 +61,11 @@
             "type": "object"
           },
           "nextButtonDisableTime": {
-            "description": "A timeout after which the next button will be disabled.",
+            "description": "A timeout (in ms) after which the next button will be disabled.",
             "type": "number"
           },
           "nextButtonEnableTime": {
-            "description": "A timer after which the next button will be enabled.",
+            "description": "A timer (in ms) after which the next button will be enabled.",
             "type": "number"
           },
           "nextButtonLocation": {
@@ -495,11 +495,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -675,11 +675,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -933,11 +933,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -1095,11 +1095,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -1272,11 +1272,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {
@@ -1758,11 +1758,11 @@
           "type": "object"
         },
         "nextButtonDisableTime": {
-          "description": "A timeout after which the next button will be disabled.",
+          "description": "A timeout (in ms) after which the next button will be disabled.",
           "type": "number"
         },
         "nextButtonEnableTime": {
-          "description": "A timer after which the next button will be enabled.",
+          "description": "A timer (in ms) after which the next button will be enabled.",
           "type": "number"
         },
         "nextButtonLocation": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -60,6 +60,14 @@
             "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "object"
           },
+          "nextButtonDisableTime": {
+            "description": "A timeout after which the next button will be disabled.",
+            "type": "number"
+          },
+          "nextButtonEnableTime": {
+            "description": "A timer after which the next button will be enabled.",
+            "type": "number"
+          },
           "nextButtonLocation": {
             "$ref": "#/definitions/ResponseBlockLocation",
             "description": "The location of the next button."
@@ -486,6 +494,14 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
           "description": "The location of the next button."
@@ -657,6 +673,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
@@ -908,6 +932,14 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
           "description": "The location of the next button."
@@ -1061,6 +1093,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
@@ -1230,6 +1270,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",
@@ -1704,6 +1752,14 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer after which the next button will be enabled.",
+          "type": "number"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ResponseBlockLocation",

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1700,6 +1700,10 @@
           "description": "The message to display when the study ends.",
           "type": "string"
         },
+        "timeoutReject": {
+          "description": "Whether to redirect a timed out participant to a rejection page. This only works for components where the `nextButtonDisableTime` field is set.",
+          "type": "boolean"
+        },
         "urlParticipantIdParam": {
           "description": "If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.",
           "type": "string"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -482,9 +482,9 @@ export interface BaseIndividualComponent {
   description?: string;
   /** The instruction of the component. This is used to identify and provide additional information for the component in the admin panel. */
   instruction?: string;
-  /** A timeout after which the next button will be disabled. */
+  /** A timeout (in ms) after which the next button will be disabled. */
   nextButtonDisableTime?: number;
-  /** A timer after which the next button will be enabled. */
+  /** A timer (in ms) after which the next button will be enabled. */
   nextButtonEnableTime?: number;
 }
 

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -114,6 +114,8 @@ export interface UIConfig {
    * Whether to prepend questions with their index (+ 1). This should only be used when all questions are in the same location, e.g. all are in the side bar.
    */
   enumerateQuestions?: boolean;
+  /** Whether to redirect a timed out participant to a rejection page. This only works for components where the `nextButtonDisableTime` field is set. */
+  timeoutReject?: boolean;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -480,6 +480,10 @@ export interface BaseIndividualComponent {
   description?: string;
   /** The instruction of the component. This is used to identify and provide additional information for the component in the admin panel. */
   instruction?: string;
+  /** A timeout after which the next button will be disabled. */
+  nextButtonDisableTime?: number;
+  /** A timer after which the next button will be enabled. */
+  nextButtonEnableTime?: number;
 }
 
 /**

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -82,7 +82,7 @@ export function useNextStep() {
   const startTime = useMemo(() => Date.now(), []);
 
   const windowEvents = useWindowEvents();
-  const goToNextStep = useCallback(() => {
+  const goToNextStep = useCallback((collectData = true) => {
     if (typeof currentStep !== 'number') {
       return;
     }
@@ -101,14 +101,18 @@ export function useNextStep() {
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
     if (dataCollectionEnabled && storedAnswer.endTime === -1) { // === -1 means the answer has not been saved yet
+      const toSave = {
+        answer: collectData ? answer : {},
+        startTime,
+        endTime,
+        provenanceGraph,
+        windowEvents: currentWindowEvents,
+        timedOut: !collectData,
+      };
       storeDispatch(
         saveTrialAnswer({
           identifier,
-          answer,
-          startTime,
-          endTime,
-          provenanceGraph,
-          windowEvents: currentWindowEvents,
+          ...toSave,
         }),
       );
       // Update database
@@ -116,9 +120,7 @@ export function useNextStep() {
         storageEngine.saveAnswers(
           {
             ...answers,
-            [identifier]: {
-              answer, startTime, endTime, provenanceGraph, windowEvents: currentWindowEvents,
-            },
+            [identifier]: toSave,
           },
         );
       }

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -22,7 +22,7 @@ export async function studyStoreCreator(
     .map((id, idx) => [
       `${id}_${idx}`,
       {
-        answer: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [],
+        answer: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [], timedOut: false,
       },
     ]));
   const emptyValidation: TrialValidation = Object.assign(
@@ -107,7 +107,7 @@ export async function studyStoreCreator(
         }: PayloadAction<{ identifier: string } & StoredAnswer>,
       ) {
         const {
-          identifier, answer, startTime, endTime, provenanceGraph, windowEvents,
+          identifier, answer, startTime, endTime, provenanceGraph, windowEvents, timedOut,
         } = payload;
         state.answers[identifier] = {
           answer,
@@ -115,6 +115,7 @@ export async function studyStoreCreator(
           endTime,
           provenanceGraph,
           windowEvents,
+          timedOut,
         };
       },
     },

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -102,6 +102,8 @@ export interface StoredAnswer {
 ```
    */
   windowEvents: EventType[];
+  /** A boolean value that indicates whether the participant timed out on this question. */
+  timedOut: boolean;
 }
 
 export interface StimulusParams<T> {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #449 

### Give a longer description of what this PR addresses and why it's needed
This pull request introduces a new feature to control the timing of the "Next" button in the response block, along with some schema updates and UI enhancements.

Adds a timer and 2 config options that either require a certain to have passed before the next button becomes available or disables the next button after a certain amount of time.

I had to modify some helpers slightly so that the participant answers would not be recorded on an incorrect answer. We still save a StoredAnswer (so we can replay provenance, etc.), but don't save any answers from the answer validator.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="301" alt="Screenshot 2024-11-01 at 10 21 23 AM" src="https://github.com/user-attachments/assets/8472e13e-e817-4b5f-9c00-f58b044d17fb">
<img width="301" alt="Screenshot 2024-11-01 at 10 21 11 AM" src="https://github.com/user-attachments/assets/1a87b20a-cf3f-4df6-b35b-7a7a54309b6d">
<img width="300" alt="Screenshot 2024-11-01 at 10 21 19 AM" src="https://github.com/user-attachments/assets/fe6a1520-097e-4e17-8891-da271cc9ce1d">


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation (typedoc)
- [ ] ...
