### PR TITLE
Allow modifying the Likert labels

### DIFF
--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -1261,6 +1261,14 @@
           "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
           "type": "string"
         },
+        "spacing": {
+          "description": "The spacing between the options. Defaults to 1.",
+          "type": "number"
+        },
+        "start": {
+          "description": "The starting value of the likert scale. Defaults to 1.",
+          "type": "number"
+        },
         "style": {
           "$ref": "#/definitions/Styles",
           "description": "You can set styles here, using React CSSProperties, for example: {\"width\": 100} or {\"width\": \"50%\"}"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -1191,6 +1191,14 @@
           "description": "The secondary text that is displayed to the participant under the prompt. This does not accept markdown.",
           "type": "string"
         },
+        "spacing": {
+          "description": "The spacing between the options. Defaults to 1.",
+          "type": "number"
+        },
+        "start": {
+          "description": "The starting value of the likert scale. Defaults to 1.",
+          "type": "number"
+        },
         "style": {
           "$ref": "#/definitions/Styles",
           "description": "You can set styles here, using React CSSProperties, for example: {\"width\": 100} or {\"width\": \"50%\"}"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -352,6 +352,10 @@ export interface LikertResponse extends BaseResponse {
   type: 'likert';
   /** The number of options to render. */
   numItems: number;
+  /** The starting value of the likert scale. Defaults to 1. */
+  start?: number;
+  /** The spacing between the options. Defaults to 1. */
+  spacing?: number;
   /** The left label of the likert scale. E.g Strongly Disagree */
   leftLabel?: string;
   /** The right label of the likert scale. E.g Strongly Agree */


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #738

### Give a longer description of what this PR addresses and why it's needed
Add `start` and `spacing` to Likert label to allow modifying number labels

```ts
export interface LikertResponse extends BaseResponse {
  type: 'likert';
  /** The number of options to render. */
  numItems: number;
  /** The starting value of the likert scale. Defaults to 1. */
  start?: number;
  /** The spacing between the options. Defaults to 1. */
  spacing?: number;
  /** The left label of the likert scale. E.g Strongly Disagree */
  leftLabel?: string;
  /** The right label of the likert scale. E.g Strongly Agree */
  rightLabel?: string;
}
```

### Provide pictures/videos of the behavior before and after these changes (optional)

numItems: 10
start: 0
spacing: 1

<img width="617" height="108" alt="likert0_1" src="https://github.com/user-attachments/assets/c9f7e6e5-6ac1-4928-a74a-b54850c6f98d" />

numItems: 3
start: 1
spacing: 2

<img width="625" height="95" alt="likert1_2" src="https://github.com/user-attachments/assets/127bafca-bc33-432e-b772-afa5ba40c399" />

numItems: 5
start: -10
spacing: 10

<img width="627" height="106" alt="likert-10_10" src="https://github.com/user-attachments/assets/d3b9c780-c799-4410-8386-90256b7928ff" />


### Are there any additional TODOs before this PR is ready to go?
No