### PR TITLE
Store training incorrect answers

### DIFF
--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -260,6 +260,8 @@ export function TableView({
           startTime: Math.min(...Object.values(record.answers).filter((a) => a.endTime !== -1 && a.endTime !== undefined).map((a) => a.startTime)),
           endTime: Math.max(...Object.values(record.answers).filter((a) => a.endTime !== -1 && a.endTime !== undefined).map((a) => a.endTime)),
           answer: {},
+          helpButtonClickedCount: 0, // not used
+          incorrectAnswers: {}, // not used
           windowEvents: Object.values(record.answers).flatMap((a) => a.windowEvents),
           timedOut: false, // not used
         }}

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -22,7 +22,7 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useRef, useState } from 'react';
 import { useHref } from 'react-router-dom';
-import { useCurrentStep, useStudyId } from '../../routes/utils';
+import { useCurrentComponent, useCurrentStep, useStudyId } from '../../routes/utils';
 import {
   useStoreDispatch, useStoreSelector, useStoreActions, useFlatSequence,
 } from '../../store/store';
@@ -37,8 +37,10 @@ export default function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled
 
   const flatSequence = useFlatSequence();
   const storeDispatch = useStoreDispatch();
-  const { toggleShowHelpText, toggleStudyBrowser } = useStoreActions();
+  const { toggleShowHelpText, toggleStudyBrowser, incrementHelpCounter } = useStoreActions();
   const { storageEngine } = useStorageEngine();
+
+  const currentComponent = useCurrentComponent();
 
   const currentStep = useCurrentStep();
 
@@ -101,7 +103,7 @@ export default function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled
             {studyConfig?.uiConfig.helpTextPath !== undefined && (
               <Button
                 variant="outline"
-                onClick={() => storeDispatch(toggleShowHelpText())}
+                onClick={() => { storeDispatch(toggleShowHelpText()); storeDispatch(incrementHelpCounter({ identifier: `${currentComponent}_${currentStep}` })); }}
               >
                 Help
               </Button>

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -36,7 +36,7 @@ export default function ResponseBlock({
 }: Props) {
   const { storageEngine } = useStorageEngine();
   const storeDispatch = useStoreDispatch();
-  const { updateResponseBlockValidation, toggleShowHelpText } = useStoreActions();
+  const { updateResponseBlockValidation, toggleShowHelpText, saveIncorrectAnswer } = useStoreActions();
   const currentStep = useCurrentStep();
   const currentComponent = useCurrentComponent();
   const storedAnswer = status?.answer;
@@ -149,6 +149,7 @@ export default function ResponseBlock({
         if (correctAnswers[response.id] && !alertConfig[response.id]?.message.includes('You\'ve failed to answer this question correctly')) {
           updateAlertConfig(response.id, true, 'Correct Answer', 'You have answered the question correctly.', 'green');
         } else {
+          storeDispatch(saveIncorrectAnswer({ question: `${currentComponent}_${currentStep}`, identifier: response.id, answer: (answerValidator.values as Record<string, unknown>)[response.id] }));
           let message = '';
           if (newAttemptsUsed >= trainingAttempts) {
             message = `You didn't answer this question correctly after ${trainingAttempts} attempts. ${allowFailedTraining ? 'You can continue to the next question.' : 'Unfortunately you have not met the criteria for continuing this study.'}`;

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -36,7 +36,9 @@ export default function ResponseBlock({
 }: Props) {
   const { storageEngine } = useStorageEngine();
   const storeDispatch = useStoreDispatch();
-  const { updateResponseBlockValidation, toggleShowHelpText, saveIncorrectAnswer } = useStoreActions();
+  const {
+    updateResponseBlockValidation, toggleShowHelpText, saveIncorrectAnswer, incrementHelpCounter,
+  } = useStoreActions();
   const currentStep = useCurrentStep();
   const currentComponent = useCurrentComponent();
   const storedAnswer = status?.answer;
@@ -218,7 +220,7 @@ export default function ResponseBlock({
                       <>
                         Please
                         {' '}
-                        <Anchor style={{ fontSize: 14 }} onClick={() => storeDispatch(toggleShowHelpText())}>click here</Anchor>
+                        <Anchor style={{ fontSize: 14 }} onClick={() => { storeDispatch(toggleShowHelpText()); storeDispatch(incrementHelpCounter({ identifier: `${currentComponent}_${currentStep}` })); }}>click here</Anchor>
                         {' '}
                         and read the help text carefully.
                       </>

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -153,7 +153,9 @@ export default function ResponseBlock({
         } else {
           storeDispatch(saveIncorrectAnswer({ question: `${currentComponent}_${currentStep}`, identifier: response.id, answer: (answerValidator.values as Record<string, unknown>)[response.id] }));
           let message = '';
-          if (newAttemptsUsed >= trainingAttempts) {
+          if (trainingAttempts === -1) {
+            message = 'Please try again.';
+          } else if (newAttemptsUsed >= trainingAttempts) {
             message = `You didn't answer this question correctly after ${trainingAttempts} attempts. ${allowFailedTraining ? 'You can continue to the next question.' : 'Unfortunately you have not met the criteria for continuing this study.'}`;
 
             // If the user has failed the training, wait 5 seconds and redirect to a fail page
@@ -227,7 +229,7 @@ export default function ResponseBlock({
                     )}
                     <br />
                     <br />
-                    {attemptsUsed >= trainingAttempts && configCorrectAnswer && ` The correct answer was: ${configCorrectAnswer}.`}
+                    {attemptsUsed >= trainingAttempts && trainingAttempts >= 0 && configCorrectAnswer && ` The correct answer was: ${configCorrectAnswer}.`}
                   </Alert>
                 )}
               </>
@@ -240,7 +242,7 @@ export default function ResponseBlock({
         {hasCorrectAnswerFeedback && showNextBtn && (
           <Button
             onClick={() => checkAnswerProvideFeedback()}
-            disabled={!answerValidator.isValid() || attemptsUsed >= trainingAttempts}
+            disabled={!answerValidator.isValid() || (attemptsUsed >= trainingAttempts && trainingAttempts >= 0)}
           >
             Check Answer
           </Button>

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -88,7 +88,7 @@ export function useNextStep() {
     const { provenanceGraph } = trialValidationCopy;
     const endTime = Date.now();
 
-    const { incorrectAnswers } = storedAnswer;
+    const { incorrectAnswers, helpButtonClickedCount } = storedAnswer;
 
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
@@ -102,6 +102,7 @@ export function useNextStep() {
         provenanceGraph,
         windowEvents: currentWindowEvents,
         timedOut: !collectData,
+        helpButtonClickedCount,
       };
       storeDispatch(
         saveTrialAnswer({
@@ -200,7 +201,7 @@ export function useNextStep() {
     }
 
     navigate(`/${studyId}/${encryptIndex(nextStep)}${window.location.search}`);
-  }, [currentStep, trialValidation, identifier, windowEvents, dataCollectionEnabled, storedAnswer?.endTime, sequence, answers, startTime, navigate, studyId, storeDispatch, saveTrialAnswer, storageEngine, setIframeAnswers, studyConfig, participantSequence]);
+  }, [currentStep, trialValidation, identifier, storedAnswer, windowEvents, dataCollectionEnabled, sequence, answers, startTime, navigate, studyId, storeDispatch, saveTrialAnswer, storageEngine, setIframeAnswers, studyConfig, participantSequence]);
 
   return {
     isNextDisabled,

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -88,6 +88,8 @@ export function useNextStep() {
     const { provenanceGraph } = trialValidationCopy;
     const endTime = Date.now();
 
+    const { incorrectAnswers } = storedAnswer;
+
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
@@ -96,6 +98,7 @@ export function useNextStep() {
         answer: collectData ? answer : {},
         startTime,
         endTime,
+        incorrectAnswers,
         provenanceGraph,
         windowEvents: currentWindowEvents,
         timedOut: !collectData,

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -24,7 +24,7 @@ export async function studyStoreCreator(
     .map((id, idx) => [
       `${id}_${idx}`,
       {
-        answer: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [], timedOut: false,
+        answer: {}, incorrectAnswers: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [], timedOut: false,
       },
     ]));
   const emptyValidation: TrialValidation = Object.assign(
@@ -154,9 +154,10 @@ export async function studyStoreCreator(
         }: PayloadAction<{ identifier: string } & StoredAnswer>,
       ) {
         const {
-          identifier, answer, startTime, endTime, provenanceGraph, windowEvents, timedOut,
+          identifier, answer, startTime, endTime, provenanceGraph, windowEvents, timedOut, incorrectAnswers,
         } = payload;
         state.answers[identifier] = {
+          incorrectAnswers,
           answer,
           startTime,
           endTime,
@@ -164,6 +165,26 @@ export async function studyStoreCreator(
           windowEvents,
           timedOut,
         };
+      },
+      saveIncorrectAnswer(
+        state,
+        {
+          payload,
+        }: PayloadAction<{ question: string, identifier: string, answer: unknown }>,
+      ) {
+        const {
+          identifier, answer, question,
+        } = payload;
+
+        if (!state.answers[question].incorrectAnswers) {
+          state.answers[question].incorrectAnswers = {};
+        }
+
+        if (!state.answers[question].incorrectAnswers[identifier]) {
+          state.answers[question].incorrectAnswers[identifier] = { id: identifier, value: [] };
+        }
+
+        state.answers[question].incorrectAnswers[identifier].value.push(answer);
       },
     },
   });

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -188,6 +188,7 @@ export async function studyStoreCreator(
           identifier, answer, question,
         } = payload;
 
+        // This handles the case that we import a participants answers from an old config version
         if (!state.answers[question].incorrectAnswers) {
           state.answers[question].incorrectAnswers = {};
         }

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -24,7 +24,7 @@ export async function studyStoreCreator(
     .map((id, idx) => [
       `${id}_${idx}`,
       {
-        answer: {}, incorrectAnswers: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [], timedOut: false,
+        answer: {}, incorrectAnswers: {}, startTime: 0, endTime: -1, provenanceGraph: undefined, windowEvents: [], timedOut: false, helpButtonClickedCount: 0,
       },
     ]));
   const emptyValidation: TrialValidation = Object.assign(
@@ -154,7 +154,7 @@ export async function studyStoreCreator(
         }: PayloadAction<{ identifier: string } & StoredAnswer>,
       ) {
         const {
-          identifier, answer, startTime, endTime, provenanceGraph, windowEvents, timedOut, incorrectAnswers,
+          identifier, answer, startTime, endTime, provenanceGraph, windowEvents, timedOut, incorrectAnswers, helpButtonClickedCount,
         } = payload;
         state.answers[identifier] = {
           incorrectAnswers,
@@ -164,7 +164,19 @@ export async function studyStoreCreator(
           provenanceGraph,
           windowEvents,
           timedOut,
+          helpButtonClickedCount,
         };
+      },
+      incrementHelpCounter(
+        state,
+        {
+          payload,
+        }: PayloadAction<{ identifier: string }>,
+      ) {
+        const {
+          identifier,
+        } = payload;
+        state.answers[identifier].helpButtonClickedCount += 1;
       },
       saveIncorrectAnswer(
         state,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -107,6 +107,9 @@ export interface StoredAnswer {
   windowEvents: EventType[];
   /** A boolean value that indicates whether the participant timed out on this question. */
   timedOut: boolean;
+  /** A counter indicating how many times participants opened the help tab during a task. Clicking help, or accessing the tab via answer feedback on an incorrect answer both are included in the counter. */
+  helpButtonClickedCount: number;
+
 }
 
 export interface StimulusParams<T> {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -67,6 +67,8 @@ Each item in the window event is given a time, a position an event name, and som
 export interface StoredAnswer {
   /** Object whose keys are the "id"s in the Response list of the component in the StudyConfiguration and whose value is the inputted value from the participant. */
   answer: Record<string, { id: string, value: unknown }>;
+  /** Object whose keys are the "id"s in the Response list of the component in the StudyConfiguration and whose value is a list of incorrect inputted values from the participant. Only relevant for trials with `provideFeedback` and correct answers enabled. */
+  incorrectAnswers: Record<string, { id: string, value: unknown[] }>;
   /** Time that the user began interacting with the component in epoch milliseconds. */
   startTime: number;
   /** Time that the user ended interaction with the component in epoch milliseconds. */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -65,9 +65,9 @@ The `answer` object here uses the "id" in the [Response](../BaseResponse) list o
 Each item in the window event is given a time, a position an event name, and some extra information for the event (for mouse events, this is the location).
 */
 export interface StoredAnswer {
-  /** Object whose keys are the "id"s in the Response list of the component in the StudyConfiguration and whose value is the inputted value from the participant. */
+  /** Object whose keys are the "id"s in the Response list of the component in the StudyConfig and whose value is the inputted value from the participant. */
   answer: Record<string, { id: string, value: unknown }>;
-  /** Object whose keys are the "id"s in the Response list of the component in the StudyConfiguration and whose value is a list of incorrect inputted values from the participant. Only relevant for trials with `provideFeedback` and correct answers enabled. */
+  /** Object whose keys are the "id"s in the Response list of the component in the StudyConfig and whose value is a list of incorrect inputted values from the participant. Only relevant for trials with `provideFeedback` and correct answers enabled. */
   incorrectAnswers: Record<string, { id: string, value: unknown[] }>;
   /** Time that the user began interacting with the component in epoch milliseconds. */
   startTime: number;
@@ -109,7 +109,6 @@ export interface StoredAnswer {
   timedOut: boolean;
   /** A counter indicating how many times participants opened the help tab during a task. Clicking help, or accessing the tab via answer feedback on an incorrect answer both are included in the counter. */
   helpButtonClickedCount: number;
-
 }
 
 export interface StimulusParams<T> {


### PR DESCRIPTION
### Does this PR close any open issues?


### Give a longer description of what this PR addresses and why it's needed
Does 3 things 

- Store any incorrect answers a participant makes during a training trial, which aren't used as the final answer. Stores them as an array of values.
- Store a click counter for the help button, to keep track of how many times someone opens the help panel. Counts both clicks of the help button directly, as well as when someone opens the panel via the feedback after getting a training trial wrong
- Makes trainingAttempts = -1 in the config work as the documentation said it did, which is giving unlimited trials and never showing the correct answer.
