### PR TITLE
Add randomize option dice icon

### DIFF
--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -3,11 +3,11 @@ import {
 } from '@mantine/core';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import {
-  IconArrowsShuffle, IconBrain, IconCheck, IconPackageImport, IconX, IconDice3, IconInfoCircle,
+  IconArrowsShuffle, IconBrain, IconCheck, IconPackageImport, IconX, IconDice3, IconDice5, IconInfoCircle,
 } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import {
-  ComponentBlock, DynamicBlock, ParticipantData, StudyConfig,
+  ComponentBlock, DynamicBlock, ParticipantData, StudyConfig, Response,
 } from '../../parser/types';
 import { Sequence, StoredAnswer } from '../../store/types';
 import { useCurrentStep, useStudyId } from '../../routes/utils';
@@ -95,6 +95,18 @@ function reorderComponents(configSequence: ComponentBlockWithOrderPath['componen
   }
 
   return newComponents;
+}
+
+function hasRandomization(responses: Response[]) {
+  return responses.some((response) => {
+    if (response.type === 'radio' || response.type === 'checkbox' || response.type === 'buttons') {
+      return response.optionOrder === 'random';
+    }
+    if (response.type === 'matrix-radio' || response.type === 'matrix-checkbox') {
+      return response.questionOrder === 'random';
+    }
+    return false;
+  });
 }
 
 function StepItem({
@@ -199,6 +211,11 @@ function StepItem({
             {task?.responseOrder === 'random' && (
             <Tooltip label="Random responses" position="right" withArrow>
               <IconDice3 size={16} opacity={0.8} style={{ marginRight: 4, flexShrink: 0 }} color="black" />
+            </Tooltip>
+            )}
+            {(task?.response && hasRandomization(task.response)) && (
+            <Tooltip label="Random options" position="right" withArrow>
+              <IconDice5 size={16} opacity={0.8} style={{ marginRight: 4, flexShrink: 0 }} color="black" />
             </Tooltip>
             )}
             {correctIncorrectIcon}


### PR DESCRIPTION
### Does this PR close any open issues?
Close #901

### Give a longer description of what this PR addresses and why it's needed
Add a die icon for randomize options

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1190" height="521" alt="image" src="https://github.com/user-attachments/assets/d9fc0b97-13d7-4fc5-87a9-782ccbcd78fa" />

### Are there any additional TODOs before this PR is ready to go?
No