### PR TITLE
Add video stimulus

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.3",
-    "react-player": "^2.16.0",
     "react-redux": "^9.2.0",
     "react-router": "^7.1.2",
     "react-timer-hook": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.3",
+    "react-player": "^2.16.0",
     "react-redux": "^9.2.0",
     "react-router": "^7.1.2",
     "react-timer-hook": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "localforage": "^1.10.0",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.2",
+    "plyr-react": "^5.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.3",

--- a/public/demo-html/config.json
+++ b/public/demo-html/config.json
@@ -66,6 +66,7 @@
     "order": "fixed",
     "components": [
       "introduction",
+      "trainingVideo",
       "barChart",
       "external_website"
     ]

--- a/public/demo-html/config.json
+++ b/public/demo-html/config.json
@@ -29,6 +29,12 @@
       "path": "demo-html/assets/introduction.md",
       "response": []
     },
+    "trainingVideo": {
+      "type": "video",
+      "path": "https://www.youtube.com/watch?v=tCDvOQI3pco",
+      "forceCompletion": true,
+      "response": []
+    },
     "barChart": {
       "type": "website",
       "nextButtonLocation": "sidebar",

--- a/public/demo-html/config.json
+++ b/public/demo-html/config.json
@@ -29,12 +29,6 @@
       "path": "demo-html/assets/introduction.md",
       "response": []
     },
-    "trainingVideo": {
-      "type": "video",
-      "path": "https://www.youtube.com/watch?v=tCDvOQI3pco",
-      "forceCompletion": true,
-      "response": []
-    },
     "barChart": {
       "type": "website",
       "nextButtonLocation": "sidebar",
@@ -66,7 +60,6 @@
     "order": "fixed",
     "components": [
       "introduction",
-      "trainingVideo",
       "barChart",
       "external_website"
     ]

--- a/public/demo-image/config.json
+++ b/public/demo-image/config.json
@@ -111,6 +111,22 @@
           ]
         }
       ]
+    },
+    "externalImage": {
+      "type": "image",
+      "path": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Shaki_waterfall.jpg",
+      "style": {
+        "width": "800px"
+      },
+      "nextButtonLocation": "sidebar",
+      "response": [
+        {
+          "id": "externalImage-response",
+          "prompt": "What is this a picture of?",
+          "location": "sidebar",
+          "type": "shortText"
+        }
+      ]
     }
   },
   "sequence": {
@@ -119,7 +135,8 @@
       "introduction",
       "dotplot-low",
       "dotplot-medium",
-      "dotplot-high"
+      "dotplot-high",
+      "externalImage"
     ]
   }
 }

--- a/public/demo-image/config.json
+++ b/public/demo-image/config.json
@@ -124,7 +124,8 @@
           "id": "externalImage-response",
           "prompt": "What is this a picture of?",
           "location": "sidebar",
-          "type": "shortText"
+          "type": "shortText",
+          "required": false
         }
       ]
     }

--- a/public/demo-video-slider/config.json
+++ b/public/demo-video-slider/config.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.0.2/src/parser/StudyConfigSchema.json",
   "studyMetadata": {
-    "title": "HTML as a Stimulus",
+    "title": "2 Videos with a Slider to Choose Between Them",
     "version": "pilot",
     "authors": [
       "The reVISit Team"
     ],
     "date": "2023-04-14",
-    "description": "A simple demo of using stimuli in an HTML file that renders a D3 visualization. Data is collected via a numeric response field.",
+    "description": "A simple demo of using video as a stimulus. Data is collected via a slider response field.",
     "organizations": [
       "University of Utah",
       "WPI",

--- a/public/demo-video/assets/help.md
+++ b/public/demo-video/assets/help.md
@@ -1,0 +1,1 @@
+This is a simple demo of using video stimuli, simply type your answer in input field and click **Next**.

--- a/public/demo-video/assets/introduction.md
+++ b/public/demo-video/assets/introduction.md
@@ -1,0 +1,3 @@
+# Introduction
+
+Welcome to our study. This is an example study to show how to use the video stimulus.

--- a/public/demo-video/config.json
+++ b/public/demo-video/config.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/video-stimulus/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "Video as a Stimulus",
+    "version": "pilot",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2023-04-14",
+    "description": "A simple demo of using video as a stimulus. Data is collected via a numeric response field.",
+    "organizations": [
+      "University of Utah",
+      "WPI",
+      "University of Toronto"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "contact@revisit.dev",
+    "helpTextPath": "demo-video/assets/help.md",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "autoDownloadStudy": false,
+    "sidebar": true,
+    "windowEventDebounceTime": 200
+  },
+  "components": {
+    "introduction": {
+      "type": "markdown",
+      "path": "demo-video/assets/introduction.md",
+      "response": []
+    },
+    "internal": {
+      "type": "video",
+      "path": "demo-video/assets/venice.mp4",
+      "forceCompletion": true,
+      "response": []
+    },
+    "missingInternal": {
+      "type": "video",
+      "path": "demo-video/assets/london.mp4",
+      "forceCompletion": true,
+      "response": []
+    },
+    "external": {
+      "type": "video",
+      "path": "https://www.youtube.com/watch?v=icPHcK_cCF4",
+      "forceCompletion": false,
+      "withTimeline": true,
+      "response": []
+    },
+    "missingExternal": {
+      "type": "video",
+      "path": "https://www.youtube.com/watch",
+      "forceCompletion": true,
+      "response": []
+    }
+  },
+  "sequence": {
+    "order": "fixed",
+    "components": [
+      "introduction",
+      "internal",
+      "missingInternal",
+      "external",
+      "missingExternal"
+    ]
+  }
+}

--- a/public/global.json
+++ b/public/global.json
@@ -18,6 +18,7 @@
     "demo-click-accuracy-test",
     "demo-image",
     "demo-video-slider",
+    "demo-video",
     "test-audio",
     "test-library",
     "library-beauvis",
@@ -70,6 +71,9 @@
     },
     "demo-training": {
       "path": "demo-training/config.json"
+    },
+    "demo-video": {
+      "path": "demo-video/config.json"
     },
     "example-VLAT-full-randomized": {
       "path": "example-VLAT-full-randomized/config.json"

--- a/src/components/interface/HelpModal.tsx
+++ b/src/components/interface/HelpModal.tsx
@@ -4,6 +4,7 @@ import { ReactMarkdownWrapper } from '../ReactMarkdownWrapper';
 import { useStoreDispatch, useStoreSelector, useStoreActions } from '../../store/store';
 import { getStaticAssetByPath } from '../../utils/getStaticAsset';
 import { ResourceNotFound } from '../../ResourceNotFound';
+import { PREFIX } from '../../utils/Prefix';
 
 export function HelpModal() {
   const showHelpText = useStoreSelector((state) => state.showHelpText);
@@ -21,7 +22,7 @@ export function HelpModal() {
         setLoading(false);
         return;
       }
-      const asset = await getStaticAssetByPath(config.uiConfig.helpTextPath);
+      const asset = await getStaticAssetByPath(`${PREFIX}${config.uiConfig.helpTextPath}`);
       if (asset !== undefined) {
         setHelpText(asset);
       }

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -27,6 +27,7 @@ import { TimedOut } from '../components/TimedOut';
 import { findBlockForStep } from '../utils/getSequenceFlatMap';
 import { VegaController, VegaProvState } from './VegaController';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
+import { VideoController } from './VideoController';
 
 // current active stimuli presented to the user
 export function ComponentController() {
@@ -183,6 +184,7 @@ export function ComponentController() {
         {currentConfig.type === 'image' && <ImageController currentConfig={currentConfig} />}
         {currentConfig.type === 'react-component' && <ReactComponentController currentConfig={currentConfig} provState={analysisProvState} />}
         {currentConfig.type === 'vega' && <VegaController currentConfig={currentConfig} provState={analysisProvState as VegaProvState} />}
+        {currentConfig.type === 'video' && <VideoController currentConfig={currentConfig} />}
 
       </Suspense>
 

--- a/src/controllers/ImageController.tsx
+++ b/src/controllers/ImageController.tsx
@@ -1,5 +1,5 @@
 import { Image } from '@mantine/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ImageComponent } from '../parser/types';
 import { PREFIX } from '../utils/Prefix';
 import { getStaticAssetByPath } from '../utils/getStaticAsset';
@@ -12,20 +12,27 @@ const defaultStyle = {
 export function ImageController({ currentConfig }: { currentConfig: ImageComponent; }) {
   const imageStyle = { ...defaultStyle, ...currentConfig.style };
 
+  const url = useMemo(() => {
+    if (currentConfig.path.startsWith('http')) {
+      return currentConfig.path;
+    }
+    return `${PREFIX}${currentConfig.path}`;
+  }, [currentConfig.path]);
+
   const [loading, setLoading] = useState(true);
   const [assetFound, setAssetFound] = useState(false);
   useEffect(() => {
     async function fetchImage() {
-      const asset = await getStaticAssetByPath(currentConfig.path);
+      let asset = await getStaticAssetByPath(url);
+      asset = asset?.includes('File not found') ? undefined : asset;
       setAssetFound(!!asset);
       setLoading(false);
     }
 
     fetchImage();
-  }, [currentConfig]);
+  }, [url]);
 
-  return loading || assetFound ? (
-    <Image mx="auto" src={`${PREFIX}${currentConfig.path}`} style={imageStyle} />
-  )
+  return loading || assetFound
+    ? <Image mx="auto" src={url} style={imageStyle} />
     : <ResourceNotFound path={currentConfig.path} />;
 }

--- a/src/controllers/MarkdownController.tsx
+++ b/src/controllers/MarkdownController.tsx
@@ -3,6 +3,7 @@ import { ReactMarkdownWrapper } from '../components/ReactMarkdownWrapper';
 import { MarkdownComponent } from '../parser/types';
 import { getStaticAssetByPath } from '../utils/getStaticAsset';
 import { ResourceNotFound } from '../ResourceNotFound';
+import { PREFIX } from '../utils/Prefix';
 
 export function MarkdownController({ currentConfig }: { currentConfig: MarkdownComponent; }) {
   const [importedText, setImportedText] = useState<string>('');
@@ -10,7 +11,7 @@ export function MarkdownController({ currentConfig }: { currentConfig: MarkdownC
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     async function fetchImage() {
-      const asset = await getStaticAssetByPath(currentConfig.path);
+      const asset = await getStaticAssetByPath(`${PREFIX}${currentConfig.path}`);
       if (asset !== undefined) {
         setImportedText(asset);
       }

--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -1,8 +1,15 @@
 import ReactPlayer from 'react-player';
+import { useState } from 'react';
 import { VideoComponent } from '../parser/types';
 
 export function VideoController({ currentConfig }: { currentConfig: VideoComponent; }) {
+  const [_, setEnded] = useState(false);
+
+  const onEnded = () => {
+    setEnded(true);
+  };
+
   return (
-    <ReactPlayer url={currentConfig.path} />
+    <ReactPlayer url={currentConfig.path} onEnded={onEnded} controls={false} />
   );
 }

--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -81,7 +81,7 @@ export function VideoController({ currentConfig }: { currentConfig: VideoCompone
 
   return loading || assetFound
     ? (
-      <Box>
+      <Box mb="md">
         <Plyr source={{ type: 'video', sources }} options={options} />
       </Box>
     )

--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -1,0 +1,8 @@
+import ReactPlayer from 'react-player';
+import { VideoComponent } from '../parser/types';
+
+export function VideoController({ currentConfig }: { currentConfig: VideoComponent; }) {
+  return (
+    <ReactPlayer url={currentConfig.path} />
+  );
+}

--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -94,7 +94,6 @@ export function VideoController({ currentConfig }: { currentConfig: VideoCompone
       'volume',
       'fullscreen',
     ],
-    settings: ['captions', 'quality', 'speed'],
   }), [currentConfig.forceCompletion, currentConfig.withTimeline]);
 
   const currentComponent = useCurrentComponent();

--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -1,15 +1,89 @@
-import ReactPlayer from 'react-player';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Box } from '@mantine/core';
+import Plyr from 'plyr-react';
 import { VideoComponent } from '../parser/types';
+import { PREFIX } from '../utils/Prefix';
+import { getStaticAssetByPath } from '../utils/getStaticAsset';
+import { ResourceNotFound } from '../ResourceNotFound';
+import 'plyr-react/plyr.css';
 
 export function VideoController({ currentConfig }: { currentConfig: VideoComponent; }) {
-  const [_, setEnded] = useState(false);
+  const url = useMemo(() => {
+    if (currentConfig.path.startsWith('http')) {
+      return currentConfig.path;
+    }
+    return `${PREFIX}${currentConfig.path}`;
+  }, [currentConfig.path]);
 
-  const onEnded = () => {
-    setEnded(true);
-  };
+  const [loading, setLoading] = useState(true);
+  const [assetFound, setAssetFound] = useState(false);
+  useEffect(() => {
+    async function fetchVideo() {
+      if (url.startsWith('http')) {
+        // It is impossible to check whether a video exists on a remote server because of CORS
+        // We just assume it exists and if it doesn't, the player will throw an error
+        // We use that error callback to set assetFound to false and show not found component
+        setAssetFound(true);
+      } else {
+        const asset = await getStaticAssetByPath(url);
+        setAssetFound(!!asset);
+      }
+      setLoading(false);
+    }
 
-  return (
-    <ReactPlayer url={currentConfig.path} onEnded={onEnded} controls={false} />
-  );
+    fetchVideo();
+  }, [url]);
+
+  const sources = useMemo<Plyr.Source[]>(() => {
+    if (url.includes('youtube')) {
+      const regex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+      // Extract video ID from the URL
+      const match = url.match(regex);
+      const videoId = match ? match[1] : '';
+      return [
+        {
+          src: videoId,
+          provider: 'youtube',
+        },
+      ];
+    }
+    if (url.includes('vimeo')) {
+      const regex = /https?:\/\/(?:www\.)?vimeo\.com\/(\d+)/;
+      // Extract video ID from the URL
+      const match = url.match(regex);
+      const videoId = match ? match[1] : '';
+      return [
+        {
+          src: videoId,
+          provider: 'vimeo',
+        },
+      ];
+    }
+    return [
+      {
+        src: url,
+        type: 'video/mp4',
+      },
+    ];
+  }, [url]);
+
+  const options = useMemo<Plyr.Options>(() => ({
+    controls: [
+      currentConfig.forceCompletion !== false ? 'play-large' : 'play',
+      'current-time',
+      ...(currentConfig.withTimeline ? ['progress'] : []),
+      'volume',
+      'fullscreen',
+    ],
+    settings: ['captions', 'quality', 'speed'],
+  }), [currentConfig.forceCompletion, currentConfig.withTimeline]);
+
+  return loading || assetFound
+    ? (
+      <Box>
+        <Plyr source={{ type: 'video', sources }} options={options} />
+      </Box>
+    )
+    : <ResourceNotFound path={currentConfig.path} />;
 }

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -51,6 +51,10 @@
             "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "string"
           },
+          "forceCompletion": {
+            "description": "Whether to force the video to play until the end.",
+            "type": "boolean"
+          },
           "instruction": {
             "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "string"
@@ -116,6 +120,10 @@
               {
                 "description": "The path to the vega file. This should be a relative path from the public folder.",
                 "type": "string"
+              },
+              {
+                "description": "The path to the video. This should be a relative path from the public folder.",
+                "type": "string"
               }
             ],
             "description": "The path to the markdown file. This should be a relative path from the public folder."
@@ -157,7 +165,8 @@
               "image",
               "website",
               "questionnaire",
-              "vega"
+              "vega",
+              "video"
             ],
             "type": "string"
           }
@@ -562,6 +571,9 @@
         },
         {
           "$ref": "#/definitions/VegaComponent"
+        },
+        {
+          "$ref": "#/definitions/VideoComponent"
         }
       ]
     },
@@ -663,6 +675,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "forceCompletion": {
+          "description": "Whether to force the video to play until the end.",
+          "type": "boolean"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -728,6 +744,10 @@
             {
               "description": "The path to the vega file. This should be a relative path from the public folder.",
               "type": "string"
+            },
+            {
+              "description": "The path to the video. This should be a relative path from the public folder.",
+              "type": "string"
             }
           ],
           "description": "The path to the markdown file. This should be a relative path from the public folder."
@@ -769,7 +789,8 @@
             "image",
             "website",
             "questionnaire",
-            "vega"
+            "vega",
+            "video"
           ],
           "type": "string"
         }
@@ -2041,6 +2062,96 @@
         },
         "type": {
           "const": "vega",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "response",
+        "type"
+      ],
+      "type": "object"
+    },
+    "VideoComponent": {
+      "additionalProperties": false,
+      "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
+        "correctAnswer": {
+          "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
+          "items": {
+            "$ref": "#/definitions/Answer"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "forceCompletion": {
+          "description": "Whether to force the video to play until the end.",
+          "type": "boolean"
+        },
+        "instruction": {
+          "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "instructionLocation": {
+          "$ref": "#/definitions/ResponseBlockLocation",
+          "description": "The location of the instructions."
+        },
+        "meta": {
+          "additionalProperties": {},
+          "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout (in ms) after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer (in ms) after which the next button will be enabled.",
+          "type": "number"
+        },
+        "nextButtonLocation": {
+          "$ref": "#/definitions/ResponseBlockLocation",
+          "description": "The location of the next button."
+        },
+        "nextButtonText": {
+          "description": "The text that is displayed on the next button.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path to the video. This should be a relative path from the public folder.",
+          "type": "string"
+        },
+        "provideFeedback": {
+          "description": "Controls whether the component should provide feedback to the participant, such as in a training trial. If not provided, the default is false.",
+          "type": "boolean"
+        },
+        "recordAudio": {
+          "description": "Whether or not to record audio for a component. Only relevant if recordStudyAudio in the uiConfig is true. Defaults to false.",
+          "type": "boolean"
+        },
+        "response": {
+          "description": "The responses to the component",
+          "items": {
+            "$ref": "#/definitions/Response"
+          },
+          "type": "array"
+        },
+        "responseDividers": {
+          "description": "Whether to show the response dividers. Defaults to false.",
+          "type": "boolean"
+        },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
+          "type": "number"
+        },
+        "type": {
+          "const": "video",
           "type": "string"
         }
       },

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -110,7 +110,7 @@
                 "type": "string"
               },
               {
-                "description": "The path to the image. This should be a relative path from the public folder.",
+                "description": "The path to the image. This could be a relative path from the public folder or a url to an external image.",
                 "type": "string"
               },
               {
@@ -122,7 +122,7 @@
                 "type": "string"
               },
               {
-                "description": "The path to the video. This should be a relative path from the public folder.",
+                "description": "The path to the video. This could be a relative path from the public folder or might be a url to an external website.",
                 "type": "string"
               }
             ],
@@ -511,7 +511,7 @@
           "type": "string"
         },
         "path": {
-          "description": "The path to the image. This should be a relative path from the public folder.",
+          "description": "The path to the image. This could be a relative path from the public folder or a url to an external image.",
           "type": "string"
         },
         "provideFeedback": {
@@ -738,7 +738,7 @@
               "type": "string"
             },
             {
-              "description": "The path to the image. This should be a relative path from the public folder.",
+              "description": "The path to the image. This could be a relative path from the public folder or a url to an external image.",
               "type": "string"
             },
             {
@@ -750,7 +750,7 @@
               "type": "string"
             },
             {
-              "description": "The path to the video. This should be a relative path from the public folder.",
+              "description": "The path to the video. This could be a relative path from the public folder or might be a url to an external website.",
               "type": "string"
             }
           ],
@@ -1489,7 +1489,7 @@
     },
     "ReactComponent": {
       "additionalProperties": false,
-      "description": "The ReactComponent interface is used to define the properties of a react component. This component is used to render react code with certain parameters. These parameters can be used within your react code to render different things.\n\nUnlike other types of components, the path for a React component is relative to the `src/public/` folder. Similar to our standard assets, we suggest creating a folder named `src/public/{studyName}/assets` to house all of the React component assets for a particular study. Your React component which you link to in the path must be default exported from its file.\n\nReact components created this way have a generic prop type passed to the component on render, `<StimulusParams<T>>`, which has the following types.\n\n```ts { parameters: T; setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: Record<string, any> }) => void } ```\n\nparameters is the same object passed in from the ReactComponent type below, allowing you to pass options in from the config to your component. setAnswer is a callback function allowing the creator of the ReactComponent to programmatically set the answer, as well as the provenance graph. This can be useful if you don't use the default answer interface, and instead have something more unique.\n\nSo, for example, if I had the following ReactComponent in my config ```js { type: 'react-component'; path: 'my_study/CoolComponent.tsx'; parameters: {  name: 'Zach';  age: 26; } } ```\n\nMy react component, CoolComponent.tsx, would exist in src/public/my_study/assets, and look something like this\n\n```ts export default function CoolComponent({ parameters, setAnswer }: StimulusParams<{name: string, age: number}>) { // render something } ```\n\nFor in depth examples, see the following studies, and their associated codebases. https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/2.0.0-rc7/src/public/demo-click-accuracy-test/assets) https://revisit.dev/study/example-brush-interactions (https://github.com/revisit-studies/study/tree/2.0.0-rc7/src/public/example-brush-interactions/assets)",
+      "description": "The ReactComponent interface is used to define the properties of a react component. This component is used to render react code with certain parameters. These parameters can be used within your react code to render different things.\n\nUnlike other types of components, the path for a React component is relative to the `src/public/` folder. Similar to our standard assets, we suggest creating a folder named `src/public/{studyName}/assets` to house all of the React component assets for a particular study. Your React component which you link to in the path must be default exported from its file.\n\nReact components created this way have a generic prop type passed to the component on render, `<StimulusParams<T>>`, which has the following types.\n\n```ts { parameters: T; setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: Record<string, any> }) => void } ```\n\nparameters is the same object passed in from the ReactComponent type below, allowing you to pass options in from the config to your component. setAnswer is a callback function allowing the creator of the ReactComponent to programmatically set the answer, as well as the provenance graph. This can be useful if you don't use the default answer interface, and instead have something more unique.\n\nSo, for example, if I had the following ReactComponent in my config ```js { type: 'react-component'; path: 'my_study/CoolComponent.tsx'; parameters: {  name: 'Zach';  age: 26; } } ```\n\nMy react component, CoolComponent.tsx, would exist in src/public/my_study/assets, and look something like this\n\n```ts export default function CoolComponent({ parameters, setAnswer }: StimulusParams<{name: string, age: number}>) { // render something } ```\n\nFor in depth examples, see the following studies, and their associated codebases. https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/v2.0.2/src/public/demo-click-accuracy-test/assets) https://revisit.dev/study/example-brush-interactions (https://github.com/revisit-studies/study/tree/v2.0.2/src/public/example-brush-interactions/assets)",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
@@ -2082,6 +2082,7 @@
     },
     "VideoComponent": {
       "additionalProperties": false,
+      "description": "The VideoComponent interface is used to define the properties of a video component. This component is used to render a video with optional controls.\n\nMost often, video components will be used for trainings, and will have a `forceCompletion` field set to true. This will prevent the participant from moving on until the video has finished playing.\n\nAs such, the `forceCompletion` field is set to true by default, and the `withTimeline` field is set to false by default.\n\nFor example, to render a training video with a path of `<study-name>/assets/video.mp4`, you would use the following snippet: ```js {   \"type\": \"video\",   \"path\": \"<study-name>/assets/video.mp4\", } ```",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
@@ -2132,7 +2133,7 @@
           "type": "string"
         },
         "path": {
-          "description": "The path to the video. This should be a relative path from the public folder.",
+          "description": "The path to the video. This could be a relative path from the public folder or might be a url to an external website.",
           "type": "string"
         },
         "provideFeedback": {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -52,7 +52,7 @@
             "type": "string"
           },
           "forceCompletion": {
-            "description": "Whether to force the video to play until the end.",
+            "description": "Whether to force the video to play until the end. Defaults to true.",
             "type": "boolean"
           },
           "instruction": {
@@ -680,7 +680,7 @@
           "type": "string"
         },
         "forceCompletion": {
-          "description": "Whether to force the video to play until the end.",
+          "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
         "instruction": {
@@ -2099,7 +2099,7 @@
           "type": "string"
         },
         "forceCompletion": {
-          "description": "Whether to force the video to play until the end.",
+          "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
         "instruction": {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -169,6 +169,10 @@
               "video"
             ],
             "type": "string"
+          },
+          "withTimeline": {
+            "description": "Whether to show the video timeline. Defaults to false.",
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -793,6 +797,10 @@
             "video"
           ],
           "type": "string"
+        },
+        "withTimeline": {
+          "description": "Whether to show the video timeline. Defaults to false.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -2153,6 +2161,10 @@
         "type": {
           "const": "video",
           "type": "string"
+        },
+        "withTimeline": {
+          "description": "Whether to show the video timeline. Defaults to false.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -169,6 +169,10 @@
               "video"
             ],
             "type": "string"
+          },
+          "withTimeline": {
+            "description": "Whether to show the video timeline. Defaults to false.",
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -793,6 +797,10 @@
             "video"
           ],
           "type": "string"
+        },
+        "withTimeline": {
+          "description": "Whether to show the video timeline. Defaults to false.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -2276,6 +2284,10 @@
         "type": {
           "const": "video",
           "type": "string"
+        },
+        "withTimeline": {
+          "description": "Whether to show the video timeline. Defaults to false.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -110,7 +110,7 @@
                 "type": "string"
               },
               {
-                "description": "The path to the image. This should be a relative path from the public folder.",
+                "description": "The path to the image. This could be a relative path from the public folder or a url to an external image.",
                 "type": "string"
               },
               {
@@ -122,7 +122,7 @@
                 "type": "string"
               },
               {
-                "description": "The path to the video. This should be a relative path from the public folder.",
+                "description": "The path to the video. This could be a relative path from the public folder or might be a url to an external website.",
                 "type": "string"
               }
             ],
@@ -511,7 +511,7 @@
           "type": "string"
         },
         "path": {
-          "description": "The path to the image. This should be a relative path from the public folder.",
+          "description": "The path to the image. This could be a relative path from the public folder or a url to an external image.",
           "type": "string"
         },
         "provideFeedback": {
@@ -738,7 +738,7 @@
               "type": "string"
             },
             {
-              "description": "The path to the image. This should be a relative path from the public folder.",
+              "description": "The path to the image. This could be a relative path from the public folder or a url to an external image.",
               "type": "string"
             },
             {
@@ -750,7 +750,7 @@
               "type": "string"
             },
             {
-              "description": "The path to the video. This should be a relative path from the public folder.",
+              "description": "The path to the video. This could be a relative path from the public folder or might be a url to an external website.",
               "type": "string"
             }
           ],
@@ -1431,7 +1431,7 @@
     },
     "ReactComponent": {
       "additionalProperties": false,
-      "description": "The ReactComponent interface is used to define the properties of a react component. This component is used to render react code with certain parameters. These parameters can be used within your react code to render different things.\n\nUnlike other types of components, the path for a React component is relative to the `src/public/` folder. Similar to our standard assets, we suggest creating a folder named `src/public/{studyName}/assets` to house all of the React component assets for a particular study. Your React component which you link to in the path must be default exported from its file.\n\nReact components created this way have a generic prop type passed to the component on render, `<StimulusParams<T>>`, which has the following types.\n\n```ts { parameters: T; setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: Record<string, any> }) => void } ```\n\nparameters is the same object passed in from the ReactComponent type below, allowing you to pass options in from the config to your component. setAnswer is a callback function allowing the creator of the ReactComponent to programmatically set the answer, as well as the provenance graph. This can be useful if you don't use the default answer interface, and instead have something more unique.\n\nSo, for example, if I had the following ReactComponent in my config ```js { type: 'react-component'; path: 'my_study/CoolComponent.tsx'; parameters: {  name: 'Zach';  age: 26; } } ```\n\nMy react component, CoolComponent.tsx, would exist in src/public/my_study/assets, and look something like this\n\n```ts export default function CoolComponent({ parameters, setAnswer }: StimulusParams<{name: string, age: number}>) { // render something } ```\n\nFor in depth examples, see the following studies, and their associated codebases. https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/2.0.0-rc7/src/public/demo-click-accuracy-test/assets) https://revisit.dev/study/example-brush-interactions (https://github.com/revisit-studies/study/tree/2.0.0-rc7/src/public/example-brush-interactions/assets)",
+      "description": "The ReactComponent interface is used to define the properties of a react component. This component is used to render react code with certain parameters. These parameters can be used within your react code to render different things.\n\nUnlike other types of components, the path for a React component is relative to the `src/public/` folder. Similar to our standard assets, we suggest creating a folder named `src/public/{studyName}/assets` to house all of the React component assets for a particular study. Your React component which you link to in the path must be default exported from its file.\n\nReact components created this way have a generic prop type passed to the component on render, `<StimulusParams<T>>`, which has the following types.\n\n```ts { parameters: T; setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: Record<string, any> }) => void } ```\n\nparameters is the same object passed in from the ReactComponent type below, allowing you to pass options in from the config to your component. setAnswer is a callback function allowing the creator of the ReactComponent to programmatically set the answer, as well as the provenance graph. This can be useful if you don't use the default answer interface, and instead have something more unique.\n\nSo, for example, if I had the following ReactComponent in my config ```js { type: 'react-component'; path: 'my_study/CoolComponent.tsx'; parameters: {  name: 'Zach';  age: 26; } } ```\n\nMy react component, CoolComponent.tsx, would exist in src/public/my_study/assets, and look something like this\n\n```ts export default function CoolComponent({ parameters, setAnswer }: StimulusParams<{name: string, age: number}>) { // render something } ```\n\nFor in depth examples, see the following studies, and their associated codebases. https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/v2.0.2/src/public/demo-click-accuracy-test/assets) https://revisit.dev/study/example-brush-interactions (https://github.com/revisit-studies/study/tree/v2.0.2/src/public/example-brush-interactions/assets)",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
@@ -1940,7 +1940,7 @@
     },
     "UIConfig": {
       "additionalProperties": false,
-      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the UI Config would look in your study configuration (note, there are optional fields that are not shown here): ```js uiConfig:{ \"contactEmail\": \"contact@revisit.dev\", \"helpTextPath\": \"<study-name>/assets/help.md\", \"logoPath\": \"<study-name>/assets/logo.jpg\", \"withProgressBar\": true, \"autoDownloadStudy\": true \"autoDownloadTime\": 5000, \"studyEndMsg\": \"Thank you for completing this study. You're the best!\", \"sidebar\": true, \"windowEventDebounceTime\": 500, \"urlParticipantIdParam\": \"PROLIFIC_ID\", \"numSequences\": 500 } ``` In the above, the `path/to/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
+      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the UI Config would look in your study configuration (note, there are optional fields that are not shown here): ```js uiConfig:{ \"contactEmail\": \"contact@revisit.dev\", \"helpTextPath\": \"<study-name>/assets/help.md\", \"logoPath\": \"<study-name>/assets/logo.jpg\", \"withProgressBar\": true, \"autoDownloadStudy\": true \"autoDownloadTime\": 5000, \"studyEndMsg\": \"Thank you for completing this study. You're the best!\", \"sidebar\": true, \"windowEventDebounceTime\": 500, \"urlParticipantIdParam\": \"PROLIFIC_ID\", \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
       "properties": {
         "autoDownloadStudy": {
           "description": "Controls whether the study data is automatically downloaded at the end of the study.",
@@ -2205,6 +2205,7 @@
     },
     "VideoComponent": {
       "additionalProperties": false,
+      "description": "The VideoComponent interface is used to define the properties of a video component. This component is used to render a video with optional controls.\n\nMost often, video components will be used for trainings, and will have a `forceCompletion` field set to true. This will prevent the participant from moving on until the video has finished playing.\n\nAs such, the `forceCompletion` field is set to true by default, and the `withTimeline` field is set to false by default.\n\nFor example, to render a training video with a path of `<study-name>/assets/video.mp4`, you would use the following snippet: ```js {   \"type\": \"video\",   \"path\": \"<study-name>/assets/video.mp4\", } ```",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
@@ -2255,7 +2256,7 @@
           "type": "string"
         },
         "path": {
-          "description": "The path to the video. This should be a relative path from the public folder.",
+          "description": "The path to the video. This could be a relative path from the public folder or might be a url to an external website.",
           "type": "string"
         },
         "provideFeedback": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -51,6 +51,10 @@
             "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "string"
           },
+          "forceCompletion": {
+            "description": "Whether to force the video to play until the end.",
+            "type": "boolean"
+          },
           "instruction": {
             "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "string"
@@ -116,6 +120,10 @@
               {
                 "description": "The path to the vega file. This should be a relative path from the public folder.",
                 "type": "string"
+              },
+              {
+                "description": "The path to the video. This should be a relative path from the public folder.",
+                "type": "string"
               }
             ],
             "description": "The path to the markdown file. This should be a relative path from the public folder."
@@ -157,7 +165,8 @@
               "image",
               "website",
               "questionnaire",
-              "vega"
+              "vega",
+              "video"
             ],
             "type": "string"
           }
@@ -562,6 +571,9 @@
         },
         {
           "$ref": "#/definitions/VegaComponent"
+        },
+        {
+          "$ref": "#/definitions/VideoComponent"
         }
       ]
     },
@@ -663,6 +675,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "forceCompletion": {
+          "description": "Whether to force the video to play until the end.",
+          "type": "boolean"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -728,6 +744,10 @@
             {
               "description": "The path to the vega file. This should be a relative path from the public folder.",
               "type": "string"
+            },
+            {
+              "description": "The path to the video. This should be a relative path from the public folder.",
+              "type": "string"
             }
           ],
           "description": "The path to the markdown file. This should be a relative path from the public folder."
@@ -769,7 +789,8 @@
             "image",
             "website",
             "questionnaire",
-            "vega"
+            "vega",
+            "video"
           ],
           "type": "string"
         }
@@ -2164,6 +2185,96 @@
         },
         "type": {
           "const": "vega",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "response",
+        "type"
+      ],
+      "type": "object"
+    },
+    "VideoComponent": {
+      "additionalProperties": false,
+      "properties": {
+        "allowFailedTraining": {
+          "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
+          "type": "boolean"
+        },
+        "correctAnswer": {
+          "description": "The correct answer to the component. This is used for training trials where the user is shown the correct answer after a guess.",
+          "items": {
+            "$ref": "#/definitions/Answer"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "forceCompletion": {
+          "description": "Whether to force the video to play until the end.",
+          "type": "boolean"
+        },
+        "instruction": {
+          "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "instructionLocation": {
+          "$ref": "#/definitions/ResponseBlockLocation",
+          "description": "The location of the instructions."
+        },
+        "meta": {
+          "additionalProperties": {},
+          "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "object"
+        },
+        "nextButtonDisableTime": {
+          "description": "A timeout (in ms) after which the next button will be disabled.",
+          "type": "number"
+        },
+        "nextButtonEnableTime": {
+          "description": "A timer (in ms) after which the next button will be enabled.",
+          "type": "number"
+        },
+        "nextButtonLocation": {
+          "$ref": "#/definitions/ResponseBlockLocation",
+          "description": "The location of the next button."
+        },
+        "nextButtonText": {
+          "description": "The text that is displayed on the next button.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path to the video. This should be a relative path from the public folder.",
+          "type": "string"
+        },
+        "provideFeedback": {
+          "description": "Controls whether the component should provide feedback to the participant, such as in a training trial. If not provided, the default is false.",
+          "type": "boolean"
+        },
+        "recordAudio": {
+          "description": "Whether or not to record audio for a component. Only relevant if recordStudyAudio in the uiConfig is true. Defaults to false.",
+          "type": "boolean"
+        },
+        "response": {
+          "description": "The responses to the component",
+          "items": {
+            "$ref": "#/definitions/Response"
+          },
+          "type": "array"
+        },
+        "responseDividers": {
+          "description": "Whether to show the response dividers. Defaults to false.",
+          "type": "boolean"
+        },
+        "trainingAttempts": {
+          "description": "The number of training attempts allowed for the component. The next button will be disabled until either the correct answer is given or the number of attempts is reached. When the number of attempts is reached, if the answer is incorrect still, the correct value will be shown to the participant. The default value is 2. Providing a value of -1 will allow infinite attempts and the participant must enter the correct answer to continue, and reVISit will not show the correct answer to the user.",
+          "type": "number"
+        },
+        "type": {
+          "const": "video",
           "type": "string"
         }
       },

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -52,7 +52,7 @@
             "type": "string"
           },
           "forceCompletion": {
-            "description": "Whether to force the video to play until the end.",
+            "description": "Whether to force the video to play until the end. Defaults to true.",
             "type": "boolean"
           },
           "instruction": {
@@ -680,7 +680,7 @@
           "type": "string"
         },
         "forceCompletion": {
-          "description": "Whether to force the video to play until the end.",
+          "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
         "instruction": {
@@ -2222,7 +2222,7 @@
           "type": "string"
         },
         "forceCompletion": {
-          "description": "Whether to force the video to play until the end.",
+          "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
         "instruction": {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -79,7 +79,7 @@ uiConfig:{
   "numSequences": 500
 }
 ```
-In the above, the `path/to/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)
+In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)
  */
 export interface UIConfig {
   /** The email address that used during the study if a participant clicks contact. */
@@ -623,8 +623,8 @@ export default function CoolComponent({ parameters, setAnswer }: StimulusParams<
 ```
  *
  * For in depth examples, see the following studies, and their associated codebases.
- * https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/2.0.0-rc7/src/public/demo-click-accuracy-test/assets)
- * https://revisit.dev/study/example-brush-interactions (https://github.com/revisit-studies/study/tree/2.0.0-rc7/src/public/example-brush-interactions/assets)
+ * https://revisit.dev/study/demo-click-accuracy-test (https://github.com/revisit-studies/study/tree/v2.0.2/src/public/demo-click-accuracy-test/assets)
+ * https://revisit.dev/study/example-brush-interactions (https://github.com/revisit-studies/study/tree/v2.0.2/src/public/example-brush-interactions/assets)
  */
 export interface ReactComponent extends BaseIndividualComponent {
   type: 'react-component';
@@ -650,7 +650,7 @@ export interface ReactComponent extends BaseIndividualComponent {
  */
 export interface ImageComponent extends BaseIndividualComponent {
   type: 'image';
-  /** The path to the image. This should be a relative path from the public folder. */
+  /** The path to the image. This could be a relative path from the public folder or a url to an external image. */
   path: string;
   /** The style of the image. This is an object with css properties as keys and css values as values. */
   style?: Record<string, string>;
@@ -816,9 +816,25 @@ export interface VegaComponentConfig extends BaseIndividualComponent {
 
 export type VegaComponent = VegaComponentPath | VegaComponentConfig;
 
+/**
+ * The VideoComponent interface is used to define the properties of a video component. This component is used to render a video with optional controls.
+ *
+ * Most often, video components will be used for trainings, and will have a `forceCompletion` field set to true. This will prevent the participant from moving on until the video has finished playing.
+ *
+ * As such, the `forceCompletion` field is set to true by default, and the `withTimeline` field is set to false by default.
+ *
+ * For example, to render a training video with a path of `<study-name>/assets/video.mp4`, you would use the following snippet:
+ * ```js
+ * {
+ *   "type": "video",
+ *   "path": "<study-name>/assets/video.mp4",
+ * }
+ * ```
+ * */
+
 export interface VideoComponent extends BaseIndividualComponent {
   type: 'video';
-  /** The path to the video. This should be a relative path from the public folder. */
+  /** The path to the video. This could be a relative path from the public folder or might be a url to an external website. */
   path: string;
   /** Whether to force the video to play until the end. Defaults to true. */
   forceCompletion?: boolean;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -822,6 +822,8 @@ export interface VideoComponent extends BaseIndividualComponent {
   path: string;
   /** Whether to force the video to play until the end. */
   forceCompletion?: boolean;
+  /** Whether to show the video timeline. Defaults to false. */
+  withTimeline?: boolean;
 }
 
 export type IndividualComponent = MarkdownComponent | ReactComponent | ImageComponent | WebsiteComponent | QuestionnaireComponent | VegaComponent | VideoComponent;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -816,7 +816,15 @@ export interface VegaComponentConfig extends BaseIndividualComponent {
 
 export type VegaComponent = VegaComponentPath | VegaComponentConfig;
 
-export type IndividualComponent = MarkdownComponent | ReactComponent | ImageComponent | WebsiteComponent | QuestionnaireComponent | VegaComponent;
+export interface VideoComponent extends BaseIndividualComponent {
+  type: 'video';
+  /** The path to the video. This should be a relative path from the public folder. */
+  path: string;
+  /** Whether to force the video to play until the end. */
+  forceCompletion?: boolean;
+}
+
+export type IndividualComponent = MarkdownComponent | ReactComponent | ImageComponent | WebsiteComponent | QuestionnaireComponent | VegaComponent | VideoComponent;
 
 /** The DeterministicInterruption interface is used to define an interruption that will be shown at a specific location in the block.
  *

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -820,7 +820,7 @@ export interface VideoComponent extends BaseIndividualComponent {
   type: 'video';
   /** The path to the video. This should be a relative path from the public folder. */
   path: string;
-  /** Whether to force the video to play until the end. */
+  /** Whether to force the video to play until the end. Defaults to true. */
   forceCompletion?: boolean;
   /** Whether to show the video timeline. Defaults to false. */
   withTimeline?: boolean;

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -30,13 +30,20 @@ export async function studyStoreCreator(
     ]));
   const emptyValidation: TrialValidation = Object.assign(
     {},
-    ...flatSequence.map((id, idx) => ({ [`${id}_${idx}`]: { aboveStimulus: { valid: false, values: {} }, belowStimulus: { valid: false, values: {} }, sidebar: { valid: false, values: {} } } })),
+    ...flatSequence.map((id, idx) => ({
+      [`${id}_${idx}`]: {
+        aboveStimulus: { valid: false, values: {} },
+        belowStimulus: { valid: false, values: {} },
+        sidebar: { valid: false, values: {} },
+        stimulus: { valid: false, values: {} },
+      },
+    })),
   );
   const allValid = Object.assign(
     {},
     ...flatSequence.map((id, idx) => ({
       [`${id}_${idx}`]: {
-        aboveStimulus: true, belowStimulus: true, sidebar: true, values: {},
+        aboveStimulus: true, belowStimulus: true, sidebar: true, stimulus: true, values: {},
       },
     })),
   );
@@ -159,7 +166,7 @@ export async function studyStoreCreator(
         {
           payload,
         }: PayloadAction<{
-          location: ResponseBlockLocation;
+          location: ResponseBlockLocation | 'stimulus';
           identifier: string;
           status: boolean;
           values: object;
@@ -171,12 +178,15 @@ export async function studyStoreCreator(
             aboveStimulus: { valid: false, values: {} },
             belowStimulus: { valid: false, values: {} },
             sidebar: { valid: false, values: {} },
+            stimulus: { valid: false, values: {} },
             provenanceGraph: undefined,
           };
         }
         if (Object.keys(payload.values).length > 0) {
           const currentValues = state.trialValidation[payload.identifier][payload.location].values;
           state.trialValidation[payload.identifier][payload.location] = { valid: payload.status, values: { ...currentValues, ...payload.values } };
+        } else {
+          state.trialValidation[payload.identifier][payload.location] = { valid: payload.status, values: {} };
         }
 
         if (payload.provenanceGraph) {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -39,6 +39,7 @@ export type TrialValidation = Record<
     aboveStimulus: ValidationStatus;
     belowStimulus: ValidationStatus;
     sidebar: ValidationStatus;
+    stimulus: ValidationStatus;
     provenanceGraph?: TrrackedProvenance;
   }
 >;

--- a/src/utils/getStaticAsset.ts
+++ b/src/utils/getStaticAsset.ts
@@ -1,10 +1,10 @@
 import { PREFIX } from './Prefix';
 
 export async function getStaticAssetByPath(path: string) {
-  const res = await fetch(`${PREFIX}${path}`);
+  const res = await fetch(path);
   const text = await res.text();
 
-  if (text.includes('<title>reVISit</title>')) {
+  if (text.includes('<title>ReVISit</title>')) {
     return undefined;
   }
   return text;

--- a/tests/demo-image.spec.ts
+++ b/tests/demo-image.spec.ts
@@ -51,6 +51,13 @@ test('test', async ({ page }) => {
   await page.getByLabel('Yes').check();
   await page.getByRole('button', { name: 'Next', exact: true }).click();
 
+  // Check the page contains the visualization
+  const img4 = await page.getByRole('main').getByRole('img');
+  await expect(img4).toBeVisible();
+
+  // Select a response and click next
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
   // Check that the end of study text renders
   const endText = await page.getByText('Please wait while your answers are uploaded.');
   await expect(endText).toBeVisible();

--- a/typedocReadMe.md
+++ b/typedocReadMe.md
@@ -27,6 +27,7 @@ The different component types:
 - [QuestionnaireComponent](interfaces/QuestionnaireComponent.md)
 - [ReactComponent](interfaces/ReactComponent.md)
 - [VegaComponent](type-aliases/VegaComponent.md)
+- [VideoComponent](interfaces/VideoComponent.md)
 - [WebsiteComponent](interfaces/WebsiteComponent.md)
 
 ## Responses

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,11 +2686,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.0.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
-  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
-
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
@@ -4337,11 +4332,6 @@ listr2@~8.2.5:
     rfdc "^1.4.1"
     wrap-ansi "^9.0.0"
 
-load-script@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
-  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
-
 loadjs@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loadjs/-/loadjs-4.3.0.tgz#38c578cbb2e08835aa4407bd4ac6507dd1f7ed10"
@@ -4552,11 +4542,6 @@ mdurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
   integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
-
-memoize-one@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -5118,7 +5103,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5183,11 +5168,6 @@ react-aptor@^2.0.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-fast-compare@^3.0.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
-  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
-
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -5213,17 +5193,6 @@ react-number-format@^5.4.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.3.tgz#e634df907da7742faf597afab3f25f9a59689d60"
   integrity sha512-VCY5hFg/soBighAoGcdE+GagkJq0230qN6jcS5sp8wQX1qy1fYN/RX7/BXkrs0oyzzwqR8/+eSUrqXbGeywdUQ==
-
-react-player@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.16.0.tgz#89070700b03f5a5ded9f0b3165d4717390796481"
-  integrity sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==
-  dependencies:
-    deepmerge "^4.0.0"
-    load-script "^1.0.0"
-    memoize-one "^5.1.1"
-    prop-types "^15.7.2"
-    react-fast-compare "^3.0.1"
 
 react-redux@^9.2.0:
   version "9.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,6 +2297,11 @@ cookie@^1.0.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
+core-js@^3.26.1:
+  version "3.40.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.40.0.tgz#2773f6b06877d8eda102fc42f828176437062476"
+  integrity sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -2325,6 +2330,11 @@ csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+custom-event-polyfill@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
+  integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==
 
 "d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@3.2.4, d3-array@^3.2.0, d3-array@^3.2.2:
   version "3.2.4"
@@ -4332,6 +4342,11 @@ load-script@^1.0.0:
   resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
   integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
 
+loadjs@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/loadjs/-/loadjs-4.3.0.tgz#38c578cbb2e08835aa4407bd4ac6507dd1f7ed10"
+  integrity sha512-vNX4ZZLJBeDEOBvdr2v/F+0aN5oMuPu7JTqrMwp+DtgK+AryOlpy6Xtm2/HpNr+azEa828oQjOtWsB6iDtSfSQ==
+
 localforage@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
@@ -5065,6 +5080,25 @@ playwright@1.49.1:
   optionalDependencies:
     fsevents "2.3.2"
 
+plyr-react@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/plyr-react/-/plyr-react-5.3.0.tgz#e2386e57563872ef6cc2c9d6d5a578ac2daac4b6"
+  integrity sha512-m36/HrpHwg1N2rq3E31E8/kpAH55vk6qHUg17MG4uu9jbWYxnkN39lLmZQwxW7/qpDPfW5aGUJ6R3u23V0R3zA==
+  dependencies:
+    plyr "^3.7.7"
+    react-aptor "^2.0.0"
+
+plyr@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/plyr/-/plyr-3.7.8.tgz#b79bccc23687705b5d9a283b2a88c124bf7471ed"
+  integrity sha512-yG/EHDobwbB/uP+4Bm6eUpJ93f8xxHjjk2dYcD1Oqpe1EcuQl5tzzw9Oq+uVAzd2lkM11qZfydSiyIpiB8pgdA==
+  dependencies:
+    core-js "^3.26.1"
+    custom-event-polyfill "^1.0.7"
+    loadjs "^4.2.0"
+    rangetouch "^2.0.1"
+    url-polyfill "^1.1.12"
+
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
@@ -5130,6 +5164,16 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+rangetouch@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rangetouch/-/rangetouch-2.0.1.tgz#c01105110fd3afca2adcb1a580692837d883cb70"
+  integrity sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA==
+
+react-aptor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-aptor/-/react-aptor-2.0.0.tgz#d78235dbcdf28889dc9a6c179035d6ca8bd7cfa1"
+  integrity sha512-YnCayokuhAwmBBP4Oc0bbT2l6ApfsjbY3DEEVUddIKZEBlGl1npzjHHzWnSqWuboSbMZvRqUM01Io9yiIp1wcg==
 
 "react-dom@16.14 - 18", react-dom@^18.3.1:
   version "18.3.1"
@@ -6234,6 +6278,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-polyfill@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.12.tgz#6cdaa17f6b022841b3aec0bf8dbd87ac0cd33331"
+  integrity sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A==
 
 use-callback-ref@^1.3.3:
   version "1.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,6 +2676,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
@@ -4322,6 +4327,11 @@ listr2@~8.2.5:
     rfdc "^1.4.1"
     wrap-ansi "^9.0.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
+
 localforage@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
@@ -4527,6 +4537,11 @@ mdurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
   integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
+
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -5069,7 +5084,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5124,6 +5139,11 @@ queue-microtask@^1.2.2:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-fast-compare@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -5149,6 +5169,17 @@ react-number-format@^5.4.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.3.tgz#e634df907da7742faf597afab3f25f9a59689d60"
   integrity sha512-VCY5hFg/soBighAoGcdE+GagkJq0230qN6jcS5sp8wQX1qy1fYN/RX7/BXkrs0oyzzwqR8/+eSUrqXbGeywdUQ==
+
+react-player@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.16.0.tgz#89070700b03f5a5ded9f0b3165d4717390796481"
+  integrity sha512-mAIPHfioD7yxO0GNYVFD1303QFtI3lyyQZLY229UEAp/a10cSW+hPcakg0Keq8uWJxT2OiT/4Gt+Lc9bD6bJmQ==
+  dependencies:
+    deepmerge "^4.0.0"
+    load-script "^1.0.0"
+    memoize-one "^5.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
 
 react-redux@^9.2.0:
   version "9.2.0"
@@ -5703,16 +5734,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5834,14 +5856,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6817,16 +6832,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #548 

### Give a longer description of what this PR addresses and why it's needed
Adds a video stimulus with options to `forceCompletion` and to `showTimeline`.

To enable the `forceCompletion` flag, I had to add an additional piece to the validation object (`'stimulus'`). This is invalidated if forceCompletion is true and re-validated when the video is completed.

One additional improvement in this PR is enabling the image component to use external images. This was always my intention, but seemed to be hard coded to only work with images in the public folder.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1624" alt="Screenshot 2025-02-04 at 10 06 53 PM" src="https://github.com/user-attachments/assets/da31f29d-efce-46c9-af02-6c3c01596b44" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation, write more for the typedoc, add to typedoc readme
- [x] Add video stimulus to revisit.dev lists (issue?) and Open an issue for image/video stimulus in designing studies (https://github.com/revisit-studies/reVISit-studies.github.io/issues/106)