### PR TITLE
close unnecessary sidebars in libraries

### DIFF
--- a/public/library-adaptive-vlat/config.json
+++ b/public/library-adaptive-vlat/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "adaptive-vlat"

--- a/public/library-berlin-num/config.json
+++ b/public/library-berlin-num/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "berlin-num"

--- a/public/library-nasa-tlx/config.json
+++ b/public/library-nasa-tlx/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "nasa-tlx"

--- a/public/library-previs/config.json
+++ b/public/library-previs/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "previs"

--- a/public/library-quis/config.json
+++ b/public/library-quis/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "quis"

--- a/public/library-sam/config.json
+++ b/public/library-sam/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "sam"

--- a/public/library-smeq/config.json
+++ b/public/library-smeq/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "smeq"

--- a/public/library-sus/config.json
+++ b/public/library-sus/config.json
@@ -18,7 +18,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "sus"


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
Some example studies of libraries do not need a sidebar. For example: 
<img width="720" height="348" alt="image" src="https://github.com/user-attachments/assets/7011182d-bcae-4ab6-b112-5c21a4433e92" />

I went through all existing libraries and turned them off.


### Are there any additional TODOs before this PR is ready to go?
No