### PR TITLE
Checkbox validation message, unique help button

### DIFF
--- a/public/demo-training/config.json
+++ b/public/demo-training/config.json
@@ -85,6 +85,37 @@
       "allowFailedTraining": false,
       "trainingAttempts": 4
     },
+    "multiSelectCheckbox": {
+      "type": "questionnaire",
+      "nextButtonLocation": "sidebar",
+      "response": [
+        {
+          "id": "quiz",
+          "prompt": "Select A, D, F",
+          "required": true,
+          "location": "sidebar",
+          "type": "checkbox",
+          "options": [
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G"
+          ]
+        }
+      ],
+      "correctAnswer": [
+        {
+          "id": "quiz",
+          "answer": ["A","D","F"]
+        }
+      ],
+      "provideFeedback": true,
+      "allowFailedTraining": false,
+      "trainingAttempts": 4
+    },
     "main-page-text-field": {
       "type": "questionnaire",
       "nextButtonLocation": "belowStimulus",
@@ -126,6 +157,7 @@
     "components": [
       "simple-dropbox",
       "slider-range",
+      "multiSelectCheckbox",
       "main-page-text-field"
     ]
   }

--- a/src/components/interface/HelpModal.tsx
+++ b/src/components/interface/HelpModal.tsx
@@ -1,10 +1,12 @@
 import { Modal } from '@mantine/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ReactMarkdownWrapper } from '../ReactMarkdownWrapper';
 import { useStoreDispatch, useStoreSelector, useStoreActions } from '../../store/store';
 import { getStaticAssetByPath } from '../../utils/getStaticAsset';
 import { ResourceNotFound } from '../../ResourceNotFound';
 import { PREFIX } from '../../utils/Prefix';
+import { useCurrentComponent } from '../../routes/utils';
+import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
 
 export function HelpModal() {
   const showHelpText = useStoreSelector((state) => state.showHelpText);
@@ -16,13 +18,24 @@ export function HelpModal() {
   const [helpText, setHelpText] = useState('');
 
   const [loading, setLoading] = useState(true);
+  const component = useCurrentComponent();
+
+  const componentConfig = useMemo(() => studyComponentToIndividualComponent(config.components[component], config), [component, config]);
+
+  const helpPath = useMemo(() => {
+    if (componentConfig.helpButtonPathOverride) {
+      return componentConfig.helpButtonPathOverride;
+    }
+    return config.uiConfig.helpTextPath;
+  }, [componentConfig.helpButtonPathOverride, config.uiConfig.helpTextPath]);
+
   useEffect(() => {
     async function fetchText() {
-      if (!config.uiConfig.helpTextPath) {
+      if (!helpPath) {
         setLoading(false);
         return;
       }
-      const asset = await getStaticAssetByPath(`${PREFIX}${config.uiConfig.helpTextPath}`);
+      const asset = await getStaticAssetByPath(`${PREFIX}${helpPath}`);
       if (asset !== undefined) {
         setHelpText(asset);
       }
@@ -30,7 +43,7 @@ export function HelpModal() {
     }
 
     fetchText();
-  }, [config.uiConfig.helpTextPath]);
+  }, [helpPath]);
 
   return (
     <Modal size="70%" opened={showHelpText} withCloseButton={false} onClose={() => storeDispatch(toggleShowHelpText())}>

--- a/src/components/interface/HelpModal.tsx
+++ b/src/components/interface/HelpModal.tsx
@@ -23,11 +23,11 @@ export function HelpModal() {
   const componentConfig = useMemo(() => studyComponentToIndividualComponent(config.components[component], config), [component, config]);
 
   const helpPath = useMemo(() => {
-    if (componentConfig.helpButtonPathOverride) {
-      return componentConfig.helpButtonPathOverride;
+    if (componentConfig.helpTextPathOverride) {
+      return componentConfig.helpTextPathOverride;
     }
     return config.uiConfig.helpTextPath;
-  }, [componentConfig.helpButtonPathOverride, config.uiConfig.helpTextPath]);
+  }, [componentConfig.helpTextPathOverride, config.uiConfig.helpTextPath]);
 
   useEffect(() => {
     async function fetchText() {

--- a/src/components/interface/HelpModal.tsx
+++ b/src/components/interface/HelpModal.tsx
@@ -20,7 +20,7 @@ export function HelpModal() {
   const [loading, setLoading] = useState(true);
   const component = useCurrentComponent();
 
-  const componentConfig = useMemo(() => studyComponentToIndividualComponent(config.components[component], config), [component, config]);
+  const componentConfig = useMemo(() => studyComponentToIndividualComponent(config.components[component] || {}, config), [component, config]);
 
   const helpPath = useMemo(() => {
     if (componentConfig.helpTextPathOverride) {

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -28,6 +28,16 @@ type Props = {
   style?: React.CSSProperties;
 };
 
+function findMatchingStrings(arr1: string[], arr2: string[]): string[] {
+  const matches: string[] = [];
+  for (const str1 of arr1) {
+    if (arr2.includes(str1)) {
+      matches.push(str1);
+    }
+  }
+  return matches;
+}
+
 export function ResponseBlock({
   config,
   location,
@@ -182,6 +192,13 @@ export function ResponseBlock({
             message = 'Please try again. You have 1 attempt left.';
           } else {
             message = `Please try again. You have ${trainingAttempts - newAttemptsUsed} attempts left.`;
+          }
+          if (response.type === 'checkbox') {
+            const correct = configInUse.correctAnswer?.find((answer) => answer.id === response.id)?.answer;
+
+            const matches = findMatchingStrings((answerValidator.values as Record<string, unknown>)[response.id] as string[], correct);
+
+            message = `${matches.length} / ${correct.length} correct. ${message}`;
           }
           updateAlertConfig(response.id, true, 'Incorrect Answer', message, 'red');
         }

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -196,9 +196,12 @@ export function ResponseBlock({
           if (response.type === 'checkbox') {
             const correct = configInUse.correctAnswer?.find((answer) => answer.id === response.id)?.answer;
 
-            const matches = findMatchingStrings((answerValidator.values as Record<string, unknown>)[response.id] as string[], correct);
+            const suppliedAnswer = (answerValidator.values as Record<string, unknown>)[response.id] as string[];
+            const matches = findMatchingStrings(suppliedAnswer, correct);
 
-            message = `${matches.length} / ${correct.length} correct. ${message}`;
+            const tooManySelected = correct.length === matches.length && suppliedAnswer.length > correct.length ? 'However, you have selected too many boxes. ' : '';
+
+            message = `You have successfully checked ${matches.length}/${correct.length} correct boxes. ${tooManySelected}${message}`;
           }
           updateAlertConfig(response.id, true, 'Incorrect Answer', message, 'red');
         }

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -55,8 +55,8 @@
             "description": "Whether to force the video to play until the end. Defaults to true.",
             "type": "boolean"
           },
-          "helpButtonPathOverride": {
-            "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "helpTextPathOverride": {
+            "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
             "type": "string"
           },
           "instruction": {
@@ -485,8 +485,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -691,8 +691,8 @@
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1043,8 +1043,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1322,8 +1322,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1526,8 +1526,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1953,8 +1953,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2040,8 +2040,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2135,8 +2135,8 @@
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2230,8 +2230,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -55,6 +55,10 @@
             "description": "Whether to force the video to play until the end. Defaults to true.",
             "type": "boolean"
           },
+          "helpButtonPathOverride": {
+            "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+            "type": "string"
+          },
           "instruction": {
             "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "string"
@@ -481,6 +485,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -682,6 +690,10 @@
         "forceCompletion": {
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
         },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
@@ -1031,6 +1043,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -1306,6 +1322,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -1504,6 +1524,10 @@
         },
         "description": {
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1929,6 +1953,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -2010,6 +2038,10 @@
         },
         "description": {
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2103,6 +2135,10 @@
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -2177,7 +2213,7 @@
     },
     "WebsiteComponent": {
       "additionalProperties": false,
-      "description": "The WebsiteComponent interface is used to define the properties of a website component. A WebsiteComponent is used to render an iframe with a website inside of it. This can be used to display an external website or an html file that is located in the public folder.\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/assets/website.html\", } ```\n\nTo pass a data from the config to the website, you can use the `parameters` field as below:\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/website.html\", \"parameters\": {  \"barData\": [0.32, 0.01, 1.2, 1.3, 0.82, 0.4, 0.3] } \"response\": [  {    \"id\": \"barChart\",    \"prompt\": \"Your selected answer:\",    \"location\": \"belowStimulus\",    \"type\": \"reactive\"  } ], } ``` In the `website.html` file, by including `revisit-communicate.js`, you can use the `Revisit.onDataReceive` method to retrieve the data, and `Revisit.postAnswers` to send the user's responses back to the reVISit as shown in the example below:\n\n```html <script src=\"../../revisitUtilities/revisit-communicate.js\"></script> <script> Revisit.onDataReceive((data) => {  const barData = data['barData'];  ... });\n\n// Call out that 'barChart' needs to match ID in 'response' object Revisit.postAnswers({ barChart: userAnswer }); </script> ```\n\n If the html website implements Trrack library for provenance tracking, you can send the provenance graph back to reVISit by calling `Revisit.postProvenanceGraph` as shown in the example below. You need to call this each time the Trrack state is updated so that reVISit is kept aware of the changes in the provenance graph.\n\n```js const trrack = initializeTrrack({ initialState, registry });\n\n... Revisit.postProvenance(trrack.graph.backend); ```",
+      "description": "The WebsiteComponent interface is used to define the properties of a website component. A WebsiteComponent is used to render an iframe with a website inside of it. This can be used to display an external website or an html file that is located in the public folder.\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/assets/website.html\", } ```\n\nTo pass a data from the config to the website, you can use the `parameters` field as below:\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/website.html\", \"parameters\": {  \"barData\": [0.32, 0.01, 1.2, 1.3, 0.82, 0.4, 0.3] }, \"response\": [  {    \"id\": \"barChart\",    \"prompt\": \"Your selected answer:\",    \"location\": \"belowStimulus\",    \"type\": \"reactive\"  } ] } ``` In the `website.html` file, by including `revisit-communicate.js`, you can use the `Revisit.onDataReceive` method to retrieve the data, and `Revisit.postAnswers` to send the user's responses back to the reVISit as shown in the example below:\n\n```html <script src=\"../../revisitUtilities/revisit-communicate.js\"></script> <script> Revisit.onDataReceive((data) => {  const barData = data['barData'];  ... });\n\n// Call out that 'barChart' needs to match ID in 'response' object Revisit.postAnswers({ barChart: userAnswer }); </script> ```\n\n If the html website implements Trrack library for provenance tracking, you can send the provenance graph back to reVISit by calling `Revisit.postProvenanceGraph` as shown in the example below. You need to call this each time the Trrack state is updated so that reVISit is kept aware of the changes in the provenance graph.\n\n```js const trrack = initializeTrrack({ initialState, registry });\n\n... Revisit.postProvenance(trrack.graph.backend); ```",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
@@ -2192,6 +2228,10 @@
         },
         "description": {
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -55,6 +55,10 @@
             "description": "Whether to force the video to play until the end. Defaults to true.",
             "type": "boolean"
           },
+          "helpButtonPathOverride": {
+            "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+            "type": "string"
+          },
           "instruction": {
             "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "string"
@@ -481,6 +485,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -682,6 +690,10 @@
         "forceCompletion": {
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
         },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
@@ -973,6 +985,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -1248,6 +1264,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -1446,6 +1466,10 @@
         },
         "description": {
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2052,6 +2076,10 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -2133,6 +2161,10 @@
         },
         "description": {
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2226,6 +2258,10 @@
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "type": "string"
+        },
         "instruction": {
           "description": "The instruction of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
@@ -2300,7 +2336,7 @@
     },
     "WebsiteComponent": {
       "additionalProperties": false,
-      "description": "The WebsiteComponent interface is used to define the properties of a website component. A WebsiteComponent is used to render an iframe with a website inside of it. This can be used to display an external website or an html file that is located in the public folder.\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/assets/website.html\", } ```\n\nTo pass a data from the config to the website, you can use the `parameters` field as below:\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/website.html\", \"parameters\": {  \"barData\": [0.32, 0.01, 1.2, 1.3, 0.82, 0.4, 0.3] } \"response\": [  {    \"id\": \"barChart\",    \"prompt\": \"Your selected answer:\",    \"location\": \"belowStimulus\",    \"type\": \"reactive\"  } ], } ``` In the `website.html` file, by including `revisit-communicate.js`, you can use the `Revisit.onDataReceive` method to retrieve the data, and `Revisit.postAnswers` to send the user's responses back to the reVISit as shown in the example below:\n\n```html <script src=\"../../revisitUtilities/revisit-communicate.js\"></script> <script> Revisit.onDataReceive((data) => {  const barData = data['barData'];  ... });\n\n// Call out that 'barChart' needs to match ID in 'response' object Revisit.postAnswers({ barChart: userAnswer }); </script> ```\n\n If the html website implements Trrack library for provenance tracking, you can send the provenance graph back to reVISit by calling `Revisit.postProvenanceGraph` as shown in the example below. You need to call this each time the Trrack state is updated so that reVISit is kept aware of the changes in the provenance graph.\n\n```js const trrack = initializeTrrack({ initialState, registry });\n\n... Revisit.postProvenance(trrack.graph.backend); ```",
+      "description": "The WebsiteComponent interface is used to define the properties of a website component. A WebsiteComponent is used to render an iframe with a website inside of it. This can be used to display an external website or an html file that is located in the public folder.\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/assets/website.html\", } ```\n\nTo pass a data from the config to the website, you can use the `parameters` field as below:\n\n```js { \"type\": \"website\", \"path\": \"<study-name>/website.html\", \"parameters\": {  \"barData\": [0.32, 0.01, 1.2, 1.3, 0.82, 0.4, 0.3] }, \"response\": [  {    \"id\": \"barChart\",    \"prompt\": \"Your selected answer:\",    \"location\": \"belowStimulus\",    \"type\": \"reactive\"  } ] } ``` In the `website.html` file, by including `revisit-communicate.js`, you can use the `Revisit.onDataReceive` method to retrieve the data, and `Revisit.postAnswers` to send the user's responses back to the reVISit as shown in the example below:\n\n```html <script src=\"../../revisitUtilities/revisit-communicate.js\"></script> <script> Revisit.onDataReceive((data) => {  const barData = data['barData'];  ... });\n\n// Call out that 'barChart' needs to match ID in 'response' object Revisit.postAnswers({ barChart: userAnswer }); </script> ```\n\n If the html website implements Trrack library for provenance tracking, you can send the provenance graph back to reVISit by calling `Revisit.postProvenanceGraph` as shown in the example below. You need to call this each time the Trrack state is updated so that reVISit is kept aware of the changes in the provenance graph.\n\n```js const trrack = initializeTrrack({ initialState, registry });\n\n... Revisit.postProvenance(trrack.graph.backend); ```",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If not provided, the default is true.",
@@ -2315,6 +2351,10 @@
         },
         "description": {
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
+          "type": "string"
+        },
+        "helpButtonPathOverride": {
+          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -55,8 +55,8 @@
             "description": "Whether to force the video to play until the end. Defaults to true.",
             "type": "boolean"
           },
-          "helpButtonPathOverride": {
-            "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+          "helpTextPathOverride": {
+            "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
             "type": "string"
           },
           "instruction": {
@@ -485,8 +485,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -691,8 +691,8 @@
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -985,8 +985,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1264,8 +1264,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -1468,8 +1468,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2076,8 +2076,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2163,8 +2163,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2258,8 +2258,8 @@
           "description": "Whether to force the video to play until the end. Defaults to true.",
           "type": "boolean"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {
@@ -2353,8 +2353,8 @@
           "description": "The description of the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "string"
         },
-        "helpButtonPathOverride": {
-          "description": "Optional override for the help button. If present, will override the default help button path set in the uiConfig.",
+        "helpTextPathOverride": {
+          "description": "Optional override for the help text. If present, will override the default help text path set in the uiConfig.",
           "type": "string"
         },
         "instruction": {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -564,6 +564,8 @@ export interface BaseIndividualComponent {
   nextButtonEnableTime?: number;
   /** Whether to show the response dividers. Defaults to false. */
   responseDividers?: boolean;
+  /** Optional override for the help button. If present, will override the default help button path set in the uiConfig. */
+  helpButtonPathOverride?: string;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -564,8 +564,8 @@ export interface BaseIndividualComponent {
   nextButtonEnableTime?: number;
   /** Whether to show the response dividers. Defaults to false. */
   responseDividers?: boolean;
-  /** Optional override for the help button. If present, will override the default help button path set in the uiConfig. */
-  helpButtonPathOverride?: string;
+  /** Optional override for the help text. If present, will override the default help text path set in the uiConfig. */
+  helpTextPathOverride?: string;
 }
 
 /**


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed

Adds a validation message for checkbox training tasks that are wrong. The message says how many out of the total are correct, though still does that if you get all 3 correct but also have extra (so the message will be 3/3, even though its wrong) which is a bit odd but couldnt think of a better way to do it. 

Also added a prop to the baseComponent which lets people override the helpPath so they can show different help pages for different components

Also made some small changes to the StepsPanel which hides and doesn't render portions of the sidebar which arent open. Only opens the portions which are active by default. This was mainly to fix problems the sidebar caused by rendering too many elements in the dom when the study is complex.
