### PR TITLE
Fix some subtle bugs with dynamic blocks, fix dynamic block tidy download

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn run lint-staged

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "localforage": "^1.10.0",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.2",
+    "lodash.throttle": "^4.1.1",
     "plyr-react": "^5.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -258,6 +258,7 @@ export function TableView({
           windowEvents: Object.values(record.answers).flatMap((a) => a.windowEvents),
           timedOut: false, // not used
           parameters: {}, // not used
+          correctAnswer: [], // not used
           provenanceGraph: {
             aboveStimulus: undefined,
             belowStimulus: undefined,

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -259,6 +259,8 @@ export function TableView({
           timedOut: false, // not used
           parameters: {}, // not used
           correctAnswer: [], // not used
+          trialOrder: '', // not used
+          componentName: '', // not used
           provenanceGraph: {
             aboveStimulus: undefined,
             belowStimulus: undefined,

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -37,8 +37,11 @@ export function StepRenderer() {
     }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     // Keyboard
-    const keypressListener = debounce((e: KeyboardEvent) => {
-      windowEvents.current.push([Date.now(), 'keypress', e.key]);
+    const keydownListener = debounce((e: KeyboardEvent) => {
+      windowEvents.current.push([Date.now(), 'keydown', e.key]);
+    }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
+    const keyupListener = debounce((e: KeyboardEvent) => {
+      windowEvents.current.push([Date.now(), 'keyup', e.key]);
     }, windowEventDebounceTime, { maxWait: windowEventDebounceTime });
 
     // Mouse/Pointer/Touch
@@ -72,7 +75,8 @@ export function StepRenderer() {
 
     window.addEventListener('focus', focusListener, true);
     window.addEventListener('input', inputListener as () => void);
-    window.addEventListener('keypress', keypressListener);
+    window.addEventListener('keydown', keydownListener);
+    window.addEventListener('keyup', keyupListener);
     window.addEventListener('mousedown', mouseDownListener);
     window.addEventListener('mouseup', mouseUpListener);
     window.addEventListener('resize', resizeListener);
@@ -83,9 +87,10 @@ export function StepRenderer() {
     return () => {
       window.removeEventListener('focus', focusListener, true);
       window.removeEventListener('input', inputListener as () => void);
-      window.removeEventListener('keypress', keypressListener);
-      window.addEventListener('mousedown', mouseDownListener);
-      window.addEventListener('mouseup', mouseUpListener);
+      window.removeEventListener('keydown', keydownListener);
+      window.removeEventListener('keyup', keyupListener);
+      window.removeEventListener('mousedown', mouseDownListener);
+      window.removeEventListener('mouseup', mouseUpListener);
       window.removeEventListener('resize', resizeListener);
       window.removeEventListener('mousemove', mouseMoveListener);
       window.removeEventListener('scroll', scrollListener);

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -16,18 +16,17 @@ import {
   IconBrandPython, IconLayoutColumns, IconTableExport, IconX,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
-import merge from 'lodash.merge';
 import { ParticipantData } from '../../storage/types';
 import {
-  Answer, IndividualComponent, Prettify, StudyConfig,
+  Answer, Prettify, StudyConfig,
 } from '../../parser/types';
-import { isInheritedComponent } from '../../parser/utils';
 import { getSequenceFlatMap } from '../../utils/getSequenceFlatMap';
 import { StorageEngine } from '../../storage/engines/StorageEngine';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { useAsync } from '../../store/hooks/useAsync';
 import { getCleanedDuration } from '../../utils/getCleanedDuration';
 import { showNotification } from '../../utils/notifications';
+import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
 
 export const OPTIONAL_COMMON_PROPS = [
   'status',
@@ -90,9 +89,7 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
       const trialId = trialIdentifier.split('_').slice(0, -1).join('_');
       const trialOrder = parseInt(`${trialIdentifier.split('_').at(-1)}`, 10);
       const trialConfig = studyConfig.components[trialId];
-      const completeComponent: IndividualComponent = isInheritedComponent(trialConfig) && trialConfig.baseComponent && studyConfig.baseComponents
-        ? merge({}, studyConfig.baseComponents[trialConfig.baseComponent], trialConfig)
-        : trialConfig;
+      const completeComponent = studyComponentToIndividualComponent(trialConfig, studyConfig);
 
       const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
       const cleanedDuration = getCleanedDuration(trialAnswer);

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -18,7 +18,6 @@ import {
 import { useCallback, useMemo, useState } from 'react';
 import { ParticipantData } from '../../storage/types';
 import { Prettify, StudyConfig } from '../../parser/types';
-import { getSequenceFlatMap } from '../../utils/getSequenceFlatMap';
 import { StorageEngine } from '../../storage/engines/StorageEngine';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { useAsync } from '../../store/hooks/useAsync';
@@ -73,7 +72,7 @@ export function download(graph: string, filename: string) {
 }
 
 function participantDataToRows(participant: ParticipantData, properties: Property[], studyConfig: StudyConfig): [TidyRow[], string[]] {
-  const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (getSequenceFlatMap(participant.sequence).length - 1)) * 100).toFixed(2);
+  const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (Object.entries(participant.answers).length)) * 100).toFixed(2);
   const newHeaders = new Set<string>();
 
   return [[

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -17,9 +17,7 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
 import { ParticipantData } from '../../storage/types';
-import {
-  Answer, Prettify, StudyConfig,
-} from '../../parser/types';
+import { Prettify, StudyConfig } from '../../parser/types';
 import { getSequenceFlatMap } from '../../utils/getSequenceFlatMap';
 import { StorageEngine } from '../../storage/engines/StorageEngine';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
@@ -139,7 +137,9 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
           tidyRow.answer = value;
         }
         if (properties.includes('correctAnswer')) {
-          const correctAnswer = (completeComponent.correctAnswer as Answer[])?.find((ans) => ans.id === key)?.answer;
+          const configCorrectAnswer = completeComponent.correctAnswer?.find((ans) => ans.id === key)?.answer;
+          const answerCorrectAnswer = trialAnswer.correctAnswer.find((ans) => ans.id === key)?.answer;
+          const correctAnswer = answerCorrectAnswer || configCorrectAnswer;
           tidyRow.correctAnswer = typeof correctAnswer === 'object' ? JSON.stringify(correctAnswer) : correctAnswer;
         }
         if (properties.includes('responseMin')) {

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -96,7 +96,8 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
       const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
       const cleanedDuration = getCleanedDuration(trialAnswer);
 
-      const rows = Object.entries(trialAnswer.answer).map(([key, value]) => {
+      const answersToLoopOver = Object.keys(trialAnswer.answer).length === 0 ? { '': undefined } : trialAnswer.answer;
+      const rows = Object.entries(answersToLoopOver).map(([key, value]) => {
         const tidyRow: TidyRow = {
           participantId: participant.participantId,
           trialId,
@@ -188,7 +189,7 @@ async function getTableData(selectedProperties: Property[], data: ParticipantDat
   }));
 
   const rows = allData.map((partData) => partData[0]);
-  const newHeaders = allData.map((partData) => partData[1]).flat();
+  const newHeaders = new Set(allData.map((partData) => partData[1]).flat());
 
   const flatRows = rows.flat().sort((a, b) => (a !== b ? a.participantId.localeCompare(b.participantId) : a.trialOrder - b.trialOrder));
 

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -21,7 +21,9 @@ import {
   IconSchema,
   IconUserPlus,
 } from '@tabler/icons-react';
-import { useEffect, useRef, useState } from 'react';
+import {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import { useHref } from 'react-router';
 import { useCurrentComponent, useCurrentStep, useStudyId } from '../../routes/utils';
 import {
@@ -36,6 +38,7 @@ export function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled }: { st
   const studyConfig = useStoreSelector((state) => state.config);
   const metadata = useStoreSelector((state) => state.metadata);
 
+  const answers = useStoreSelector((state) => state.answers);
   const flatSequence = useFlatSequence();
   const storeDispatch = useStoreDispatch();
   const { toggleShowHelpText, toggleStudyBrowser, incrementHelpCounter } = useStoreActions();
@@ -45,8 +48,23 @@ export function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled }: { st
 
   const currentStep = useCurrentStep();
 
-  const progressBarMax = flatSequence.length - 1;
-  const progressPercent = typeof currentStep === 'number' ? (currentStep / progressBarMax) * 100 : 0;
+  const progressPercent = useMemo(() => {
+    const answered = Object.values(answers).filter((answer) => answer.endTime > -1).length;
+    const total = flatSequence.map((step, idx) => {
+      // If the step is a component, it adds 1 to the total
+      if (studyConfig.components[step]) {
+        return 1;
+      }
+      // If we're in a dynamic block, guess a maximum of 30 steps
+      if (typeof currentStep === 'number' && currentStep <= idx && step !== 'end') {
+        return 30;
+      }
+      // Otherwise, count the number of answers for this dynamic block
+      return Object.entries(answers).filter(([key, _]) => key.includes(`${step}_`)).length;
+    }).reduce((a, b) => a + b, 0);
+
+    return (answered / total) * 100;
+  }, [answers, currentStep, flatSequence, studyConfig.components]);
 
   const [menuOpened, setMenuOpened] = useState(false);
 

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -57,7 +57,7 @@ export function AppHeader({ studyNavigatorEnabled, dataCollectionEnabled }: { st
       }
       // If we're in a dynamic block, guess a maximum of 30 steps
       if (typeof currentStep === 'number' && currentStep <= idx && step !== 'end') {
-        return 30;
+        return 55;
       }
       // Otherwise, count the number of answers for this dynamic block
       return Object.entries(answers).filter(([key, _]) => key.includes(`${step}_`)).length;

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -1,7 +1,6 @@
 import {
   Suspense, useEffect, useMemo, useRef, useState,
 } from 'react';
-import merge from 'lodash.merge';
 import { useSearchParams } from 'react-router';
 import { Center, Loader } from '@mantine/core';
 import { ResponseBlock } from '../components/response/ResponseBlock';
@@ -10,10 +9,9 @@ import { ImageController } from './ImageController';
 import { ReactComponentController } from './ReactComponentController';
 import { MarkdownController } from './MarkdownController';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
-import { useCurrentComponent, useCurrentStep } from '../routes/utils';
+import { useCurrentComponent, useCurrentIdentifier, useCurrentStep } from '../routes/utils';
 import { useStoredAnswer } from '../store/hooks/useStoredAnswer';
 import { ReactMarkdownWrapper } from '../components/ReactMarkdownWrapper';
-import { isInheritedComponent } from '../parser/utils';
 import { IndividualComponent } from '../parser/types';
 import { useDisableBrowserBack } from '../utils/useDisableBrowserBack';
 import { useStorageEngine } from '../storage/storageEngineHooks';
@@ -28,6 +26,7 @@ import { findBlockForStep } from '../utils/getSequenceFlatMap';
 import { VegaController, VegaProvState } from './VegaController';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
 import { VideoController } from './VideoController';
+import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 
 // current active stimuli presented to the user
 export function ComponentController() {
@@ -135,8 +134,17 @@ export function ComponentController() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentStep, storageEngine, sequence]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const currentConfig = useMemo(() => (currentComponent && currentComponent !== 'end' && !currentComponent.startsWith('__') && isInheritedComponent(stepConfig) && studyConfig.baseComponents ? merge({}, studyConfig.baseComponents?.[stepConfig.baseComponent], stepConfig) as IndividualComponent : stepConfig as IndividualComponent), [stepConfig, studyConfig]);
+  const currentIdentifier = useCurrentIdentifier();
+  const currentConfig = useMemo(() => {
+    const toReturn = currentComponent && currentComponent !== 'end' && !currentComponent.startsWith('__') && studyComponentToIndividualComponent(stepConfig, studyConfig) as IndividualComponent;
+    if (typeof toReturn === 'object') {
+      const funcParams = answers[currentIdentifier]?.parameters;
+      const funcCorrectAnswer = answers[currentIdentifier]?.correctAnswer;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return { ...toReturn, parameters: funcParams || (toReturn as any).parameters || undefined, correctAnswer: funcCorrectAnswer || (toReturn as any).correctAnswer || undefined };
+    }
+    return toReturn as unknown as IndividualComponent;
+  }, [answers, currentComponent, currentIdentifier, stepConfig, studyConfig]);
 
   // We're not using hooks below here, so we can return early if we're at the end of the study.
   // This avoids issues with the component config being undefined for the end of the study.

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -152,6 +152,10 @@ export function ComponentController() {
     return <StudyEnd />;
   }
 
+  if (currentComponent === '__dynamicLoading') {
+    return null;
+  }
+
   // Handle failed training
   if (currentComponent === '__trainingFailed') {
     return <TrainingFailed />;

--- a/src/controllers/ReactComponentController.tsx
+++ b/src/controllers/ReactComponentController.tsx
@@ -1,9 +1,9 @@
-import { Suspense, useCallback, useMemo } from 'react';
+import { Suspense, useCallback } from 'react';
 import { ModuleNamespace } from 'vite/types/hot';
 import { ReactComponent } from '../parser/types';
 import { StimulusParams, StoredAnswer } from '../store/types';
 import { ResourceNotFound } from '../ResourceNotFound';
-import { useStoreDispatch, useStoreActions, useStoreSelector } from '../store/store';
+import { useStoreDispatch, useStoreActions } from '../store/store';
 import { useCurrentIdentifier } from '../routes/utils';
 import { ErrorBoundary } from './ErrorBoundary';
 
@@ -13,8 +13,6 @@ const modules = import.meta.glob(
 );
 
 export function ReactComponentController({ currentConfig, provState, answers }: { currentConfig: ReactComponent; provState?: unknown, answers: Record<string, StoredAnswer> }) {
-  const funcParams = useStoreSelector((state) => state.funcParams);
-
   const reactPath = `../public/${currentConfig.path}`;
   const StimulusComponent = reactPath in modules ? (modules[reactPath] as ModuleNamespace).default : null;
   const identifier = useCurrentIdentifier();
@@ -33,15 +31,13 @@ export function ReactComponentController({ currentConfig, provState, answers }: 
     storeDispatch(setReactiveAnswers(stimulusAnswers));
   }, [setReactiveAnswers, storeDispatch, updateResponseBlockValidation, identifier]);
 
-  const params = useMemo(() => (funcParams !== undefined ? funcParams : currentConfig.parameters), [currentConfig.parameters, funcParams]);
-
   return (
     <Suspense fallback={<div>Loading...</div>}>
       {StimulusComponent
         ? (
           <ErrorBoundary>
             <StimulusComponent
-              parameters={params}
+              parameters={currentConfig.parameters}
               setAnswer={setAnswer}
               answers={answers}
               provenanceState={provState}

--- a/src/controllers/VegaController.tsx
+++ b/src/controllers/VegaController.tsx
@@ -4,12 +4,14 @@ import {
 import { Vega, VisualizationSpec, View } from 'react-vega';
 import { initializeTrrack, Registry } from '@trrack/core';
 import { VegaProps } from 'react-vega/lib/Vega';
-import { VegaComponent } from '../parser/types';
+import { ValueOf, VegaComponent } from '../parser/types';
 import { getJsonAssetByPath } from '../utils/getStaticAsset';
 import { ResourceNotFound } from '../ResourceNotFound';
 import { useStoreActions, useStoreDispatch } from '../store/store';
 import { StimulusParams } from '../store/types';
 import { useCurrentIdentifier } from '../routes/utils';
+
+type Listeners = { [key: string]: (key: string, value: { responseId: string, response: string | number }) => void };
 
 export interface VegaProvState {
   event: {
@@ -78,8 +80,8 @@ export function VegaController({ currentConfig, provState }: { currentConfig: Ve
     }));
   }, [actions, trrack]);
 
-  const handleRevisitAnswer = useCallback((key: string, value: unknown) => {
-    const { responseId, response } = value as { responseId: string, response: unknown };
+  const handleRevisitAnswer = useCallback((key: string, value: Parameters<ValueOf<Listeners>>[1]) => {
+    const { responseId, response } = value;
 
     setAnswer({
       status: true,
@@ -90,7 +92,6 @@ export function VegaController({ currentConfig, provState }: { currentConfig: Ve
     });
   }, [setAnswer, trrack.graph.backend]);
 
-  type Listeners = { [key: string]: (key: string, value: unknown) => void };
   const signalListeners = useMemo(() => {
     const signals = vegaConfig?.config?.signals;
     if (!signals) return {};
@@ -142,5 +143,5 @@ export function VegaController({ currentConfig, provState }: { currentConfig: Ve
     return <div>Failed to load vega config</div>;
   }
 
-  return (<InternalVega spec={structuredClone(vegaConfig)} signalListeners={signalListeners} onNewView={(v) => setView(v)} />);
+  return (<InternalVega spec={structuredClone(vegaConfig)} signalListeners={signalListeners as never} onNewView={(v) => setView(v)} />);
 }

--- a/src/lodash.d.ts
+++ b/src/lodash.d.ts
@@ -1,2 +1,3 @@
 declare module 'lodash.merge';
 declare module 'lodash.debounce';
+declare module 'lodash.throttle';

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -64,7 +64,7 @@
             "type": "string"
           },
           "instructionLocation": {
-            "$ref": "#/definitions/ResponseBlockLocation",
+            "$ref": "#/definitions/ConfigResponseBlockLocation",
             "description": "The location of the instructions."
           },
           "meta": {
@@ -81,7 +81,7 @@
             "type": "number"
           },
           "nextButtonLocation": {
-            "$ref": "#/definitions/ResponseBlockLocation",
+            "$ref": "#/definitions/ConfigResponseBlockLocation",
             "description": "The location of the next button."
           },
           "nextButtonText": {
@@ -197,7 +197,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -274,7 +274,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "maxSelections": {
@@ -437,6 +437,14 @@
       ],
       "type": "object"
     },
+    "ConfigResponseBlockLocation": {
+      "enum": [
+        "sidebar",
+        "aboveStimulus",
+        "belowStimulus"
+      ],
+      "type": "string"
+    },
     "DeterministicInterruption": {
       "additionalProperties": false,
       "description": "The DeterministicInterruption interface is used to define an interruption that will be shown at a specific location in the block.\n\nFor example, if you want to show an interruption after the second component in the block, you would set firstLocation to 2. If you want to show an interruption after every 3 components, you would set spacing to 3. If you want to show an interruption after the second component and then every 3 components, you would set firstLocation to 2 and spacing to 3.\n\nThe components property is an array of the components that will be inserted at the location specified by firstLocation and spacing. These components should reference components in the StudyConfig.components section of the config.\n\nHere's an example of how to use the DeterministicInterruption:\n\n```js { \"order\": \"fixed\", \"components\": [ \"component1\", \"component2\", \"component3\", \"component4\", \"component5\", \"component6\" ], \"interruptions\": [ {   \"firstLocation\": 2,   \"spacing\": 3,   \"components\": [     \"interruption1\",     \"interruption2\"   ] } ] } ```\n\nThe resulting sequence array could be:\n\n```js [ [\"component1\", \"component2\", \"interruption1\", \"component3\", \"component4\", \"component5\", \"interruption2\", \"component6\"], [\"component1\", \"component2\", \"interruption1\", \"component3\", \"component4\", \"component5\", \"interruption2\", \"component6\"], [\"component1\", \"component2\", \"interruption1\", \"component3\", \"component4\", \"component5\", \"interruption2\", \"component6\"], ... ] ```",
@@ -477,7 +485,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -600,7 +608,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -617,7 +625,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -806,7 +814,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -823,7 +831,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1020,7 +1028,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "numItems": {
@@ -1088,7 +1096,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1166,7 +1174,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -1183,7 +1191,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1269,7 +1277,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1359,7 +1367,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "max": {
@@ -1445,7 +1453,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -1462,7 +1470,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1524,7 +1532,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -1649,7 +1657,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -1666,7 +1674,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1730,7 +1738,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1852,14 +1860,6 @@
         }
       ]
     },
-    "ResponseBlockLocation": {
-      "enum": [
-        "sidebar",
-        "aboveStimulus",
-        "belowStimulus"
-      ],
-      "type": "string"
-    },
     "ShortTextResponse": {
       "additionalProperties": false,
       "description": "The ShortTextResponse interface is used to define the properties of a short text response. ShortTextResponses render as a text input that accepts any text and can optionally have a placeholder.\n\n```js { \"id\": \"q-short-text\", \"prompt\": \"Short text example\", \"location\": \"aboveStimulus\", \"type\": \"shortText\", \"placeholder\": \"Enter your answer here\" } ```",
@@ -1873,7 +1873,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1956,7 +1956,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -2091,7 +2091,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2108,7 +2108,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -2178,7 +2178,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2195,7 +2195,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -2273,7 +2273,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2290,7 +2290,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -2368,7 +2368,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2385,7 +2385,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -64,7 +64,7 @@
             "type": "string"
           },
           "instructionLocation": {
-            "$ref": "#/definitions/ResponseBlockLocation",
+            "$ref": "#/definitions/ConfigResponseBlockLocation",
             "description": "The location of the instructions."
           },
           "meta": {
@@ -81,7 +81,7 @@
             "type": "number"
           },
           "nextButtonLocation": {
-            "$ref": "#/definitions/ResponseBlockLocation",
+            "$ref": "#/definitions/ConfigResponseBlockLocation",
             "description": "The location of the next button."
           },
           "nextButtonText": {
@@ -197,7 +197,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -274,7 +274,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "maxSelections": {
@@ -437,6 +437,14 @@
       ],
       "type": "object"
     },
+    "ConfigResponseBlockLocation": {
+      "enum": [
+        "sidebar",
+        "aboveStimulus",
+        "belowStimulus"
+      ],
+      "type": "string"
+    },
     "DeterministicInterruption": {
       "additionalProperties": false,
       "description": "The DeterministicInterruption interface is used to define an interruption that will be shown at a specific location in the block.\n\nFor example, if you want to show an interruption after the second component in the block, you would set firstLocation to 2. If you want to show an interruption after every 3 components, you would set spacing to 3. If you want to show an interruption after the second component and then every 3 components, you would set firstLocation to 2 and spacing to 3.\n\nThe components property is an array of the components that will be inserted at the location specified by firstLocation and spacing. These components should reference components in the StudyConfig.components section of the config.\n\nHere's an example of how to use the DeterministicInterruption:\n\n```js { \"order\": \"fixed\", \"components\": [ \"component1\", \"component2\", \"component3\", \"component4\", \"component5\", \"component6\" ], \"interruptions\": [ {   \"firstLocation\": 2,   \"spacing\": 3,   \"components\": [     \"interruption1\",     \"interruption2\"   ] } ] } ```\n\nThe resulting sequence array could be:\n\n```js [ [\"component1\", \"component2\", \"interruption1\", \"component3\", \"component4\", \"component5\", \"interruption2\", \"component6\"], [\"component1\", \"component2\", \"interruption1\", \"component3\", \"component4\", \"component5\", \"interruption2\", \"component6\"], [\"component1\", \"component2\", \"interruption1\", \"component3\", \"component4\", \"component5\", \"interruption2\", \"component6\"], ... ] ```",
@@ -477,7 +485,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -600,7 +608,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -617,7 +625,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -806,7 +814,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -823,7 +831,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -954,7 +962,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "numItems": {
@@ -1022,7 +1030,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1100,7 +1108,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -1117,7 +1125,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1203,7 +1211,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1293,7 +1301,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "max": {
@@ -1379,7 +1387,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -1396,7 +1404,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1458,7 +1466,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -1583,7 +1591,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -1600,7 +1608,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -1664,7 +1672,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1786,14 +1794,6 @@
         }
       ]
     },
-    "ResponseBlockLocation": {
-      "enum": [
-        "sidebar",
-        "aboveStimulus",
-        "belowStimulus"
-      ],
-      "type": "string"
-    },
     "ShortTextResponse": {
       "additionalProperties": false,
       "description": "The ShortTextResponse interface is used to define the properties of a short text response. ShortTextResponses render as a text input that accepts any text and can optionally have a placeholder.\n\n```js { \"id\": \"q-short-text\", \"prompt\": \"Short text example\", \"location\": \"aboveStimulus\", \"type\": \"shortText\", \"placeholder\": \"Enter your answer here\" } ```",
@@ -1807,7 +1807,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "paramCapture": {
@@ -1890,7 +1890,7 @@
           "type": "string"
         },
         "location": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
         "options": {
@@ -2213,7 +2213,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2230,7 +2230,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -2300,7 +2300,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2317,7 +2317,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -2395,7 +2395,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2412,7 +2412,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {
@@ -2490,7 +2490,7 @@
           "type": "string"
         },
         "instructionLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the instructions."
         },
         "meta": {
@@ -2507,7 +2507,7 @@
           "type": "number"
         },
         "nextButtonLocation": {
-          "$ref": "#/definitions/ResponseBlockLocation",
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button."
         },
         "nextButtonText": {

--- a/src/public/test-step-logic/func.ts
+++ b/src/public/test-step-logic/func.ts
@@ -9,5 +9,5 @@ export default function func({ answers, customParameters } : JumpFunctionParamet
     return { component: null };
   }
 
-  return { component: 'reactComponent', parameters: { n: topAnswerLength || 0 } };
+  return { component: 'reactComponent', parameters: { n: topAnswerLength || 0 }, correctAnswer: [{ id: 'test', answer: 'correct' }] };
 }

--- a/src/public/test-step-logic/func.ts
+++ b/src/public/test-step-logic/func.ts
@@ -1,11 +1,12 @@
 import { JumpFunctionParameters, JumpFunctionReturnVal } from '../../store/types';
 
 export default function func({ answers, customParameters } : JumpFunctionParameters<{name: string}>) : JumpFunctionReturnVal {
-  const topAnswerLength = Object.keys(answers)
-    .filter((answer) => answer.startsWith(`${customParameters.name}`))
+  const topAnswerLength = Object.entries(answers)
+    .filter(([key, _]) => key.startsWith(`${customParameters.name}`))
+    .filter(([_, value]) => value.endTime > -1)
     .length;
 
-  if (topAnswerLength > 5) {
+  if (topAnswerLength === 5) {
     return { component: null };
   }
 

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -45,7 +45,7 @@ export function useCurrentComponent(): string {
   const navigate = useNavigate();
   const studyId = useStudyId();
   const storeDispatch = useStoreDispatch();
-  const { pushToFuncSequence, setFuncParams } = useStoreActions();
+  const { pushToFuncSequence } = useStoreActions();
 
   const currentComponent = useMemo(() => (typeof currentStep === 'number' ? getComponent(flatSequence[currentStep], studyConfig) : null), [currentStep, flatSequence, studyConfig]);
 
@@ -79,17 +79,20 @@ export function useCurrentComponent(): string {
 
       // in a func component
       if (!component && nextFunc !== null) {
-        const { component: currCompName, parameters: _params } = nextFunc({
+        const { component: currCompName, parameters: _params, correctAnswer } = nextFunc({
           components: [], answers: _answers, sequenceSoFar: [], customParameters: findFuncBlock(flatSequence[currentStep], studyConfig.sequence)?.parameters,
         });
         if (currCompName !== null) {
           setCompName(currCompName);
 
           storeDispatch(pushToFuncSequence({
-            component: currCompName, funcName: flatSequence[currentStep], index: currentStep, funcIndex: funcIndex ? decryptIndex(funcIndex) : 0, parameters: _params || {},
+            component: currCompName,
+            funcName: flatSequence[currentStep],
+            index: currentStep,
+            funcIndex: funcIndex ? decryptIndex(funcIndex) : 0,
+            parameters: _params || {},
+            correctAnswer: correctAnswer || [],
           }));
-
-          storeDispatch(setFuncParams(_params));
         } else {
           navigate(`/${studyId}/${encryptIndex(currentStep + 1)}${window.location.search}`);
         }
@@ -99,7 +102,7 @@ export function useCurrentComponent(): string {
     } else {
       setCompName(currentStep.replace('reviewer-', ''));
     }
-  }, [_answers, currentStep, flatSequence, funcIndex, navigate, nextFunc, pushToFuncSequence, setFuncParams, storeDispatch, studyConfig, studyId]);
+  }, [_answers, currentStep, flatSequence, funcIndex, navigate, nextFunc, pushToFuncSequence, storeDispatch, studyConfig, studyId]);
 
   return currentComponent ? typeof currentStep === 'number' ? flatSequence[currentStep] : currentStep.replace('reviewer-', '') : compName;
 }

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -49,7 +49,7 @@ export function useCurrentComponent(): string {
 
   const [indexWhenSettingComponentName, setIndexWhenSettingComponentName] = useState<number | null>(null);
 
-  const currentComponent = useMemo(() => (typeof currentStep === 'number' ? getComponent(flatSequence[currentStep], studyConfig) : null), [currentStep, flatSequence, studyConfig]);
+  const currentComponent = useMemo(() => (typeof currentStep === 'number' ? getComponent(flatSequence[currentStep], studyConfig) : currentStep.includes('reviewer-') ? currentStep : null), [currentStep, flatSequence, studyConfig]);
 
   const [compName, setCompName] = useState('__dynamicLoading');
 

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -49,7 +49,7 @@ export function useCurrentComponent(): string {
 
   const currentComponent = useMemo(() => (typeof currentStep === 'number' ? getComponent(flatSequence[currentStep], studyConfig) : null), [currentStep, flatSequence, studyConfig]);
 
-  const [compName, setCompName] = useState(flatSequence[0]);
+  const [compName, setCompName] = useState('__dynamicLoading');
 
   const nextFunc:(({ components, answers, sequenceSoFar }: JumpFunctionParameters<unknown>) => JumpFunctionReturnVal) | null = useMemo(() => {
     if (typeof currentStep === 'number' && !currentComponent) {
@@ -94,17 +94,17 @@ export function useCurrentComponent(): string {
             correctAnswer: correctAnswer || undefined,
           }));
         } else {
+          setCompName('__dynamicLoading');
           navigate(`/${studyId}/${encryptIndex(currentStep + 1)}${window.location.search}`);
         }
-      } else {
-        setCompName(flatSequence[currentStep]);
       }
-    } else {
-      setCompName(currentStep.replace('reviewer-', ''));
     }
   }, [_answers, currentStep, flatSequence, funcIndex, navigate, nextFunc, pushToFuncSequence, storeDispatch, studyConfig, studyId]);
 
-  return currentComponent ? typeof currentStep === 'number' ? flatSequence[currentStep] : currentStep.replace('reviewer-', '') : compName;
+  return (typeof currentStep === 'number' && flatSequence[currentStep] === 'end' ? 'end'
+    : currentComponent ? (
+      typeof currentStep === 'number' ? flatSequence[currentStep] : currentStep.replace('reviewer-', '')
+    ) : compName);
 }
 
 export function useCurrentIdentifier(): string {

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -90,8 +90,8 @@ export function useCurrentComponent(): string {
             funcName: flatSequence[currentStep],
             index: currentStep,
             funcIndex: funcIndex ? decryptIndex(funcIndex) : 0,
-            parameters: _params || {},
-            correctAnswer: correctAnswer || [],
+            parameters: _params || undefined,
+            correctAnswer: correctAnswer || undefined,
           }));
         } else {
           navigate(`/${studyId}/${encryptIndex(currentStep + 1)}${window.location.search}`);

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -32,6 +32,7 @@ import { ReCaptchaV3Provider, initializeAppCheck } from '@firebase/app-check';
 import { getAuth, signInAnonymously } from '@firebase/auth';
 import localforage from 'localforage';
 import { v4 as uuidv4 } from 'uuid';
+import throttle from 'lodash.throttle';
 import {
   StorageEngine,
   UserWrapped,
@@ -346,7 +347,22 @@ export class FirebaseStorageEngine extends StorageEngine {
     // Don't clean up the listener. The stream will be destroyed.
   }
 
-  async saveAnswers(answers: Record<string, StoredAnswer>) {
+  private throttleSaveAnswers = throttle(async () => { await this._saveAnswers(); }, 3000);
+
+  async saveAnswers(answers: Record<string, StoredAnswer>): Promise<void> {
+    if (!this.currentParticipantId || this.participantData === null) {
+      throw new Error('Participant not initialized');
+    }
+    // Update the local copy of the participant data
+    this.participantData = {
+      ...this.participantData,
+      answers,
+    };
+
+    await this.throttleSaveAnswers(answers);
+  }
+
+  async _saveAnswers() {
     if (!this._verifyStudyDatabase(this.studyCollection)) {
       throw new Error('Study database not initialized');
     }
@@ -354,12 +370,6 @@ export class FirebaseStorageEngine extends StorageEngine {
     if (!this.currentParticipantId || this.participantData === null) {
       throw new Error('Participant not initialized');
     }
-
-    // Update the local copy of the participant data
-    this.participantData = {
-      ...this.participantData,
-      answers,
-    };
 
     // Push the updated participant data to Firebase
     await this._pushToFirebaseStorage(
@@ -628,39 +638,45 @@ export class FirebaseStorageEngine extends StorageEngine {
     }
 
     // Get the participantData
-    await this.getParticipantData();
-    if (!this.participantData) {
+    const participantData = await this.getParticipantData();
+    if (!participantData) {
       throw new Error('Participant not initialized');
     }
 
     // Get modes
     const modes = await this.getModes(this.studyId);
 
-    if (this.participantData.completed) {
+    if (participantData.completed) {
       return true;
     }
 
-    this.participantData.completed = true;
-    if (modes.dataCollectionEnabled) {
-      await this._pushToFirebaseStorage(
-        `participants/${this.currentParticipantId}`,
-        'participantData',
-        this.participantData,
+    const serverEndTime = Object.values(participantData.answers).map((answer) => answer.endTime).reduce((a, b) => Math.max(a, b), 0);
+    const localEndTime = Object.values(this.participantData?.answers || {}).map((answer) => answer.endTime).reduce((a, b) => Math.max(a, b), 0);
+    if (this.participantData && serverEndTime === localEndTime) {
+      this.participantData.completed = true;
+      if (modes.dataCollectionEnabled) {
+        await this._pushToFirebaseStorage(
+          `participants/${this.currentParticipantId}`,
+          'participantData',
+          this.participantData,
+        );
+      }
+
+      const sequenceAssignmentDoc = doc(this.studyCollection, 'sequenceAssignment');
+      const sequenceAssignmentCollection = collection(
+        sequenceAssignmentDoc,
+        'sequenceAssignment',
       );
+      const participantSequenceAssignmentDoc = doc(
+        sequenceAssignmentCollection,
+        this.currentParticipantId,
+      );
+      await updateDoc(participantSequenceAssignmentDoc, { completed: serverTimestamp() });
+
+      return true;
     }
 
-    const sequenceAssignmentDoc = doc(this.studyCollection, 'sequenceAssignment');
-    const sequenceAssignmentCollection = collection(
-      sequenceAssignmentDoc,
-      'sequenceAssignment',
-    );
-    const participantSequenceAssignmentDoc = doc(
-      sequenceAssignmentCollection,
-      this.currentParticipantId,
-    );
-    await updateDoc(participantSequenceAssignmentDoc, { completed: serverTimestamp() });
-
-    return true;
+    return false;
   }
 
   private userManagementData: Record<string, unknown> = {};

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -75,7 +75,8 @@ export function useNextStep() {
 
   const navigate = useNavigate();
 
-  const startTime = useMemo(() => Date.now(), []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const startTime = useMemo(() => Date.now(), [funcIndex, currentStep]);
 
   const windowEvents = useWindowEvents();
   const goToNextStep = useCallback((collectData = true) => {

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -94,32 +94,24 @@ export function useNextStep() {
     const { provenanceGraph } = trialValidationCopy;
     const endTime = Date.now();
 
-    const {
-      incorrectAnswers, helpButtonClickedCount, parameters, correctAnswer, trialOrder, componentName,
-    } = storedAnswer;
+    const { componentName } = storedAnswer;
 
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
     if (dataCollectionEnabled && storedAnswer.endTime === -1) { // === -1 means the answer has not been saved yet
       const toSave = {
+        ...storedAnswer,
         answer: collectData ? answer : {},
         startTime,
         endTime,
-        incorrectAnswers,
         provenanceGraph,
         windowEvents: currentWindowEvents,
         timedOut: !collectData,
-        helpButtonClickedCount,
-        parameters,
-        correctAnswer,
-        trialOrder,
-        componentName,
       };
       storeDispatch(
         saveTrialAnswer({
           identifier,
-
           ...toSave,
         }),
       );
@@ -149,7 +141,11 @@ export function useNextStep() {
     const answersWithNewAnswer = {
       ...answers,
       [identifier]: {
-        answer, startTime, endTime, provenanceGraph, windowEvents: currentWindowEvents,
+        answer,
+        startTime,
+        endTime,
+        provenanceGraph,
+        windowEvents: currentWindowEvents,
       },
     };
 

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -92,7 +92,9 @@ export function useNextStep() {
     const { provenanceGraph } = trialValidationCopy;
     const endTime = Date.now();
 
-    const { incorrectAnswers, helpButtonClickedCount, parameters } = storedAnswer;
+    const {
+      incorrectAnswers, helpButtonClickedCount, parameters, correctAnswer,
+    } = storedAnswer;
 
     // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
     const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
@@ -108,6 +110,7 @@ export function useNextStep() {
         timedOut: !collectData,
         helpButtonClickedCount,
         parameters,
+        correctAnswer,
       };
       storeDispatch(
         saveTrialAnswer({

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -154,8 +154,9 @@ export async function studyStoreCreator(
           windowEvents: [],
           timedOut: false,
           helpButtonClickedCount: 0,
-          parameters: payload.payload.parameters,
-          correctAnswer: payload.payload.correctAnswer,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          parameters: Object.keys(payload.payload.parameters).length > 0 ? payload.payload.parameters : (componentConfig as any).parameters,
+          correctAnswer: (payload.payload.correctAnswer.length > 0 ? payload.payload.correctAnswer : componentConfig.correctAnswer) || [],
         };
         state.trialValidation[`${payload.payload.funcName}_${payload.payload.index}_${payload.payload.component}_${payload.payload.funcIndex}`] = {
           aboveStimulus: { valid: false, values: {} },

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -128,30 +128,32 @@ export async function studyStoreCreator(
     name: 'storeSlice',
     initialState,
     reducers: {
-      setConfig(state, payload: PayloadAction<StudyConfig>) {
-        state.config = payload.payload;
+      setConfig(state, { payload }: PayloadAction<StudyConfig>) {
+        state.config = payload;
       },
-      setIsRecording(state, payload: PayloadAction<boolean>) {
-        state.isRecording = payload.payload;
+      setIsRecording(state, { payload }: PayloadAction<boolean>) {
+        state.isRecording = payload;
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      pushToFuncSequence(state, payload: PayloadAction<{component: string, funcName: string, index: number, funcIndex: number, parameters: Record<string, any> | undefined, correctAnswer: Answer[] | undefined}>) {
-        if (!state.funcSequence[payload.payload.funcName]) {
-          state.funcSequence[payload.payload.funcName] = [];
+      pushToFuncSequence(state, { payload }: PayloadAction<{component: string, funcName: string, index: number, funcIndex: number, parameters: Record<string, any> | undefined, correctAnswer: Answer[] | undefined}>) {
+        if (!state.funcSequence[payload.funcName]) {
+          state.funcSequence[payload.funcName] = [];
         }
 
-        if (state.funcSequence[payload.payload.funcName].length > payload.payload.funcIndex) {
+        if (state.funcSequence[payload.funcName].length > payload.funcIndex) {
           return;
         }
 
-        const componentConfig = studyComponentToIndividualComponent(state.config.components[payload.payload.component] || { response: [] }, config);
+        const componentConfig = studyComponentToIndividualComponent(state.config.components[payload.component] || { response: [] }, config);
 
-        state.funcSequence[payload.payload.funcName].push(payload.payload.component);
-        state.answers[`${payload.payload.funcName}_${payload.payload.index}_${payload.payload.component}_${payload.payload.funcIndex}`] = {
+        const identifier = `${payload.funcName}_${payload.index}_${payload.component}_${payload.funcIndex}`;
+
+        state.funcSequence[payload.funcName].push(payload.component);
+        state.answers[identifier] = {
           answer: {},
           incorrectAnswers: {},
-          componentName: payload.payload.component,
-          trialOrder: `${payload.payload.index}_${payload.payload.funcIndex}`,
+          componentName: payload.component,
+          trialOrder: `${payload.index}_${payload.funcIndex}`,
           startTime: 0,
           endTime: -1,
           provenanceGraph: {
@@ -164,10 +166,10 @@ export async function studyStoreCreator(
           timedOut: false,
           helpButtonClickedCount: 0,
 
-          parameters: payload.payload.parameters || ('parameters' in componentConfig ? componentConfig.parameters : {}) || {},
-          correctAnswer: payload.payload.correctAnswer || componentConfig.correctAnswer || [],
+          parameters: payload.parameters || ('parameters' in componentConfig ? componentConfig.parameters : {}) || {},
+          correctAnswer: payload.correctAnswer || componentConfig.correctAnswer || [],
         };
-        state.trialValidation[`${payload.payload.funcName}_${payload.payload.index}_${payload.payload.component}_${payload.payload.funcIndex}`] = {
+        state.trialValidation[identifier] = {
           aboveStimulus: { valid: false, values: {} },
           belowStimulus: { valid: false, values: {} },
           stimulus: { valid: componentConfig.response.every((response) => response.type !== 'reactive'), values: {} },

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -69,7 +69,7 @@ Each item in the window event is given a time, a position an event name, and som
 */
 export interface StoredAnswer {
   /** Object whose keys are the "id"s in the Response list of the component in the StudyConfig and whose value is the inputted value from the participant. */
-  answer: Record<string, string | number | boolean | string[] | Record<string, unknown>>;
+  answer: Record<string, string | number | boolean | string[]>;
   /** Object whose keys are the "id"s in the Response list of the component in the StudyConfig and whose value is a list of incorrect inputted values from the participant. Only relevant for trials with `provideFeedback` and correct answers enabled. */
   incorrectAnswers: Record<string, { id: string, value: unknown[] }>;
   /** Time that the user began interacting with the component in epoch milliseconds. */
@@ -135,7 +135,7 @@ export interface StimulusParams<T, S = never> {
   parameters: T;
   provenanceState?: S;
   answers: Record<string, StoredAnswer>;
-  setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: Record<string, any> }) => void
+  setAnswer: ({ status, provenanceGraph, answers }: { status: boolean, provenanceGraph?: TrrackedProvenance, answers: StoredAnswer['answer'] }) => void
 }
 
 export interface Sequence {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -70,6 +70,10 @@ Each item in the window event is given a time, a position an event name, and som
 export interface StoredAnswer {
   /** Object whose keys are the "id"s in the Response list of the component in the StudyConfig and whose value is the inputted value from the participant. */
   answer: Record<string, string | number | boolean | string[]>;
+
+  componentName: string;
+  /** The order of the trial in the sequence. */
+  trialOrder: string;
   /** Object whose keys are the "id"s in the Response list of the component in the StudyConfig and whose value is a list of incorrect inputted values from the participant. Only relevant for trials with `provideFeedback` and correct answers enabled. */
   incorrectAnswers: Record<string, { id: string, value: unknown[] }>;
   /** Time that the user began interacting with the component in epoch milliseconds. */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -25,14 +25,15 @@ export type TrrackedProvenance = ProvenanceGraph<any, any>;
 // timestamp, event type, event data
 type FocusEvent = [number, 'focus', string];
 type InputEvent = [number, 'input', string];
-type KeypressEvent = [number, 'keypress', string];
+type KeydownEvent = [number, 'keydown', string];
+type KeyupEvent = [number, 'keyup', string];
 type MouseDownEvent = [number, 'mousedown', number[]];
 type MouseUpEvent = [number, 'mouseup', number[]];
 type MouseMoveEvent = [number, 'mousemove', number[]];
 type ResizeEvent = [number, 'resize', number[]];
 type ScrollEvent = [number, 'scroll', number[]];
 type VisibilityEvent = [number, 'visibility', string];
-export type EventType = MouseMoveEvent | MouseDownEvent | MouseUpEvent | KeypressEvent | ScrollEvent | FocusEvent | InputEvent | ResizeEvent | VisibilityEvent;
+export type EventType = MouseMoveEvent | MouseDownEvent | MouseUpEvent | KeydownEvent | KeyupEvent | ScrollEvent | FocusEvent | InputEvent | ResizeEvent | VisibilityEvent;
 
 export type ValidationStatus = { valid: boolean, values: object }
 export type TrialValidation = Record<

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ProvenanceGraph } from '@trrack/core/graph/graph-slice';
 import type {
+  Answer,
   ComponentBlock, ConfigResponseBlockLocation, ResponseBlockLocation, SkipConditions, StudyConfig, ValueOf,
 } from '../parser/types';
 import { type REVISIT_MODE } from '../storage/engines/StorageEngine';
@@ -109,18 +110,25 @@ export interface StoredAnswer {
   windowEvents: EventType[];
   /** A boolean value that indicates whether the participant timed out on this question. */
   timedOut: boolean;
-  /**  */
-  parameters: Record<string, any>;
   /** A counter indicating how many times participants opened the help tab during a task. Clicking help, or accessing the tab via answer feedback on an incorrect answer both are included in the counter. */
   helpButtonClickedCount: number;
+  /** The parameters that were passed to the component. */
+  parameters: Record<string, any>;
+  /** The correct answer for the component. */
+  correctAnswer: Answer[];
 }
 
 export interface JumpFunctionParameters<T> {
-  components: (string | ComponentBlock)[], answers: Record<string, StoredAnswer>, sequenceSoFar: string[], customParameters: T
+  components: (string | ComponentBlock)[],
+  answers: Record<string, StoredAnswer>,
+  sequenceSoFar: string[],
+  customParameters: T
 }
 
 export interface JumpFunctionReturnVal {
-  component: string | null, parameters?: Record<string, any>
+  component: string | null,
+  parameters?: Record<string, any>,
+  correctAnswer?: Answer[],
 }
 
 export interface StimulusParams<T, S = never> {
@@ -159,5 +167,4 @@ export interface StoreState {
   modes: Record<REVISIT_MODE, boolean>;
   matrixAnswers: Record<string, Record<string, string>>;
   funcSequence: Record<string, string[]>;
-  funcParams: unknown | undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5245,6 +5245,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
+
 lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"


### PR DESCRIPTION
### Does this PR close any open issues?
No?

### Give a longer description of what this PR addresses and why it's needed
The main purpose of this PR is to fix the tidy data downloader for dynamic blocks and to spread params out into columns. Along the way, we also allowed dynamic blocks to set correct answers, made setAnswer not take nested objects, throttled firebase calls to reduce API limiting, fixed key press events, and fixed the progress bar for dynamic blocks.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No