### PR TITLE
Fix forced video completion next-state and add regression test

### DIFF
--- a/src/controllers/VideoController.tsx
+++ b/src/controllers/VideoController.tsx
@@ -45,23 +45,39 @@ const CustomPlyrInstance = forwardRef<APITypes, PlyrProps & { endedCallback:() =
     const raptorRef = usePlyr(ref, { options, source });
 
     useEffect(() => {
-      const plyr = (ref as RefObject<APITypes>).current?.plyr;
-      if (!plyr || typeof plyr.on !== 'function' || typeof plyr.off !== 'function') return undefined;
+      let animationFrameId: number | undefined;
+      let cleanup = () => {};
 
-      try {
-        // Make registration idempotent across StrictMode mount/unmount cycles.
-        plyr.off('ended', endedCallback);
-        plyr.on('ended', endedCallback);
-      } catch {
-        return undefined;
-      }
+      const registerEndedHandler = () => {
+        const plyr = (ref as RefObject<APITypes>).current?.plyr;
+        if (!plyr || typeof plyr.on !== 'function' || typeof plyr.off !== 'function') {
+          animationFrameId = window.requestAnimationFrame(registerEndedHandler);
+          return;
+        }
+
+        try {
+          // Make registration idempotent across StrictMode mount/unmount cycles.
+          plyr.off('ended', endedCallback);
+          plyr.on('ended', endedCallback);
+          cleanup = () => {
+            try {
+              plyr.off('ended', endedCallback);
+            } catch {
+              // Plyr instance can already be disposed during teardown.
+            }
+          };
+        } catch {
+          cleanup = () => {};
+        }
+      };
+
+      registerEndedHandler();
 
       return () => {
-        try {
-          plyr.off('ended', endedCallback);
-        } catch {
-          // Plyr instance can already be disposed during teardown.
+        if (animationFrameId !== undefined) {
+          window.cancelAnimationFrame(animationFrameId);
         }
+        cleanup();
       };
     }, [endedCallback, ref, source]);
 
@@ -69,6 +85,8 @@ const CustomPlyrInstance = forwardRef<APITypes, PlyrProps & { endedCallback:() =
       <video
         ref={raptorRef}
         className="plyr-react plyr"
+        // Ensure HTML5 videos still trigger completion even if Plyr event wiring fails.
+        onEnded={endedCallback}
       />
     );
   });

--- a/tests/demo-video.spec.ts
+++ b/tests/demo-video.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { nextClick, openStudyFromLanding, resetClientStudyState } from './utils';
+
+test('forceCompletion video enables Next after video end', async ({ page }) => {
+  await resetClientStudyState(page);
+  await openStudyFromLanding(page, 'Demo Studies', 'Video as a Stimulus');
+
+  await expect(page.getByText(/example study.*video stimulus/i)).toBeVisible();
+  await nextClick(page);
+
+  const video = page.locator('video');
+  const nextButton = page.getByRole('button', { name: 'Next', exact: true });
+
+  await expect(video).toBeVisible();
+  await expect(nextButton).toBeDisabled();
+
+  await video.evaluate((videoNode) => {
+    videoNode.dispatchEvent(new Event('ended', { bubbles: true }));
+  });
+
+  await expect(nextButton).toBeEnabled();
+});


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1134 

### Give a longer description of what this PR addresses and why it's needed
Fixes a regression where video components with forceCompletion: true kept Next disabled after playback ended, because the video-ended completion callback could fail to bind.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No