### PR TITLE
Stop audio recorder when stopping screen recording

### DIFF
--- a/src/store/hooks/useScreenRecording.ts
+++ b/src/store/hooks/useScreenRecording.ts
@@ -85,6 +85,13 @@ export function useScreenRecording() {
       currentMediaRecorder.current.stop();
       currentMediaRecorder.current = null;
     }
+
+    if (audioMediaRecorder.current) {
+      audioMediaRecorder.current.stream.getTracks().forEach((track) => { track.stop(); audioMediaRecorder.current?.stream.removeTrack(track); });
+      audioMediaRecorder.current.stream.getAudioTracks().forEach((track) => { track.stop(); audioMediaRecorder.current?.stream.removeTrack(track); });
+      audioMediaRecorder.current.stop();
+      audioMediaRecorder.current = null;
+    }
   }, []);
 
   // Start screen recording
@@ -175,6 +182,7 @@ export function useScreenRecording() {
     setIsScreenRecording(false);
     setScreenWithAudioRecording(false);
     currentMediaRecorder.current?.stop();
+    audioMediaRecorder.current?.stop();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #910 

### Give a longer description of what this PR addresses and why it's needed
Audio media recorder is used in parallel with screen recording to generate transcriptions. Previously, audio recorder wasn't stopped when stopping screen recording causing transcriptions to be merged in subsequent recordings.


### Provide pictures/videos of the behavior before and after these changes (optional)
x
