### PR TITLE
added auto redirect after a delay

### DIFF
--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -156,15 +156,15 @@ export function StudyEnd() {
   }, [studyConfig, participantId]);
 
   useEffect(() => {
-    const { autoRedirectURL, autoRedirectDelay } = studyConfig.uiConfig;
+    const { studyEndAutoRedirectURL, studyEndAutoRedirectDelay } = studyConfig.uiConfig;
 
-    if (isAnalysis || !completed || !autoRedirectURL) {
+    if (isAnalysis || !completed || !studyEndAutoRedirectURL) {
       return undefined;
     }
 
     const timeoutId = setTimeout(() => {
-      window.location.replace(autoRedirectURL);
-    }, autoRedirectDelay ?? 10000);
+      window.location.replace(studyEndAutoRedirectURL);
+    }, studyEndAutoRedirectDelay ?? 10000);
 
     return () => {
       clearTimeout(timeoutId);

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -158,12 +158,18 @@ export function StudyEnd() {
   useEffect(() => {
     const { autoRedirectURL, autoRedirectDelay } = studyConfig.uiConfig;
 
-    if (autoRedirectURL) {
-      setTimeout(() => {
-        window.location.replace(autoRedirectURL);
-      }, autoRedirectDelay || 10000);
+    if (isAnalysis || !completed || !autoRedirectURL) {
+      return undefined;
     }
-  }, [completed, studyConfig.uiConfig]);
+
+    const timeoutId = setTimeout(() => {
+      window.location.replace(autoRedirectURL);
+    }, autoRedirectDelay ?? 10000);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [completed, isAnalysis, studyConfig.uiConfig]);
 
   return (
     <Center style={{ height: '100%' }}>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -161,9 +161,9 @@ export function StudyEnd() {
     if (autoRedirectURL) {
       setTimeout(() => {
         window.location.replace(autoRedirectURL);
-      }, autoRedirectDelay ? autoRedirectDelay : 10000)
+      }, autoRedirectDelay || 10000);
     }
-  }, [completed]);
+  }, [completed, studyConfig.uiConfig]);
 
   return (
     <Center style={{ height: '100%' }}>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -155,6 +155,16 @@ export function StudyEnd() {
     return studyEndMsg.replace(/\{PARTICIPANT_ID\}/g, () => participantId);
   }, [studyConfig, participantId]);
 
+  useEffect(() => {
+    const { autoRedirectURL, autoRedirectDelay } = studyConfig.uiConfig;
+
+    if (autoRedirectURL) {
+      setTimeout(() => {
+        window.location.replace(autoRedirectURL);
+      }, autoRedirectDelay ? autoRedirectDelay : 10000)
+    }
+  }, [completed]);
+
   return (
     <Center style={{ height: '100%' }}>
       <Flex direction="column">

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -3476,7 +3476,7 @@
     },
     "UIConfig": {
       "additionalProperties": false,
-      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the `uiConfig` would look in your study configuration (note, there are optional fields that are not shown here): ```json uiConfig:{   \"logoPath\": \"<study-name>/assets/logo.jpg\",   \"contactEmail\": \"contact@revisit.dev\",   \"withProgressBar\": true,   \"withSidebar\": true,   \"helpTextPath\": \"<study-name>/assets/help.md\",   \"autoDownloadStudy\": true,   \"autoDownloadTime\": 5000,   \"studyEndMsg\": \"Thank you for completing this study. You're the best!\",   \"windowEventDebounceTime\": 500,   \"urlParticipantIdParam\": \"PROLIFIC_ID\",   \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
+      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the `uiConfig` would look in your study configuration (note, there are optional fields that are not shown here): ```json uiConfig:{   \"logoPath\": \"<study-name>/assets/logo.jpg\",   \"contactEmail\": \"contact@revisit.dev\",   \"withProgressBar\": true,   \"withSidebar\": true,   \"helpTextPath\": \"<study-name>/assets/help.md\",   \"autoDownloadStudy\": true,   \"autoDownloadTime\": 5000,   \"studyEndMsg\": \"Thank you for completing this study. You're the best!\",   \"autoRedirectURL\": \"https://app.prolific.com/submissions/complete?cc=abc123\",   \"autoRedirectDelay\": 10000,   \"windowEventDebounceTime\": 500,   \"urlParticipantIdParam\": \"PROLIFIC_ID\",   \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. Defaults to true.",
@@ -3489,6 +3489,14 @@
         "autoDownloadTime": {
           "description": "The time in milliseconds to wait before automatically downloading the study data.",
           "type": "number"
+        },
+        "autoRedirectDelay": {
+          "description": "The duration after which participants will auto-redirected to the URL specified in autoRedirectURL. Defaults to 10000 milliseconds (10 seconds).",
+          "type": "number"
+        },
+        "autoRedirectURL": {
+          "description": "The URL which participants will be auto-redirected to. The default time before redirecting is 10 seconds, but this can be configured with the autoRedirectDelay field.",
+          "type": "string"
         },
         "clickToRecord": {
           "description": "Enables a click-and-hold microphone button instead of continuous recording. When true, audio is muted by default and is recorded only while the button is held. When false, recording starts immediately and can be paused/resumed via the microphone button. Defaults to false.",
@@ -3581,14 +3589,6 @@
         "studyEndMsg": {
           "description": "The message to display when the study ends.",
           "type": "string"
-        },
-        "autoRedirectURL": {
-          "description": "If not empty, the URL which participants will auto-redirected to",
-          "type": "string"
-        },
-        "autoRedirectDelay": {
-          "description": "The delay after which participants will be auto-redirected",
-          "type": "number"
         },
         "stylesheetPath": {
           "description": "The path to the external stylesheet file.",

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -3476,7 +3476,7 @@
     },
     "UIConfig": {
       "additionalProperties": false,
-      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the `uiConfig` would look in your study configuration (note, there are optional fields that are not shown here): ```json uiConfig:{   \"logoPath\": \"<study-name>/assets/logo.jpg\",   \"contactEmail\": \"contact@revisit.dev\",   \"withProgressBar\": true,   \"withSidebar\": true,   \"helpTextPath\": \"<study-name>/assets/help.md\",   \"autoDownloadStudy\": true,   \"autoDownloadTime\": 5000,   \"studyEndMsg\": \"Thank you for completing this study. You're the best!\",   \"autoRedirectURL\": \"https://app.prolific.com/submissions/complete?cc=abc123\",   \"autoRedirectDelay\": 10000,   \"windowEventDebounceTime\": 500,   \"urlParticipantIdParam\": \"PROLIFIC_ID\",   \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
+      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the `uiConfig` would look in your study configuration (note, there are optional fields that are not shown here): ```json uiConfig:{   \"logoPath\": \"<study-name>/assets/logo.jpg\",   \"contactEmail\": \"contact@revisit.dev\",   \"withProgressBar\": true,   \"withSidebar\": true,   \"helpTextPath\": \"<study-name>/assets/help.md\",   \"autoDownloadStudy\": true,   \"autoDownloadTime\": 5000,   \"studyEndMsg\": \"Thank you for completing this study. You're the best!\",   \"studyEndAutoRedirectURL\": \"https://app.prolific.com/submissions/complete?cc=abc123\",   \"studyEndAutoRedirectDelay\": 10000,   \"windowEventDebounceTime\": 500,   \"urlParticipantIdParam\": \"PROLIFIC_ID\",   \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. Defaults to true.",
@@ -3489,14 +3489,6 @@
         "autoDownloadTime": {
           "description": "The time in milliseconds to wait before automatically downloading the study data.",
           "type": "number"
-        },
-        "autoRedirectDelay": {
-          "description": "The duration after which participants will auto-redirected to the URL specified in autoRedirectURL. Defaults to 10000 milliseconds (10 seconds).",
-          "type": "number"
-        },
-        "autoRedirectURL": {
-          "description": "The URL which participants will be auto-redirected to. The default time before redirecting is 10 seconds, but this can be configured with the autoRedirectDelay field.",
-          "type": "string"
         },
         "clickToRecord": {
           "description": "Enables a click-and-hold microphone button instead of continuous recording. When true, audio is muted by default and is recorded only while the button is held. When false, recording starts immediately and can be paused/resumed via the microphone button. Defaults to false.",
@@ -3585,6 +3577,14 @@
         "sidebarWidth": {
           "description": "The width of the left sidebar. Defaults to 300.",
           "type": "number"
+        },
+        "studyEndAutoRedirectDelay": {
+          "description": "The duration after which participants will be auto-redirected to the URL specified in studyEndAutoRedirectURL. Defaults to 10000 milliseconds (10 seconds).",
+          "type": "number"
+        },
+        "studyEndAutoRedirectURL": {
+          "description": "The URL which participants will be auto-redirected to when the study ends. The default time before redirecting is 10 seconds, but this can be configured with the studyEndAutoRedirectDelay field.",
+          "type": "string"
         },
         "studyEndMsg": {
           "description": "The message to display when the study ends.",

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -3582,6 +3582,14 @@
           "description": "The message to display when the study ends.",
           "type": "string"
         },
+        "autoRedirectURL": {
+          "description": "If not empty, the URL which participants will auto-redirected to",
+          "type": "string"
+        },
+        "autoRedirectDelay": {
+          "description": "The delay after which participants will be auto-redirected",
+          "type": "number"
+        },
         "stylesheetPath": {
           "description": "The path to the external stylesheet file.",
           "type": "string"

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -298,9 +298,9 @@ export interface UIConfig {
   windowEventDebounceTime?: number;
   /** The message to display when the study ends. */
   studyEndMsg?: string;
-  /** The URL which participants will be auto-redirected to after a timeout of n s */
+  /** The URL which participants will be auto-redirected to. The default time before redirecting is 10 seconds, but this can be configured with the autoRedirectDelay field. */
   autoRedirectURL?: string;
-  /** The duration after which participants will auto-redirected to */
+  /** The duration after which participants will auto-redirected to the URL specified in autoRedirectURL. Defaults to 10000 milliseconds (10 seconds). */
   autoRedirectDelay?: number;
   /** Controls whether the study data is automatically downloaded at the end of the study. */
   autoDownloadStudy?: boolean;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -231,6 +231,8 @@ export type Styles = {
  *   "autoDownloadStudy": true,
  *   "autoDownloadTime": 5000,
  *   "studyEndMsg": "Thank you for completing this study. You're the best!",
+ *   "autoRedirectURL": "https://app.prolific.com/submissions/complete?cc=abc123",
+ *   "autoRedirectDelay": 10000,
  *   "windowEventDebounceTime": 500,
  *   "urlParticipantIdParam": "PROLIFIC_ID",
  *   "numSequences": 500
@@ -296,6 +298,10 @@ export interface UIConfig {
   windowEventDebounceTime?: number;
   /** The message to display when the study ends. */
   studyEndMsg?: string;
+  /** The URL which participants will be auto-redirected to after a timeout of n s */
+  autoRedirectURL?: string;
+  /** The duration after which participants will auto-redirected to */
+  autoRedirectDelay?: number;
   /** Controls whether the study data is automatically downloaded at the end of the study. */
   autoDownloadStudy?: boolean;
   /** The time in milliseconds to wait before automatically downloading the study data. */

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -231,8 +231,8 @@ export type Styles = {
  *   "autoDownloadStudy": true,
  *   "autoDownloadTime": 5000,
  *   "studyEndMsg": "Thank you for completing this study. You're the best!",
- *   "autoRedirectURL": "https://app.prolific.com/submissions/complete?cc=abc123",
- *   "autoRedirectDelay": 10000,
+ *   "studyEndAutoRedirectURL": "https://app.prolific.com/submissions/complete?cc=abc123",
+ *   "studyEndAutoRedirectDelay": 10000,
  *   "windowEventDebounceTime": 500,
  *   "urlParticipantIdParam": "PROLIFIC_ID",
  *   "numSequences": 500
@@ -298,10 +298,10 @@ export interface UIConfig {
   windowEventDebounceTime?: number;
   /** The message to display when the study ends. */
   studyEndMsg?: string;
-  /** The URL which participants will be auto-redirected to. The default time before redirecting is 10 seconds, but this can be configured with the autoRedirectDelay field. */
-  autoRedirectURL?: string;
-  /** The duration after which participants will auto-redirected to the URL specified in autoRedirectURL. Defaults to 10000 milliseconds (10 seconds). */
-  autoRedirectDelay?: number;
+  /** The URL which participants will be auto-redirected to when the study ends. The default time before redirecting is 10 seconds, but this can be configured with the studyEndAutoRedirectDelay field. */
+  studyEndAutoRedirectURL?: string;
+  /** The duration after which participants will be auto-redirected to the URL specified in studyEndAutoRedirectURL. Defaults to 10000 milliseconds (10 seconds). */
+  studyEndAutoRedirectDelay?: number;
   /** Controls whether the study data is automatically downloaded at the end of the study. */
   autoDownloadStudy?: boolean;
   /** The time in milliseconds to wait before automatically downloading the study data. */


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1161

### Give a longer description of what this PR addresses and why it's needed
This PR allows a researcher to auto-redirect participants to Prolific after the study end.

This can be done by adding twooptional parameters in `config.json` under `UIConfig`:
- `"autoRedirectURL"`: <string> a URL which a participant would be redirected to
- `"autoRedirectDelay"`: <integer> a number (in ms) after which a participant will be auto-redirected

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Update relevant documentation: https://github.com/revisit-studies/reVISit-studies.github.io/issues/216