### PR TITLE
Fix sidebar to withSidebar in demo-yaml

### DIFF
--- a/public/demo-yaml/config.yaml
+++ b/public/demo-yaml/config.yaml
@@ -16,7 +16,7 @@ uiConfig:
   logoPath: "revisitAssets/revisitLogoSquare.svg"
   withProgressBar: true
   autoDownloadStudy: false
-  sidebar: true
+  withSidebar: true
   windowEventDebounceTime: 200
 components:
   introduction:


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed
demo-yaml had an error because it was using `sidebar` instead of `withSidebar`

### Provide pictures/videos of the behavior before and after these changes (optional)

Before
<img width="765" height="236" alt="image" src="https://github.com/user-attachments/assets/b58a61fe-604a-4e8d-9c5a-5cd1b4f68c2a" />

After
<img width="757" height="270" alt="image" src="https://github.com/user-attachments/assets/72d8cf9f-abee-4567-8ce7-eae3aef77a63" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
None