### PR TITLE
allow adding same components multiple times in 'sequence' using blocks

### DIFF
--- a/src/analysis/individualStudy/stats/TrialVisualization.tsx
+++ b/src/analysis/individualStudy/stats/TrialVisualization.tsx
@@ -4,7 +4,7 @@ import {
 import { useMemo } from 'react';
 import { ParticipantData } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
-import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
+import { getComponentName, studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { ResponseVisualization } from './ResponseVisualization';
 
 export function TrialVisualization({
@@ -12,7 +12,8 @@ export function TrialVisualization({
 }: {
   participantData: ParticipantData[]; studyConfig: StudyConfig, trialId?: string;
 }) {
-  const trialConfig = trialId && trialId !== 'end' && studyComponentToIndividualComponent(studyConfig.components[trialId], studyConfig);
+  const componentName = getComponentName(trialId || '');
+  const trialConfig = trialId && trialId !== 'end' && studyComponentToIndividualComponent(studyConfig.components[componentName], studyConfig);
 
   const items = useMemo(() => [
     { id: 'Config and Timing', type: 'metadata' } as { id: 'Config and Timing', type: 'metadata'},

--- a/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
+++ b/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
@@ -160,7 +160,7 @@ export function ThinkAloudFooter({
       setSearchParams({ participantId, currentTrial: Object.entries(participant.answers).find(([_, ans]) => +ans.trialOrder.split('_')[0] === 0)?.[0] || '' });
     }
 
-    return participant?.answers[currentTrial]?.componentName ?? '';
+    return participant?.answers[currentTrial]?.identifier.replace(/_[^_]*$/, '') ?? '';
   }, [currentTrial, participant, participantId, setSearchParams]);
 
   const xScale = useMemo(() => {
@@ -416,7 +416,7 @@ export function ThinkAloudFooter({
               // this needs to be in a helper or two which we dont currently have
               onChange={(e: string | null) => {
                 if (participant && e) {
-                  const trial = Object.entries(participant.answers).find(([_key, ans]) => +ans.trialOrder.split('_')[0] === getSequenceFlatMap(participant?.sequence).indexOf(e))?.[0] || '';
+                  const trial = Object.entries(participant.answers).find(([_key, ans]) => +ans.trialOrder.split('_')[0] === getSequenceFlatMap(participant?.sequence, '').indexOf(e))?.[0] || '';
                   localStorage.setItem('currentTrial', trial);
 
                   setSearchParams({ participantId, currentTrial: trial });

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -17,7 +17,7 @@ import { WindowEventsContext } from '../store/hooks/useWindowEvents';
 import { useStoreSelector, useStoreDispatch, useStoreActions } from '../store/store';
 import { AnalysisFooter } from './interface/AnalysisFooter';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
-import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
+import { getComponentName, studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 import { useCurrentComponent } from '../routes/utils';
 import { ResolutionWarning } from './interface/ResolutionWarning';
 import { useFetchStylesheet } from '../utils/fetchStylesheet';
@@ -35,7 +35,7 @@ export function StepRenderer() {
   const studyConfig = useStudyConfig();
   const currentComponent = useCurrentComponent();
 
-  const componentConfig = useMemo(() => studyComponentToIndividualComponent(studyConfig.components[currentComponent] || {}, studyConfig), [currentComponent, studyConfig]);
+  const componentConfig = useMemo(() => studyComponentToIndividualComponent(studyConfig.components[getComponentName(currentComponent)] || {}, studyConfig), [currentComponent, studyConfig]);
 
   const windowEventDebounceTime = useMemo(() => componentConfig.windowEventDebounceTime ?? studyConfig.uiConfig.windowEventDebounceTime ?? 100, [componentConfig, studyConfig]);
 
@@ -130,7 +130,7 @@ export function StepRenderer() {
   const { developmentModeEnabled, dataCollectionEnabled } = useMemo(() => modes, [modes]);
 
   // No default value for withSidebar since it's a required field in uiConfig
-  const sidebarOpen = useMemo(() => (((analysisHasScreenRecording && analysisCanPlayScreenRecording) || currentComponent === 'end') ? false : (componentConfig.withSidebar ?? studyConfig.uiConfig.withSidebar)), [analysisHasScreenRecording, analysisCanPlayScreenRecording, currentComponent, componentConfig.withSidebar, studyConfig.uiConfig.withSidebar]);
+  const sidebarOpen = useMemo(() => (((analysisHasScreenRecording && analysisCanPlayScreenRecording) || getComponentName(currentComponent) === 'end') ? false : (componentConfig.withSidebar ?? studyConfig.uiConfig.withSidebar)), [analysisHasScreenRecording, analysisCanPlayScreenRecording, currentComponent, componentConfig.withSidebar, studyConfig.uiConfig.withSidebar]);
   const sidebarWidth = useMemo(() => componentConfig?.sidebarWidth ?? studyConfig.uiConfig.sidebarWidth ?? 300, [componentConfig, studyConfig]);
   const showTitleBar = useMemo(() => componentConfig.showTitleBar ?? studyConfig.uiConfig.showTitleBar ?? true, [componentConfig, studyConfig]);
 

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -36,7 +36,7 @@ import { calculateProgressData } from '../../storage/engines/utils';
 import { PREFIX } from '../../utils/Prefix';
 import { getNewParticipant } from '../../utils/nextParticipant';
 import { RecordingAudioWaveform } from './RecordingAudioWaveform';
-import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
+import { getComponentName, studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
 import { useRecordingContext } from '../../store/hooks/useRecording';
 
 export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { developmentModeEnabled: boolean; dataCollectionEnabled: boolean }) {
@@ -50,7 +50,7 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
   const { storageEngine } = useStorageEngine();
 
   const currentComponent = useCurrentComponent();
-  const componentConfig = useMemo(() => studyComponentToIndividualComponent(studyConfig.components[currentComponent] || {}, studyConfig), [currentComponent, studyConfig]);
+  const componentConfig = useMemo(() => studyComponentToIndividualComponent(studyConfig.components[getComponentName(currentComponent)] || {}, studyConfig), [currentComponent, studyConfig]);
 
   const currentStep = useCurrentStep();
 

--- a/src/components/interface/AppNavBar.tsx
+++ b/src/components/interface/AppNavBar.tsx
@@ -5,13 +5,13 @@ import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import { useStoredAnswer } from '../../store/hooks/useStoredAnswer';
 import { ResponseBlock } from '../response/ResponseBlock';
 import { useCurrentComponent } from '../../routes/utils';
-import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
+import { getComponentName, studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
 
 export function AppNavBar({ width, top, sidebarOpen }: { width: number, top: number, sidebarOpen: boolean }) {
   // Get the config for the current step
   const studyConfig = useStudyConfig();
   const currentComponent = useCurrentComponent();
-  const stepConfig = studyConfig.components[currentComponent];
+  const stepConfig = studyConfig.components[getComponentName(currentComponent)];
 
   const currentConfig = useMemo(() => {
     if (stepConfig) {

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -31,7 +31,7 @@ import { findBlockForStep } from '../utils/getSequenceFlatMap';
 import { VegaController, VegaProvState } from './VegaController';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
 import { VideoController } from './VideoController';
-import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
+import { getComponentName, studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 import { useFetchStylesheet } from '../utils/fetchStylesheet';
 import { ScreenRecordingReplay } from '../components/screenRecording/ScreenRecordingReplay';
 import { decryptIndex, encryptIndex } from '../utils/encryptDecryptIndex';
@@ -45,7 +45,7 @@ export function ComponentController() {
   const currentComponent = useCurrentComponent();
   const studyId = useStudyId();
 
-  const stepConfig = studyConfig.components[currentComponent];
+  const stepConfig = studyConfig.components[getComponentName(currentComponent)];
   const { storageEngine } = useStorageEngine();
 
   const answers = useStoreSelector((store) => store.answers);

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -10,7 +10,7 @@ import { decryptIndex, encryptIndex } from '../utils/encryptDecryptIndex';
 import { JumpFunctionParameters, JumpFunctionReturnVal } from '../store/types';
 import { findFuncBlock } from '../utils/getSequenceFlatMap';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
-import { getComponent } from '../utils/handleComponentInheritance';
+import { getComponent, getComponentName } from '../utils/handleComponentInheritance';
 
 export function useStudyId(): string {
   const { studyId } = useParams();
@@ -54,7 +54,7 @@ export function useCurrentComponent(): string {
 
   const [indexWhenSettingComponentName, setIndexWhenSettingComponentName] = useState<number | null>(null);
 
-  const currentComponent = useMemo(() => (typeof currentStep === 'number' ? getComponent(flatSequence[currentStep], studyConfig) : currentStep.includes('reviewer-') || currentStep.startsWith('__') ? currentStep : null), [currentStep, flatSequence, studyConfig]);
+  const currentComponent = useMemo(() => (typeof currentStep === 'number' ? getComponent(getComponentName(flatSequence[currentStep]), studyConfig) : currentStep.includes('reviewer-') || currentStep.startsWith('__') ? currentStep : null), [currentStep, flatSequence, studyConfig]);
 
   const [compName, setCompName] = useState('__dynamicLoading');
 
@@ -82,7 +82,7 @@ export function useCurrentComponent(): string {
 
   useEffect(() => {
     if (typeof currentStep === 'number') {
-      const component = getComponent(flatSequence[currentStep], studyConfig);
+      const component = getComponent(getComponentName(flatSequence[currentStep]), studyConfig);
 
       const funcName = flatSequence[currentStep];
       const decryptedFuncIndex = funcIndex ? decryptIndex(funcIndex) : 0;

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -23,9 +23,11 @@ import {
 import { decryptIndex, encryptIndex } from '../../utils/encryptDecryptIndex';
 import { useIsAnalysis } from './useIsAnalysis';
 import { componentAnswersAreCorrect } from '../../utils/correctAnswer';
+import { getComponentName } from '../../utils/handleComponentInheritance';
 
 function checkAllAnswersCorrect(answers: StoredAnswer['answer'], componentId: string, componentConfig: IndividualComponent | InheritedComponent, studyConfig: StudyConfig) {
-  const componentName = componentId.slice(0, componentId.lastIndexOf('_'));
+  const component = componentId.slice(0, componentId.lastIndexOf('_'));
+  const componentName = getComponentName(component);
 
   // Find the matching component in the study config
   const foundConfigComponent = Object.entries(studyConfig.components).find(([configComponentId]) => configComponentId === componentName);

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -11,7 +11,7 @@ import {
 } from './types';
 import { getSequenceFlatMap } from '../utils/getSequenceFlatMap';
 import { REVISIT_MODE } from '../storage/engines/types';
-import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
+import { getComponentName, studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 import { randomizeOptions, randomizeQuestionOrder, randomizeForm } from '../utils/handleResponseRandomization';
 
 export async function studyStoreCreator(
@@ -29,10 +29,10 @@ export async function studyStoreCreator(
 
   const emptyAnswers: ParticipantData['answers'] = Object.fromEntries(flatSequence.filter((id) => id !== 'end')
     .map((id, idx) => {
-      const componentConfig = studyComponentToIndividualComponent(config.components[id] || {}, config);
-
+      const componentName = getComponentName(id);
+      const componentConfig = studyComponentToIndividualComponent(config.components[componentName] || {}, config);
       // Make sure we dont include dynamic blocks as empty answers
-      if (!config.components[id]) {
+      if (!config.components[componentName]) {
         return null;
       }
 
@@ -42,7 +42,7 @@ export async function studyStoreCreator(
           answer: {},
           identifier: `${id}_${idx}`,
           trialOrder: `${idx}`,
-          componentName: id,
+          componentName,
           incorrectAnswers: {},
           startTime: 0,
           endTime: -1,

--- a/src/utils/getSequenceFlatMap.ts
+++ b/src/utils/getSequenceFlatMap.ts
@@ -2,8 +2,10 @@ import { DynamicBlock, StudyConfig } from '../parser/types';
 import { isDynamicBlock } from '../parser/utils';
 import { Sequence } from '../store/types';
 
-export function getSequenceFlatMap<T extends Sequence | StudyConfig['sequence']>(sequence: T): string[] {
-  return isDynamicBlock(sequence) ? [sequence.id] : sequence.components.flatMap((component) => (typeof component === 'string' ? component : getSequenceFlatMap(component)));
+export function getSequenceFlatMap<T extends Sequence | StudyConfig['sequence']>(sequence: T, block:string = ''): string[] {
+  return isDynamicBlock(sequence)
+    ? [`${block ? `${block}:` : ''}${sequence.id}`]
+    : sequence.components.flatMap((component) => (typeof component === 'string' ? (`${sequence.id ? `${sequence.id}:` : ''}${component}`) : getSequenceFlatMap(component, `${block}:${sequence.id || ''}`)));
 }
 
 function findAllFuncBlocks(sequence: StudyConfig['sequence']): DynamicBlock[] {

--- a/src/utils/handleComponentInheritance.ts
+++ b/src/utils/handleComponentInheritance.ts
@@ -19,3 +19,8 @@ export function getComponent(name: string, studyConfig: StudyConfig): Individual
   }
   return studyComponentToIndividualComponent(studyConfig.components[name], studyConfig);
 }
+
+export function getComponentName(sequenceName: string) {
+  const m = sequenceName.split(':');
+  return m[m.length - 1];
+}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1029 

### Give a longer description of what this PR addresses and why it's needed
Currently, same component cannot be added twice in `sequence` restricting us to reuse components. This also applied to libraries.
This PR allows same component name to be in the `sequence` by separating into blocks.

Example:
```json
{
    "components": [
      "introduction",
      "$demographics.components.demographics",
      "barChart",
      {
        "id": "block1",
        "order": "fixed",
        "components": ["barChart"]
      },
      {
        "id": "block2",
        "order": "fixed",
        "components": ["barChart"]
      },
      {
        "id": "block3",
        "order": "fixed",
        "components": ["$demographics.components.demographics"]
      },
      {
        "id": "block4",
        "order": "fixed",
        "components": ["$demographics.components.demographics"]
      },
      {
        "id": "block5",
        "order": "fixed",
        "components": [
          {
            "order": "fixed",
            "id": "block5-1",
            "components": ["$demographics.components.demographics"]
          }
        ]
      },
      "external_website"
    ]
}
```
 