### PR TITLE
Fix libraries in random blocks fail to produce sequences

### DIFF
--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -22,7 +22,7 @@ function _componentBlockToSequence(
   let computedComponents = order.components;
 
   if (order.order === 'random') {
-    const randomArr = [...order.components].sort(() => 0.5 - Math.random());
+    const randomArr = structuredClone(order.components).sort(() => 0.5 - Math.random());
 
     computedComponents = randomArr;
   } else if (order.order === 'latinSquare' && latinSquareObject) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #784

### Give a longer description of what this PR addresses and why it's needed
Fix libraries in random blocks fail to produce sequences

### Provide pictures/videos of the behavior before and after these changes (optional)
Before
<img width="1024" height="222" alt="image" src="https://github.com/user-attachments/assets/30eb609c-ea5d-4934-b8b8-57acf465f88b" />

After

```js
"sequence": {
    "order": "fixed",
    "components": [
      "introduction",
      "$mic-check.co.audioTest",
      {
        "id": "test",
        "order": "random",
        "components": [
          {
            "id": "critiquePart",
            "components": [
              "critiqueCalvi1",
              "critiqueCalvi2",
              "critiqueUntimelyDeath",
              "critiqueWealth"
            ],
            "order": "random"
          },
          "drawingTraining",
          {
            "id": "drawingPart",
            "components": [
              "drawingTree",
              "drawingNetwork",
              "drawingBpm",
              "drawingRanking",
              "drawing100m"
            ],
            "order": "random"
          },
          "$mini-vlat.se.full"
        ]
      }
    ]
  }
```
when `config.json` looks like the one above, the random sequence is generated correctly, and the mini-VLAT is also generated in a latin square sequence.

https://github.com/user-attachments/assets/0fd93ab2-2450-456e-9e67-70f72484c51d

### Are there any additional TODOs before this PR is ready to go?
No