### PR TITLE
Refactor timer logic in NextButton to use Date.now() for accurate timing

### DIFF
--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -32,12 +32,12 @@ export function NextButton({
   const nextButtonEnableTime = useMemo(() => config?.nextButtonEnableTime ?? studyConfig.uiConfig.nextButtonEnableTime ?? 0, [config, studyConfig]);
 
   const [timer, setTimer] = useState<number | undefined>(undefined);
-  // Start a timer on first render, update timer every 100ms
+  // Use Date.now() to keep time even if tab is hidden
   useEffect(() => {
-    let time = 0;
+    const start = Date.now();
+    setTimer(0);
     const interval = setInterval(() => {
-      time += 100;
-      setTimer(time);
+      setTimer(Date.now() - start);
     }, 100);
     return () => {
       clearInterval(interval);


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #976 

### Give a longer description of what this PR addresses and why it's needed
With @jaykim1213, we fixed the issue with the next button timer. The timer was using an internal state to keep track of time, but we now use Dates, which are more reliable when the tab is hidden.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Some testing