### PR TITLE
Fix missing video crash

### DIFF
--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -25,10 +25,10 @@ function isValidVimeoUrl(url: string): boolean {
 }
 
 // eslint-disable-next-line react/display-name
-const CustomPlyrInstance = forwardRef<APITypes, PlyrProps & { endedCallback:() => void; errorCallback: () => void }>(
+const CustomPlyrInstance = forwardRef<APITypes, PlyrProps & { endedCallback:() => void; }>(
   (props, ref) => {
     const {
-      source, options = null, endedCallback, errorCallback,
+      source, options = null, endedCallback,
     } = props;
     const raptorRef = usePlyr(ref, { options, source });
 
@@ -36,7 +36,6 @@ const CustomPlyrInstance = forwardRef<APITypes, PlyrProps & { endedCallback:() =
       const { current } = ref as RefObject<APITypes>;
       if (current.plyr.source === null) return;
       current.plyr.on('ended', endedCallback);
-      current.plyr.on('error', errorCallback);
     });
 
     return (
@@ -175,7 +174,6 @@ export function VideoController({ currentConfig }: { currentConfig: VideoCompone
           source={{ type: 'video', sources }}
           options={options}
           endedCallback={endedCallback}
-          errorCallback={() => {}}
         />
       </Box>
     )


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #790 

### Give a longer description of what this PR addresses and why it's needed
External videos crashed the browser because of poor error handling inside of plyr. I now check if the YouTube video exists before rendering it

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1624" height="1060" alt="Screenshot 2025-10-04 at 2 18 55 PM" src="https://github.com/user-attachments/assets/1ca0b24d-4390-4358-b37a-98d6d948f160" />

### Are there any additional TODOs before this PR is ready to go?
No