### PR TITLE
Add libraries for the UMUX and UMUX-Lite questionnaires

### DIFF
--- a/public/libraries/umux-lite/assets/umux-lite.md
+++ b/public/libraries/umux-lite/assets/umux-lite.md
@@ -1,0 +1,3 @@
+## UMUX-LITE
+
+The UMUX-Lite is a two-item questionnaire derived from the original UMUX. It is designed for situations where testing time is limited, offering a brief yet reliable measure of perceived usability. The two statements assess how usable and easy to use you find the system, providing a quick indication of overall user experience quality.

--- a/public/libraries/umux-lite/config.json
+++ b/public/libraries/umux-lite/config.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.3.1/src/parser/LibraryConfigSchema.json",
+  "description": "The UMUX-Lite is a two-item questionnaire derived from the original UMUX. It is designed for situations where testing time is limited, offering a brief yet reliable measure of perceived usability. The two statements assess how usable and easy to use you find the system, providing a quick indication of overall user experience quality.",
+  "reference": "Lewis, James R., Brian S. Utesch, and Deborah E. Maher. \"UMUX-LITE: when there's no time for the SUS.\" Proceedings of the SIGCHI conference on human factors in computing systems. 2013.",
+  "doi": "10.1145/2470654.2481287", 
+  "components": {
+    "umux-lite": {
+      "type": "questionnaire",
+      "response": [
+        {
+          "id": "effectiveness",
+          "prompt": "This system's capabilities meet my **requirements**",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "rightLabel": "Strongly Agree",
+          "leftLabel": "Strongly Disagree"
+        },
+        {
+          "id": "easy-to-use",
+          "prompt": "This system is **easy to use**",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 5,
+          "rightLabel": "Strongly Agree",
+          "leftLabel": "Strongly Disagree"
+        }
+      ]
+    }
+  },
+  "sequences": {}
+}

--- a/public/libraries/umux/assets/umux.md
+++ b/public/libraries/umux/assets/umux.md
@@ -1,0 +1,3 @@
+## UMUX
+
+The evaluation you're about to complete is the Usability Metric for User Experience (UMUX). The UMUX is a short, standardized usability questionnaire developed as a concise and conceptually similar alternative to the System Usability Scale (SUS). It includes four statements designed to assess how effective, efficient, and satisfying you find the system to use.

--- a/public/libraries/umux/config.json
+++ b/public/libraries/umux/config.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.3.1/src/parser/LibraryConfigSchema.json",
+  "description": "The evaluation you're about to complete is the Usability Metric for User Experience (UMUX). The UMUX is a short, standardized usability questionnaire developed as a concise and conceptually similar alternative to the System Usability Scale (SUS). It includes four statements designed to assess how effective, efficient, and satisfying you find the system to use.",
+  "reference": "Finstad, Kraig. \"The usability metric for user experience.\" Interacting with computers 22.5 (2010): 323-327.",
+  "doi": "10.1016/j.intcom.2010.04.004", 
+  "components": {
+    "umux": {
+      "type": "questionnaire",
+      "response": [
+        {
+          "id": "effectiveness",
+          "prompt": "This system's capabilities meet my **requirements**",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "rightLabel": "Strongly Agree",
+          "leftLabel": "Strongly Disagree"
+        },
+        {
+          "id": "satisfaction",
+          "prompt": "Using this system is a **frustrating** experience",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "rightLabel": "Strongly Agree",
+          "leftLabel": "Strongly Disagree"
+        },
+        {
+          "id": "easy-to-use",
+          "prompt": "This system is **easy to use**",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 5,
+          "rightLabel": "Strongly Agree",
+          "leftLabel": "Strongly Disagree"
+        },
+        {
+          "id": "time-consuming",
+          "prompt": "I have to spend too much time learning how to use this system",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "rightLabel": "Strongly Agree",
+          "leftLabel": "Strongly Disagree"
+        }
+      ]
+    }
+  },
+  "sequences": {}
+}


### PR DESCRIPTION
### Does this PR close any open issues?
It’s a feature I found useful for conducting user studies.

### Give a longer description of what this PR addresses and why it's needed
This PR adds the **UMUX (Usability Metric for User Experience)** and **UMUX-Lite** questionnaires to the study library.  

- UMUX is a short, standardized usability questionnaire developed as a concise and conceptually similar alternative to the System Usability Scale (SUS). It includes four items designed to assess how effective, efficient, and satisfying you find the system to use.
- UMUX-Lite is a two-item short-form usability measure (Lewis et al., 2013), designed for time-constrained user studies.  

This implementation includes:
- JSON configuration for question structure and response format  
- Markdown documentation (`umux.md`,`umux-lite.md`) describing the questionnaire and citation.

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation