### PR TITLE
Add status icons 

### DIFF
--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -143,7 +143,7 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
               <Flex ml="auto" gap="sm" opacity={0.7}>
                 {modes?.studyNavigatorEnabled ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} /></Tooltip> : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} /></Tooltip>}
                 {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} /></Tooltip>}
-                {storageEngine?.getEngine() !== 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} /></Tooltip>}
+                {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} /></Tooltip>}
               </Flex>
             </Flex>
 

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -141,9 +141,15 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
               {studyStatusAndTiming
                 && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
               <Flex ml="auto" gap="sm" opacity={0.7}>
-                {modes?.studyNavigatorEnabled ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} color="green" /></Tooltip> : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} color="red" /></Tooltip>}
-                {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} color="green" /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} color="red" /></Tooltip>}
-                {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} color="green" /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} color="red" /></Tooltip>}
+                {modes?.studyNavigatorEnabled
+                  ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} color="green" /></Tooltip>
+                  : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} color="red" /></Tooltip>}
+                {modes?.analyticsInterfacePubliclyAccessible
+                  ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} color="green" /></Tooltip>
+                  : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} color="red" /></Tooltip>}
+                {storageEngine?.getEngine() === 'localStorage'
+                  ? <Tooltip label="Local storage enabled" withinPortal><IconDatabase size={16} color="green" /></Tooltip>
+                  : <Tooltip label="Firebase enabled" withinPortal><IconFlame size={16} color="green" /></Tooltip>}
               </Flex>
             </Flex>
 

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -1,6 +1,5 @@
 import {
-  Anchor, AppShell, Button, Card, Container, Divider, Flex, Image, rem, Tabs, Text,
-  Tooltip,
+  Anchor, AppShell, Button, Card, Container, Divider, Flex, Image, rem, Tabs, Text, Tooltip,
 } from '@mantine/core';
 import {
   IconAlertTriangle, IconChartHistogram, IconDatabase, IconExternalLink, IconFlame, IconGraph, IconGraphOff, IconListCheck, IconSchema, IconSchemaOff,

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -3,7 +3,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 import {
-  IconAlertTriangle, IconChartHistogram, IconDatabase, IconExternalLink, IconFlame, IconListCheck, IconLock, IconLockOpen, IconSchema, IconSchemaOff,
+  IconAlertTriangle, IconChartHistogram, IconDatabase, IconExternalLink, IconFlame, IconGraph, IconGraphOff, IconListCheck, IconSchema, IconSchemaOff,
 } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Timestamp } from 'firebase/firestore';
@@ -142,8 +142,8 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
                 && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
               <Flex ml="auto" gap="sm" opacity={0.7}>
                 {modes?.studyNavigatorEnabled ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} /></Tooltip> : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} /></Tooltip>}
-                {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconLock size={16} /></Tooltip>}
-                {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} /></Tooltip>}
+                {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} /></Tooltip>}
+                {storageEngine?.getEngine() !== 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} /></Tooltip>}
               </Flex>
             </Flex>
 

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -1,8 +1,9 @@
 import {
   Anchor, AppShell, Button, Card, Container, Divider, Flex, Image, rem, Tabs, Text,
+  Tooltip,
 } from '@mantine/core';
 import {
-  IconAlertTriangle, IconChartHistogram, IconExternalLink, IconListCheck,
+  IconAlertTriangle, IconChartHistogram, IconDatabase, IconExternalLink, IconFlame, IconListCheck, IconLock, IconLockOpen, IconSchema, IconSchemaOff,
 } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Timestamp } from 'firebase/firestore';
@@ -22,7 +23,7 @@ import { useAuth } from '../store/hooks/useAuth';
 function StudyCard({ configName, config, url }: { configName: string; config: ParsedConfig<StudyConfig>; url: string }) {
   const { storageEngine } = useStorageEngine();
 
-  const [studyStatusAndTiming, setStudyStatusAndTiming] = useState<{completed: number; rejected: number; inProgress: number; minTime: Timestamp | number | null; maxTime: Timestamp | number | null} | null>(null);
+  const [studyStatusAndTiming, setStudyStatusAndTiming] = useState<{ completed: number; rejected: number; inProgress: number; minTime: Timestamp | number | null; maxTime: Timestamp | number | null } | null>(null);
   useEffect(() => {
     if (!storageEngine) return;
 
@@ -138,21 +139,26 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
                 {currentMode}
               </Text>
               {studyStatusAndTiming
-              && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
+                && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
+              <Flex ml="auto" gap="sm" opacity={0.7}>
+                {modes?.studyNavigatorEnabled ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} /></Tooltip> : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} /></Tooltip>}
+                {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconLock size={16} /></Tooltip>}
+                {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} /></Tooltip>}
+              </Flex>
             </Flex>
 
             {minTime && maxTime
-            && (
-            <Text c="dimmed" mt={4}>
-              Activity:
-              {' '}
-              {minTime}
-              {' '}
-              –
-              {' '}
-              {maxTime}
-            </Text>
-            )}
+              && (
+                <Text c="dimmed" mt={4}>
+                  Activity:
+                  {' '}
+                  {minTime}
+                  {' '}
+                  –
+                  {' '}
+                  {maxTime}
+                </Text>
+              )}
 
             <Flex direction="row" align="end" gap="sm" mt="md">
               <Button
@@ -178,7 +184,7 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
   );
 }
 
-function StudyCards({ configNames, studyConfigs } : { configNames: string[]; studyConfigs: Record<string, ParsedConfig<StudyConfig> | null> }) {
+function StudyCards({ configNames, studyConfigs }: { configNames: string[]; studyConfigs: Record<string, ParsedConfig<StudyConfig> | null> }) {
   return configNames.map((configName) => {
     const config = studyConfigs[configName];
     if (!config) {

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -141,8 +141,8 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
                 && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
               <Flex ml="auto" gap="sm" opacity={0.7}>
                 {modes?.studyNavigatorEnabled
-                  ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} color="green" /></Tooltip>
-                  : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} color="red" /></Tooltip>}
+                  ? <Tooltip label="Study navigator enabled" withinPortal><IconSchema size={16} color="green" /></Tooltip>
+                  : <Tooltip label="Study navigator disabled" withinPortal><IconSchemaOff size={16} color="red" /></Tooltip>}
                 {modes?.analyticsInterfacePubliclyAccessible
                   ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} color="green" /></Tooltip>
                   : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} color="red" /></Tooltip>}

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -141,9 +141,9 @@ function StudyCard({ configName, config, url }: { configName: string; config: Pa
               {studyStatusAndTiming
                 && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
               <Flex ml="auto" gap="sm" opacity={0.7}>
-                {modes?.studyNavigatorEnabled ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} /></Tooltip> : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} /></Tooltip>}
-                {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} /></Tooltip>}
-                {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} /></Tooltip>}
+                {modes?.studyNavigatorEnabled ? <Tooltip label="Study Navigator enabled" withinPortal><IconSchema size={16} color="green" /></Tooltip> : <Tooltip label="Study Navigator disabled" withinPortal><IconSchemaOff size={16} color="red" /></Tooltip>}
+                {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal><IconGraph size={16} color="green" /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal><IconGraphOff size={16} color="red" /></Tooltip>}
+                {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal><IconDatabase size={16} color="green" /></Tooltip> : <Tooltip label="Firebase" withinPortal><IconFlame size={16} color="red" /></Tooltip>}
               </Flex>
             </Flex>
 

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import { useMemo, useState } from 'react';
 import {
-  IconDatabase, IconFlame, IconGraph, IconGraphOff, IconInfoCircle, IconProgress, IconProgressX, IconUserPlus,
+  IconDatabase, IconFlame, IconGraph, IconGraphOff, IconInfoCircle, IconUserPlus,
 } from '@tabler/icons-react';
 import { useHref } from 'react-router';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
@@ -86,10 +86,16 @@ export function AppAside() {
             mt={1}
           />
         </Flex>
-        <Flex direction="row" gap="sm" opacity={0.7}>
-          {modes?.dataCollectionEnabled ? <Tooltip label="Data collection enabled" withinPortal position="bottom"><IconProgress size={16} color="green" /></Tooltip> : <Tooltip label="Data collection disabled" withinPortal position="bottom"><IconProgressX size={16} color="red" /></Tooltip>}
-          {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal position="bottom"><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal position="bottom"><IconGraphOff size={16} /></Tooltip>}
-          {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
+        <Flex direction="row" justify="space-between" mt="sm" opacity={0.7}>
+          <Text size="sm">
+            Study Status:
+            {' '}
+            {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
+          </Text>
+          <Flex gap="sm">
+            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} /></Tooltip>}
+            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
+          </Flex>
         </Flex>
       </AppShell.Section>
 

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import { useMemo, useState } from 'react';
 import {
-  IconDatabase, IconFlame, IconInfoCircle, IconLock, IconLockOpen, IconUserPlus,
+  IconDatabase, IconFlame, IconGraph, IconGraphOff, IconInfoCircle, IconUserPlus,
 } from '@tabler/icons-react';
 import { useHref } from 'react-router';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
@@ -93,7 +93,7 @@ export function AppAside() {
             {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
           </Text>
           <Flex gap="sm">
-            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLock size={16} /></Tooltip>}
+            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} /></Tooltip>}
             {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
           </Flex>
         </Flex>

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -86,8 +86,8 @@ export function AppAside() {
             mt={1}
           />
         </Flex>
-        <Flex direction="row" justify="space-between" mt="sm">
-          <Text size="sm" opacity={0.7}>
+        <Flex direction="row" justify="space-between" mt="sm" opacity={0.7}>
+          <Text size="sm">
             Study Status:
             {' '}
             {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import { useMemo, useState } from 'react';
 import {
-  IconDatabase, IconFlame, IconGraph, IconGraphOff, IconInfoCircle, IconUserPlus,
+  IconDatabase, IconFlame, IconGraph, IconGraphOff, IconInfoCircle, IconProgress, IconProgressX, IconUserPlus,
 } from '@tabler/icons-react';
 import { useHref } from 'react-router';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
@@ -86,16 +86,10 @@ export function AppAside() {
             mt={1}
           />
         </Flex>
-        <Flex direction="row" justify="space-between" mt="sm" opacity={0.7}>
-          <Text size="sm">
-            Study Status:
-            {' '}
-            {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
-          </Text>
-          <Flex gap="sm">
-            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} /></Tooltip>}
-            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
-          </Flex>
+        <Flex direction="row" gap="sm" opacity={0.7}>
+          {modes?.dataCollectionEnabled ? <Tooltip label="Data collection enabled" withinPortal position="bottom"><IconProgress size={16} color="green" /></Tooltip> : <Tooltip label="Data collection disabled" withinPortal position="bottom"><IconProgressX size={16} color="red" /></Tooltip>}
+          {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" withinPortal position="bottom"><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" withinPortal position="bottom"><IconGraphOff size={16} /></Tooltip>}
+          {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
         </Flex>
       </AppShell.Section>
 

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -64,7 +64,7 @@ export function AppAside() {
   return (
     <AppShell.Aside p="0">
       <AppShell.Section
-        p="md"
+        p="sm"
       >
         <Flex direction="row" justify="space-between">
           <Text size="md" fw={700} pt={3}>
@@ -86,7 +86,7 @@ export function AppAside() {
             mt={1}
           />
         </Flex>
-        <Flex direction="row" justify="space-between" mt="sm" opacity={0.7}>
+        <Flex direction="row" justify="space-between" mt="md" opacity={0.7}>
           <Text size="sm">
             Study Status:
             {' '}
@@ -102,7 +102,7 @@ export function AppAside() {
       <AppShell.Section
         grow
         component={ScrollArea}
-        p="md"
+        p="xs"
       >
         <Tabs value={activeTab} onChange={setActiveTab}>
           <Box style={{

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -65,6 +65,7 @@ export function AppAside() {
     <AppShell.Aside p="0">
       <AppShell.Section
         p="sm"
+        pb={0}
       >
         <Flex direction="row" justify="space-between">
           <Text size="md" fw={700} pt={3}>
@@ -86,15 +87,19 @@ export function AppAside() {
             mt={1}
           />
         </Flex>
-        <Flex direction="row" justify="space-between" mt="md" opacity={0.7}>
+        <Flex direction="row" justify="space-between" mt="xs" opacity={0.7}>
           <Text size="sm">
             Study Status:
             {' '}
             {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
           </Text>
           <Flex gap="sm">
-            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
-            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} color="red" /></Tooltip>}
+            {modes?.analyticsInterfacePubliclyAccessible
+              ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip>
+              : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
+            {storageEngine?.getEngine() === 'localStorage'
+              ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip>
+              : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} color="green" /></Tooltip>}
           </Flex>
         </Flex>
       </AppShell.Section>
@@ -103,6 +108,7 @@ export function AppAside() {
         grow
         component={ScrollArea}
         p="xs"
+        pt={8}
       >
         <Tabs value={activeTab} onChange={setActiveTab}>
           <Box style={{

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -92,8 +92,10 @@ export function AppAside() {
             {' '}
             {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
           </Text>
-          {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLock size={16} /></Tooltip>}
-          {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
+          <Flex gap="sm">
+            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLock size={16} /></Tooltip>}
+            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
+          </Flex>
         </Flex>
       </AppShell.Section>
 

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -98,8 +98,8 @@ export function AppAside() {
               ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip>
               : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
             {storageEngine?.getEngine() === 'localStorage'
-              ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip>
-              : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} color="green" /></Tooltip>}
+              ? <Tooltip label="Local storage enabled" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip>
+              : <Tooltip label="Firebase enabled" withinPortal position="bottom"><IconFlame size={16} color="green" /></Tooltip>}
           </Flex>
         </Flex>
       </AppShell.Section>

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -94,7 +94,7 @@ export function AppAside() {
           </Text>
           <Flex gap="sm">
             {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
-            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} color="blue" /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} color="red" /></Tooltip>}
+            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} color="red" /></Tooltip>}
           </Flex>
         </Flex>
       </AppShell.Section>

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -9,8 +9,10 @@ import {
   AppShell,
   Tooltip,
 } from '@mantine/core';
-import React, { useMemo, useState } from 'react';
-import { IconInfoCircle, IconUserPlus } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import {
+  IconDatabase, IconFlame, IconInfoCircle, IconLock, IconLockOpen, IconUserPlus,
+} from '@tabler/icons-react';
 import { useHref } from 'react-router';
 import { ComponentBlockWithOrderPath, StepsPanel } from './StepsPanel';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
@@ -57,6 +59,8 @@ export function AppAside() {
 
   const nextParticipantDisabled = useMemo(() => activeTab === 'allTrials' || isAnalysis, [activeTab, isAnalysis]);
 
+  const modes = useStoreSelector((state) => state.modes);
+
   return (
     <AppShell.Aside p="0">
       <AppShell.Section
@@ -81,6 +85,15 @@ export function AppAside() {
             onClick={() => dispatch(toggleStudyBrowser())}
             mt={1}
           />
+        </Flex>
+        <Flex direction="row" justify="space-between" mt="sm">
+          <Text size="sm" opacity={0.7}>
+            Study Status:
+            {' '}
+            {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
+          </Text>
+          {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLock size={16} /></Tooltip>}
+          {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
         </Flex>
       </AppShell.Section>
 

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -93,8 +93,8 @@ export function AppAside() {
             {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
           </Text>
           <Flex gap="sm">
-            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} /></Tooltip>}
-            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
+            {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
+            {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} color="blue" /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} color="red" /></Tooltip>}
           </Flex>
         </Flex>
       </AppShell.Section>

--- a/src/components/interface/AppAside.tsx
+++ b/src/components/interface/AppAside.tsx
@@ -93,7 +93,7 @@ export function AppAside() {
             {modes?.dataCollectionEnabled ? 'Collecting Data' : 'Data Collection Disabled'}
           </Text>
           {modes?.analyticsInterfacePubliclyAccessible ? <Tooltip label="Analytics interface publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLockOpen size={16} /></Tooltip> : <Tooltip label="Analytics interface not publicly accessible" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconLock size={16} /></Tooltip>}
-          {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" multiline w={200} style={{ whiteSpace: 'normal' }} withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
+          {storageEngine?.getEngine() === 'localStorage' ? <Tooltip label="Local storage" withinPortal position="bottom"><IconDatabase size={16} /></Tooltip> : <Tooltip label="Firebase" withinPortal position="bottom"><IconFlame size={16} /></Tooltip>}
         </Flex>
       </AppShell.Section>
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #622 

### Give a longer description of what this PR addresses and why it's needed
Show icons and tooltips at study broswer and study overview

#### Study Overview
- [x] Study Status
- [x] Study Navigator Enabled
- [x] Analytics Interface Publicly Accessible
- [x] Storage Location: Firebase or Local

#### Study Browser
- [x] Study Status
- [x] Analytics Interface Publicly Accessible
- [x] Storage Location: Firebase or Local

### Provide pictures/videos of the behavior before and after these changes (optional)

#### Study Overview
Study Status: Collecting data
Study Navigator: Enabled
Analytics Interface: Accessible
Storage: Firebase

https://github.com/user-attachments/assets/5cd38347-392a-4ba1-ba77-1cdddaa6f304

Study Status: Data Collection Disabled
Study Navigator: Disabled
Analytics Interface: Not accessible
Storage: Local Storage

https://github.com/user-attachments/assets/488056de-be6b-4d97-9b22-b8ab3361f61c

#### Study Browser
Study Status: Collecting data
Analytics Interface: Accessible
Storage: Local

https://github.com/user-attachments/assets/53b4a02e-e0a7-42ab-a9ce-85fbe7c0bd4d

Study Status: Data Collection Disabled
Analytics Interface: Not accessible
Storage: Firebase

https://github.com/user-attachments/assets/47e37df1-386b-4536-80e8-a58c11524193

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Discuss if we need Study Status in Study Browser
-> "Demo mode" shown if the data collection is disabled
![image](https://github.com/user-attachments/assets/15f9fcf5-d47e-437a-b150-b59f3ab3aeb9)