### PR TITLE
Fix random interruption placement in study sequences

### DIFF
--- a/src/utils/handleInterruptionSequences.spec.ts
+++ b/src/utils/handleInterruptionSequences.spec.ts
@@ -87,7 +87,61 @@ describe('handleInterruptionSequences', () => {
         .map(({ index }) => index);
 
       expect(interruptionIndices).toHaveLength(2);
+      expect(sequence.components[0]).not.toBe('brk');
       expect(sequence.components[sequence.components.length - 1]).toBe('end');
+    });
+  });
+
+  test('does not place random interruptions first or back to back across groups', () => {
+    const config: StudyConfig = {
+      ...createBaseConfig(),
+      uiConfig: {
+        ...createBaseConfig().uiConfig,
+        numSequences: 500,
+      },
+      components: {
+        a: { type: 'questionnaire', response: [] },
+        b: { type: 'questionnaire', response: [] },
+        c: { type: 'questionnaire', response: [] },
+        d: { type: 'questionnaire', response: [] },
+        e: { type: 'questionnaire', response: [] },
+        f: { type: 'questionnaire', response: [] },
+        g: { type: 'questionnaire', response: [] },
+        h: { type: 'questionnaire', response: [] },
+        low: { type: 'questionnaire', response: [] },
+        high: { type: 'questionnaire', response: [] },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+        interruptions: [
+          {
+            spacing: 'random',
+            numInterruptions: 1,
+            components: ['low'],
+          },
+          {
+            spacing: 'random',
+            numInterruptions: 1,
+            components: ['high'],
+          },
+        ],
+      },
+    };
+
+    const sequenceArray = generateSequenceArray(config);
+    sequenceArray.forEach((sequence) => {
+      expect(sequence.components[0]).not.toBe('low');
+      expect(sequence.components[0]).not.toBe('high');
+
+      for (let i = 0; i < sequence.components.length - 1; i += 1) {
+        const current = sequence.components[i];
+        const next = sequence.components[i + 1];
+        const currentIsInterruption = current === 'low' || current === 'high';
+        const nextIsInterruption = next === 'low' || next === 'high';
+
+        expect(currentIsInterruption && nextIsInterruption).toBe(false);
+      }
     });
   });
 

--- a/src/utils/handleInterruptionSequences.spec.ts
+++ b/src/utils/handleInterruptionSequences.spec.ts
@@ -145,6 +145,82 @@ describe('handleInterruptionSequences', () => {
     });
   });
 
+  test('fills every possible random interruption slot across groups when all slots are requested', () => {
+    const config: StudyConfig = {
+      ...createBaseConfig(),
+      components: {
+        a: { type: 'questionnaire', response: [] },
+        b: { type: 'questionnaire', response: [] },
+        c: { type: 'questionnaire', response: [] },
+        d: { type: 'questionnaire', response: [] },
+        low: { type: 'questionnaire', response: [] },
+        high: { type: 'questionnaire', response: [] },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['a', 'b', 'c', 'd'],
+        interruptions: [
+          {
+            spacing: 'random',
+            numInterruptions: 1,
+            components: ['low'],
+          },
+          {
+            spacing: 'random',
+            numInterruptions: 2,
+            components: ['high'],
+          },
+        ],
+      },
+    };
+
+    const [sequence] = generateSequenceArray(config);
+
+    expect(sequence.components).toHaveLength(8);
+    expect(sequence.components[0]).toBe('a');
+    expect(sequence.components[2]).toBe('b');
+    expect(sequence.components[4]).toBe('c');
+    expect(sequence.components[6]).toBe('d');
+    expect(sequence.components[7]).toBe('end');
+    expect(['low', 'high']).toContain(sequence.components[1]);
+    expect(['low', 'high']).toContain(sequence.components[3]);
+    expect(['low', 'high']).toContain(sequence.components[5]);
+    expect(sequence.components.filter((component) => component === 'low')).toHaveLength(1);
+    expect(sequence.components.filter((component) => component === 'high')).toHaveLength(2);
+  });
+
+  test('throws when grouped random interruptions request more slots than available', () => {
+    const config: StudyConfig = {
+      ...createBaseConfig(),
+      components: {
+        a: { type: 'questionnaire', response: [] },
+        b: { type: 'questionnaire', response: [] },
+        c: { type: 'questionnaire', response: [] },
+        d: { type: 'questionnaire', response: [] },
+        low: { type: 'questionnaire', response: [] },
+        high: { type: 'questionnaire', response: [] },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['a', 'b', 'c', 'd'],
+        interruptions: [
+          {
+            spacing: 'random',
+            numInterruptions: 2,
+            components: ['low'],
+          },
+          {
+            spacing: 'random',
+            numInterruptions: 2,
+            components: ['high'],
+          },
+        ],
+      },
+    };
+
+    expect(() => generateSequenceArray(config)).toThrow('Number of interruptions cannot be greater than the number of available interruption slots');
+  });
+
   test('throws when random interruptions exceed allowed maximum', () => {
     const config: StudyConfig = {
       ...createBaseConfig(),
@@ -166,6 +242,6 @@ describe('handleInterruptionSequences', () => {
       },
     };
 
-    expect(() => generateSequenceArray(config)).toThrow('Number of interruptions cannot be greater than the number of components');
+    expect(() => generateSequenceArray(config)).toThrow('Number of interruptions cannot be greater than the number of available interruption slots');
   });
 });

--- a/src/utils/handleRandomSequences.spec.ts
+++ b/src/utils/handleRandomSequences.spec.ts
@@ -297,6 +297,6 @@ describe('Generating sequences works as expected', () => {
       },
     };
 
-    expect(() => generateSequenceArray(invalidInterruptionConfig)).toThrow('Number of interruptions cannot be greater than the number of components');
+    expect(() => generateSequenceArray(invalidInterruptionConfig)).toThrow('Number of interruptions cannot be greater than the number of available interruption slots');
   });
 });

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -96,7 +96,7 @@ function insertRandomInterruptions(
     .reduce((count, interruption) => count + interruption.numInterruptions, 0);
 
   if (totalInterruptions > components.length - 1) {
-    throw new Error('Number of interruptions cannot be greater than the number of components');
+    throw new Error('Number of interruptions cannot be greater than the number of available interruption slots');
   }
 
   const availableLocations = Array.from(
@@ -111,7 +111,7 @@ function insertRandomInterruptions(
       const randomLocation = availableLocations.pop();
 
       if (randomLocation === undefined) {
-        throw new Error('Number of interruptions cannot be greater than the number of components');
+        throw new Error('Number of interruptions cannot be greater than the number of available interruption slots');
       }
 
       const interruptionsAtLocation = interruptionsByLocation.get(randomLocation) || [];

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -1,11 +1,16 @@
 // eslint-disable-next-line import/no-unresolved
 import latinSquare from '@quentinroy/latin-square';
 import isEqual from 'lodash.isequal';
-import { ComponentBlock, DynamicBlock, StudyConfig } from '../parser/types';
+import {
+  ComponentBlock,
+  DynamicBlock,
+  RandomInterruption,
+  StudyConfig,
+} from '../parser/types';
 import { Sequence } from '../store/types';
 import { isDynamicBlock } from '../parser/utils';
 
-function shuffle(array: (string | ComponentBlock | DynamicBlock)[]) {
+function shuffle<T>(array: T[]) {
   let currentIndex = array.length;
 
   // While there remain elements to shuffle...
@@ -83,6 +88,49 @@ function generateLatinSquareRows(config: StudyConfig, path: string, count: numbe
   return rows;
 }
 
+function insertRandomInterruptions(
+  components: (string | ComponentBlock | DynamicBlock)[],
+  randomInterruptions: RandomInterruption[],
+) {
+  const totalInterruptions = randomInterruptions
+    .reduce((count, interruption) => count + interruption.numInterruptions, 0);
+
+  if (totalInterruptions > components.length - 1) {
+    throw new Error('Number of interruptions cannot be greater than the number of components');
+  }
+
+  const availableLocations = Array.from(
+    { length: components.length - 1 },
+    (_, index) => index + 1,
+  );
+  shuffle(availableLocations);
+
+  const interruptionsByLocation = new Map<number, string[][]>();
+  randomInterruptions.forEach((interruption) => {
+    for (let i = 0; i < interruption.numInterruptions; i += 1) {
+      const randomLocation = availableLocations.pop();
+
+      if (randomLocation === undefined) {
+        throw new Error('Number of interruptions cannot be greater than the number of components');
+      }
+
+      const interruptionsAtLocation = interruptionsByLocation.get(randomLocation) || [];
+      interruptionsAtLocation.push(interruption.components);
+      interruptionsByLocation.set(randomLocation, interruptionsAtLocation);
+    }
+  });
+
+  const newComponents: (string | ComponentBlock | DynamicBlock)[] = [];
+  for (let i = 0; i < components.length; i += 1) {
+    interruptionsByLocation.get(i)?.forEach((interruptionComponents) => {
+      newComponents.push(...interruptionComponents);
+    });
+    newComponents.push(components[i]);
+  }
+
+  return newComponents;
+}
+
 function _componentBlockToSequence(
   order: StudyConfig['sequence'],
   latinSquareObject: Record<string, string[][]>,
@@ -157,8 +205,9 @@ function _componentBlockToSequence(
 
   // If we have a break, insert it into the sequence at the correct intervals
   if (order.interruptions) {
-    order.interruptions.forEach((interruption) => {
-      const newComponents = [];
+    for (let interruptionIndex = 0; interruptionIndex < order.interruptions.length; interruptionIndex += 1) {
+      const interruption = order.interruptions[interruptionIndex];
+      const newComponents: (string | ComponentBlock | DynamicBlock)[] = [];
       if (interruption.spacing !== 'random') {
         for (let i = 0; i < computedComponents.length; i += 1) {
           if (
@@ -169,32 +218,21 @@ function _componentBlockToSequence(
           }
           newComponents.push(computedComponents[i]);
         }
-      }
 
-      // Handle random interruptions
-      if (interruption.spacing === 'random') {
-        // Generate the random locations
-        const randomInterruptionLocations = new Set<number>();
-        if (interruption.numInterruptions > computedComponents.length - 1) {
-          throw new Error('Number of interruptions cannot be greater than the number of components');
+        computedComponents = newComponents;
+      } else {
+        const groupedRandomInterruptions: RandomInterruption[] = [interruption];
+        while (
+          interruptionIndex + 1 < order.interruptions.length
+          && order.interruptions[interruptionIndex + 1].spacing === 'random'
+        ) {
+          interruptionIndex += 1;
+          groupedRandomInterruptions.push(order.interruptions[interruptionIndex] as RandomInterruption);
         }
-        while (randomInterruptionLocations.size < interruption.numInterruptions) {
-          const randomLocation = Math.floor(Math.random() * computedComponents.length - 1) + 1;
-          randomInterruptionLocations.add(randomLocation);
-        }
-        const sortedRandomInterruptionLocations = Array.from(randomInterruptionLocations).sort((a, b) => a - b);
 
-        let j = 0;
-        for (let i = 0; i < computedComponents.length; i += 1) {
-          if (i === sortedRandomInterruptionLocations[j]) {
-            newComponents.push(...interruption.components);
-            j += 1;
-          }
-          newComponents.push(computedComponents[i]);
-        }
+        computedComponents = insertRandomInterruptions(computedComponents, groupedRandomInterruptions);
       }
-      computedComponents = newComponents;
-    });
+    }
   }
 
   return {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1151 

### Give a longer description of what this PR addresses and why it's needed
This PR fixes a bug in sequence generation where random interruptions could appear before the first trial in a block, despite the documented behavior that attention checks and breaks should never be first.

It also fixes a second issue affecting configs with multiple random interruption groups: because interruptions were inserted sequentially into an already-modified block, separate random attention checks could end up adjacent to each other. The updated logic now samples random interruption slots from the valid trial gaps only, without replacement, so random interruptions do not appear first and do not stack back to back across groups.

The PR also adds regression tests covering both guarantees:

- random interruptions are never placed first
- multiple random interruption groups do not produce adjacent interruptions

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...

### Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/216

- [x] Done
- [ ] N/A