### PR TITLE
Add event counts to tidy download

### DIFF
--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -53,6 +53,7 @@ export const OPTIONAL_COMMON_PROPS = [
   'resizeEvents',
   'scrollEvents',
   'visibilityEvents',
+  'windowEvents',
 ] as const;
 
 export const REQUIRED_PROPS = [
@@ -199,6 +200,9 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
         }
         if (properties.includes('visibilityEvents')) {
           tidyRow.visibilityEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length;
+        }
+        if (properties.includes('windowEvents')) {
+          tidyRow.windowEvents = JSON.stringify(trialAnswer.windowEvents);
         }
         return tidyRow;
       }).flat();

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -10,7 +10,6 @@ import {
   Space,
   Table,
   Text,
-  Tooltip,
 } from '@mantine/core';
 import {
   IconBrandPython, IconLayoutColumns, IconTableExport, IconX,
@@ -43,16 +42,6 @@ export const OPTIONAL_COMMON_PROPS = [
   'responseMin',
   'responseMax',
   'configHash',
-  'focusEvents',
-  'inputEvents',
-  'keydownEvents',
-  'keyupEvents',
-  'mousemoveEvents',
-  'mousedownEvents',
-  'mouseupEvents',
-  'resizeEvents',
-  'scrollEvents',
-  'visibilityEvents',
   'windowEvents',
 ] as const;
 
@@ -171,38 +160,22 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
         if (properties.includes('responseMax')) {
           tidyRow.responseMax = response?.type === 'numerical' ? response.max : undefined;
         }
-        if (properties.includes('focusEvents')) {
-          tidyRow.focusEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length;
-        }
-        if (properties.includes('inputEvents')) {
-          tidyRow.inputEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'input').length;
-        }
-        if (properties.includes('keydownEvents')) {
-          tidyRow.keydownEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length;
-        }
-        if (properties.includes('keyupEvents')) {
-          tidyRow.keyupEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length;
-        }
-        if (properties.includes('mousemoveEvents')) {
-          tidyRow.mousemoveEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length;
-        }
-        if (properties.includes('mousedownEvents')) {
-          tidyRow.mousedownEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length;
-        }
-        if (properties.includes('mouseupEvents')) {
-          tidyRow.mouseupEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length;
-        }
-        if (properties.includes('resizeEvents')) {
-          tidyRow.resizeEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length;
-        }
-        if (properties.includes('scrollEvents')) {
-          tidyRow.scrollEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length;
-        }
-        if (properties.includes('visibilityEvents')) {
-          tidyRow.visibilityEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length;
-        }
+
         if (properties.includes('windowEvents')) {
-          tidyRow.windowEvents = JSON.stringify(trialAnswer.windowEvents);
+          const windowEventsCount = {
+            focus: trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length,
+            input: trialAnswer.windowEvents.filter((event) => event[1] === 'input').length,
+            keydown: trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length,
+            keyup: trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length,
+            mousemove: trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length,
+            mousedown: trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length,
+            mouseup: trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length,
+            resize: trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length,
+            scroll: trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length,
+            visibility: trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length,
+          };
+
+          tidyRow.windowEvents = JSON.stringify(windowEventsCount);
         }
         return tidyRow;
       }).flat();
@@ -322,19 +295,6 @@ export function DownloadTidy({
           {OPTIONAL_COMMON_PROPS.map((prop) => {
             const isSelected = selectedProperties.includes(prop);
 
-            const eventTooltips: Record<string, string> = {
-              focusEvents: 'Tab focus events',
-              inputEvents: 'Form input events',
-              keydownEvents: 'Key press events',
-              keyupEvents: 'Key release events',
-              mousemoveEvents: 'Mouse movement tracking',
-              mousedownEvents: 'Mouse button press events',
-              mouseupEvents: 'Mouse button release events',
-              resizeEvents: 'Window resize events',
-              scrollEvents: 'Page scroll events',
-              visibilityEvents: 'Page visibility changes',
-            };
-
             const button = (
               <Button
                 key={prop}
@@ -360,14 +320,6 @@ export function DownloadTidy({
                 {prop}
               </Button>
             );
-
-            if (eventTooltips[prop]) {
-              return (
-                <Tooltip key={prop} label={eventTooltips[prop]}>
-                  {button}
-                </Tooltip>
-              );
-            }
 
             return button;
           })}

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -8,6 +8,7 @@ import {
   LoadingOverlay,
   Modal,
   Space,
+  Switch,
   Table,
   Text,
 } from '@mantine/core';
@@ -257,6 +258,7 @@ export function DownloadTidy({
     'duration',
     'cleanedDuration',
   ]);
+  const [isComponentView, setIsComponentView] = useState(true);
 
   const storageEngine = useStorageEngine();
   const { value: tableData, status: tableDataStatus, error: tableError } = useAsync(getTableData, [selectedProperties, data, storageEngine.storageEngine, studyId]);
@@ -306,6 +308,15 @@ export function DownloadTidy({
       centered
       withCloseButton={false}
     >
+      <Flex justify="flex-end">
+        <Switch
+          checked={isComponentView}
+          onChange={(event) => setIsComponentView(event.currentTarget.checked)}
+          label={isComponentView ? 'Component View' : 'Response View'}
+          size="sm"
+        />
+      </Flex>
+
       <Box>
         <Text size="sm" fw={500} mb="xs">
           <Flex align="center" gap="xs">

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -36,6 +36,7 @@ export const OPTIONAL_COMMON_PROPS = [
   'correctAnswer',
   'duration',
   'cleanedDuration',
+  'meta',
   'startTime',
   'endTime',
   'responseMin',
@@ -151,6 +152,9 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
         }
         if (properties.includes('cleanedDuration')) {
           tidyRow.cleanedDuration = cleanedDuration;
+        }
+        if (properties.includes('meta')) {
+          tidyRow.meta = JSON.stringify(completeComponent.meta, null, 2);
         }
         if (properties.includes('responseMin')) {
           tidyRow.responseMin = response?.type === 'numerical' ? response.min : undefined;

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -8,7 +8,6 @@ import {
   LoadingOverlay,
   Modal,
   Space,
-  Switch,
   Table,
   Text,
   Tooltip,
@@ -259,7 +258,6 @@ export function DownloadTidy({
     'duration',
     'cleanedDuration',
   ]);
-  const [isComponentView, setIsComponentView] = useState(true);
 
   const storageEngine = useStorageEngine();
   const { value: tableData, status: tableDataStatus, error: tableError } = useAsync(getTableData, [selectedProperties, data, storageEngine.storageEngine, studyId]);
@@ -309,15 +307,6 @@ export function DownloadTidy({
       centered
       withCloseButton={false}
     >
-      <Flex justify="flex-end">
-        <Switch
-          checked={isComponentView}
-          onChange={(event) => setIsComponentView(event.currentTarget.checked)}
-          label={isComponentView ? 'Component View' : 'Response View'}
-          size="sm"
-        />
-      </Flex>
-
       <Box>
         <Text size="sm" fw={500} mb="xs">
           <Flex align="center" gap="xs">

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -11,6 +11,7 @@ import {
   Switch,
   Table,
   Text,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconBrandPython, IconLayoutColumns, IconTableExport, IconX,
@@ -327,7 +328,21 @@ export function DownloadTidy({
         <Flex wrap="wrap" gap="4px">
           {OPTIONAL_COMMON_PROPS.map((prop) => {
             const isSelected = selectedProperties.includes(prop);
-            return (
+
+            const eventTooltips: Record<string, string> = {
+              focusEvents: 'Tab focus events',
+              inputEvents: 'Form input events',
+              keydownEvents: 'Key press events',
+              keyupEvents: 'Key release events',
+              mousemoveEvents: 'Mouse movement tracking',
+              mousedownEvents: 'Mouse button press events',
+              mouseupEvents: 'Mouse button release events',
+              resizeEvents: 'Window resize events',
+              scrollEvents: 'Page scroll events',
+              visibilityEvents: 'Page visibility changes',
+            };
+
+            const button = (
               <Button
                 key={prop}
                 variant={isSelected ? 'light' : 'white'}
@@ -352,6 +367,16 @@ export function DownloadTidy({
                 {prop}
               </Button>
             );
+
+            if (eventTooltips[prop]) {
+              return (
+                <Tooltip key={prop} label={eventTooltips[prop]}>
+                  {button}
+                </Tooltip>
+              );
+            }
+
+            return button;
           })}
         </Flex>
       </Box>

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -34,7 +34,6 @@ export const OPTIONAL_COMMON_PROPS = [
   'responsePrompt',
   'answer',
   'correctAnswer',
-
   'duration',
   'cleanedDuration',
   'startTime',

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -179,6 +179,7 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
         visibility: trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length,
       };
 
+      // Add a window events count row for each component
       rows.push({
         participantId: participant.participantId,
         trialId,

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -327,7 +327,7 @@ export function DownloadTidy({
 
       <Space h="md" />
 
-      <Box mih={300} style={{ width: '100%', overflow: 'scroll' }}>
+      <Box h={400} style={{ width: '100%', overflow: 'scroll' }}>
         {tableDataStatus === 'success' && tableData
           ? (
             <Table striped captionSide="bottom" withTableBorder>

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -43,6 +43,16 @@ export const OPTIONAL_COMMON_PROPS = [
   'cleanedDuration',
   'meta',
   'configHash',
+  'focusEvents',
+  'inputEvents',
+  'keydownEvents',
+  'keyupEvents',
+  'mousemoveEvents',
+  'mousedownEvents',
+  'mouseupEvents',
+  'resizeEvents',
+  'scrollEvents',
+  'visibilityEvents',
 ] as const;
 
 export const REQUIRED_PROPS = [
@@ -162,7 +172,36 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
         if (properties.includes('meta')) {
           tidyRow.meta = JSON.stringify(completeComponent.meta, null, 2);
         }
-
+        if (properties.includes('focusEvents')) {
+          tidyRow.focusEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length;
+        }
+        if (properties.includes('inputEvents')) {
+          tidyRow.inputEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'input').length;
+        }
+        if (properties.includes('keydownEvents')) {
+          tidyRow.keydownEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length;
+        }
+        if (properties.includes('keyupEvents')) {
+          tidyRow.keyupEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length;
+        }
+        if (properties.includes('mousemoveEvents')) {
+          tidyRow.mousemoveEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length;
+        }
+        if (properties.includes('mousedownEvents')) {
+          tidyRow.mousedownEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length;
+        }
+        if (properties.includes('mouseupEvents')) {
+          tidyRow.mouseupEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length;
+        }
+        if (properties.includes('resizeEvents')) {
+          tidyRow.resizeEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length;
+        }
+        if (properties.includes('scrollEvents')) {
+          tidyRow.scrollEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length;
+        }
+        if (properties.includes('visibilityEvents')) {
+          tidyRow.visibilityEvents = trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length;
+        }
         return tidyRow;
       }).flat();
 

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -41,7 +41,6 @@ export const OPTIONAL_COMMON_PROPS = [
   'responseMin',
   'responseMax',
   'configHash',
-  'windowEvents',
 ] as const;
 
 export const REQUIRED_PROPS = [
@@ -160,24 +159,29 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
           tidyRow.responseMax = response?.type === 'numerical' ? response.max : undefined;
         }
 
-        if (properties.includes('windowEvents')) {
-          const windowEventsCount = {
-            focus: trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length,
-            input: trialAnswer.windowEvents.filter((event) => event[1] === 'input').length,
-            keydown: trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length,
-            keyup: trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length,
-            mousemove: trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length,
-            mousedown: trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length,
-            mouseup: trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length,
-            resize: trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length,
-            scroll: trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length,
-            visibility: trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length,
-          };
-
-          tidyRow.windowEvents = JSON.stringify(windowEventsCount);
-        }
         return tidyRow;
       }).flat();
+
+      const windowEventsCount = {
+        focus: trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length,
+        input: trialAnswer.windowEvents.filter((event) => event[1] === 'input').length,
+        keydown: trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length,
+        keyup: trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length,
+        mousemove: trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length,
+        mousedown: trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length,
+        mouseup: trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length,
+        resize: trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length,
+        scroll: trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length,
+        visibility: trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length,
+      };
+
+      rows.push({
+        participantId: participant.participantId,
+        trialId,
+        trialOrder,
+        responseId: 'windowEvents',
+        answer: JSON.stringify(windowEventsCount),
+      } as TidyRow);
 
       return rows;
     }).flat()], Array.from(newHeaders)];


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #685 

### Give a longer description of what this PR addresses and why it's needed
Add window event counts to the tidy download

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1912" height="878" alt="image" src="https://github.com/user-attachments/assets/045f7bcd-1bd5-4186-9baf-13f040f6a5d0" />

<img width="1887" height="890" alt="image" src="https://github.com/user-attachments/assets/51726658-7be2-48b7-8767-eff2d1a800b7" />

### Are there any additional TODOs before this PR is ready to go?
- [x] Move window events to a row
- [ ] Update relevant documentation