### PR TITLE
Fix dotted study IDs in routing/config lookup and add tests

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -4,6 +4,8 @@ Files that are in the `public` folder are exposed on the study website. For tech
 
 If you want to create a new experiment, you should create a new subfolder in this `public` folder that contains your reVISit config.
 
+Study folder names can include periods (`.`), spaces, and other characters, but reVISit normalizes study URLs by replacing periods/spaces/slashes with underscores. Use links generated in the app to avoid mismatched manual URLs.
+
 Example projects that explain basic reVISit functionality are: 
 
  * [image-demo](image-demo) is the most basic study example that uses images for study stimuli. 

--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -20,7 +20,7 @@ import { fetchStudyConfigs } from './utils/fetchConfig';
 import { initializeStorageEngine } from './storage/initialize';
 import { useStorageEngine } from './storage/storageEngineHooks';
 import { PageTitle } from './utils/PageTitle';
-import { isCloudStorageEngine } from './storage/engines/utils';
+import { shouldProtectAnalysisRoute } from './utils/analysisRouteAccess';
 
 async function fetchGlobalConfigArray() {
   const globalFile = await fetch(`${PREFIX}global.json`);
@@ -62,16 +62,11 @@ export function GlobalConfigParser() {
   }, [setStorageEngine, storageEngine]);
 
   const analysisProtectedCallback = async (studyId: string) => {
-    if (storageEngine && isCloudStorageEngine(storageEngine)) {
-      const modes = await storageEngine.getModes(studyId);
-      if (modes.dataSharingEnabled) {
-        // If accessible, disable
-        return false;
-      }
-      // If not accessible, enable protection
-      return true;
+    if (!globalConfig) {
+      return false;
     }
-    return false;
+
+    return shouldProtectAnalysisRoute(studyId, globalConfig, storageEngine);
   };
 
   return globalConfig ? (

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -16,7 +16,7 @@ import {
 import { useResizeObserver } from '@mantine/hooks';
 import { AppHeader } from '../interface/AppHeader';
 import { GlobalConfig, ParticipantData, StudyConfig } from '../../parser/types';
-import { getStudyConfig } from '../../utils/fetchConfig';
+import { getStudyConfig, resolveConfigKey } from '../../utils/fetchConfig';
 import { LiveMonitorView } from './LiveMonitor/LiveMonitorView';
 import { SummaryView } from './summary/SummaryView';
 import { TableView } from './table/TableView';
@@ -63,7 +63,7 @@ async function getParticipantsData(studyConfig: StudyConfig | undefined, storage
 }
 
 export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig; }) {
-  const { studyId } = useParams();
+  const { studyId: routeStudyId } = useParams();
   const [studyConfig, setStudyConfig] = useState<StudyConfig | undefined>(undefined);
 
   const [includedParticipants, setIncludedParticipants] = useState<string[]>(['completed', 'inprogress', 'rejected']);
@@ -84,10 +84,18 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   const { analysisTab } = useParams();
   const { user } = useAuth();
   const [ref, { width }] = useResizeObserver();
+  const canonicalStudyId = useMemo(() => {
+    if (!routeStudyId || routeStudyId === '__revisit-widget') {
+      return routeStudyId;
+    }
+
+    return resolveConfigKey(routeStudyId, globalConfig);
+  }, [globalConfig, routeStudyId]);
+  const displayStudyId = canonicalStudyId ?? routeStudyId;
 
   // 0-1 percentage of scroll height
 
-  const { value: expData, execute, status } = useAsync(getParticipantsData, [studyConfig, storageEngine, studyId]);
+  const { value: expData, execute, status } = useAsync(getParticipantsData, [studyConfig, storageEngine, canonicalStudyId ?? undefined]);
 
   const participantCounts = useMemo(() => {
     if (!expData) return { completed: 0, inprogress: 0, rejected: 0 };
@@ -163,10 +171,10 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
 
   // Load available stages
   const loadStages = useCallback(async () => {
-    if (!studyId || !storageEngine) return;
+    if (!canonicalStudyId || !storageEngine) return;
 
     try {
-      const stageData = await storageEngine.getStageData(studyId);
+      const stageData = await storageEngine.getStageData(canonicalStudyId);
       const stageOptions = stageData.allStages.map((stage) => ({
         value: stage.stageName,
         label: stage.stageName,
@@ -183,11 +191,11 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       setAvailableStages([{ value: 'ALL', label: 'ALL' }]);
       setStageColors({});
     }
-  }, [studyId, storageEngine]);
+  }, [canonicalStudyId, storageEngine]);
 
   // Load available configs
   const loadConfigs = useCallback(async () => {
-    if (!studyId || !storageEngine) return;
+    if (!canonicalStudyId || !storageEngine) return;
 
     try {
       const participantData = expData ? Object.values(expData) : [];
@@ -195,7 +203,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
         participantData.map((participant) => participant.participantConfigHash),
       )];
 
-      const fetchedConfigs = await storageEngine.getAllConfigsFromHash(participantConfig, studyId);
+      const fetchedConfigs = await storageEngine.getAllConfigsFromHash(participantConfig, canonicalStudyId);
 
       const configOptions = Object.entries(fetchedConfigs)
         .map(([hash, config]) => ({
@@ -207,7 +215,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       console.error('Failed to load configs:', error);
       setAvailableConfigs([{ value: 'ALL', label: 'ALL' }]);
     }
-  }, [studyId, storageEngine, expData]);
+  }, [canonicalStudyId, storageEngine, expData]);
 
   const allConditions = useMemo(() => {
     if (!expData) return [];
@@ -255,8 +263,8 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   }, [allConditions]);
 
   useEffect(() => {
-    if (!studyId) return () => { };
-    if (studyId === '__revisit-widget') {
+    if (!routeStudyId) return () => { };
+    if (routeStudyId === '__revisit-widget') {
       const messageListener = async (event: MessageEvent) => {
         if (event.data.type === 'revisitWidget/CONFIG' && storageEngine) {
           const cf = await parseStudyConfig(event.data.payload);
@@ -270,16 +278,16 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
         window.removeEventListener('message', messageListener);
       };
     }
-    getStudyConfig(studyId, globalConfig).then((cf) => {
+    getStudyConfig(routeStudyId, globalConfig).then((cf) => {
       if (cf) {
         setStudyConfig(cf);
       }
     });
 
     return () => { };
-  }, [studyId, globalConfig, storageEngine]);
+  }, [routeStudyId, globalConfig, storageEngine]);
 
-  if (!studyId) {
+  if (!routeStudyId) {
     return (
       <>
         <AppHeader studyIds={globalConfig.configsList} />
@@ -294,16 +302,16 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
 
   return (
     <>
-      <AppHeader studyIds={globalConfig.configsList} />
+      <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyHref={routeStudyId ? `/${routeStudyId}` : undefined} />
       <AppShell.Main style={{ height: '100dvh' }}>
         <Stack ref={ref} style={{ height: '100%', maxHeight: '100dvh', overflow: 'hidden' }} justify="space-between">
           <Flex direction="row" align="center" justify="space-between" p="sm" gap="md">
             <Flex direction="row" align="center" gap="md">
-              <Title order={5}>{studyId}</Title>
-              {studyConfig && (
+              <Title order={5}>{displayStudyId}</Title>
+              {studyConfig && canonicalStudyId && (
                 <DownloadButtons
                   visibleParticipants={selectedParticipants.length > 0 ? selectedParticipants : visibleParticipants}
-                  studyId={studyId || ''}
+                  studyId={canonicalStudyId}
                   gap="10px"
                   hasAudio={hasAudioRecording}
                   hasScreenRecording={hasScreenRecording}
@@ -440,7 +448,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
               keepMounted={false}
               variant="outline"
               value={analysisTab}
-              onChange={(value) => navigate(`/analysis/stats/${studyId}/${value}`)}
+              onChange={(value) => navigate(`/analysis/stats/${routeStudyId}/${value}`)}
             >
               <Tabs.List>
                 <Tabs.Tab value="summary" leftSection={<IconChartPie size={16} />}>Study Summary</Tabs.Tab>
@@ -454,27 +462,27 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin}>Manage</Tabs.Tab>
               </Tabs.List>
               <Tabs.Panel style={{ overflow: 'auto' }} value="summary" pt="xs">
-                {studyConfig && <SummaryView studyConfig={studyConfig} visibleParticipants={visibleParticipants} />}
+                {studyConfig && <SummaryView studyConfig={studyConfig} visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ height: `calc(100% - ${TABLE_HEADER_HEIGHT}px)` }} value="table" pt="xs">
-                {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} refresh={() => execute(studyConfig, storageEngine, studyId)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
+                {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="stats" pt="xs">
-                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} />}
+                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel value="tagging" pt="xs">
                 {studyConfig && storageEngine?.getEngine() === 'firebase' ? <ThinkAloudAnalysis visibleParticipants={visibleParticipants} storageEngine={storageEngine as FirebaseStorageEngine} /> : <Center>Think aloud coding is only available when using Firebase.</Center>}
               </Tabs.Panel>
               {storageEngine?.getEngine() === 'firebase' && (
                 <Tabs.Panel style={{ overflow: 'auto' }} value="live-monitor" pt="xs">
-                  {studyConfig && <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={studyId} includedParticipants={includedParticipants} selectedStages={selectedStages} />}
+                  {studyConfig && <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />}
                 </Tabs.Panel>
               )}
               <Tabs.Panel style={{ overflow: 'auto' }} value="config" pt="xs">
-                {studyConfig && <ConfigView visibleParticipants={visibleParticipants} />}
+                {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="manage" pt="xs">
-                {studyId && user.isAdmin ? <ManageView studyId={studyId} refresh={() => execute(studyConfig, storageEngine, studyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
+                {canonicalStudyId && user.isAdmin ? <ManageView studyId={canonicalStudyId} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
               </Tabs.Panel>
             </Tabs>
           ) : null}

--- a/src/analysis/individualStudy/config/ConfigView.tsx
+++ b/src/analysis/individualStudy/config/ConfigView.tsx
@@ -5,7 +5,6 @@ import {
 import {
   useCallback, useEffect, useMemo, useState,
 } from 'react';
-import { useParams } from 'react-router';
 import {
   MantineReactTable, MRT_Cell as MrtCell, MRT_ColumnDef as MrtColumnDef, MRT_RowSelectionState as MrtRowSelectionState, useMantineReactTable,
 } from 'mantine-react-table';
@@ -20,10 +19,11 @@ import { ConfigDiffModal } from './ConfigDiffModal';
 
 export function ConfigView({
   visibleParticipants,
+  studyId,
 }: {
   visibleParticipants: ParticipantData[];
+  studyId?: string;
 }) {
-  const { studyId } = useParams();
   const [checked, setChecked] = useState<MrtRowSelectionState>({});
   const { storageEngine } = useStorageEngine();
   const [configs, setConfigs] = useState<ConfigInfo[]>([]);

--- a/src/analysis/individualStudy/stats/StatsView.tsx
+++ b/src/analysis/individualStudy/stats/StatsView.tsx
@@ -14,9 +14,11 @@ export function StatsView(
   {
     studyConfig,
     visibleParticipants,
+    studyId,
   }: {
     studyConfig: StudyConfig;
     visibleParticipants: ParticipantData[];
+    studyId?: string;
   },
 ) {
   const { trialId } = useParams();
@@ -29,7 +31,7 @@ export function StatsView(
   return (
     <>
       {overviewData && (
-        <OverviewStats overviewData={overviewData} />
+        <OverviewStats overviewData={overviewData} studyId={studyId} />
       )}
       <Paper shadow="sm" p="md" mt="md" withBorder>
         {

--- a/src/analysis/individualStudy/summary/OverviewStats.tsx
+++ b/src/analysis/individualStudy/summary/OverviewStats.tsx
@@ -3,7 +3,6 @@ import {
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useMemo } from 'react';
-import { useParams } from 'react-router';
 import { convertNumberToString } from './utils';
 import { OverviewData } from '../../types';
 import { useStorageEngine } from '../../../storage/storageEngineHooks';
@@ -17,13 +16,14 @@ async function getStoredParticipantCounts(storageEngine: StorageEngine, studyId:
 
 export function OverviewStats({
   overviewData,
+  studyId,
 }: {
   overviewData: OverviewData;
+  studyId?: string;
 }) {
   // Check if there are participants with invalid clean time (e.g. due to a window events bug)
   const hasExcluded = overviewData && overviewData.participantsWithInvalidCleanTimeCount > 0;
 
-  const { studyId } = useParams();
   const { storageEngine } = useStorageEngine();
 
   // Get the stored participant counts from the storage engine

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -10,15 +10,17 @@ import { getOverviewStats } from './utils';
 export function SummaryView({
   visibleParticipants,
   studyConfig,
+  studyId,
 }: {
   visibleParticipants: ParticipantData[];
   studyConfig: StudyConfig;
+  studyId?: string;
 }) {
   const overviewData = useMemo(() => getOverviewStats(visibleParticipants), [visibleParticipants]);
 
   return (
     <Stack gap="md">
-      <OverviewStats overviewData={overviewData} />
+      <OverviewStats overviewData={overviewData} studyId={studyId} />
       <Group align="flex-start" gap="md" grow>
         <ComponentStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} />
         <ResponseStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} />

--- a/src/analysis/interface/AppHeader.tsx
+++ b/src/analysis/interface/AppHeader.tsx
@@ -7,7 +7,15 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { IconListCheck, IconSettings } from '@tabler/icons-react';
 import { PREFIX } from '../../utils/Prefix';
 
-export function AppHeader({ studyIds }: { studyIds: string[] }) {
+export function AppHeader({
+  studyIds,
+  selectedStudyId,
+  studyHref,
+}: {
+  studyIds: string[];
+  selectedStudyId?: string;
+  studyHref?: string;
+}) {
   const navigate = useNavigate();
   const { studyId } = useParams();
   const location = useLocation();
@@ -40,11 +48,11 @@ export function AppHeader({ studyIds }: { studyIds: string[] }) {
                   allowDeselect={false}
                   placeholder="Select Study"
                   data={selectorData}
-                  value={studyId}
+                  value={selectedStudyId ?? studyId}
                   onChange={(value) => navigate(`/analysis/stats/${value}`)}
                   mr={16}
                 />
-                <Button component="a" href={`${PREFIX}${studyId}`} target="_blank" leftSection={<IconListCheck />} mr="sm">
+                <Button component="a" href={studyHref ?? `${PREFIX}${studyId}`} target="_blank" leftSection={<IconListCheck />} mr="sm">
                   Go to Study
                 </Button>
               </>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -25,7 +25,7 @@ import { NavigateWithParams } from '../utils/NavigateWithParams';
 import { StepRenderer } from './StepRenderer';
 import { useStorageEngine } from '../storage/storageEngineHooks';
 import { generateSequenceArray } from '../utils/handleRandomSequences';
-import { getStudyConfig } from '../utils/fetchConfig';
+import { getStudyConfig, resolveConfigKey } from '../utils/fetchConfig';
 import { ParticipantMetadata } from '../store/types';
 import { ErrorLoadingConfig } from './ErrorLoadingConfig';
 import { ResourceNotFound } from '../ResourceNotFound';
@@ -42,7 +42,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   // Pull study config
   const studyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedConfig<StudyConfig> | null>(null);
-  const isValidStudyId = globalConfig.configsList.includes(studyId) || studyId === '__revisit-widget';
+  const isValidStudyId = studyId === '__revisit-widget' || resolveConfigKey(studyId, globalConfig) !== null;
 
   useEffect(() => {
     if (studyId !== '__revisit-widget') {

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -40,18 +40,25 @@ import {
 
 export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   // Pull study config
-  const studyId = useStudyId();
+  const routeStudyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedConfig<StudyConfig> | null>(null);
-  const isValidStudyId = studyId === '__revisit-widget' || resolveConfigKey(studyId, globalConfig) !== null;
+  const canonicalStudyId = useMemo(() => {
+    if (routeStudyId === '__revisit-widget') {
+      return routeStudyId;
+    }
+
+    return resolveConfigKey(routeStudyId, globalConfig);
+  }, [globalConfig, routeStudyId]);
+  const isValidStudyId = routeStudyId === '__revisit-widget' || canonicalStudyId !== null;
 
   useEffect(() => {
-    if (studyId !== '__revisit-widget') {
-      getStudyConfig(studyId, globalConfig).then((config) => {
+    if (routeStudyId !== '__revisit-widget') {
+      getStudyConfig(routeStudyId, globalConfig).then((config) => {
         setActiveConfig(config);
       });
       return () => { };
     }
-    if (globalConfig && studyId) {
+    if (globalConfig && routeStudyId) {
       const messageListener = (event: MessageEvent) => {
         if (event.data.type === 'revisitWidget/CONFIG') {
           parseStudyConfig(event.data.payload).then(async (config) => {
@@ -71,7 +78,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       };
     }
     return () => { };
-  }, [globalConfig, studyId]);
+  }, [globalConfig, routeStudyId]);
 
   const [routes, setRoutes] = useState<RouteObject[]>([]);
   const [store, setStore] = useState<Nullable<StudyStore>>(null);
@@ -84,11 +91,11 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   useEffect(() => {
     async function initializeUserStoreRouting() {
       // Check that we have a storage engine and active config (studyId is set for config, but typescript complains)
-      if (!storageEngine || !activeConfig || !studyId) return;
+      if (!storageEngine || !activeConfig || !canonicalStudyId) return;
 
       try {
         // Make sure that we have a study database and that the study database has a sequence array
-        await storageEngine.initializeStudyDb(studyId);
+        await storageEngine.initializeStudyDb(canonicalStudyId);
         await storageEngine.saveConfig(activeConfig);
 
         const sequenceArray = await storageEngine.getSequenceArray();
@@ -98,7 +105,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           );
         }
 
-        const modes = await storageEngine.getModes(studyId);
+        const modes = await storageEngine.getModes(canonicalStudyId);
 
         // Get or generate participant session
         const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam
@@ -155,7 +162,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         let participantConfig = activeConfig;
 
         if (participantSession.participantConfigHash !== activeHash) {
-          participantConfig = (await storageEngine.getAllConfigsFromHash([participantSession.participantConfigHash], studyId))[participantSession.participantConfigHash] as ParsedConfig<StudyConfig>;
+          participantConfig = (await storageEngine.getAllConfigsFromHash([participantSession.participantConfigHash], canonicalStudyId))[participantSession.participantConfigHash] as ParsedConfig<StudyConfig>;
         }
 
         const effectiveStudyCondition = resolveParticipantConditions({
@@ -167,7 +174,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         const filteredParticipantSequence = filterSequenceByCondition(participantSession.sequence, effectiveStudyCondition);
         // Initialize the redux stores
         const newStore = await studyStoreCreator(
-          studyId,
+          canonicalStudyId,
           participantConfig,
           filteredParticipantSequence,
           metadata,
@@ -190,7 +197,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         );
 
         const emptyStore = await studyStoreCreator(
-          studyId,
+          canonicalStudyId,
           activeConfig,
           fallbackSequence,
           {
@@ -247,7 +254,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       ]);
     }
     initializeUserStoreRouting();
-  }, [storageEngine, activeConfig, studyId, searchParams, participantId, studyCondition]);
+  }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
 
   const routing = useRoutes(routes);
 

--- a/src/utils/analysisRouteAccess.spec.ts
+++ b/src/utils/analysisRouteAccess.spec.ts
@@ -1,0 +1,41 @@
+import {
+  describe, expect, it, vi,
+} from 'vitest';
+import { GlobalConfig } from '../parser/types';
+import { shouldProtectAnalysisRoute } from './analysisRouteAccess';
+
+describe('shouldProtectAnalysisRoute', () => {
+  const globalConfig: GlobalConfig = {
+    $schema: '',
+    configs: {
+      'screening-gpt-5.2': {
+        path: 'screening-gpt-5.2/config.json',
+      },
+    },
+    configsList: ['screening-gpt-5.2'],
+  };
+
+  it('uses the canonical config key when the route uses a sanitized study slug', async () => {
+    const storageEngine = {
+      getModes: vi.fn().mockResolvedValue({ dataSharingEnabled: false }),
+      isCloudEngine: vi.fn().mockReturnValue(true),
+    };
+
+    const result = await shouldProtectAnalysisRoute('screening-gpt-5_2', globalConfig, storageEngine);
+
+    expect(result).toBe(true);
+    expect(storageEngine.getModes).toHaveBeenCalledWith('screening-gpt-5.2');
+  });
+
+  it('protects unknown study routes without creating a modes record', async () => {
+    const storageEngine = {
+      getModes: vi.fn(),
+      isCloudEngine: vi.fn().mockReturnValue(true),
+    };
+
+    const result = await shouldProtectAnalysisRoute('missing-study', globalConfig, storageEngine);
+
+    expect(result).toBe(true);
+    expect(storageEngine.getModes).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/analysisRouteAccess.ts
+++ b/src/utils/analysisRouteAccess.ts
@@ -1,0 +1,21 @@
+import { GlobalConfig } from '../parser/types';
+import { StorageEngine } from '../storage/engines/types';
+import { resolveConfigKey } from './fetchConfig';
+
+export async function shouldProtectAnalysisRoute(
+  studyId: string,
+  globalConfig: GlobalConfig,
+  storageEngine: StorageEngine | undefined,
+) {
+  if (!storageEngine || !storageEngine.isCloudEngine()) {
+    return false;
+  }
+
+  const resolvedStudyId = resolveConfigKey(studyId, globalConfig);
+  if (!resolvedStudyId) {
+    return true;
+  }
+
+  const modes = await storageEngine.getModes(resolvedStudyId);
+  return !modes.dataSharingEnabled;
+}

--- a/src/utils/fetchConfig.spec.ts
+++ b/src/utils/fetchConfig.spec.ts
@@ -1,0 +1,78 @@
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { parseStudyConfig } from '../parser/parser';
+import { GlobalConfig, ParsedConfig, StudyConfig } from '../parser/types';
+import { fetchStudyConfigs, getStudyConfig, resolveConfigKey } from './fetchConfig';
+
+vi.mock('../parser/parser', () => ({
+  parseStudyConfig: vi.fn(),
+}));
+
+describe('fetchConfig', () => {
+  const globalConfig: GlobalConfig = {
+    $schema: '',
+    configs: {
+      'screening-gpt-5.2': {
+        path: 'screening-gpt-5.2/config.json',
+      },
+      'plain-study': {
+        path: 'plain-study/config.json',
+      },
+    },
+    configsList: ['screening-gpt-5.2', 'plain-study'],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      text: async () => JSON.stringify({ test: true }),
+    }) as unknown as typeof fetch;
+    const parsedConfig = {
+      errors: [],
+      warnings: [],
+      studyMetadata: {
+        title: 'Test',
+        version: '1',
+        authors: [],
+        date: '2026-01-01',
+        description: '',
+        organizations: [],
+      },
+      uiConfig: {
+        logoPath: '',
+        contactEmail: '',
+        withProgressBar: true,
+        withSidebar: true,
+      },
+      sequence: {
+        order: 'fixed',
+        components: [],
+        skip: [],
+      },
+      components: {},
+    } as unknown as ParsedConfig<StudyConfig>;
+    vi.mocked(parseStudyConfig).mockResolvedValue(parsedConfig);
+  });
+
+  it('resolves both raw and sanitized study ids to a config key', () => {
+    expect(resolveConfigKey('screening-gpt-5.2', globalConfig)).toBe('screening-gpt-5.2');
+    expect(resolveConfigKey('screening-gpt-5_2', globalConfig)).toBe('screening-gpt-5.2');
+  });
+
+  it('loads a study config for sanitized route ids', async () => {
+    const result = await getStudyConfig('screening-gpt-5_2', globalConfig);
+
+    expect(result).not.toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith('/screening-gpt-5.2/config.json');
+    expect(parseStudyConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads every listed config including dotted names', async () => {
+    const results = await fetchStudyConfigs(globalConfig);
+
+    expect(results['screening-gpt-5.2']).not.toBeNull();
+    expect(results['plain-study']).not.toBeNull();
+    expect(parseStudyConfig).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/fetchConfig.spec.ts
+++ b/src/utils/fetchConfig.spec.ts
@@ -60,6 +60,10 @@ describe('fetchConfig', () => {
     expect(resolveConfigKey('screening-gpt-5_2', globalConfig)).toBe('screening-gpt-5.2');
   });
 
+  it('returns null for unknown study ids', () => {
+    expect(resolveConfigKey('missing-study', globalConfig)).toBeNull();
+  });
+
   it('loads a study config for sanitized route ids', async () => {
     const result = await getStudyConfig('screening-gpt-5_2', globalConfig);
 

--- a/src/utils/fetchConfig.ts
+++ b/src/utils/fetchConfig.ts
@@ -8,10 +8,28 @@ async function fetchStudyConfig(configLocation: string) {
   return await parseStudyConfig(config);
 }
 
+function sanitizeStringForUrlLegacy(fileName: string) {
+  const groups = fileName.split('/') || [];
+  const last = groups[groups.length - 1];
+  return last
+    .replace(/\.[^.]+$/, '')
+    .replace('.', '_')
+    .replace(' ', '_')
+    .replace('/', '_');
+}
+
+export function resolveConfigKey(studyId: string, globalConfig: GlobalConfig): string | null {
+  if (Object.prototype.hasOwnProperty.call(globalConfig.configs, studyId)) {
+    return studyId;
+  }
+
+  return globalConfig.configsList.find(
+    (configName) => sanitizeStringForUrl(configName) === studyId || sanitizeStringForUrlLegacy(configName) === studyId,
+  ) || null;
+}
+
 export async function getStudyConfig(studyId: string, globalConfig: GlobalConfig) {
-  const configKey = globalConfig.configsList.find(
-    (c) => sanitizeStringForUrl(c) === studyId,
-  );
+  const configKey = resolveConfigKey(studyId, globalConfig);
   if (configKey) {
     const configJSON = globalConfig.configs[configKey];
     return await fetchStudyConfig(`${configJSON.path}`);

--- a/src/utils/sanitizeStringForUrl.spec.ts
+++ b/src/utils/sanitizeStringForUrl.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { sanitizeStringForUrl } from './sanitizeStringForUrl';
 
 describe('sanitizeStringForUrl', () => {
-  it('keeps semantic version dots as part of the slug', () => {
+  it('keeps semantic version suffix in the slug while normalizing dots to underscores', () => {
     expect(sanitizeStringForUrl('screening-gpt-5.2')).toBe('screening-gpt-5_2');
   });
 

--- a/src/utils/sanitizeStringForUrl.spec.ts
+++ b/src/utils/sanitizeStringForUrl.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeStringForUrl } from './sanitizeStringForUrl';
+
+describe('sanitizeStringForUrl', () => {
+  it('keeps semantic version dots as part of the slug', () => {
+    expect(sanitizeStringForUrl('screening-gpt-5.2')).toBe('screening-gpt-5_2');
+  });
+
+  it('replaces all periods, spaces, and slashes', () => {
+    expect(sanitizeStringForUrl('my.study v1.0')).toBe('my_study_v1_0');
+    expect(sanitizeStringForUrl('folder/sub.study name')).toBe('sub_study_name');
+  });
+
+  it('removes known file extensions', () => {
+    expect(sanitizeStringForUrl('config.json')).toBe('config');
+    expect(sanitizeStringForUrl('config.yaml')).toBe('config');
+    expect(sanitizeStringForUrl('config.hjson')).toBe('config');
+  });
+});

--- a/src/utils/sanitizeStringForUrl.ts
+++ b/src/utils/sanitizeStringForUrl.ts
@@ -2,7 +2,7 @@ export function sanitizeStringForUrl(fileName: string) {
   const groups = fileName.split('/') || [];
   const last = groups[groups.length - 1];
   return last
-    // Keep semantic version dots (e.g., study-5.2) and normalize for route safety.
+    // Do not strip version-like suffixes as file extensions; normalize remaining characters for route safety.
     .replace(/\.(json|ya?ml|hjson)$/i, '') // Remove known file extensions
     .replace(/\./g, '_') // Replace periods
     .replace(/\s/g, '_') // Replace spaces

--- a/src/utils/sanitizeStringForUrl.ts
+++ b/src/utils/sanitizeStringForUrl.ts
@@ -1,10 +1,10 @@
-/* eslint-disable no-useless-escape */
 export function sanitizeStringForUrl(fileName: string) {
   const groups = fileName.split('/') || [];
   const last = groups[groups.length - 1];
   return last
-    .replace(/\.[^\.]+$/, '') // Remove extension
-    .replace('.', '_') // Replace other periods
-    .replace(' ', '_') // Replace spaces
-    .replace('/', '_'); // Replace paths
+    // Keep semantic version dots (e.g., study-5.2) and normalize for route safety.
+    .replace(/\.(json|ya?ml|hjson)$/i, '') // Remove known file extensions
+    .replace(/\./g, '_') // Replace periods
+    .replace(/\s/g, '_') // Replace spaces
+    .replace(/\//g, '_'); // Replace paths
 }


### PR DESCRIPTION
### Does this PR close any open issues?
No, address bug report from Rahat

### Give a longer description of what this PR addresses and why it's needed
This PR fixes study discovery/routing for global.json entries whose study keys include periods (for example screening-gpt-5.2), which previously failed silently in config lookup.
It standardizes slug handling and adds robust key resolution so the app can map both raw IDs and URL-safe IDs (including legacy behavior) back to the correct study config.
It is needed to prevent missing-study regressions, preserve backward compatibility for existing links, and document naming/URL normalization behavior clearly for study designers.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
- [x] Update relevant documentation: https://github.com/revisit-studies/reVISit-studies.github.io/issues/216