### PR TITLE
957 unable to track participant speed adjustments in demo click accuracy test replay

### DIFF
--- a/src/public/demo-click-accuracy-test/assets/ClickAccuracyTest.tsx
+++ b/src/public/demo-click-accuracy-test/assets/ClickAccuracyTest.tsx
@@ -24,7 +24,7 @@ interface ClickAccuracyTest {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ClickAccuracyTest({ parameters, setAnswer, provenanceState }: StimulusParams<any, {distance: number, speed: number, clickX: number, clickY: number}>) {
+function ClickAccuracyTest({ parameters, setAnswer, provenanceState }: StimulusParams<any, { distance: number, speed: number, clickX: number, clickY: number }>) {
   const [ref, dms] = useChartDimensions(chartSettings);
   const [x, setX] = useState(100);
   const [y, setY] = useState(100);


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #957 

### Give a longer description of what this PR addresses and why it's needed
Adds tracking of speed adjustment slider
Fixes circle offset. Previously, when clicking at the circle's center, distance from click wasn't zero.

### Provide pictures/videos of the behavior before and after these changes (optional)
x

### Are there any additional TODOs before this PR is ready to go?
x