### PR TITLE
Add umux and umux-lite library example studies

### DIFF
--- a/public/global.json
+++ b/public/global.json
@@ -41,6 +41,8 @@
     "library-screen-recording",
     "library-smeq",
     "library-sus",
+    "library-umux",
+    "library-umux-lite",
     "library-virtual-chinrest",
     "library-vlat",
     "test-audio",
@@ -214,6 +216,14 @@
     },
     "test-step-logic": {
       "path": "test-step-logic/config.json",
+      "test": true
+    },
+    "library-umux": {
+      "path": "library-umux/config.json",
+      "test": true
+    },
+    "library-umux-lite": {
+      "path": "library-umux-lite/config.json",
       "test": true
     },
     "library-virtual-chinrest": {

--- a/public/library-umux-lite/assets/umux-lite.md
+++ b/public/library-umux-lite/assets/umux-lite.md
@@ -1,0 +1,26 @@
+
+# umux-lite
+
+This is an example study of the library `umux-lite`.
+
+The UMUX-Lite is a two-item questionnaire derived from the original UMUX. It is designed for situations where testing time is limited, offering a brief yet reliable measure of perceived usability. The two statements assess how usable and easy to use you find the system, providing a quick indication of overall user experience quality.
+
+## Reference
+
+Lewis, James R., Brian S. Utesch, and Deborah E. Maher. "UMUX-LITE: when there's no time for the SUS." Proceedings of the SIGCHI conference on human factors in computing systems. 2013.
+
+DOI: [10.1145/2470654.2481287](https://dx.doi.org/10.1145/2470654.2481287)
+
+
+
+## Available Components
+
+- umux-lite
+
+## Available Sequences
+
+None
+
+
+
+

--- a/public/library-umux-lite/config.json
+++ b/public/library-umux-lite/config.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/dev/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "UMUX-Lite: Usability Metric for User Experience (Short Version, 2 Items)",
+    "version": "1.0.0",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2025-11-20",
+    "description": "Example study using the umux-lite library.",
+    "organizations": [
+      "University of Utah",
+      "WPI",
+      "University of Toronto"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "withSidebar": true
+  },
+  "importedLibraries": [
+    "umux-lite"
+  ],
+  "components": {
+    "introduction": {
+      "type": "markdown",
+      "path": "library-umux-lite/assets/umux-lite.md",
+      "response": []
+    }
+  },
+  "sequence": {
+    "order": "fixed",
+    "components": [
+      "introduction",
+      "$umux-lite.co.umux-lite"
+    ]
+  }
+}

--- a/public/library-umux/assets/umux.md
+++ b/public/library-umux/assets/umux.md
@@ -1,0 +1,26 @@
+
+# umux
+
+This is an example study of the library `umux`.
+
+The evaluation you're about to complete is the Usability Metric for User Experience (UMUX). The UMUX is a short, standardized usability questionnaire developed as a concise and conceptually similar alternative to the System Usability Scale (SUS). It includes four statements designed to assess how effective, efficient, and satisfying you find the system to use.
+
+## Reference
+
+Finstad, Kraig. "The usability metric for user experience." Interacting with computers 22.5 (2010): 323-327.
+
+DOI: [10.1016/j.intcom.2010.04.004](https://dx.doi.org/10.1016/j.intcom.2010.04.004)
+
+
+
+## Available Components
+
+- umux
+
+## Available Sequences
+
+None
+
+
+
+

--- a/public/library-umux/config.json
+++ b/public/library-umux/config.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/dev/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "UMUX: Usability Metric for User Experience",
+    "version": "1.0.0",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2025-11-20",
+    "description": "Example study using the umux library.",
+    "organizations": [
+      "University of Utah",
+      "WPI",
+      "University of Toronto"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "withSidebar": true
+  },
+  "importedLibraries": [
+    "umux"
+  ],
+  "components": {
+    "introduction": {
+      "type": "markdown",
+      "path": "library-umux/assets/umux.md",
+      "response": []
+    }
+  },
+  "sequence": {
+    "order": "fixed",
+    "components": [
+      "introduction",
+      "$umux.co.umux"
+    ]
+  }
+}


### PR DESCRIPTION
### Does this PR close any open issues?
no

### Give a longer description of what this PR addresses and why it's needed

- Added example study of the umux library
- Added example study of the umux-lite library

### Provide pictures/videos of the behavior before and after these changes (optional)

UMUX: 
<img width="1463" height="771" alt="image" src="https://github.com/user-attachments/assets/ba83cf4c-243e-4f74-ac20-d4524dd56085" />

<img width="1463" height="670" alt="image" src="https://github.com/user-attachments/assets/49ba5128-28a8-4735-a527-e5bc2f9618df" />

UMUX-lite:

<img width="1462" height="682" alt="image" src="https://github.com/user-attachments/assets/83030816-99ed-4cd5-a1d9-46519acbcd52" />
<img width="1464" height="610" alt="image" src="https://github.com/user-attachments/assets/61fa9f7d-cee5-4d45-a6fd-1b3ae298d4dc" />


### Are there any additional TODOs before this PR is ready to go?
no