### PR TITLE
Add timestamp string to replay url

### DIFF
--- a/src/utils/useNavigateToTrial.tsx
+++ b/src/utils/useNavigateToTrial.tsx
@@ -3,10 +3,15 @@ import { encryptIndex } from './encryptDecryptIndex';
 import { PREFIX } from './Prefix';
 
 export function useNavigateToTrial() {
-  return useCallback((trialOrder: string, participantId: string, studyId: string) => {
+  return useCallback((trialOrder: string, participantId: string, studyId: string, timeString?: string) => {
     const rejoined = trialOrder.split('_').map((index) => encryptIndex(+index)).join('/');
 
-    const url = `${studyId}/${rejoined}?participantId=${participantId}`;
+    let url = `${studyId}/${rejoined}?participantId=${participantId}`;
+
+    if (timeString) {
+      url += `&t=${timeString}`;
+    }
+
     window.open(`${PREFIX}${url}`, '_blank');
   }, []);
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #698 

### Give a longer description of what this PR addresses and why it's needed
Add replay timestamp to URL




Youtube Timestamp
<img width="706" height="357" alt="youtubeTimestamp" src="https://github.com/user-attachments/assets/51ec16bf-d06c-4c93-89f2-c5384b3d3319" />


### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation