### PR TITLE
Add a ButtonsInput

### DIFF
--- a/public/demo-survey/config.json
+++ b/public/demo-survey/config.json
@@ -29,7 +29,7 @@
       "response": [
         {
           "id": "q-dropdown",
-          "prompt": "Dropdown example – which chart do you like best?",
+          "prompt": "Dropdown example – which chart do you like best?",
           "secondaryText": "You can specify secondary text to clarify your question.",
           "location": "aboveStimulus",
           "type": "dropdown",

--- a/public/demo-survey/config.json
+++ b/public/demo-survey/config.json
@@ -198,7 +198,8 @@
           "options": [
             "Option 1",
             "Option 2",
-            "Option 3"
+            "Option 3",
+            "Option 4"
           ]
         }
       ]

--- a/public/demo-survey/config.json
+++ b/public/demo-survey/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.0.2/src/parser/StudyConfigSchema.json",
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/cursor-buttons/src/parser/StudyConfigSchema.json",
   "studyMetadata": {
     "title": "Question Types and Form Elements Demo",
     "version": "pilot",
@@ -187,6 +187,18 @@
               "label": "Good",
               "value": 100
             }
+          ]
+        },
+        {
+          "id": "q-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "location": "aboveStimulus",
+          "options": [
+            "Option 1",
+            "Option 2",
+            "Option 3"
           ]
         }
       ]

--- a/src/components/response/ButtonsInput.module.css
+++ b/src/components/response/ButtonsInput.module.css
@@ -1,0 +1,22 @@
+.root {
+  position: relative;
+  padding: var(--mantine-spacing-md);
+  transition: border-color 150ms ease;
+  background-color: var(--mantine-color-blue-3);
+  color: var(--mantine-color-white);
+
+  &[data-checked] {
+    background-color: var(--mantine-color-blue-filled);
+  }
+
+  &[disabled] {
+    background-color: var(--mantine-color-gray-2);
+    color: var(--mantine-color-gray);
+    cursor: default;
+
+    &[data-checked] {
+      background-color: var(--mantine-color-blue-6);
+      color: var(--mantine-color-white);
+    }
+  }
+}

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -59,6 +59,7 @@ export function ButtonsInput({
             onClick={() => setCheckedValue(radio.value)}
             ta="center"
             className={classes.root}
+            p="xs"
           >
             <Text>{radio.label}</Text>
           </Radio.Card>

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -1,0 +1,69 @@
+import {
+  Box, Flex, Radio, Text,
+} from '@mantine/core';
+import { useState } from 'react';
+import { ButtonsResponse } from '../../parser/types';
+import { generateErrorMessage } from './utils';
+import { ReactMarkdownWrapper } from '../ReactMarkdownWrapper';
+import classes from './ButtonsInput.module.css';
+
+export function ButtonsInput({
+  response,
+  disabled,
+  answer,
+  index,
+  enumerateQuestions,
+}: {
+  response: ButtonsResponse;
+  disabled: boolean;
+  answer: { value?: string };
+  index: number;
+  enumerateQuestions: boolean;
+}) {
+  const {
+    prompt,
+    required,
+    options,
+    secondaryText,
+  } = response;
+
+  const optionsAsStringOptions = options.map((option) => (typeof option === 'string' ? { value: option, label: option } : option));
+
+  const [checkedValue, setCheckedValue] = useState(answer.value ?? '');
+
+  return (
+    <Radio.Group
+      name={`radioInput${response.id}`}
+      label={(
+        <Flex direction="row" wrap="nowrap" gap={4}>
+          {enumerateQuestions && <Box style={{ minWidth: 'fit-content', fontSize: 16, fontWeight: 500 }}>{`${index}. `}</Box>}
+          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+            <ReactMarkdownWrapper text={prompt} required={required} />
+          </Box>
+        </Flex>
+      )}
+      description={secondaryText}
+      key={response.id}
+      {...answer}
+          // This overrides the answers error. Which..is bad?
+      error={generateErrorMessage(response, answer, optionsAsStringOptions)}
+      style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
+    >
+      <Flex justify="space-between" align="center" gap="xl" mt="xs">
+        {optionsAsStringOptions.map((radio) => (
+          <Radio.Card
+            key={radio.value}
+            value={radio.value}
+            disabled={disabled}
+            checked={checkedValue === radio.value}
+            onClick={() => setCheckedValue(radio.value)}
+            ta="center"
+            className={classes.root}
+          >
+            <Text>{radio.label}</Text>
+          </Radio.Card>
+        ))}
+      </Flex>
+    </Radio.Group>
+  );
+}

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Flex, Radio, Text,
+  Box, Flex, FocusTrap, Radio, Text,
 } from '@mantine/core';
 import { useState } from 'react';
 import { ButtonsResponse } from '../../parser/types';
@@ -32,39 +32,41 @@ export function ButtonsInput({
   const [checkedValue, setCheckedValue] = useState(answer.value ?? '');
 
   return (
-    <Radio.Group
-      name={`radioInput${response.id}`}
-      label={(
-        <Flex direction="row" wrap="nowrap" gap={4}>
-          {enumerateQuestions && <Box style={{ minWidth: 'fit-content', fontSize: 16, fontWeight: 500 }}>{`${index}. `}</Box>}
-          <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
-            <ReactMarkdownWrapper text={prompt} required={required} />
-          </Box>
-        </Flex>
+    <FocusTrap>
+      <Radio.Group
+        name={`radioInput${response.id}`}
+        label={(
+          <Flex direction="row" wrap="nowrap" gap={4}>
+            {enumerateQuestions && <Box style={{ minWidth: 'fit-content', fontSize: 16, fontWeight: 500 }}>{`${index}. `}</Box>}
+            <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+              <ReactMarkdownWrapper text={prompt} required={required} />
+            </Box>
+          </Flex>
       )}
-      description={secondaryText}
-      key={response.id}
-      {...answer}
+        description={secondaryText}
+        key={response.id}
+        {...answer}
           // This overrides the answers error. Which..is bad?
-      error={generateErrorMessage(response, answer, optionsAsStringOptions)}
-      style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
-    >
-      <Flex justify="space-between" align="center" gap="xl" mt="xs">
-        {optionsAsStringOptions.map((radio) => (
-          <Radio.Card
-            key={radio.value}
-            value={radio.value}
-            disabled={disabled}
-            checked={checkedValue === radio.value}
-            onClick={() => setCheckedValue(radio.value)}
-            ta="center"
-            className={classes.root}
-            p="xs"
-          >
-            <Text>{radio.label}</Text>
-          </Radio.Card>
-        ))}
-      </Flex>
-    </Radio.Group>
+        error={generateErrorMessage(response, answer, optionsAsStringOptions)}
+        style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
+      >
+        <Flex justify="space-between" align="center" gap="xl" mt="xs">
+          {optionsAsStringOptions.map((radio) => (
+            <Radio.Card
+              key={radio.value}
+              value={radio.value}
+              disabled={disabled}
+              checked={checkedValue === radio.value}
+              onClick={() => setCheckedValue(radio.value)}
+              ta="center"
+              className={classes.root}
+              p="xs"
+            >
+              <Text>{radio.label}</Text>
+            </Radio.Card>
+          ))}
+        </Flex>
+      </Radio.Group>
+    </FocusTrap>
   );
 }

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -14,6 +14,7 @@ import { StringInput } from './StringInput';
 import { TextAreaInput } from './TextAreaInput';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import { MatrixInput } from './MatrixInput';
+import { ButtonsInput } from './ButtonsInput';
 
 export function ResponseSwitcher({
   response,
@@ -144,6 +145,15 @@ export function ResponseSwitcher({
           disabled={isDisabled || dontKnowCheckbox}
           response={response}
           answer={ans as { value: Record<string, string> }}
+          index={index}
+          enumerateQuestions={enumerateQuestions}
+        />
+      )}
+      {response.type === 'buttons' && (
+        <ButtonsInput
+          response={response}
+          disabled={isDisabled || dontKnowCheckbox}
+          answer={ans as { value: string }}
           index={index}
           enumerateQuestions={enumerateQuestions}
         />

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1979,7 +1979,7 @@
     },
     "StringOption": {
       "additionalProperties": false,
-      "description": "The StringOption interface is used to define the options for a dropdown, radio, or checkbox response. The label is the text that is displayed to the user, and the value is the value that is stored in the data file.",
+      "description": "The StringOption interface is used to define the options for a dropdown, radio, buttons, or checkbox response. The label is the text that is displayed to the user, and the value is the value that is stored in the data file.",
       "properties": {
         "label": {
           "description": "The label displayed to participants.",

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -202,7 +202,14 @@
         },
         "options": {
           "items": {
-            "$ref": "#/definitions/StringOption"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/StringOption"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -184,6 +184,72 @@
       "description": "The baseComponents is an optional set of components which can help template other components. For example, suppose you have a single HTML file that you want to display to the user several times. Instead of having the same component twice in the `components` list, you can have a single baseComponent with all the information that the two HTML components will share. A great example is showing the same HTML component but with two different questions;\n\n Using baseComponents:\n\n```js \"baseComponents\": { \"my-image-component\": { \"instructionLocation\": \"sidebar\", \"nextButtonLocation\": \"sidebar\", \"path\": \"<study-name>/assets/my-image.jpg\", \"response\": [   {     \"id\": \"my-image-id\",     \"options\": [\"Europe\", \"Japan\", \"USA\"],     \"prompt\": \"Your Selected Answer:\",     \"type\": \"dropdown\"   } ], \"type\": \"image\" } } ``` In the above code snippet, we have a single base component which holds the information about the type of component, the path to the image, and the response (which is a dropdown containing three choices). Any component which contains the `\"baseComponent\":\"my-image-component\"` key-value pair will inherit each of these properties. Thus, if we have three different questions which have the same choices and are concerning the same image, we can define our components like below: ```js \"components\": { \"q1\": { \"baseComponent\": \"my-image-component\", \"description\": \"Choosing section with largest GDP\", \"instruction\": \"Which region has the largest GDP?\" }, \"q2\": { \"baseComponent\": \"my-image-component\", \"description\": \"Choosing section with lowest GDP\", \"instruction\": \"Which region has the lowest GDP?\" }, \"q3\": { \"baseComponent\": \"my-image-component\", \"description\": \"Choosing section with highest exports of Wheat\", \"instruction\": \"Which region had the most Wheat exported in 2022?\" } } ```",
       "type": "object"
     },
+    "ButtonsResponse": {
+      "additionalProperties": false,
+      "description": "The ButtonsResponse interface is used to define the properties of a buttons response. ButtonsResponses render as a list of buttons that the participant can click. When a button is clicked, the value of the button is stored in the data file. Participants can cycle through the options using the arrow keys.\n\nExample: ```js {   \"id\": \"buttonsResponse\",   \"type\": \"buttons\",   \"prompt\": \"Click a button\",   \"location\": \"belowStimulus\",   \"options\": [     \"Option 1\",     \"Option 2\",     \"Option 3\"   ] } ``` In this example, the participant can click one of the buttons labeled \"Option 1\", \"Option 2\", or \"Option 3\".",
+      "properties": {
+        "hidden": {
+          "description": "Controls whether the response is hidden.",
+          "type": "boolean"
+        },
+        "id": {
+          "description": "The id of the response. This is used to identify the response in the data file.",
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/definitions/ResponseBlockLocation",
+          "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
+        },
+        "options": {
+          "items": {
+            "$ref": "#/definitions/StringOption"
+          },
+          "type": "array"
+        },
+        "paramCapture": {
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
+          "type": "string"
+        },
+        "prompt": {
+          "description": "The prompt that is displayed to the participant. You can use markdown here to render images, links, etc.",
+          "type": "string"
+        },
+        "required": {
+          "description": "Controls whether the response is required to be answered. Defaults to true.",
+          "type": "boolean"
+        },
+        "requiredLabel": {
+          "description": "You can provide a required label, which makes it so a participant has to answer with a response that matches label.",
+          "type": "string"
+        },
+        "requiredValue": {
+          "description": "You can provide a required value, which makes it so a participant has to answer with that value."
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
+        },
+        "type": {
+          "const": "buttons",
+          "type": "string"
+        },
+        "withDivider": {
+          "description": "Renders the response with a trailing divider.",
+          "type": "boolean"
+        },
+        "withDontKnow": {
+          "description": "Renders the response with an option for \"I don't know\". This counts as a completed answer for the validation.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "options",
+        "prompt",
+        "type"
+      ],
+      "type": "object"
+    },
     "CheckboxResponse": {
       "additionalProperties": false,
       "description": "The CheckboxResponse interface is used to define the properties of a checkbox response. CheckboxResponses render as a checkbox input with user specified options.\n\n```js { \"id\": \"q7\", \"prompt\": \"Checkbox example (not required)\", \"location\": \"aboveStimulus\", \"type\": \"checkbox\", \"options\": [\"Option 1\", \"Option 2\", \"Option 3\"] } ```",
@@ -1732,6 +1798,9 @@
         },
         {
           "$ref": "#/definitions/MatrixResponse"
+        },
+        {
+          "$ref": "#/definitions/ButtonsResponse"
         }
       ]
     },

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -184,6 +184,72 @@
       "description": "The baseComponents is an optional set of components which can help template other components. For example, suppose you have a single HTML file that you want to display to the user several times. Instead of having the same component twice in the `components` list, you can have a single baseComponent with all the information that the two HTML components will share. A great example is showing the same HTML component but with two different questions;\n\n Using baseComponents:\n\n```js \"baseComponents\": { \"my-image-component\": { \"instructionLocation\": \"sidebar\", \"nextButtonLocation\": \"sidebar\", \"path\": \"<study-name>/assets/my-image.jpg\", \"response\": [   {     \"id\": \"my-image-id\",     \"options\": [\"Europe\", \"Japan\", \"USA\"],     \"prompt\": \"Your Selected Answer:\",     \"type\": \"dropdown\"   } ], \"type\": \"image\" } } ``` In the above code snippet, we have a single base component which holds the information about the type of component, the path to the image, and the response (which is a dropdown containing three choices). Any component which contains the `\"baseComponent\":\"my-image-component\"` key-value pair will inherit each of these properties. Thus, if we have three different questions which have the same choices and are concerning the same image, we can define our components like below: ```js \"components\": { \"q1\": { \"baseComponent\": \"my-image-component\", \"description\": \"Choosing section with largest GDP\", \"instruction\": \"Which region has the largest GDP?\" }, \"q2\": { \"baseComponent\": \"my-image-component\", \"description\": \"Choosing section with lowest GDP\", \"instruction\": \"Which region has the lowest GDP?\" }, \"q3\": { \"baseComponent\": \"my-image-component\", \"description\": \"Choosing section with highest exports of Wheat\", \"instruction\": \"Which region had the most Wheat exported in 2022?\" } } ```",
       "type": "object"
     },
+    "ButtonsResponse": {
+      "additionalProperties": false,
+      "description": "The ButtonsResponse interface is used to define the properties of a buttons response. ButtonsResponses render as a list of buttons that the participant can click. When a button is clicked, the value of the button is stored in the data file. Participants can cycle through the options using the arrow keys.\n\nExample: ```js {   \"id\": \"buttonsResponse\",   \"type\": \"buttons\",   \"prompt\": \"Click a button\",   \"location\": \"belowStimulus\",   \"options\": [     \"Option 1\",     \"Option 2\",     \"Option 3\"   ] } ``` In this example, the participant can click one of the buttons labeled \"Option 1\", \"Option 2\", or \"Option 3\".",
+      "properties": {
+        "hidden": {
+          "description": "Controls whether the response is hidden.",
+          "type": "boolean"
+        },
+        "id": {
+          "description": "The id of the response. This is used to identify the response in the data file.",
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/definitions/ResponseBlockLocation",
+          "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
+        },
+        "options": {
+          "items": {
+            "$ref": "#/definitions/StringOption"
+          },
+          "type": "array"
+        },
+        "paramCapture": {
+          "description": "Use to capture querystring parameters in answers such as participant_name. See the examples for how this is used, but prefer uiConfig.urlParticipantIdParam if you are capturing a participant ID.",
+          "type": "string"
+        },
+        "prompt": {
+          "description": "The prompt that is displayed to the participant. You can use markdown here to render images, links, etc.",
+          "type": "string"
+        },
+        "required": {
+          "description": "Controls whether the response is required to be answered. Defaults to true.",
+          "type": "boolean"
+        },
+        "requiredLabel": {
+          "description": "You can provide a required label, which makes it so a participant has to answer with a response that matches label.",
+          "type": "string"
+        },
+        "requiredValue": {
+          "description": "You can provide a required value, which makes it so a participant has to answer with that value."
+        },
+        "secondaryText": {
+          "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
+          "type": "string"
+        },
+        "type": {
+          "const": "buttons",
+          "type": "string"
+        },
+        "withDivider": {
+          "description": "Renders the response with a trailing divider.",
+          "type": "boolean"
+        },
+        "withDontKnow": {
+          "description": "Renders the response with an option for \"I don't know\". This counts as a completed answer for the validation.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "options",
+        "prompt",
+        "type"
+      ],
+      "type": "object"
+    },
     "CheckboxResponse": {
       "additionalProperties": false,
       "description": "The CheckboxResponse interface is used to define the properties of a checkbox response. CheckboxResponses render as a checkbox input with user specified options.\n\n```js { \"id\": \"q7\", \"prompt\": \"Checkbox example (not required)\", \"location\": \"aboveStimulus\", \"type\": \"checkbox\", \"options\": [\"Option 1\", \"Option 2\", \"Option 3\"] } ```",
@@ -1674,6 +1740,9 @@
         },
         {
           "$ref": "#/definitions/MatrixResponse"
+        },
+        {
+          "$ref": "#/definitions/ButtonsResponse"
         }
       ]
     },

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -202,7 +202,14 @@
         },
         "options": {
           "items": {
-            "$ref": "#/definitions/StringOption"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/StringOption"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1921,7 +1921,7 @@
     },
     "StringOption": {
       "additionalProperties": false,
-      "description": "The StringOption interface is used to define the options for a dropdown, radio, or checkbox response. The label is the text that is displayed to the user, and the value is the value that is stored in the data file.",
+      "description": "The StringOption interface is used to define the options for a dropdown, radio, buttons, or checkbox response. The label is the text that is displayed to the user, and the value is the value that is stored in the data file.",
       "properties": {
         "label": {
           "description": "The label displayed to participants.",

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -504,7 +504,7 @@ export interface ReactiveResponse extends BaseResponse {
  */
 export interface ButtonsResponse extends BaseResponse {
   type: 'buttons';
-  options: StringOption[];
+  options: (StringOption | string)[];
 }
 
 export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse | ButtonsResponse;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -136,7 +136,7 @@ export interface NumberOption {
 }
 
 /**
- * The StringOption interface is used to define the options for a dropdown, radio, or checkbox response.
+ * The StringOption interface is used to define the options for a dropdown, radio, buttons, or checkbox response.
  * The label is the text that is displayed to the user, and the value is the value that is stored in the data file.
  */
 export interface StringOption {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -481,7 +481,33 @@ export interface ReactiveResponse extends BaseResponse {
   type: 'reactive';
 }
 
-export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse;
+/**
+ * The ButtonsResponse interface is used to define the properties of a buttons response.
+ * ButtonsResponses render as a list of buttons that the participant can click. When a button is clicked, the value of the button is stored in the data file.
+ * Participants can cycle through the options using the arrow keys.
+ *
+ * Example:
+ * ```js
+ * {
+ *   "id": "buttonsResponse",
+ *   "type": "buttons",
+ *   "prompt": "Click a button",
+ *   "location": "belowStimulus",
+ *   "options": [
+ *     "Option 1",
+ *     "Option 2",
+ *     "Option 3"
+ *   ]
+ * }
+ * ```
+ * In this example, the participant can click one of the buttons labeled "Option 1", "Option 2", or "Option 3".
+ */
+export interface ButtonsResponse extends BaseResponse {
+  type: 'buttons';
+  options: StringOption[];
+}
+
+export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse | ButtonsResponse;
 
 /**
  * The Answer interface is used to define the properties of an answer. Answers are used to define the correct answer for a task. These are generally used in training tasks or if skip logic is required based on the answer.

--- a/tests/demo-survey.spec.ts
+++ b/tests/demo-survey.spec.ts
@@ -45,6 +45,8 @@ test('test', async ({ page }) => {
     await checkboxes2.nth(i).click();
   }
 
+  await page.getByRole('radio', { name: 'Option 4' }).nth(0).click();
+
   await page.getByRole('button', { name: 'Next', exact: true }).click();
 
   // Check that the thank you message is displayed

--- a/typedocReadMe.md
+++ b/typedocReadMe.md
@@ -55,10 +55,11 @@ Numerical responses via fields or sliders:
 - [NumericalResponse](interfaces/NumericalResponse.md)
 - [SliderResponse](interfaces/SliderResponse.md)
 
-Choices of items via checkboxes or drop-downs: 
+Choices of items via checkboxes, drop-downs, or buttons: 
 - [CheckboxResponse](interfaces/CheckboxResponse.md)
 - [RadioResponse](interfaces/RadioResponse.md)
 - [DropdownResponse](interfaces/DropdownResponse.md)
+- [ButtonsResponse](interfaces/ButtonsResponse.md)
 
 Likert-style rating scales: 
 - [LikertResponse](interfaces/LikertResponse.md)


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #610 

### Give a longer description of what this PR addresses and why it's needed
Adds cursor buttons that function as a radio. They work with the left and right arrows by default, I didn't need to add any additional logic to handle that.

### Provide pictures/videos of the behavior before and after these changes (optional)
Unselected:
<img width="1624" alt="Screenshot 2025-02-25 at 11 48 49 AM" src="https://github.com/user-attachments/assets/9a87266d-0bc2-4437-90ce-44134e3f139b" />

Selected:
<img width="1624" alt="Screenshot 2025-02-25 at 11 49 04 AM" src="https://github.com/user-attachments/assets/a827f937-0499-438e-b7c1-10959ff39361" />

Hydrated from answers:
<img width="1624" alt="Screenshot 2025-02-25 at 11 49 19 AM" src="https://github.com/user-attachments/assets/5106f981-e681-41d7-9e11-4344b2155b76" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation (https://github.com/revisit-studies/reVISit-studies.github.io/issues/118)