### PR TITLE
Add TextOnlyResponse which just renders text (optionally as a header)

### DIFF
--- a/public/demo-survey/config.json
+++ b/public/demo-survey/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.1.1/src/parser/StudyConfigSchema.json",
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/improve-forms/src/parser/StudyConfigSchema.json",
   "studyMetadata": {
     "title": "Question Types and Form Elements Demo",
     "version": "pilot",
@@ -40,6 +40,13 @@
             "Pie",
             "Stacked Bar"
           ]
+        },
+        {
+          "id": "textField",
+          "type": "textOnly",
+          "location": "aboveStimulus",
+          "prompt": "# This is a header that is text only with some text below\n\n## This is a subheader\n\nThis is some text that is not a question, but just some information to help the user understand what they are doing. You can use markdown to format this text. For example, you can make it **bold** or *italic*. You can also add links like [this](https://revisit.dev)",
+          "restartEnumeration": true          
         },
         {
           "id": "q-numerical",

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -18,6 +18,7 @@ import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import { MatrixInput } from './MatrixInput';
 import { ButtonsInput } from './ButtonsInput';
 import classes from './css/Checkbox.module.css';
+import { TextOnlyInput } from './TextOnlyInput';
 
 export function ResponseSwitcher({
   response,
@@ -177,6 +178,9 @@ export function ResponseSwitcher({
           index={index}
           enumerateQuestions={enumerateQuestions}
         />
+      )}
+      {response.type === 'textOnly' && (
+        <TextOnlyInput response={response} />
       )}
 
       {response.withDontKnow && (

--- a/src/components/response/TextOnlyInput.tsx
+++ b/src/components/response/TextOnlyInput.tsx
@@ -1,0 +1,19 @@
+import { Flex, Box } from '@mantine/core';
+import { ReactMarkdownWrapper } from '../ReactMarkdownWrapper';
+import { TextOnlyResponse } from '../../parser/types';
+
+export function TextOnlyInput({
+  response,
+}: {
+  response: TextOnlyResponse;
+}) {
+  const { prompt } = response;
+
+  return (
+    <Flex direction="row" wrap="nowrap" gap={4}>
+      <Box style={{ display: 'block' }} className="no-last-child-bottom-padding">
+        <ReactMarkdownWrapper text={prompt} required={false} />
+      </Box>
+    </Flex>
+  );
+}

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -2082,6 +2082,10 @@
         "requiredValue": {
           "not": {}
         },
+        "restartEnumeration": {
+          "description": "Whether to restart the enumeration of the questions. Defaults to false.",
+          "type": "boolean"
+        },
         "secondaryText": {
           "not": {}
         },

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1857,6 +1857,9 @@
         },
         {
           "$ref": "#/definitions/ButtonsResponse"
+        },
+        {
+          "$ref": "#/definitions/TextField"
         }
       ]
     },
@@ -2046,6 +2049,37 @@
       "required": [
         "label",
         "value"
+      ],
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "The id of the response. This is used to identify the response in the data file.",
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
+          "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
+        },
+        "prompt": {
+          "description": "The markdown text that is displayed to the user.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        },
+        "withDivider": {
+          "description": "Renders the response with a trailing divider.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "prompt",
+        "type"
       ],
       "type": "object"
     },

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1859,7 +1859,7 @@
           "$ref": "#/definitions/ButtonsResponse"
         },
         {
-          "$ref": "#/definitions/TextField"
+          "$ref": "#/definitions/TextOnlyResponse"
         }
       ]
     },
@@ -2052,9 +2052,12 @@
       ],
       "type": "object"
     },
-    "TextField": {
+    "TextOnlyResponse": {
       "additionalProperties": false,
       "properties": {
+        "hidden": {
+          "not": {}
+        },
         "id": {
           "description": "The id of the response. This is used to identify the response in the data file.",
           "type": "string"
@@ -2063,9 +2066,24 @@
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
+        "paramCapture": {
+          "not": {}
+        },
         "prompt": {
           "description": "The markdown text that is displayed to the user.",
           "type": "string"
+        },
+        "required": {
+          "not": {}
+        },
+        "requiredLabel": {
+          "not": {}
+        },
+        "requiredValue": {
+          "not": {}
+        },
+        "secondaryText": {
+          "not": {}
         },
         "type": {
           "const": "textOnly",
@@ -2074,6 +2092,9 @@
         "withDivider": {
           "description": "Renders the response with a trailing divider.",
           "type": "boolean"
+        },
+        "withDontKnow": {
+          "not": {}
         }
       },
       "required": [

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -2068,7 +2068,7 @@
           "type": "string"
         },
         "type": {
-          "const": "text",
+          "const": "textOnly",
           "type": "string"
         },
         "withDivider": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2109,7 +2109,7 @@
           "type": "string"
         },
         "type": {
-          "const": "text",
+          "const": "textOnly",
           "type": "string"
         },
         "withDivider": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1791,6 +1791,9 @@
         },
         {
           "$ref": "#/definitions/ButtonsResponse"
+        },
+        {
+          "$ref": "#/definitions/TextField"
         }
       ]
     },
@@ -2087,6 +2090,37 @@
         "date",
         "description",
         "organizations"
+      ],
+      "type": "object"
+    },
+    "TextField": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "The id of the response. This is used to identify the response in the data file.",
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/definitions/ConfigResponseBlockLocation",
+          "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
+        },
+        "prompt": {
+          "description": "The markdown text that is displayed to the user.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        },
+        "withDivider": {
+          "description": "Renders the response with a trailing divider.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "prompt",
+        "type"
       ],
       "type": "object"
     },

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2123,6 +2123,10 @@
         "requiredValue": {
           "not": {}
         },
+        "restartEnumeration": {
+          "description": "Whether to restart the enumeration of the questions. Defaults to false.",
+          "type": "boolean"
+        },
         "secondaryText": {
           "not": {}
         },

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1793,7 +1793,7 @@
           "$ref": "#/definitions/ButtonsResponse"
         },
         {
-          "$ref": "#/definitions/TextField"
+          "$ref": "#/definitions/TextOnlyResponse"
         }
       ]
     },
@@ -2093,9 +2093,12 @@
       ],
       "type": "object"
     },
-    "TextField": {
+    "TextOnlyResponse": {
       "additionalProperties": false,
       "properties": {
+        "hidden": {
+          "not": {}
+        },
         "id": {
           "description": "The id of the response. This is used to identify the response in the data file.",
           "type": "string"
@@ -2104,9 +2107,24 @@
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"
         },
+        "paramCapture": {
+          "not": {}
+        },
         "prompt": {
           "description": "The markdown text that is displayed to the user.",
           "type": "string"
+        },
+        "required": {
+          "not": {}
+        },
+        "requiredLabel": {
+          "not": {}
+        },
+        "requiredValue": {
+          "not": {}
+        },
+        "secondaryText": {
+          "not": {}
         },
         "type": {
           "const": "textOnly",
@@ -2115,6 +2133,9 @@
         "withDivider": {
           "description": "Renders the response with a trailing divider.",
           "type": "boolean"
+        },
+        "withDontKnow": {
+          "not": {}
         }
       },
       "required": [

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -505,6 +505,24 @@ export interface ButtonsResponse extends BaseResponse {
   options: (StringOption | string)[];
 }
 
+/**
+ * The TextOnlyResponse interface is used to define the properties of a text only response.
+ * TextOnlyResponses render as a block of text that is displayed to the user. This can be used to display instructions or other information.
+ * It does not accept any input from the user.
+ *
+ * Example:
+ * ```js
+ * {
+ *   "id": "textOnlyResponse",
+ *   "type": "textOnly",
+ *   "prompt": "This is a text only response, it accepts markdown so you can **bold** or _italicize_ text.",
+ *   "location": "belowStimulus",
+ *   "restartEnumeration": true
+ * }
+ * ```
+ *
+ * In this example, the text only response is displayed below the stimulus and the enumeration of the questions is restarted.
+ */
 export interface TextOnlyResponse extends Omit<BaseResponse, 'secondaryText' | 'required' | 'requiredValue' | 'requiredLabel' | 'paramCapture' | 'hidden' | 'withDontKnow'> {
   type: 'textOnly';
   /** The markdown text that is displayed to the user. */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -509,6 +509,8 @@ export interface TextOnlyResponse extends Omit<BaseResponse, 'secondaryText' | '
   type: 'textOnly';
   /** The markdown text that is displayed to the user. */
   prompt: string;
+  /** Whether to restart the enumeration of the questions. Defaults to false. */
+  restartEnumeration?: boolean;
 
   secondaryText?: undefined;
   required?: undefined;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -506,7 +506,7 @@ export interface ButtonsResponse extends BaseResponse {
 }
 
 export interface TextField extends Omit<BaseResponse, 'secondaryText' | 'required' | 'requiredValue' | 'requiredLabel' | 'paramCapture' | 'hidden' | 'withDontKnow'> {
-  type: 'text';
+  type: 'textOnly';
   /** The markdown text that is displayed to the user. */
   prompt: string;
 }

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -505,13 +505,21 @@ export interface ButtonsResponse extends BaseResponse {
   options: (StringOption | string)[];
 }
 
-export interface TextField extends Omit<BaseResponse, 'secondaryText' | 'required' | 'requiredValue' | 'requiredLabel' | 'paramCapture' | 'hidden' | 'withDontKnow'> {
+export interface TextOnlyResponse extends Omit<BaseResponse, 'secondaryText' | 'required' | 'requiredValue' | 'requiredLabel' | 'paramCapture' | 'hidden' | 'withDontKnow'> {
   type: 'textOnly';
   /** The markdown text that is displayed to the user. */
   prompt: string;
+
+  secondaryText?: undefined;
+  required?: undefined;
+  requiredValue?: undefined;
+  requiredLabel?: undefined;
+  paramCapture?: undefined;
+  hidden?: undefined;
+  withDontKnow?: undefined;
 }
 
-export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse | ButtonsResponse | TextField;
+export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse | ButtonsResponse | TextOnlyResponse;
 
 /**
  * The Answer interface is used to define the properties of an answer. Answers are used to define the correct answer for a task. These are generally used in training tasks or if skip logic is required based on the answer.

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -505,7 +505,13 @@ export interface ButtonsResponse extends BaseResponse {
   options: (StringOption | string)[];
 }
 
-export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse | ButtonsResponse;
+export interface TextField extends Omit<BaseResponse, 'secondaryText' | 'required' | 'requiredValue' | 'requiredLabel' | 'paramCapture' | 'hidden' | 'withDontKnow'> {
+  type: 'text';
+  /** The markdown text that is displayed to the user. */
+  prompt: string;
+}
+
+export type Response = NumericalResponse | ShortTextResponse | LongTextResponse | LikertResponse | DropdownResponse | SliderResponse | RadioResponse | CheckboxResponse | ReactiveResponse | MatrixResponse | ButtonsResponse | TextField;
 
 /**
  * The Answer interface is used to define the properties of an answer. Answers are used to define the correct answer for a task. These are generally used in training tasks or if skip logic is required based on the answer.

--- a/tests/demo-survey.spec.ts
+++ b/tests/demo-survey.spec.ts
@@ -11,7 +11,7 @@ test('test', async ({ page }) => {
   await page.getByPlaceholder('Enter your preference').click();
   await page.getByRole('option', { name: 'Bar', exact: true }).click();
   await page.getByPlaceholder('Enter your age here, range from 0 - 100').fill('12');
-  await page.getByLabel('5').check();
+  await page.getByRole('radio', { name: '5' }).nth(0).click();
   await page.getByPlaceholder('Enter your answer here').fill('ads');
   await page.getByPlaceholder('Enter your long comments here').fill('asdf');
   await page.locator('.mantine-Slider-track').click();

--- a/typedocReadMe.md
+++ b/typedocReadMe.md
@@ -71,6 +71,9 @@ You can specify numerical and textual responses through those interfaces:
 - [NumberOption](interfaces/NumberOption.md)
 - [StringOption](interfaces/StringOption.md)
 
+There is also a response that doesn't actually take a response, which is useful when you want to show some text in the middle of a form:
+- [TextOnlyResponse](interfaces/TextOnlyResponse.md)
+
 ## Sequencing
 
 Sequencing determines the order in which components appear.


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #515 

### Give a longer description of what this PR addresses and why it's needed
Add a markdown field to responses that don't capture any user input. This can be used to define a header or other text that will be shown to the user. 

There is an optional flag for restarting the enumeration of questions.

It's all documented up for the typedoc.

### Provide pictures/videos of the behavior before and after these changes (optional)
Without `restartEnumeration`:
<img width="829" alt="Screenshot 2025-04-02 at 1 58 16 PM" src="https://github.com/user-attachments/assets/b8428810-8bc0-4281-950b-92105d835df0" />

With `restartEnumeration: true`:
<img width="832" alt="Screenshot 2025-04-02 at 1 57 51 PM" src="https://github.com/user-attachments/assets/d7a9a104-9d0f-45b7-bbc6-7e3b851cd803" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation