### PR TITLE
Fix MatrixResponse stored as [object Object] in tidy download

### DIFF
--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -133,7 +133,7 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
           tidyRow.responsePrompt = response?.prompt;
         }
         if (properties.includes('answer')) {
-          tidyRow.answer = value;
+          tidyRow.answer = typeof value === 'object' ? JSON.stringify(value) : value;
         }
         if (properties.includes('correctAnswer')) {
           const configCorrectAnswer = completeComponent.correctAnswer?.find((ans) => ans.id === key)?.answer;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #783

### Give a longer description of what this PR addresses and why it's needed
Fix MatrixResponse stored as [object Object] in tidy download

### Provide pictures/videos of the behavior before and after these changes (optional)
Before
<img width="900" height="25" alt="image" src="https://github.com/user-attachments/assets/4013f975-d866-4103-a4dc-71a05f775cd7" />

After
<img width="1542" height="600" alt="image" src="https://github.com/user-attachments/assets/7bc33e85-00c2-4564-bba4-905fd7946a4a" />

<img width="2522" height="232" alt="image" src="https://github.com/user-attachments/assets/3934b7a0-c9e8-47c1-94b1-574bf1d6361b" />

### Are there any additional TODOs before this PR is ready to go?
No