### PR TITLE
Add participant responses to the tooltip in the study browser

### DIFF
--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -158,6 +158,12 @@ function StepItem({
   const correctAnswer = taskAnswer && taskAnswer.correctAnswer.length > 0 && Object.keys(taskAnswer.answer).length > 0 && taskAnswer.correctAnswer;
   const correct = correctAnswer && taskAnswer && Object.values(correctAnswer).every((value) => taskAnswer.answer[value.id] === value.answer);
 
+  const correctIncorrectIcon = taskAnswer && correctAnswer ? (
+    correct
+      ? <IconCheck size={16} style={{ marginRight: 4, marginBottom: -2 }} color="green" />
+      : <IconX size={16} style={{ marginRight: 4, marginBottom: -2 }} color="red" />
+  ) : null;
+
   return (
     <HoverCard withinPortal position="left" withArrow arrowSize={10} shadow="md" offset={0}>
       <HoverCard.Target>
@@ -173,14 +179,7 @@ function StepItem({
               {step !== cleanedStep && (
                 <IconPackageImport size={16} style={{ marginRight: 4, marginBottom: -2 }} color="blue" />
               )}
-              {taskAnswer && correctAnswer ? (
-                correct ? (
-                  <IconCheck size={16} style={{ marginRight: 4, marginBottom: -2 }} color="green" />
-                )
-                  : (
-                    <IconX size={16} style={{ marginRight: 4, marginBottom: -2 }} color="red" />
-                  )
-              ) : null}
+              {correctIncorrectIcon}
               <Text size="sm" span={active} fw={active ? '700' : undefined} display="inline" style={{ textWrap: 'nowrap' }}>{cleanedStep}</Text>
             </Box>
           )}
@@ -223,6 +222,7 @@ function StepItem({
             {taskAnswer && Object.keys(taskAnswer.answer).length > 0 && (
               <Box>
                 <Text fw={900} display="inline-block" mr={2}>
+                  {correctIncorrectIcon}
                   Participant Answer:
                 </Text>
                 {' '}

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -160,8 +160,8 @@ function StepItem({
 
   const correctIncorrectIcon = taskAnswer && correctAnswer ? (
     correct
-      ? <IconCheck size={16} style={{ marginRight: 4, marginBottom: -2 }} color="green" />
-      : <IconX size={16} style={{ marginRight: 4, marginBottom: -2 }} color="red" />
+      ? <IconCheck size={16} style={{ marginRight: 4, marginBottom: -3 }} color="green" />
+      : <IconX size={16} style={{ marginRight: 4, marginBottom: -3 }} color="red" />
   ) : null;
 
   return (

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -1,5 +1,5 @@
 import {
-  Badge, Box, NavLink, HoverCard, Text, Tooltip, Code,
+  Badge, Box, NavLink, HoverCard, Text, Tooltip, Code, Flex, Button,
 } from '@mantine/core';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import {
@@ -164,6 +164,17 @@ function StepItem({
       : <IconX size={16} style={{ marginRight: 4, marginBottom: -3 }} color="red" />
   ) : null;
 
+  const INITIAL_CLAMP = 6;
+  const responseJSONText = task && JSON.stringify(task.response, null, 2);
+  const [responseClamp, setResponseClamp] = useState<number | undefined>(INITIAL_CLAMP);
+
+  const correctAnswerJSONText = taskAnswer && taskAnswer.correctAnswer.length > 0
+    ? JSON.stringify(taskAnswer.correctAnswer, null, 2)
+    : task && task.correctAnswer
+      ? JSON.stringify(task.correctAnswer, null, 2)
+      : undefined;
+  const [correctAnswerClamp, setCorrectAnswerClamp] = useState<number | undefined>(INITIAL_CLAMP);
+
   return (
     <HoverCard withinPortal position="left" withArrow arrowSize={10} shadow="md" offset={0}>
       <HoverCard.Target>
@@ -229,13 +240,24 @@ function StepItem({
                 <Code block>{JSON.stringify(taskAnswer.answer, null, 2)}</Code>
               </Box>
             )}
-            {task.correctAnswer && (
+            {correctAnswerJSONText && (
               <Box>
                 <Text fw={900} display="inline-block" mr={2}>
                   Correct Answer:
                 </Text>
                 {' '}
-                <Code block>{JSON.stringify(task.correctAnswer, null, 2)}</Code>
+                <Code block>
+                  <Text size="xs" lineClamp={correctAnswerClamp}>{correctAnswerJSONText}</Text>
+                  {correctAnswerJSONText.split('\n').length > INITIAL_CLAMP && (
+                    <Flex justify="flex-end">
+                      {(correctAnswerClamp === undefined || correctAnswerJSONText.split('\n').length > correctAnswerClamp) && (
+                      <Button variant="light" size="xs" onClick={() => { setCorrectAnswerClamp((prev) => (prev === INITIAL_CLAMP ? undefined : INITIAL_CLAMP)); }}>
+                        {correctAnswerClamp !== undefined ? 'Show more' : 'Show less'}
+                      </Button>
+                      )}
+                    </Flex>
+                  )}
+                </Code>
               </Box>
             )}
             <Box>
@@ -243,7 +265,18 @@ function StepItem({
                 Response:
               </Text>
               {' '}
-              <Code block>{JSON.stringify(task.response, null, 2)}</Code>
+              <Code block>
+                <Text size="xs" lineClamp={responseClamp}>{responseJSONText}</Text>
+                {responseJSONText.split('\n').length > INITIAL_CLAMP && (
+                  <Flex justify="flex-end">
+                    {(responseClamp === undefined || responseJSONText.split('\n').length > responseClamp) && (
+                    <Button variant="light" size="xs" onClick={() => { setResponseClamp((prev) => (prev === INITIAL_CLAMP ? undefined : INITIAL_CLAMP)); }}>
+                      {responseClamp !== undefined ? 'Show more' : 'Show less'}
+                    </Button>
+                    )}
+                  </Flex>
+                )}
+              </Code>
             </Box>
             {task.meta && (
             <Box>

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -190,7 +190,7 @@ function StepItem({
       </HoverCard.Target>
       {task && (
         <HoverCard.Dropdown>
-          <Box mah={700} style={{ overflow: 'auto' }}>
+          <Box mah={700} maw={500} style={{ overflow: 'auto' }}>
             <Box>
               <Text fw={900} display="inline-block" mr={2}>
                 Name:
@@ -220,13 +220,15 @@ function StepItem({
                 <Code block>{taskAnswer && JSON.stringify(Object.keys(taskAnswer).length > 0 ? taskAnswer.parameters : ('parameters' in task ? task.parameters : {}), null, 2)}</Code>
               </Box>
             )}
-            <Box>
-              <Text fw={900} display="inline-block" mr={2}>
-                Response:
-              </Text>
-              {' '}
-              <Code block>{JSON.stringify(task.response, null, 2)}</Code>
-            </Box>
+            {taskAnswer && Object.keys(taskAnswer.answer).length > 0 && (
+              <Box>
+                <Text fw={900} display="inline-block" mr={2}>
+                  Participant Answer:
+                </Text>
+                {' '}
+                <Code block>{JSON.stringify(taskAnswer.answer, null, 2)}</Code>
+              </Box>
+            )}
             {task.correctAnswer && (
               <Box>
                 <Text fw={900} display="inline-block" mr={2}>
@@ -236,6 +238,13 @@ function StepItem({
                 <Code block>{JSON.stringify(task.correctAnswer, null, 2)}</Code>
               </Box>
             )}
+            <Box>
+              <Text fw={900} display="inline-block" mr={2}>
+                Response:
+              </Text>
+              {' '}
+              <Code block>{JSON.stringify(task.response, null, 2)}</Code>
+            </Box>
             {task.meta && (
             <Box>
               <Text fw="900" component="span">Task Meta: </Text>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #691 

### Give a longer description of what this PR addresses and why it's needed
Adds participant responses to the tooltip in the study browser and reorders some of the information to show most relevant info first.

I also added a max width of 500px.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODO:
- [ ] Tidy CSV bug?