### PR TITLE
Custom audio waveform to improve performance

### DIFF
--- a/src/components/interface/RecordingAudioWaveform.tsx
+++ b/src/components/interface/RecordingAudioWaveform.tsx
@@ -1,15 +1,6 @@
 import { Flex } from '@mantine/core';
 import { useRef, useEffect, useState } from 'react';
 
-interface AudioVisualizerProps {
-  width?: number;
-  height?: number;
-  fps?: number;
-  fftSize?: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
-  barColor?: string;
-  barWidth?: number;
-}
-
 export function RecordingAudioWaveform({
   width = 60,
   height = 36,
@@ -17,7 +8,14 @@ export function RecordingAudioWaveform({
   fftSize = 256,
   barColor = '#FA5252',
   barWidth = 2,
-}: AudioVisualizerProps) {
+}: {
+  width?: number;
+  height?: number;
+  fps?: number;
+  fftSize?: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+  barColor?: string;
+  barWidth?: number;
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);

--- a/src/components/interface/RecordingAudioWaveform.tsx
+++ b/src/components/interface/RecordingAudioWaveform.tsx
@@ -1,52 +1,148 @@
-import {
-  Box,
-} from '@mantine/core';
+import { Flex } from '@mantine/core';
+import { useRef, useEffect, useState } from 'react';
 
-import {
-  useCallback, useEffect, useRef, useState,
-} from 'react';
-import { WaveForm, WaveSurfer } from 'wavesurfer-react';
-import WaveSurferRef from 'wavesurfer.js';
-import RecordPlugin from 'wavesurfer.js/dist/plugins/record';
+interface AudioVisualizerProps {
+  width?: number;
+  height?: number;
+  fps?: number;
+  fftSize?: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+  barColor?: string;
+  barWidth?: number;
+}
 
-export function RecordingAudioWaveform({ width = 70, height = 36 }: { width?: number, height?: number }) {
-  const wavesurferRef = useRef<WaveSurferRef | null>(null);
-  const recording = useRef<RecordPlugin | null>(null);
-  const [isMounted, setIsMounted] = useState(false);
+export function RecordingAudioWaveform({
+  width = 60,
+  height = 36,
+  fps = 30,
+  fftSize = 256,
+  barColor = '#FA5252',
+  barWidth = 2,
+}: AudioVisualizerProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const animationFrameIdRef = useRef<number>(0);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (isMounted && wavesurferRef.current) {
-      const record = wavesurferRef.current.registerPlugin(RecordPlugin.create({ scrollingWaveform: true, renderRecordedAudio: false } as never));
-      recording.current = record;
+    let lastTime = 0;
+    const frameInterval = 1000 / fps;
+    const draw = (now: number) => {
+      animationFrameIdRef.current = requestAnimationFrame(draw);
 
-      if (!navigator.userAgent.includes('Firefox')) {
-        record.startRecording();
+      // Limit framerate
+      if (now - lastTime < frameInterval) return;
+      lastTime = now;
+
+      const canvas = canvasRef.current;
+      const analyser = analyserRef.current;
+      if (!canvas || !analyser) return;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const bufferLength = analyser.fftSize;
+      const dataArray = new Uint8Array(bufferLength);
+      analyser.getByteTimeDomainData(dataArray);
+
+      // Compute normalized max amplitude (-1 to 1)
+      const max = Math.max(...dataArray) / 128.0 - 1.0;
+
+      // Scroll canvas left by barWidth / 2 pixels
+      const imageData = ctx.getImageData(barWidth / 2, 0, canvas.width - barWidth / 2, canvas.height);
+      ctx.putImageData(imageData, 0, 0);
+
+      // Clear the rightmost column to make space for the new bar
+      ctx.clearRect(canvas.width - barWidth, 0, barWidth, canvas.height);
+
+      // Map audio amplitude to vertical positions on the canvas
+      const yMax = (1 - max) * (canvas.height / 2);
+
+      ctx.beginPath();
+      ctx.moveTo(canvas.width - barWidth - 10, canvas.height / 2);
+      ctx.lineTo(canvas.width - barWidth, canvas.height / 2);
+      ctx.moveTo(canvas.width - barWidth, canvas.height - yMax);
+      ctx.lineTo(canvas.width - barWidth, yMax);
+      ctx.strokeStyle = barColor;
+      ctx.lineWidth = barWidth;
+      ctx.stroke();
+    };
+
+    const setupAudio = async () => {
+      const canvas = canvasRef.current;
+
+      if (!canvas) {
+        return;
       }
 
-      wavesurferRef.current.setOptions({ height, waveColor: '#FA5252' });
-    }
+      const ctx = canvas.getContext('2d');
 
-    return () => {
-      if (isMounted && wavesurferRef.current) {
-        recording.current?.stopRecording();
-        recording.current?.destroy();
+      if (!ctx) {
+        return;
+      }
 
-        wavesurferRef.current.destroy();
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        mediaStreamRef.current = stream;
+
+        const context = new window.AudioContext();
+
+        audioContextRef.current = context;
+
+        const source = context.createMediaStreamSource(stream);
+        sourceRef.current = source;
+
+        const analyser = context.createAnalyser();
+        analyserRef.current = analyser;
+
+        analyser.fftSize = fftSize;
+        source.connect(analyser);
+
+        animationFrameIdRef.current = requestAnimationFrame(draw);
+      } catch (err) {
+        console.error('Error accessing microphone:', err);
+        if (err instanceof Error) {
+          setError(`Error accessing microphone: ${err.message}. Please grant permission.`);
+        } else {
+          setError('An unknown error occurred while accessing the microphone.');
+        }
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMounted]);
 
-  const handleWSMount = useCallback((waveSurfer: WaveSurferRef | null) => {
-    wavesurferRef.current = waveSurfer;
-    setIsMounted(true);
-  }, []);
+    setupAudio();
+
+    return () => {
+      cancelAnimationFrame(animationFrameIdRef.current);
+      if (analyserRef.current) analyserRef.current.disconnect();
+      if (sourceRef.current) sourceRef.current.disconnect();
+
+      // Stop microphone track
+      if (mediaStreamRef.current) {
+        mediaStreamRef.current.getTracks().forEach((track) => track.stop());
+      }
+
+      // Close the AudioContext
+      if (audioContextRef.current && audioContextRef.current.state !== 'closed') {
+        audioContextRef.current.close();
+      }
+    };
+  }, [width, height, fps, fftSize, barColor, barWidth]);
 
   return (
-    <Box id="waveformDiv" style={{ width: `${width}px`, height: `${height}px` }}>
-      <WaveSurfer onMount={handleWSMount} plugins={[]} container="#waveformDiv" height={height}>
-        <WaveForm id="waveform" height={height} />
-      </WaveSurfer>
-    </Box>
+    <Flex>
+      {error && <p style={{ color: 'red', maxWidth: `${width}px` }}>{error}</p>}
+      <canvas ref={canvasRef} />
+    </Flex>
   );
 }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #684 

### Give a longer description of what this PR addresses and why it's needed
Addresses the high CPU usage caused by Wavesurfer when rendering even small waveforms in the app header during think-aloud sessions.

This PR can possibly be extended to
- Accepting an audio stream (e.g., from screen recording or another component) as a prop.
- Storing waveform data during recording, reducing the need to repeatedly decode the entire audio/video file during analysis.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="2853" height="1011" alt="image" src="https://github.com/user-attachments/assets/990f1725-cdb5-4e91-bddd-741998838edc" />

