### PR TITLE
Fixes divider overlap on the Stats View page

### DIFF
--- a/src/analysis/individualStudy/stats/ResponseVisualization.tsx
+++ b/src/analysis/individualStudy/stats/ResponseVisualization.tsx
@@ -237,7 +237,7 @@ export function ResponseVisualization({
       <Collapse in={opened} mah={400}>
         <Box
           style={{
-            top: 0, position: 'sticky', backgroundColor: 'white', zIndex: 2,
+            position: 'sticky', backgroundColor: 'white', zIndex: 2,
           }}
           py="md"
         >


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #963

### Give a longer description of what this PR addresses and why it's needed
Fixes divider overlap on the Stats View page

### Provide pictures/videos of the behavior before and after these changes (optional)
Before
<img width="1320" height="896" alt="image" src="https://github.com/user-attachments/assets/9cce940c-510b-4750-82bf-9fd6dd3c6e0b" />

After
<img width="3092" height="1808" alt="Screenshot 2026-01-19 at 3 17 05 PM" src="https://github.com/user-attachments/assets/313c06aa-0e5e-4422-817d-6a33300ae722" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
No