### PR TITLE
Fix issue with slider label alignment, hide not publicly accessible studies from "your studies" on landing page

### DIFF
--- a/src/components/response/SliderInput.module.css
+++ b/src/components/response/SliderInput.module.css
@@ -1,0 +1,3 @@
+.markLabel {
+  transform: translate(calc((var(--mark-offset) * -1)), calc(var(--mantine-spacing-xs) / 2));
+}

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { SliderResponse } from '../../parser/types';
 import { generateErrorMessage } from './utils';
 import { ReactMarkdownWrapper } from '../ReactMarkdownWrapper';
+import classes from './SliderInput.module.css';
 
 export function SliderInput({
   response,
@@ -53,6 +54,7 @@ export function SliderInput({
         {...answer}
         h={40}
         mt={4}
+        classNames={{ markLabel: classes.markLabel }}
       />
     </Input.Wrapper>
   );

--- a/src/components/settings/GlobalSettings.tsx
+++ b/src/components/settings/GlobalSettings.tsx
@@ -11,7 +11,7 @@ import { StoredUser } from '../../storage/engines/StorageEngine';
 import { signInWithGoogle } from '../../Login';
 
 export function GlobalSettings() {
-  const { user, triggerAuth } = useAuth();
+  const { user, triggerAuth, logout } = useAuth();
   const { storageEngine } = useStorageEngine();
 
   const [isAuthEnabled, setAuthEnabled] = useState<boolean>(false);
@@ -155,6 +155,14 @@ export function GlobalSettings() {
                     </Flex>
                   ),
                 ) : null}
+                <Flex direction="row" justify="left">
+                  <Button
+                    onClick={() => logout()}
+                    mt={20}
+                  >
+                    Log out
+                  </Button>
+                </Flex>
               </Flex>
             )
             : null}


### PR DESCRIPTION
### Does this PR close any open issues?
No, user reported bugs

### Give a longer description of what this PR addresses and why it's needed
Slider labels could overflow, this should fix that with a small CSS tweak.

We want to be able to hide studies in the "your studies" tab on the main page. If the revisit mode has `analyticsInterfacePubliclyAccessible = true`, then it renders, otherwise, it does not render on the front page. Obviously if the user is an admin, it still shows.

### Provide pictures/videos of the behavior before and after these changes (optional)
Slider:
<img width="825" alt="Screenshot 2025-01-27 at 6 14 44 PM" src="https://github.com/user-attachments/assets/89fcf6b7-5c98-41dc-a047-4f4d076f0814" />

### Are there any additional TODOs before this PR is ready to go?
No