### PR TITLE
Add auto generating library links (live demo, demo codes, references - doi, external link)

### DIFF
--- a/libraryDocGenerator.cjs
+++ b/libraryDocGenerator.cjs
@@ -9,6 +9,25 @@ const path = require('path');
 const generateMd = (library, libraryConfig, forDocs) => `
 # ${library}
 
+${
+`import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "${library} Demo", url: "https://revisit.dev/study/library-${library}"}
+    ]}
+    codeLinks={[
+      {name: "${library} Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-${library}"}
+    ]}
+    ${
+      (libraryConfig.doi || libraryConfig.externalLink)
+      ? `referenceLinks={[
+      ${libraryConfig.doi ? `{name: "DOI", url: "https://dx.doi.org/${libraryConfig.doi}"}` : ''}${libraryConfig.doi && libraryConfig.externalLink ? ',' : ''}
+      ${libraryConfig.externalLink ? `{name: "External Link", url: "${libraryConfig.externalLink}"}` : ''}
+    ]}`
+    : ''}
+/>`}
+
 ${!forDocs ? `This is an example study of the library \`${library}\`.` : ''}
 
 ${libraryConfig.description}

--- a/libraryDocGenerator.cjs
+++ b/libraryDocGenerator.cjs
@@ -9,24 +9,24 @@ const path = require('path');
 const generateMd = (library, libraryConfig, forDocs) => `
 # ${library}
 
-${
-`import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
-
-<StructuredLinks
-    demoLinks={[
-      {name: "${library} Demo", url: "https://revisit.dev/study/library-${library}"}
-    ]}
-    codeLinks={[
-      {name: "${library} Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-${library}"}
-    ]}
-    ${
-      (libraryConfig.doi || libraryConfig.externalLink)
-      ? `referenceLinks={[
-      ${libraryConfig.doi ? `{name: "DOI", url: "https://dx.doi.org/${libraryConfig.doi}"}` : ''}${libraryConfig.doi && libraryConfig.externalLink ? ',' : ''}
-      ${libraryConfig.externalLink ? `{name: "External Link", url: "${libraryConfig.externalLink}"}` : ''}
-    ]}`
-    : ''}
-/>`}
+${forDocs ?
+  `import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+  
+  <StructuredLinks
+      demoLinks={[
+        {name: "${library} Demo", url: "https://revisit.dev/study/library-${library}"}
+      ]}
+      codeLinks={[
+        {name: "${library} Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-${library}"}
+      ]}
+      ${
+        (libraryConfig.doi || libraryConfig.externalLink)
+        ? `referenceLinks={[
+        ${libraryConfig.doi ? `{name: "DOI", url: "https://dx.doi.org/${libraryConfig.doi}"}` : ''}${libraryConfig.doi && libraryConfig.externalLink ? ',' : ''}
+        ${libraryConfig.externalLink ? `{name: "External Link", url: "${libraryConfig.externalLink}"}` : ''}
+      ]}`
+      : ''}
+  />` :  ''}
 
 ${!forDocs ? `This is an example study of the library \`${library}\`.` : ''}
 

--- a/public/library-beauvis/assets/beauvis.md
+++ b/public/library-beauvis/assets/beauvis.md
@@ -1,6 +1,21 @@
 
 # beauvis
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "beauvis Demo", url: "https://revisit.dev/study/library-beauvis"}
+    ]}
+    codeLinks={[
+      {name: "beauvis Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-beauvis"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1109/tvcg.2022.3209390"},
+      {name: "External Link", url: "https://www.aviz.fr/Research/BeauVis-Scale"}
+    ]}
+/>
+
 This is an example study of the library `beauvis`.
 
 BeauVis is a validated scale for assessing the aesthetic pleasure of visualizations. This library contains three components for the 3-, 4-, and 5-item versions of the BeauVis scale.

--- a/public/library-beauvis/assets/beauvis.md
+++ b/public/library-beauvis/assets/beauvis.md
@@ -1,20 +1,7 @@
 
 # beauvis
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "beauvis Demo", url: "https://revisit.dev/study/library-beauvis"}
-    ]}
-    codeLinks={[
-      {name: "beauvis Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-beauvis"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1109/tvcg.2022.3209390"},
-      {name: "External Link", url: "https://www.aviz.fr/Research/BeauVis-Scale"}
-    ]}
-/>
 
 This is an example study of the library `beauvis`.
 

--- a/public/library-calvi/assets/calvi.md
+++ b/public/library-calvi/assets/calvi.md
@@ -1,20 +1,7 @@
 
 # calvi
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "calvi Demo", url: "https://revisit.dev/study/library-calvi"}
-    ]}
-    codeLinks={[
-      {name: "calvi Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-calvi"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1145/3544548.3581406"}
-      
-    ]}
-/>
 
 This is an example study of the library `calvi`.
 

--- a/public/library-calvi/assets/calvi.md
+++ b/public/library-calvi/assets/calvi.md
@@ -1,7 +1,22 @@
 
-# CALVI: Critical Thinking Assessment for Literacy in Visualizations
+# calvi
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
+<StructuredLinks
+    demoLinks={[
+      {name: "calvi Demo", url: "https://revisit.dev/study/library-calvi"}
+    ]}
+    codeLinks={[
+      {name: "calvi Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-calvi"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1145/3544548.3581406"}
+      
+    ]}
+/>
+
+This is an example study of the library `calvi`.
 
 The Critical Thinking Assessment for Literacy in Visualizations (CALVI) library is a collection of visualizations and questions designed to assess the ability to interpret data visualizations. The library includes a variety of visualizations, such as line graphs, bar charts, and pie charts, along with corresponding questions that test the user's understanding of the data presented. The questions are designed to be challenging and require critical thinking skills to answer correctly.
 

--- a/public/library-color-blindness/assets/color-blindness.md
+++ b/public/library-color-blindness/assets/color-blindness.md
@@ -1,6 +1,21 @@
 
 # color-blindness
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "color-blindness Demo", url: "https://revisit.dev/study/library-color-blindness"}
+    ]}
+    codeLinks={[
+      {name: "color-blindness Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-color-blindness"}
+    ]}
+    referenceLinks={[
+      
+      {name: "External Link", url: "https://www.colour-blindness.com/colour-blindness-tests/ishihara-colour-test-plates/"}
+    ]}
+/>
+
 This is an example study of the library `color-blindness`.
 
 This library is the Ishihara color blindness test. Each component contains an image of an Ishihara plate. The meta attribute of each plate describe what normal vision people, red color blind people, green color blind people, and total color blind people see from this plate. The user is asked to identify the number or pattern in the image. The library also contains two sequences: a short test and a full test. The short test contains 4 components and the full test contains all 24 components.

--- a/public/library-color-blindness/assets/color-blindness.md
+++ b/public/library-color-blindness/assets/color-blindness.md
@@ -1,20 +1,7 @@
 
 # color-blindness
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "color-blindness Demo", url: "https://revisit.dev/study/library-color-blindness"}
-    ]}
-    codeLinks={[
-      {name: "color-blindness Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-color-blindness"}
-    ]}
-    referenceLinks={[
-      
-      {name: "External Link", url: "https://www.colour-blindness.com/colour-blindness-tests/ishihara-colour-test-plates/"}
-    ]}
-/>
 
 This is an example study of the library `color-blindness`.
 

--- a/public/library-demographics/assets/demographics.md
+++ b/public/library-demographics/assets/demographics.md
@@ -1,17 +1,7 @@
 
 # demographics
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "demographics Demo", url: "https://revisit.dev/study/library-demographics"}
-    ]}
-    codeLinks={[
-      {name: "demographics Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-demographics"}
-    ]}
-    
-/>
 
 This is an example study of the library `demographics`.
 

--- a/public/library-demographics/assets/demographics.md
+++ b/public/library-demographics/assets/demographics.md
@@ -1,6 +1,18 @@
 
 # demographics
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "demographics Demo", url: "https://revisit.dev/study/library-demographics"}
+    ]}
+    codeLinks={[
+      {name: "demographics Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-demographics"}
+    ]}
+    
+/>
+
 This is an example study of the library `demographics`.
 
 This is a library for demographic questions. It contains one component, demographics, with three questions: gender, age, and education.

--- a/public/library-mic-check/assets/mic-check.md
+++ b/public/library-mic-check/assets/mic-check.md
@@ -1,6 +1,18 @@
 
 # mic-check
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "mic-check Demo", url: "https://revisit.dev/study/library-mic-check"}
+    ]}
+    codeLinks={[
+      {name: "mic-check Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-mic-check"}
+    ]}
+    
+/>
+
 This is an example study of the library `mic-check`.
 
 This is a library for testing the microphone. It provides a component that listens to the microphone and only enables the next button when audio is detected.

--- a/public/library-mic-check/assets/mic-check.md
+++ b/public/library-mic-check/assets/mic-check.md
@@ -1,17 +1,7 @@
 
 # mic-check
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "mic-check Demo", url: "https://revisit.dev/study/library-mic-check"}
-    ]}
-    codeLinks={[
-      {name: "mic-check Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-mic-check"}
-    ]}
-    
-/>
 
 This is an example study of the library `mic-check`.
 

--- a/public/library-mini-vlat/assets/mini-vlat.md
+++ b/public/library-mini-vlat/assets/mini-vlat.md
@@ -1,20 +1,7 @@
 
 # mini-vlat
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "mini-vlat Demo", url: "https://revisit.dev/study/library-mini-vlat"}
-    ]}
-    codeLinks={[
-      {name: "mini-vlat Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-mini-vlat"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1111/cgf.14809"}
-      
-    ]}
-/>
 
 This is an example study of the library `mini-vlat`.
 

--- a/public/library-mini-vlat/assets/mini-vlat.md
+++ b/public/library-mini-vlat/assets/mini-vlat.md
@@ -1,6 +1,21 @@
 
 # mini-vlat
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "mini-vlat Demo", url: "https://revisit.dev/study/library-mini-vlat"}
+    ]}
+    codeLinks={[
+      {name: "mini-vlat Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-mini-vlat"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1111/cgf.14809"}
+      
+    ]}
+/>
+
 This is an example study of the library `mini-vlat`.
 
 Mini-VLAT is a short and effective measure of visualization literacy. Mini-VLAT has 12 questions and participants should answer each question within 25 seconds. This library contains 12 components. Each component contains one question of the Mini-VLAT. This library also contains a sequence of all 12 components (the full Mini-VLAT).

--- a/public/library-nasa-tlx/assets/nasa-tlx.md
+++ b/public/library-nasa-tlx/assets/nasa-tlx.md
@@ -1,20 +1,7 @@
 
 # nasa-tlx
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "nasa-tlx Demo", url: "https://revisit.dev/study/library-nasa-tlx"}
-    ]}
-    codeLinks={[
-      {name: "nasa-tlx Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-nasa-tlx"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1016/S0166-4115(08)62386-9"}
-      
-    ]}
-/>
 
 This is an example study of the library `nasa-tlx`.
 

--- a/public/library-nasa-tlx/assets/nasa-tlx.md
+++ b/public/library-nasa-tlx/assets/nasa-tlx.md
@@ -1,6 +1,21 @@
 
 # nasa-tlx
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "nasa-tlx Demo", url: "https://revisit.dev/study/library-nasa-tlx"}
+    ]}
+    codeLinks={[
+      {name: "nasa-tlx Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-nasa-tlx"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1016/S0166-4115(08)62386-9"}
+      
+    ]}
+/>
+
 This is an example study of the library `nasa-tlx`.
 
 The NASA-TLX is a widely used subjective workload assessment tool. It consists of six subscales: Mental Demand, Physical Demand, Temporal Demand, Performance, Effort, and Frustration. The NASA-TLX is designed to assess the perceived workload of a task and is commonly used in human factors and ergonomics research. We provide a component of the NASA-TLX itself, and a sequence that includes a source of load evaluation. The source of load evaluation is based on the pairwise weighting procedure described in the NASA-TLX manual.
@@ -16,43 +31,8 @@ DOI: [10.1016/S0166-4115(08)62386-9](https://dx.doi.org/10.1016/S0166-4115(08)62
 ## Available Components
 
 - nasa-tlx
+- source-of-load
 
 ## Available Sequences
 
 - nasa-tlx-with-source-of-load-evaluation
-
-
-## Source of Workload Evaluation (Pairwise Weighting Procedure)
-
-Reference: [NASA TLX manual](https://ntrs.nasa.gov/api/citations/20000021488/downloads/20000021488.pdf) (Section 2.2)
-
-This step of the NASA-TLX assesses the relative importance of different factors that contribute to a person's experience of workload during a task. Rather than assuming all workload components are equally important, this procedure captures individual differences in how workload is perceived.
-
-Participants are presented with 15 pairwise comparisons between the six NASA-TLX subscales:
-
-- Mental Demand
-- Physical Demand
-- Temporal Demand
-- Performance
-- Effort
-- Frustration
-
-For each pair, participants are asked to select the factor that contributed more to their workload experience in the given task.
-
-### How It Works
-Each chosen subscale earns one point (a “tally mark”).
-
-After 15 comparisons, each subscale has a weight from 0 to 5.
-
-These weights reflect the participant’s personal weighting of each workload dimension.
-
-### How to Use the Result
-After task performance, participants also rate the magnitude (0–100) of each of the six subscales.
-
-For each subscale:
-Adjusted Score = Raw Rating × Weight
-
-The overall workload score is calculated by summing all adjusted scores and dividing by 15:
-Overall Workload = Σ(Adjusted Scores) ÷ 15
-
-This weighted workload score accounts for both perceived intensity and individual prioritization, improving sensitivity and personalization in workload analysis.

--- a/public/library-previs/assets/previs.md
+++ b/public/library-previs/assets/previs.md
@@ -1,6 +1,21 @@
 
 # previs
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "previs Demo", url: "https://revisit.dev/study/library-previs"}
+    ]}
+    codeLinks={[
+      {name: "previs Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-previs"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1109/tvcg.2024.3456318"},
+      {name: "External Link", url: "https://aviz.fr/PREVis/"}
+    ]}
+/>
+
 This is an example study of the library `previs`.
 
 PREVis allows you to quickly and reliably measure how readable people find a data visualization. There are 4 individual scales in PREVis, each measuring a particular dimension of perceived readability. This library includes four components, one for each individual scale, as well as a sequence containing all four scales (the full PREVis). 

--- a/public/library-previs/assets/previs.md
+++ b/public/library-previs/assets/previs.md
@@ -1,20 +1,7 @@
 
 # previs
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "previs Demo", url: "https://revisit.dev/study/library-previs"}
-    ]}
-    codeLinks={[
-      {name: "previs Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-previs"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1109/tvcg.2024.3456318"},
-      {name: "External Link", url: "https://aviz.fr/PREVis/"}
-    ]}
-/>
 
 This is an example study of the library `previs`.
 

--- a/public/library-sus/assets/sus.md
+++ b/public/library-sus/assets/sus.md
@@ -1,6 +1,21 @@
 
 # sus
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "sus Demo", url: "https://revisit.dev/study/library-sus"}
+    ]}
+    codeLinks={[
+      {name: "sus Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-sus"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1201/9781498710411-35"}
+      
+    ]}
+/>
+
 This is an example study of the library `sus`.
 
 The System Usability Scale (SUS) is a 10-item questionnaire that measures perceived ease of use, perceived usefulness, and overall satisfaction with a system. The SUS has been widely used in usability studies and is considered a standard measure of usability. This library contains one component with 10 questions. The component is the full SUS questionnaire with 10 questions.

--- a/public/library-sus/assets/sus.md
+++ b/public/library-sus/assets/sus.md
@@ -1,20 +1,7 @@
 
 # sus
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "sus Demo", url: "https://revisit.dev/study/library-sus"}
-    ]}
-    codeLinks={[
-      {name: "sus Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-sus"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1201/9781498710411-35"}
-      
-    ]}
-/>
 
 This is an example study of the library `sus`.
 

--- a/public/library-vlat/assets/vlat.md
+++ b/public/library-vlat/assets/vlat.md
@@ -1,6 +1,21 @@
 
 # vlat
 
+import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
+
+<StructuredLinks
+    demoLinks={[
+      {name: "vlat Demo", url: "https://revisit.dev/study/library-vlat"}
+    ]}
+    codeLinks={[
+      {name: "vlat Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-vlat"}
+    ]}
+    referenceLinks={[
+      {name: "DOI", url: "https://dx.doi.org/10.1109/TVCG.2016.2598920"}
+      
+    ]}
+/>
+
 This is an example study of the library `vlat`.
 
 Visualization Literacy Assessment Test (VLAT) is developed to measure users' ability to read, understand, and use data visualizations to solve problems. The VLAT consists of 12 data visualizations and 53 multiple-choice questions. This library contains 53 components, each corresponding to a question of the VLAT. It also includes a sequence of all 53 components (the full VLAT).

--- a/public/library-vlat/assets/vlat.md
+++ b/public/library-vlat/assets/vlat.md
@@ -1,20 +1,7 @@
 
 # vlat
 
-import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';
 
-<StructuredLinks
-    demoLinks={[
-      {name: "vlat Demo", url: "https://revisit.dev/study/library-vlat"}
-    ]}
-    codeLinks={[
-      {name: "vlat Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-vlat"}
-    ]}
-    referenceLinks={[
-      {name: "DOI", url: "https://dx.doi.org/10.1109/TVCG.2016.2598920"}
-      
-    ]}
-/>
 
 This is an example study of the library `vlat`.
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #780 

### Give a longer description of what this PR addresses and why it's needed
Adds Structured Links on library documentation page

`import StructuredLinks from '@site/src/components/StructuredLinks/StructuredLinks.tsx';

<StructuredLinks
    demoLinks={[
      {name: "beauvis Demo", url: "https://revisit.dev/study/library-beauvis"}
    ]}
    codeLinks={[
      {name: "beauvis Code", url: "https://github.com/revisit-studies/study/tree/main/public/library-beauvis"}
    ]}
    referenceLinks={[
      {name: "DOI", url: "https://dx.doi.org/10.1109/tvcg.2022.3209390"},
      {name: "External Link", url: "https://www.aviz.fr/Research/BeauVis-Scale"}
    ]}
/>`

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="2511" height="1172" alt="image" src="https://github.com/user-attachments/assets/9b3c8085-a2a5-4bd4-a58e-4133070c4299" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
None