### PR TITLE
Optional slider fill

### DIFF
--- a/src/components/response/SliderInput.module.css
+++ b/src/components/response/SliderInput.module.css
@@ -1,3 +1,9 @@
-.markLabel {
-  transform: translate(calc((var(--mark-offset) * -1) + (var(--slider-size) / 2)), calc(var(--mantine-spacing-xs) / 2));
+.track {
+  &::before {
+    top: 12px;
+    height: 5px;
+    left: -2px;
+    width: calc(100% + 4px);
+    border-radius: 0;
+  }
 }

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -28,6 +28,7 @@ export function SliderInput({
     options,
     secondaryText,
     snap,
+    step,
   } = response;
 
   const [min, max] = useMemo(() => [Math.min(...options.map((opt) => opt.value)), Math.max(...options.map((opt) => opt.value))], [options]);
@@ -52,6 +53,7 @@ export function SliderInput({
         marks={options as SliderProps['marks']}
         min={min}
         max={max}
+        step={step ?? (snap ? 0.001 : (max - min) / 100)}
         {...answer}
         h={40}
         mt={4}

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -1,7 +1,5 @@
 import {
-  Box,
-  Flex,
-  Input, Slider, SliderProps,
+  Box, Flex, Input, Slider, SliderProps,
 } from '@mantine/core';
 import { useMemo } from 'react';
 import { SliderResponse } from '../../parser/types';
@@ -30,11 +28,13 @@ export function SliderInput({
     snap,
     step,
     withBar,
+    tlxStyle,
   } = response;
 
   const [min, max] = useMemo(() => [Math.min(...options.map((opt) => opt.value)), Math.max(...options.map((opt) => opt.value))], [options]);
-
+  const hasLabels = options.some((opt) => opt.label !== '');
   const errorMessage = generateErrorMessage(response, answer);
+
   return (
     <Input.Wrapper
       label={(
@@ -55,16 +55,27 @@ export function SliderInput({
         min={min}
         max={max}
         step={step ?? (snap ? 0.001 : (max - min) / 100)}
+        h={hasLabels ? 40 : undefined}
         {...answer}
-        h={40}
-        mt={4}
-        classNames={{ markLabel: classes.markLabel }}
+        classNames={{ track: tlxStyle ? classes.track : '' }}
         restrictToMarks={snap}
         label={(value) => (snap ? null : value)}
-        styles={{
-          bar: !withBar ? { display: 'none' } : {},
-          mark: !withBar ? { borderColor: 'var(--mantine-color-gray-2)' } : {},
-        }}
+        styles={(theme) => ({
+          mark: {
+            ...(tlxStyle ? {
+              height: 20, width: 1, marginTop: -6, marginLeft: 2, borderRadius: 0,
+            } : {}),
+            ...(withBar === false ? { borderColor: 'var(--mantine-color-gray-2)' } : {}),
+          },
+          bar: withBar === false || tlxStyle ? { display: 'none' } : {},
+          markLabel: {
+            fontSize: theme.fontSizes.sm,
+            color: theme.colors.gray[7],
+            transform: 'translate(calc((var(--mark-offset) * -1) + (var(--slider-size) / 2)), calc(var(--mantine-spacing-xs) / 2)',
+          },
+        })}
+        flex={1}
+        mt={tlxStyle ? 'sm' : 'xs'}
       />
     </Input.Wrapper>
   );

--- a/src/components/response/SliderInput.tsx
+++ b/src/components/response/SliderInput.tsx
@@ -29,6 +29,7 @@ export function SliderInput({
     secondaryText,
     snap,
     step,
+    withBar,
   } = response;
 
   const [min, max] = useMemo(() => [Math.min(...options.map((opt) => opt.value)), Math.max(...options.map((opt) => opt.value))], [options]);
@@ -60,6 +61,10 @@ export function SliderInput({
         classNames={{ markLabel: classes.markLabel }}
         restrictToMarks={snap}
         label={(value) => (snap ? null : value)}
+        styles={{
+          bar: !withBar ? { display: 'none' } : {},
+          mark: !withBar ? { borderColor: 'var(--mantine-color-gray-2)' } : {},
+        }}
       />
     </Input.Wrapper>
   );

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1964,6 +1964,10 @@
           "const": "slider",
           "type": "string"
         },
+        "withBar": {
+          "description": "Whether to render the slider with a bar to the left. Defaults to true.",
+          "type": "boolean"
+        },
         "withDivider": {
           "description": "Renders the response with a trailing divider.",
           "type": "boolean"

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1956,6 +1956,10 @@
           "description": "The starting value of the slider. Defaults to the minimum value.",
           "type": "number"
         },
+        "step": {
+          "description": "The step value of the slider. If not provided (and snap not enabled), the step value is calculated as the range of the slider divided by 100.",
+          "type": "number"
+        },
         "type": {
           "const": "slider",
           "type": "string"

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1960,6 +1960,10 @@
           "description": "The step value of the slider. If not provided (and snap not enabled), the step value is calculated as the range of the slider divided by 100.",
           "type": "number"
         },
+        "tlxStyle": {
+          "description": "Whether to render the slider with a NASA-tlx style. Defaults to false.",
+          "type": "boolean"
+        },
         "type": {
           "const": "slider",
           "type": "string"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1906,6 +1906,10 @@
           "const": "slider",
           "type": "string"
         },
+        "withBar": {
+          "description": "Whether to render the slider with a bar to the left. Defaults to true.",
+          "type": "boolean"
+        },
         "withDivider": {
           "description": "Renders the response with a trailing divider.",
           "type": "boolean"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1902,6 +1902,10 @@
           "description": "The step value of the slider. If not provided (and snap not enabled), the step value is calculated as the range of the slider divided by 100.",
           "type": "number"
         },
+        "tlxStyle": {
+          "description": "Whether to render the slider with a NASA-tlx style. Defaults to false.",
+          "type": "boolean"
+        },
         "type": {
           "const": "slider",
           "type": "string"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1898,6 +1898,10 @@
           "description": "The starting value of the slider. Defaults to the minimum value.",
           "type": "number"
         },
+        "step": {
+          "description": "The step value of the slider. If not provided (and snap not enabled), the step value is calculated as the range of the slider divided by 100.",
+          "type": "number"
+        },
         "type": {
           "const": "slider",
           "type": "string"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -406,6 +406,8 @@ export interface SliderResponse extends BaseResponse {
   snap?: boolean;
   /** The step value of the slider. If not provided (and snap not enabled), the step value is calculated as the range of the slider divided by 100. */
   step?: number;
+  /** Whether to render the slider with a bar to the left. Defaults to true. */
+  withBar?: boolean;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -404,6 +404,8 @@ export interface SliderResponse extends BaseResponse {
   startingValue?: number;
   /** Whether the slider should snap between values. Defaults to false. Slider snapping disables the label above the handle. */
   snap?: boolean;
+  /** The step value of the slider. If not provided (and snap not enabled), the step value is calculated as the range of the slider divided by 100. */
+  step?: number;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -408,6 +408,8 @@ export interface SliderResponse extends BaseResponse {
   step?: number;
   /** Whether to render the slider with a bar to the left. Defaults to true. */
   withBar?: boolean;
+  /** Whether to render the slider with a NASA-tlx style. Defaults to false. */
+  tlxStyle?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #615 
#519?

### Give a longer description of what this PR addresses and why it's needed
Makes the slider fill optional, so that the thumb moves without filling a bar.

### Provide pictures/videos of the behavior before and after these changes (optional)
`withBar: false`
<img width="833" alt="Screenshot 2025-02-26 at 12 49 48 PM" src="https://github.com/user-attachments/assets/34645dec-232e-4bf8-a03d-24c35c11a8b7" />

### Are there any additional TODOs before this PR is ready to go?
No