### PR TITLE
Custom audio waveform to improve performance

### DIFF
--- a/src/components/interface/RecordingAudioWaveform.tsx
+++ b/src/components/interface/RecordingAudioWaveform.tsx
@@ -1,15 +1,6 @@
 import { Flex } from '@mantine/core';
 import { useRef, useEffect, useState } from 'react';
 
-interface AudioVisualizerProps {
-  width?: number;
-  height?: number;
-  fps?: number;
-  fftSize?: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
-  barColor?: string;
-  barWidth?: number;
-}
-
 export function RecordingAudioWaveform({
   width = 60,
   height = 36,
@@ -17,7 +8,14 @@ export function RecordingAudioWaveform({
   fftSize = 256,
   barColor = '#FA5252',
   barWidth = 2,
-}: AudioVisualizerProps) {
+}: {
+  width?: number;
+  height?: number;
+  fps?: number;
+  fftSize?: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+  barColor?: string;
+  barWidth?: number;
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);


### PR DESCRIPTION
### Does this PR close any open issues?
N/A

### Give a longer description of what this PR addresses and why it's needed
Addresses the high CPU usage caused by Wavesurfer when rendering even small waveforms in the app header during think-aloud sessions.

This PR can possibly be extended to
- Accepting an audio stream (e.g., from screen recording or another component) as a prop.
- Storing waveform data during recording, reducing the need to repeatedly decode the entire audio/video file during analysis.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="2853" height="1011" alt="image" src="https://github.com/user-attachments/assets/990f1725-cdb5-4e91-bddd-741998838edc" />

