### PR TITLE
Fixing bug in play button

### DIFF
--- a/src/components/audioAnalysis/AudioProvenanceVis.tsx
+++ b/src/components/audioAnalysis/AudioProvenanceVis.tsx
@@ -428,7 +428,7 @@ export function AudioProvenanceVis({
         {xScale ? (
           <Timer
             duration={totalAudioLength * 1000}
-            initialTime={jumpedToAudioTime ? startTime + jumpedToAudioTime * 1000 + 1 : replayTimestamp ? startTime + replayTimestamp : 0}
+            initialTime={jumpedToAudioTime ? startTime + jumpedToAudioTime * 1000 + 1 : replayTimestamp ? startTime + replayTimestamp : startTime}
             height={(analysisHasAudio ? 50 : 0) + 25}
             isPlaying={analysisIsPlaying}
             speed={speed}

--- a/src/components/audioAnalysis/Timer.tsx
+++ b/src/components/audioAnalysis/Timer.tsx
@@ -14,7 +14,7 @@ export function Timer({
   useEffect(() => {
     if (startTime) {
       // Initial time is the time the user wants to start at, if it's not provided, we start at the beginning
-      const time = initialTime !== undefined ? initialTime : startTime;
+      const time = initialTime;
       timer.current = time - startTime;
       directUpdateTimer(time, (time - startTime) / duration);
 


### PR DESCRIPTION
Fixed a small bug where playback in replays didnt work if you just pressed the play button without clicking on the timeline first. 