### PR TITLE
Fix options for radio and checkbox input

### DIFF
--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -37,7 +37,7 @@ export function CheckBoxInput({
   const storedAnswer = useStoredAnswer();
   const optionOrders: Record<string, StringOption[]> = useMemo(() => (storedAnswer ? storedAnswer.optionOrders : {}), [storedAnswer]);
 
-  const orderedOptions = useMemo(() => optionOrders[response.id] || options, [optionOrders, options, response.id]);
+  const orderedOptions = useMemo(() => optionOrders[response.id] || options.map((option) => (typeof (option) === 'string' ? { label: option, value: option } : option)), [optionOrders, options, response.id]);
 
   const [otherSelected, setOtherSelected] = useState(false);
 

--- a/src/components/response/RadioInput.tsx
+++ b/src/components/response/RadioInput.tsx
@@ -41,7 +41,7 @@ export function RadioInput({
   const storedAnswer = useStoredAnswer();
   const optionOrders: Record<string, StringOption[]> = useMemo(() => (storedAnswer ? storedAnswer.optionOrders : {}), [storedAnswer]);
 
-  const orderedOptions = useMemo(() => optionOrders[response.id] || options, [optionOrders, options, response.id]);
+  const orderedOptions = useMemo(() => optionOrders[response.id] || options.map((option) => (typeof (option) === 'string' ? { label: option, value: option } : option)), [optionOrders, options, response.id]);
 
   const [otherSelected, setOtherSelected] = useState(false);
 


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed
When radio/checkbox options are provided with list of strings in dynamic stimuli, the options are rendered as empty string. This was occurring because of same key attribute for each option.

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/user-attachments/assets/e28d967b-244c-48d9-bf37-56a59f3194f1)
![image](https://github.com/user-attachments/assets/390e5e44-dd35-4703-9206-5a2734b5658e)
