### PR TITLE
Allow variable injection at the study end

### DIFF
--- a/public/example-VLAT-full-randomized/config.json
+++ b/public/example-VLAT-full-randomized/config.json
@@ -21,8 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
-
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["vlat"],

--- a/public/example-VLAT-full-randomized/config.json
+++ b/public/example-VLAT-full-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["vlat"],

--- a/public/example-VLAT-full-randomized/config.json
+++ b/public/example-VLAT-full-randomized/config.json
@@ -21,7 +21,8 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID})",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
+
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["vlat"],

--- a/public/example-VLAT-full-randomized/config.json
+++ b/public/example-VLAT-full-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["vlat"],

--- a/public/example-VLAT-full-randomized/config.json
+++ b/public/example-VLAT-full-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: https://app.prolific.com/submissions/complete?cc=CE96X7ST",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["vlat"],

--- a/public/example-VLAT-mini-randomized/config.json
+++ b/public/example-VLAT-mini-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["mini-vlat"],

--- a/public/example-VLAT-mini-randomized/config.json
+++ b/public/example-VLAT-mini-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["mini-vlat"],

--- a/public/example-VLAT-mini-randomized/config.json
+++ b/public/example-VLAT-mini-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=CE96X7ST](https://app.prolific.com/submissions/complete?cc=CE96X7ST)",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["mini-vlat"],

--- a/public/example-VLAT-mini-randomized/config.json
+++ b/public/example-VLAT-mini-randomized/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_ID})",
     "urlParticipantIdParam": "PROLIFIC_ID"
   },
   "importedLibraries": ["mini-vlat"],

--- a/public/example-brush-interactions/config.json
+++ b/public/example-brush-interactions/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
     "urlParticipantIdParam": "PROLIFIC_PID",
     "participantNameField": "introduction.prolificId"
   },

--- a/public/example-brush-interactions/config.json
+++ b/public/example-brush-interactions/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=C1MXB7XQ](https://app.prolific.com/submissions/complete?cc=C1MXB7XQ)",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
     "urlParticipantIdParam": "PROLIFIC_PID",
     "participantNameField": "introduction.prolificId"
   },

--- a/public/example-brush-interactions/config.json
+++ b/public/example-brush-interactions/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID})",
     "urlParticipantIdParam": "PROLIFIC_PID",
     "participantNameField": "introduction.prolificId"
   },

--- a/public/test-audio/config.json
+++ b/public/test-audio/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PARTICIPANT_ID})",
     "urlParticipantIdParam": "PROLIFIC_PID",
     "recordStudyAudio": true
   },

--- a/public/test-audio/config.json
+++ b/public/test-audio/config.json
@@ -21,7 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
+    "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
     "urlParticipantIdParam": "PROLIFIC_PID",
     "recordStudyAudio": true
   },

--- a/public/test-audio/config.json
+++ b/public/test-audio/config.json
@@ -22,6 +22,7 @@
     "autoDownloadStudy": false,
     "sidebar": true,
     "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
+    "urlParticipantIdParam": "PROLIFIC_PID",
     "recordStudyAudio": true
   },
   "baseComponents": {

--- a/public/test-audio/config.json
+++ b/public/test-audio/config.json
@@ -21,8 +21,7 @@
     "withProgressBar": true,
     "autoDownloadStudy": false,
     "sidebar": true,
-    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc=C1MXB7XQ](https://app.prolific.com/submissions/complete?cc=C1MXB7XQ)",
-    "urlParticipantIdParam": "PROLIFIC_PID",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID}](https://app.prolific.com/submissions/complete?cc={PROLIFIC_PID})",
     "recordStudyAudio": true
   },
   "baseComponents": {

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -14,6 +14,7 @@ import { download } from './downloader/DownloadTidy';
 import { useStudyId } from '../routes/utils';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
 import type { Response } from '../parser/types';
+import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 
 export function StudyEnd() {
   const studyConfig = useStudyConfig();
@@ -115,11 +116,8 @@ export function StudyEnd() {
     const templateData: Record<string, string> = { PARTICIPANT_ID: participantId };
 
     const responses = Object.values(studyConfig.components)
-      .flatMap((component) => (
-        Array.isArray((component as { response?: Response[] }).response)
-          ? (component as { response: Response[] }).response
-          : []
-      ));
+      .map((component) => studyComponentToIndividualComponent(component, studyConfig))
+      .flatMap((component) => (Array.isArray(component.response) ? component.response : []));
 
     const fieldId = responses.find((r: Response) => r.paramCapture === urlParticipantIdParam)?.id;
 

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -100,12 +100,34 @@ export function StudyEnd() {
     checkDataCollectionEnabled();
   }, [storageEngine, studyId]);
 
+  let { studyEndMsg } = studyConfig.uiConfig;
+
+  if (studyConfig.uiConfig.urlParticipantIdParam) {
+    const serviceName = studyConfig.uiConfig.urlParticipantIdParam;
+    const screenerComponent = Object.keys(answers).find((key) => key.toLowerCase().startsWith('screener'));
+
+    if (screenerComponent) {
+      const screenerAnswers = answers[screenerComponent].answer;
+      const participantIdField = Object.keys(screenerAnswers).find((key) => key.toLowerCase().includes(serviceName.toLowerCase())
+         || key.toLowerCase().includes('id'));
+
+      if (participantIdField && screenerAnswers[participantIdField]) {
+        const externalServiceId = String(screenerAnswers[participantIdField]);
+        const returnUrl = studyConfig.uiConfig.returnUrlTemplate
+          ? studyConfig.uiConfig.returnUrlTemplate.replaceAll('{id}', externalServiceId)
+          : `https://app.prolific.com/submissions/complete?cc=${externalServiceId}`;
+
+        studyEndMsg = `Thank you for completing the study.\n\n [Please click here to return to ${serviceName} and receive credit.](${returnUrl})`;
+      }
+    }
+  }
+
   return (
     <Center style={{ height: '100%' }}>
       <Flex direction="column">
         {completed || !dataCollectionEnabled
-          ? (studyConfig.uiConfig.studyEndMsg
-            ? <ReactMarkdownWrapper text={studyConfig.uiConfig.studyEndMsg} />
+          ? (studyEndMsg
+            ? <ReactMarkdownWrapper text={studyEndMsg} />
             : <Text size="xl" display="block">Thank you for completing the study. You may close this window now.</Text>)
           : (
             <>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -111,7 +111,8 @@ export function StudyEnd() {
       return studyEndMsg;
     }
 
-    return studyEndMsg.replace(/\{(\w+)\}/g, () => participantId);
+    // return the study end message with the participant ID
+    return studyEndMsg.replace(/\{(\w+)\}/, () => participantId);
   }, [studyConfig, participantId]);
 
   return (

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -107,12 +107,12 @@ export function StudyEnd() {
     const studyEndMsg = studyConfig.uiConfig.studyEndMsg;
     const urlParticipantIdParam = studyConfig.uiConfig.urlParticipantIdParam;
 
-    if (!urlParticipantIdParam || !studyEndMsg?.includes('{')) {
+    if (!urlParticipantIdParam || !studyEndMsg?.includes('{PARTICIPANT_ID}')) {
       return studyEndMsg;
     }
 
     // return the study end message with the participant ID
-    return studyEndMsg.replace(/\{(\w+)\}/, () => participantId);
+    return studyEndMsg.replace(/\{PARTICIPANT_ID\}/g, () => participantId);
   }, [studyConfig, participantId]);
 
   return (

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -104,8 +104,7 @@ export function StudyEnd() {
   }, [storageEngine, studyId]);
 
   const processedStudyEndMsg = useMemo(() => {
-    const studyEndMsg = studyConfig.uiConfig.studyEndMsg;
-    const urlParticipantIdParam = studyConfig.uiConfig.urlParticipantIdParam;
+    const { studyEndMsg, urlParticipantIdParam } = studyConfig.uiConfig;
 
     if (!urlParticipantIdParam || !studyEndMsg?.includes('{PARTICIPANT_ID}')) {
       return studyEndMsg;

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2347,7 +2347,7 @@
           "type": "number"
         },
         "studyEndMsg": {
-          "description": "The message to display when the study ends. Supports templating with variables in curly braces. Available variables include {PARTICIPANT_ID} for the internal participant ID, and any URL parameter names (e.g., {PROLIFIC_ID}, {SONA_ID}, etc.).",
+          "description": "The message to display when the study ends. Supports templating with the participant ID. e.g. \"Thank you for completing the study. You may click this link and return to Prolific: [Go to Prolific](https://app.prolific.com/submissions/complete?cc=StudyID&PROLIFIC_ID={PROLIFIC_ID}))\"",
           "type": "string"
         },
         "timeoutReject": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2334,10 +2334,6 @@
           "description": "The return url template for the study. This is used to redirect the participant to a specific url after the study is completed.",
           "type": "string"
         },
-        "screenerReturnMessage": {
-          "description": "The screener return message for the study. This is used to display a message to the participant after the study is completed.",
-          "type": "string"
-        },
         "showTitle": {
           "description": "Controls whether the title should be hidden in the study.",
           "type": "boolean"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2330,10 +2330,6 @@
           "description": "Whether or not we want to utilize think-aloud features. If true, will record audio on all components unless deactivated on individual components. Defaults to false.",
           "type": "boolean"
         },
-        "returnUrlTemplate": {
-          "description": "The return url template for the study. This is used to redirect the participant to a specific url after the study is completed.",
-          "type": "string"
-        },
         "showTitle": {
           "description": "Controls whether the title should be hidden in the study.",
           "type": "boolean"
@@ -2351,7 +2347,7 @@
           "type": "number"
         },
         "studyEndMsg": {
-          "description": "The message to display when the study ends.",
+          "description": "The message to display when the study ends. Supports templating with variables in curly braces. Available variables include {PARTICIPANT_ID} for the internal participant ID, and any URL parameter names (e.g., {PROLIFIC_ID}, {SONA_ID}, etc.).",
           "type": "string"
         },
         "timeoutReject": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2330,6 +2330,14 @@
           "description": "Whether or not we want to utilize think-aloud features. If true, will record audio on all components unless deactivated on individual components. Defaults to false.",
           "type": "boolean"
         },
+        "returnUrlTemplate": {
+          "description": "The return url template for the study. This is used to redirect the participant to a specific url after the study is completed.",
+          "type": "string"
+        },
+        "screenerReturnMessage": {
+          "description": "The screener return message for the study. This is used to display a message to the participant after the study is completed.",
+          "type": "string"
+        },
         "showTitle": {
           "description": "Controls whether the title should be hidden in the study.",
           "type": "boolean"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -97,7 +97,7 @@ export interface UIConfig {
   autoDownloadStudy?: boolean;
   /** The time in milliseconds to wait before automatically downloading the study data. */
   autoDownloadTime?: number;
-  /** The message to display when the study ends. Supports templating with variables in curly braces. Available variables include {PARTICIPANT_ID} for the internal participant ID, and any URL parameter names (e.g., {PROLIFIC_ID}, {SONA_ID}, etc.). */
+  /** The message to display when the study ends. Supports templating with the {PARTICIPANT_ID} variable. e.g. "Thank you for completing the study. You may click this link and return to Prolific: [Go to Prolific](https://app.prolific.com/submissions/complete?cc=StudyID&PROLIFIC_ID={PROLIFIC_ID}))" */
   studyEndMsg?: string;
   /** Whether or not we want to utilize think-aloud features. If true, will record audio on all components unless deactivated on individual components. Defaults to false.  */
   recordStudyAudio?: boolean;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -111,7 +111,6 @@ export interface UIConfig {
    * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.
    */
   urlParticipantIdParam?: string;
-
   /**
    * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.
    */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -97,7 +97,7 @@ export interface UIConfig {
   autoDownloadStudy?: boolean;
   /** The time in milliseconds to wait before automatically downloading the study data. */
   autoDownloadTime?: number;
-  /** The message to display when the study ends. */
+  /** The message to display when the study ends. Supports templating with variables in curly braces. Available variables include {PARTICIPANT_ID} for the internal participant ID, and any URL parameter names (e.g., {PROLIFIC_ID}, {SONA_ID}, etc.). */
   studyEndMsg?: string;
   /** Whether or not we want to utilize think-aloud features. If true, will record audio on all components unless deactivated on individual components. Defaults to false.  */
   recordStudyAudio?: boolean;
@@ -111,8 +111,7 @@ export interface UIConfig {
    * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.
    */
   urlParticipantIdParam?: string;
-  /** The return url template for the study. This is used to redirect the participant to a specific url after the study is completed. */
-  returnUrlTemplate?: string;
+
   /**
    * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.
    */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -97,7 +97,7 @@ export interface UIConfig {
   autoDownloadStudy?: boolean;
   /** The time in milliseconds to wait before automatically downloading the study data. */
   autoDownloadTime?: number;
-  /** The message to display when the study ends. Supports templating with the {PARTICIPANT_ID} variable. e.g. "Thank you for completing the study. You may click this link and return to Prolific: [Go to Prolific](https://app.prolific.com/submissions/complete?cc=StudyID&PROLIFIC_ID={PROLIFIC_ID}))" */
+  /** The message to display when the study ends. Supports templating with the participant ID. e.g. "Thank you for completing the study. You may click this link and return to Prolific: [Go to Prolific](https://app.prolific.com/submissions/complete?cc=StudyID&PROLIFIC_ID={PROLIFIC_ID}))" */
   studyEndMsg?: string;
   /** Whether or not we want to utilize think-aloud features. If true, will record audio on all components unless deactivated on individual components. Defaults to false.  */
   recordStudyAudio?: boolean;
@@ -107,9 +107,7 @@ export interface UIConfig {
   sidebarWidth?: number;
   /** Debounce time in milliseconds for automatically tracked window events. Defaults to 100. E.g 100 here means 1000ms / 100ms = 10 times a second, 200 here means 1000ms / 200ms = 5 times per second  */
   windowEventDebounceTime?: number;
-  /**
-   * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.
-   */
+  /** If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers. */
   urlParticipantIdParam?: string;
   /**
    * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -111,6 +111,10 @@ export interface UIConfig {
    * If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers.
    */
   urlParticipantIdParam?: string;
+  /** The return url template for the study. This is used to redirect the participant to a specific url after the study is completed. */
+  returnUrlTemplate?: string;
+  /** The screener return message for the study. This is used to display a message to the participant after the study is completed. */
+  screenerReturnMessage?: string;
   /**
    * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.
    */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -113,8 +113,6 @@ export interface UIConfig {
   urlParticipantIdParam?: string;
   /** The return url template for the study. This is used to redirect the participant to a specific url after the study is completed. */
   returnUrlTemplate?: string;
-  /** The screener return message for the study. This is used to display a message to the participant after the study is completed. */
-  screenerReturnMessage?: string;
   /**
    * The number of sequences to generate for the study. This is used to generate the random sequences for the study. The default is 1000.
    */


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #739 

### Give a longer description of what this PR addresses and why it's needed
Allow variable injection at the study end

Uses
``` ts
/** The message to display when the study ends. Supports templating with the participant ID. e.g. "Thank you for completing the study. You may click this link and return to Prolific: [Go to Prolific](https://app.prolific.com/submissions/complete?cc=StudyID&PROLIFIC_ID={PROLIFIC_ID}))" */
  studyEndMsg?: string;
/** If the participant ID is passed in the URL, this is the name of the querystring parameter that is used to capture the participant ID (e.g. PROLIFIC_ID). This will allow a user to continue a study on different devices and browsers. */
  urlParticipantIdParam?: string;
```

### Provide pictures/videos of the behavior before and after these changes (optional)
```json
"uiConfig": {
  "studyEndMsg": "Thank you for completing the study. You may click this link and return to Prolific: [https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID}](https://app.prolific.com/submissions/complete?cc=CE96X7ST&PROLIFIC_ID={PROLIFIC_ID})",
  "urlParticipantIdParam": "PROLIFIC_PID",
}
```
e.g. http://revisit.dev/example-brush-interactions/SURHUmJIblo3Uk4xUUhNUHQ1VTRIQT09?PROLIFIC_PID=123456

![image](https://github.com/user-attachments/assets/de375e35-c9fd-437d-a273-9352716137be)

![image](https://github.com/user-attachments/assets/640b9371-3a5e-4fa5-a1e9-67ec1bbcfdda)

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [x] Update studies to use studyEndMsg template
- [x] Add example url template to comment