### PR TITLE
Add participantTags and add sequence block tags when navigating through the sequence

### DIFF
--- a/public/test-skip-logic/config.json
+++ b/public/test-skip-logic/config.json
@@ -113,6 +113,7 @@
       },
       "continuingComponent",
       {
+        "id": "testBlockId",
         "order": "fixed",
         "components": ["trial1"],
         "skip": [{

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -161,6 +161,7 @@ export function TableView({
     </Table.Th>,
     <Table.Th key="ID">ID</Table.Th>,
     <Table.Th key="status">Status</Table.Th>,
+    <Table.Th key="tags">Tags</Table.Th>,
     <Table.Th key="meta">Meta</Table.Th>,
     ...uniqueTrials.flatMap((trial) => [
       <Table.Th key={`header-${trial.componentName}-${trial.timesSeenInBlock}`}>{trial.componentName}</Table.Th>,
@@ -205,6 +206,18 @@ export function TableView({
               {record.rejected.reason}
             </Text>
           )}
+        </Flex>
+      </Table.Td>
+
+      <Table.Td>
+        <Flex direction="column" miw={100}>
+          {record.participantTags.map((tag) => (
+            <Text key={`tag-${tag}`} fz={10}>
+              -
+              {' '}
+              {tag}
+            </Text>
+          ))}
         </Flex>
       </Table.Td>
       {record.metadata ? <MetaCell metaData={record.metadata} /> : <Table.Td>N/A</Table.Td>}

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -75,87 +75,95 @@ export function download(graph: string, filename: string) {
 
 function participantDataToRows(participant: ParticipantData, properties: Property[], studyConfig: StudyConfig): TidyRow[] {
   const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (getSequenceFlatMap(participant.sequence).length - 1)) * 100).toFixed(2);
-  return Object.entries(participant.answers).map(([trialIdentifier, trialAnswer]) => {
+  return [
+    {
+      participantId: participant.participantId,
+      trialId: 'participantTags',
+      trialOrder: null,
+      responseId: 'participantTags',
+      answer: JSON.stringify(participant.participantTags),
+    },
+    ...Object.entries(participant.answers).map(([trialIdentifier, trialAnswer]) => {
     // Get the whole component, including the base component if there is inheritance
-    const trialId = trialIdentifier.split('_').slice(0, -1).join('_');
-    const trialOrder = parseInt(`${trialIdentifier.split('_').at(-1)}`, 10);
-    const trialConfig = studyConfig.components[trialId];
-    const completeComponent: IndividualComponent = isInheritedComponent(trialConfig) && trialConfig.baseComponent && studyConfig.baseComponents
-      ? merge({}, studyConfig.baseComponents[trialConfig.baseComponent], trialConfig)
-      : trialConfig;
+      const trialId = trialIdentifier.split('_').slice(0, -1).join('_');
+      const trialOrder = parseInt(`${trialIdentifier.split('_').at(-1)}`, 10);
+      const trialConfig = studyConfig.components[trialId];
+      const completeComponent: IndividualComponent = isInheritedComponent(trialConfig) && trialConfig.baseComponent && studyConfig.baseComponents
+        ? merge({}, studyConfig.baseComponents[trialConfig.baseComponent], trialConfig)
+        : trialConfig;
 
-    const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
-    const cleanedDuration = getCleanedDuration(trialAnswer);
+      const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
+      const cleanedDuration = getCleanedDuration(trialAnswer);
 
-    const rows = Object.entries(trialAnswer.answer).map(([key, value]) => {
-      const tidyRow: TidyRow = {
-        participantId: participant.participantId,
-        trialId,
-        trialOrder,
-        responseId: key,
-      };
+      const rows = Object.entries(trialAnswer.answer).map(([key, value]) => {
+        const tidyRow: TidyRow = {
+          participantId: participant.participantId,
+          trialId,
+          trialOrder,
+          responseId: key,
+        };
 
-      const response = completeComponent.response.find((resp) => resp.id === key);
-      if (properties.includes('status')) {
+        const response = completeComponent.response.find((resp) => resp.id === key);
+        if (properties.includes('status')) {
         // eslint-disable-next-line no-nested-ternary
-        tidyRow.status = participant.rejected ? 'rejected' : (participant.completed ? 'completed' : 'in progress');
-      }
-      if (properties.includes('rejectReason')) {
-        tidyRow.rejectReason = participant.rejected ? participant.rejected.reason : undefined;
-      }
-      if (properties.includes('rejectTime')) {
-        tidyRow.rejectTime = participant.rejected ? new Date(participant.rejected.timestamp).toISOString() : undefined;
-      }
-      if (properties.includes('configHash')) {
+          tidyRow.status = participant.rejected ? 'rejected' : (participant.completed ? 'completed' : 'in progress');
+        }
+        if (properties.includes('rejectReason')) {
+          tidyRow.rejectReason = participant.rejected ? participant.rejected.reason : undefined;
+        }
+        if (properties.includes('rejectTime')) {
+          tidyRow.rejectTime = participant.rejected ? new Date(participant.rejected.timestamp).toISOString() : undefined;
+        }
+        if (properties.includes('configHash')) {
         // eslint-disable-next-line no-nested-ternary
-        tidyRow.configHash = participant.participantConfigHash;
-      }
-      if (properties.includes('percentComplete')) {
-        tidyRow.percentComplete = percentComplete;
-      }
-      if (properties.includes('description')) {
-        tidyRow.description = completeComponent.description;
-      }
-      if (properties.includes('instruction')) {
-        tidyRow.instruction = completeComponent.instruction;
-      }
-      if (properties.includes('responsePrompt')) {
-        tidyRow.responsePrompt = response?.prompt;
-      }
-      if (properties.includes('answer')) {
-        tidyRow.answer = value;
-      }
-      if (properties.includes('correctAnswer')) {
-        const correctAnswer = (completeComponent.correctAnswer as Answer[])?.find((ans) => ans.id === key)?.answer;
-        tidyRow.correctAnswer = typeof correctAnswer === 'object' ? JSON.stringify(correctAnswer) : correctAnswer;
-      }
-      if (properties.includes('responseMin')) {
-        tidyRow.responseMin = response?.type === 'numerical' ? response.min : undefined;
-      }
-      if (properties.includes('responseMax')) {
-        tidyRow.responseMax = response?.type === 'numerical' ? response.max : undefined;
-      }
-      if (properties.includes('startTime')) {
-        tidyRow.startTime = new Date(trialAnswer.startTime).toISOString();
-      }
-      if (properties.includes('endTime')) {
-        tidyRow.endTime = new Date(trialAnswer.endTime).toISOString();
-      }
-      if (properties.includes('duration')) {
-        tidyRow.duration = duration;
-      }
-      if (properties.includes('cleanedDuration')) {
-        tidyRow.cleanedDuration = cleanedDuration;
-      }
-      if (properties.includes('meta')) {
-        tidyRow.meta = JSON.stringify(completeComponent.meta, null, 2);
-      }
+          tidyRow.configHash = participant.participantConfigHash;
+        }
+        if (properties.includes('percentComplete')) {
+          tidyRow.percentComplete = percentComplete;
+        }
+        if (properties.includes('description')) {
+          tidyRow.description = completeComponent.description;
+        }
+        if (properties.includes('instruction')) {
+          tidyRow.instruction = completeComponent.instruction;
+        }
+        if (properties.includes('responsePrompt')) {
+          tidyRow.responsePrompt = response?.prompt;
+        }
+        if (properties.includes('answer')) {
+          tidyRow.answer = value;
+        }
+        if (properties.includes('correctAnswer')) {
+          const correctAnswer = (completeComponent.correctAnswer as Answer[])?.find((ans) => ans.id === key)?.answer;
+          tidyRow.correctAnswer = typeof correctAnswer === 'object' ? JSON.stringify(correctAnswer) : correctAnswer;
+        }
+        if (properties.includes('responseMin')) {
+          tidyRow.responseMin = response?.type === 'numerical' ? response.min : undefined;
+        }
+        if (properties.includes('responseMax')) {
+          tidyRow.responseMax = response?.type === 'numerical' ? response.max : undefined;
+        }
+        if (properties.includes('startTime')) {
+          tidyRow.startTime = new Date(trialAnswer.startTime).toISOString();
+        }
+        if (properties.includes('endTime')) {
+          tidyRow.endTime = new Date(trialAnswer.endTime).toISOString();
+        }
+        if (properties.includes('duration')) {
+          tidyRow.duration = duration;
+        }
+        if (properties.includes('cleanedDuration')) {
+          tidyRow.cleanedDuration = cleanedDuration;
+        }
+        if (properties.includes('meta')) {
+          tidyRow.meta = JSON.stringify(completeComponent.meta, null, 2);
+        }
 
-      return tidyRow;
-    }).flat();
+        return tidyRow;
+      }).flat();
 
-    return rows;
-  }).flat();
+      return rows;
+    }).flat()];
 }
 
 async function getTableData(selectedProperties: Property[], data: ParticipantData[], storageEngine: StorageEngine | undefined, studyId: string) {

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -48,13 +48,14 @@ export default function ComponentController() {
   }, [setAlertModal, storageEngine, storeDispatch]);
 
   // Find current block, if it has an ID, add it as a participant tag
-  const [blockForStep, setBlockForStep] = useState<string | undefined>(undefined);
+  const [blockForStep, setBlockForStep] = useState<string[]>([]);
   useEffect(() => {
     async function getBlockForStep() {
       const participantData = await storageEngine?.getParticipantData();
       if (participantData) {
-        const mostNestedBlock = findBlockForStep(participantData.sequence, currentStep)?.[0];
-        setBlockForStep(mostNestedBlock?.currentBlock.id);
+        // Get all nested block IDs
+        const blockIds = findBlockForStep(participantData.sequence, currentStep)?.map((block) => block.currentBlock.id).filter<string>((blockId) => blockId !== undefined) || [];
+        setBlockForStep(blockIds);
       }
     }
     getBlockForStep();
@@ -62,7 +63,7 @@ export default function ComponentController() {
   useEffect(() => {
     async function addParticipantTag() {
       if (blockForStep && storageEngine) {
-        storageEngine.addParticipantTags([blockForStep]);
+        storageEngine.addParticipantTags(blockForStep);
       }
     }
     addParticipantTag();

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -54,7 +54,7 @@ export default function ComponentController() {
       const participantData = await storageEngine?.getParticipantData();
       if (participantData) {
         // Get all nested block IDs
-        const blockIds = findBlockForStep(participantData.sequence, currentStep)?.map((block) => block.currentBlock.id).filter<string>((blockId) => blockId !== undefined) || [];
+        const blockIds = findBlockForStep(participantData.sequence, currentStep)?.map((block) => block.currentBlock.id).filter((blockId) => blockId !== undefined) as string[] | undefined || [];
         setBlockForStep(blockIds);
       }
     }

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -493,6 +493,57 @@ export class FirebaseStorageEngine extends StorageEngine {
     return isParticipantData(participantData) ? participantData : null;
   }
 
+  async getParticipantTags(): Promise<string[]> {
+    if (!this._verifyStudyDatabase(this.studyCollection)) {
+      throw new Error('Study database not initialized');
+    }
+
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    return participantData.participantTags;
+  }
+
+  async addParticipantTags(tags: string[]): Promise<void> {
+    if (!this._verifyStudyDatabase(this.studyCollection)) {
+      throw new Error('Study database not initialized');
+    }
+
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    participantData.participantTags = [...new Set([...participantData.participantTags, ...tags])];
+
+    await this._pushToFirebaseStorage(
+      `participants/${this.currentParticipantId}`,
+      'participantData',
+      participantData,
+    );
+  }
+
+  async removeParticipantTags(tags: string[]): Promise<void> {
+    if (!this._verifyStudyDatabase(this.studyCollection)) {
+      throw new Error('Study database not initialized');
+    }
+
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    participantData.participantTags = participantData.participantTags.filter((tag) => !tags.includes(tag));
+
+    await this._pushToFirebaseStorage(
+      `participants/${this.currentParticipantId}`,
+      'participantData',
+      participantData,
+    );
+  }
+
   async nextParticipant() {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -231,6 +231,7 @@ export class FirebaseStorageEngine extends StorageEngine {
       metadata,
       completed: false,
       rejected: false,
+      participantTags: [],
     };
 
     if (modes.dataCollectionEnabled) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -249,6 +249,47 @@ export class LocalStorageEngine extends StorageEngine {
     return await this.studyDatabase.getItem(participantId) as ParticipantData | null;
   }
 
+  async getParticipantTags(): Promise<string[]> {
+    if (!this._verifyStudyDatabase(this.studyDatabase)) {
+      throw new Error('Study database not initialized');
+    }
+
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    return participantData.participantTags;
+  }
+
+  async addParticipantTags(tags: string[]): Promise<void> {
+    if (!this._verifyStudyDatabase(this.studyDatabase)) {
+      throw new Error('Study database not initialized');
+    }
+
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    participantData.participantTags = [...new Set([...participantData.participantTags, ...tags])];
+    await this.studyDatabase.setItem(this.currentParticipantId as string, participantData);
+  }
+
+  async removeParticipantTags(tags: string[]): Promise<void> {
+    if (!this._verifyStudyDatabase(this.studyDatabase)) {
+      throw new Error('Study database not initialized');
+    }
+
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
+      throw new Error('Participant not initialized');
+    }
+
+    participantData.participantTags = participantData.participantTags.filter((tag) => !tags.includes(tag));
+    await this.studyDatabase.setItem(this.currentParticipantId as string, participantData);
+  }
+
   async nextParticipant() {
     if (!this._verifyStudyDatabase(this.studyDatabase)) {
       throw new Error('Study database not initialized');

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -76,6 +76,7 @@ export class LocalStorageEngine extends StorageEngine {
       metadata,
       completed: false,
       rejected: false,
+      participantTags: [],
     };
 
     if (modes.dataCollectionEnabled) {

--- a/src/storage/engines/StorageEngine.ts
+++ b/src/storage/engines/StorageEngine.ts
@@ -72,6 +72,16 @@ export abstract class StorageEngine {
 
   abstract getParticipantData(): Promise<ParticipantData | null>;
 
+  abstract getParticipantTags(): Promise<string[]>;
+
+  /**
+   * This function adds tags to the participant. It ensures that the tags are unique, so if a tag is already present, it will not be added again.
+   * @param tags An array of tags to add to the participant
+   */
+  abstract addParticipantTags(tags: string[]): Promise<void>;
+
+  abstract removeParticipantTags(tags: string[]): Promise<void>;
+
   abstract nextParticipant(): Promise<void>;
 
   abstract verifyCompletion(answers: Record<string, StoredAnswer>): Promise<boolean>;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -69,4 +69,6 @@ export interface ParticipantData {
     reason: string;
     timestamp: number;
   } | false;
+  /** The component blocks that the participant entered. */
+  participantTags: string[];
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #474
Closes #475 
Closes #485 

### Give a longer description of what this PR addresses and why it's needed
This pull request introduces `participantTags`. Participant tags exist to allow tagging whole participants based on some criteria. The initial, automatic tagging that I've added is to tag when a participant enters into a sequence block with an ID. This could be useful if there is branching logic, to quickly find participants that took path A vs path B.

The code changes are as follows:
- Updated `ParticipantData` interface to include `participantTags` property.
- Added methods to get, add, and remove participant tags in the storage engines.
- Updated the ComponentController to fetch the block for the current step and add it as a participant tag automatically.
- Modified the skip logic test to verify the correct handling of participant tags, ensuring tags are added and removed appropriately.


### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="786" alt="Screenshot 2024-11-04 at 1 41 21 PM" src="https://github.com/user-attachments/assets/d4dd8525-6273-4b01-955e-4bf870942b73">


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation (typedoc)
- [x] Add the tags to the analysis table
- [x] Add the tags to the tidy data download 
