### PR TITLE
Allow failed training next on invalid

### DIFF
--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -127,13 +127,14 @@ export function ResponseBlock({
   const studyConfig = useStudyConfig();
 
   const provideFeedback = useMemo(() => config?.provideFeedback ?? studyConfig.uiConfig.provideFeedback, [config, studyConfig]);
-  const hasCorrectAnswerFeedback = provideFeedback && ((config?.correctAnswer?.length || 0) > 0);
+  const hasCorrectAnswerFeedback = !!provideFeedback && ((config?.correctAnswer?.length || 0) > 0);
   const allowFailedTraining = useMemo(() => config?.allowFailedTraining ?? studyConfig.uiConfig.allowFailedTraining ?? true, [config, studyConfig]);
   const [attemptsUsed, setAttemptsUsed] = useState(0);
   const trainingAttempts = useMemo(() => config?.trainingAttempts ?? studyConfig.uiConfig.trainingAttempts ?? 2, [config, studyConfig]);
   const [enableNextButton, setEnableNextButton] = useState(false);
   const [hasCorrectAnswer, setHasCorrectAnswer] = useState(false);
   const usedAllAttempts = attemptsUsed >= trainingAttempts && trainingAttempts >= 0;
+  const bypassValidationForFailedTraining = hasCorrectAnswerFeedback && allowFailedTraining && usedAllAttempts;
   const disabledAttempts = usedAllAttempts || hasCorrectAnswer;
   const showBtnsInLocation = useMemo(() => location === (config?.nextButtonLocation ?? studyConfig.uiConfig.nextButtonLocation ?? 'belowStimulus'), [config, studyConfig, location]);
   const identifier = useCurrentIdentifier();
@@ -200,13 +201,13 @@ export function ResponseBlock({
       updateResponseBlockValidation({
         location,
         identifier,
-        status: answerValidator.isValid(),
+        status: answerValidator.isValid() || bypassValidationForFailedTraining,
         values: structuredClone(answerValidator.values),
         provenanceGraph: trrack.graph.backend,
       }),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [answerValidator.values, identifier, location, storeDispatch, updateResponseBlockValidation]);
+  }, [answerValidator.values, bypassValidationForFailedTraining, identifier, location, storeDispatch, updateResponseBlockValidation]);
   const [alertConfig, setAlertConfig] = useState(Object.fromEntries(allResponsesWithDefaults.map((response) => ([response.id, {
     visible: false,
     title: 'Correct Answer',
@@ -379,7 +380,8 @@ export function ResponseBlock({
 
       {showBtnsInLocation && (
       <NextButton
-        disabled={(hasCorrectAnswerFeedback && !enableNextButton) || !answerValidator.isValid()}
+        disabled={(hasCorrectAnswerFeedback && !enableNextButton)
+          || (!bypassValidationForFailedTraining && !answerValidator.isValid())}
         label={nextButtonText}
         config={config}
         location={location}

--- a/tests/test-training-feedback.spec.ts
+++ b/tests/test-training-feedback.spec.ts
@@ -1,5 +1,6 @@
+/* eslint-disable no-await-in-loop */
 import { test, expect, Page } from '@playwright/test';
-import { nextClick } from './utils';
+import { nextClick, openStudyFromLanding, resetClientStudyState } from './utils';
 
 async function goToTraining(page: Page) {
   await expect(page.getByRole('heading', { name: 'Introduction' })).toBeVisible();
@@ -35,6 +36,66 @@ async function answerTrainingTrialCorrectly(page: Page) {
   await expect(nextButton).toBeEnabled();
   await nextClick(page);
 }
+
+async function answerSimpleDropboxIncorrectly(page: Page) {
+  await page.getByPlaceholder('Choose mark').click();
+  await page.getByRole('option', { name: 'Bubble', exact: true }).click();
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+}
+
+async function exhaustSimpleDropboxAttemptsWithoutAnswer(page: Page, attempts: number) {
+  const checkAnswerButton = page.getByRole('button', { name: 'Check Answer' });
+  for (let i = 0; i < attempts; i += 1) {
+    await checkAnswerButton.click();
+  }
+}
+
+test('allowFailedTraining=true enables Next after max failed attempts', async ({ page }) => {
+  await resetClientStudyState(page);
+  await openStudyFromLanding(page, 'Demo Studies', 'How To Do Training Demo');
+
+  // Move from intro to first training component.
+  await nextClick(page);
+  await expect(page.getByPlaceholder('Choose mark')).toBeVisible();
+
+  const nextButton = page.getByRole('button', { name: 'Next', exact: true });
+  const checkAnswerButton = page.getByRole('button', { name: 'Check Answer' });
+
+  await expect(nextButton).toBeDisabled();
+
+  await answerSimpleDropboxIncorrectly(page);
+  await answerSimpleDropboxIncorrectly(page);
+  await answerSimpleDropboxIncorrectly(page);
+  await answerSimpleDropboxIncorrectly(page);
+
+  await expect(page.getByText('You didn\'t answer this question correctly after 4 attempts. You can continue to the next question.')).toBeVisible();
+  await expect(page.getByText('The correct answer was: Bar.')).toBeVisible();
+  await expect(nextButton).toBeEnabled();
+  await expect(checkAnswerButton).toBeDisabled();
+  await expect(page.getByPlaceholder('Choose mark')).toBeDisabled();
+});
+
+test('allowFailedTraining=true enables Next after max failed invalid attempts', async ({ page }) => {
+  await resetClientStudyState(page);
+  await openStudyFromLanding(page, 'Demo Studies', 'How To Do Training Demo');
+
+  // Move from intro to first training component.
+  await nextClick(page);
+  await expect(page.getByPlaceholder('Choose mark')).toBeVisible();
+
+  const nextButton = page.getByRole('button', { name: 'Next', exact: true });
+  const checkAnswerButton = page.getByRole('button', { name: 'Check Answer' });
+
+  await expect(nextButton).toBeDisabled();
+
+  // Leave the required dropdown unanswered and consume all attempts.
+  await exhaustSimpleDropboxAttemptsWithoutAnswer(page, 4);
+
+  await expect(page.getByText('You didn\'t answer this question correctly after 4 attempts. You can continue to the next question.')).toBeVisible();
+  await expect(page.getByText('The correct answer was: Bar.')).toBeVisible();
+  await expect(nextButton).toBeEnabled();
+  await expect(checkAnswerButton).toBeDisabled();
+});
 
 test('test', async ({ page }) => {
   await page.goto('/');


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1136

### Give a longer description of what this PR addresses and why it's needed
Next will still stay disabled if the response is invalid/empty (!answerValidator.isValid()), even after max attempts.

I'm fixing it up so that this isn't the case

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No