### PR TITLE
Harden participant completion flow against latency and write races

### DIFF
--- a/public/example-brush-interactions/config.json
+++ b/public/example-brush-interactions/config.json
@@ -431,8 +431,9 @@
       ]
     },
     "survey": {
-      "type": "markdown",
-      "path": "example-VLAT-mini-randomized/assets/survey.md",
+      "type": "questionnaire",
+      "instruction": "Thanks for completing the study! We are testing our survey tool and we could use your valuable feedback in the questions below:",
+      "instructionLocation": "aboveStimulus",
       "response": [
         {
           "id": "surveyExperience",

--- a/public/test-audio/config.json
+++ b/public/test-audio/config.json
@@ -431,8 +431,9 @@
       ]
     },
     "survey": {
-      "type": "markdown",
-      "path": "example-VLAT-mini-randomized/assets/survey.md",
+      "type": "questionnaire",
+      "instruction": "Thanks for completing the study! We are testing our survey tool and we could use your valuable feedback in the questions below:",
+      "instructionLocation": "aboveStimulus",
       "response": [
         {
           "id": "surveyExperience",

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -9,7 +9,7 @@ import { useAuth } from './store/hooks/useAuth';
 import { useStorageEngine } from './storage/storageEngineHooks';
 import { StorageEngine } from './storage/engines/types';
 import { showNotification } from './utils/notifications';
-import { isCloudStorageEngine } from './storage/engines/utils';
+import { isCloudStorageEngine } from './storage/engines/utils/storageEngineHelpers';
 
 export async function signIn(storageEngine: StorageEngine | undefined, setLoading: (val: boolean) => void) {
   if (storageEngine && isCloudStorageEngine(storageEngine)) {

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -17,7 +17,7 @@ import { ParticipantStatusBadges } from '../analysis/interface/ParticipantStatus
 import { useStorageEngine } from '../storage/storageEngineHooks';
 import { REVISIT_MODE } from '../storage/engines/types';
 import { useAuth } from '../store/hooks/useAuth';
-import { isCloudStorageEngine } from '../storage/engines/utils';
+import { isCloudStorageEngine } from '../storage/engines/utils/storageEngineHelpers';
 import { getSequenceConditions } from '../utils/handleConditionLogic';
 import { useStudyRecordings } from '../utils/useStudyRecordings';
 import { useDeviceRules } from '../utils/useDeviceRules';

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -31,7 +31,7 @@ import { ErrorLoadingConfig } from './ErrorLoadingConfig';
 import { ResourceNotFound } from '../ResourceNotFound';
 import { encryptIndex } from '../utils/encryptDecryptIndex';
 import { parseStudyConfig } from '../parser/parser';
-import { hash } from '../storage/engines/utils';
+import { hash } from '../storage/engines/utils/storageEngineHelpers';
 import {
   filterSequenceByCondition,
   parseConditionParam,

--- a/src/components/StudyEnd.spec.tsx
+++ b/src/components/StudyEnd.spec.tsx
@@ -9,8 +9,10 @@ import {
 import { StudyEnd } from './StudyEnd';
 
 vi.mock('@mantine/core', () => ({
+  Button: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
   Center: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Flex: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Group: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Loader: () => <div>Loading</div>,
   Space: () => <div />,
   Text: ({ children }: { children?: ReactNode }) => <div>{children}</div>,

--- a/src/components/StudyEnd.spec.tsx
+++ b/src/components/StudyEnd.spec.tsx
@@ -1,0 +1,68 @@
+import { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import { StudyEnd } from './StudyEnd';
+
+vi.mock('@mantine/core', () => ({
+  Center: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Flex: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Loader: () => <div>Loading</div>,
+  Space: () => <div />,
+  Text: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../store/hooks/useStudyConfig', () => ({
+  useStudyConfig: () => ({
+    studyMetadata: { title: 'Latency Study' },
+    uiConfig: {
+      studyEndMsg: 'Study complete',
+      autoDownloadStudy: false,
+    },
+  }),
+}));
+
+vi.mock('./ReactMarkdownWrapper', () => ({
+  ReactMarkdownWrapper: ({ text }: { text?: string }) => <div>{text}</div>,
+}));
+
+vi.mock('../utils/useDisableBrowserBack', () => ({
+  useDisableBrowserBack: () => undefined,
+}));
+
+vi.mock('../storage/storageEngineHooks', () => ({
+  useStorageEngine: () => ({ storageEngine: undefined }),
+}));
+
+vi.mock('../routes/utils', () => ({
+  useStudyId: () => 'test-study',
+}));
+
+vi.mock('../store/hooks/useIsAnalysis', () => ({
+  useIsAnalysis: () => false,
+}));
+
+vi.mock('../store/store', () => ({
+  useStoreDispatch: () => vi.fn(),
+  useStoreActions: () => ({
+    setParticipantCompleted: vi.fn((value: boolean) => ({
+      type: 'setParticipantCompleted',
+      payload: value,
+    })),
+  }),
+}));
+
+vi.mock('./downloader/DownloadTidy', () => ({
+  download: vi.fn(),
+}));
+
+describe('StudyEnd', () => {
+  test('renders the study end message', () => {
+    const html = renderToStaticMarkup(<StudyEnd />);
+    expect(html).toContain('Study complete');
+  });
+});

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -13,6 +13,7 @@ import { download } from './downloader/DownloadTidy';
 import { useStudyId } from '../routes/utils';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
 import { useStoreDispatch, useStoreActions } from '../store/store';
+import { getStudyEndFinalizeState } from './StudyEnd.utils';
 
 export function StudyEnd() {
   const studyConfig = useStudyConfig();
@@ -23,6 +24,7 @@ export function StudyEnd() {
   const isAnalysis = useIsAnalysis();
 
   const [completed, setCompleted] = useState(false);
+  const [finalizeError, setFinalizeError] = useState<string | null>(null);
   const storageEngineRef = useRef(storageEngine);
 
   useEffect(() => {
@@ -48,14 +50,26 @@ export function StudyEnd() {
         }
 
         try {
-          const isComplete = await engine.verifyCompletion();
-          if (isComplete) {
+          const result = await engine.finalizeParticipant();
+
+          const nextFinalizeState = getStudyEndFinalizeState(result);
+          if (nextFinalizeState.completed) {
+            setFinalizeError(null);
             setCompleted(true);
             dispatch(setParticipantCompleted(true));
             return;
           }
+
+          if (!nextFinalizeState.shouldRetry) {
+            setFinalizeError(nextFinalizeState.error);
+            return;
+          }
+
+          setFinalizeError(nextFinalizeState.error);
         } catch (error) {
           console.error('An error occurred while verifying completion', error);
+          setFinalizeError('An error occurred while uploading your answers.');
+          return;
         }
 
         if (!cancelled) {
@@ -180,11 +194,19 @@ export function StudyEnd() {
             : <Text size="xl" display="block">Thank you for completing the study. You may close this window now.</Text>)
           : (
             <>
-              <Text size="xl" display="block">Please wait while your answers are uploaded.</Text>
+              <Text size="xl" display="block">
+                {finalizeError
+                  ? 'We hit an error while uploading your answers.'
+                  : 'Please wait while your answers are uploaded.'}
+              </Text>
               <Space h="lg" />
-              <Center>
-                <Loader color="blue" />
-              </Center>
+              {finalizeError
+                ? <Text c="red" maw={520}>{`${finalizeError} Please keep this page open and contact the study administrator if the issue persists.`}</Text>
+                : (
+                  <Center>
+                    <Loader color="blue" />
+                  </Center>
+                )}
             </>
           )}
       </Flex>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -197,6 +197,7 @@ export function StudyEnd() {
   const showRetryNotice = failedAttemptCount > 0;
   const downloadUnavailable = !participantId || participantData === null || participantData === undefined;
   const automaticRetryDelaySeconds = retryDelayMs ? Math.ceil(retryDelayMs / 1000) : null;
+  const automaticRetryLabel = `${failedAttemptCount}/3 retries`;
 
   return (
     <Center style={{ height: '100%' }}>
@@ -246,6 +247,7 @@ export function StudyEnd() {
                       <Text c={finalizeError ? 'red' : undefined} maw={560}>
                         {finalizeError || 'The upload confirmation is taking longer than expected.'}
                         {' '}
+                        {`${automaticRetryLabel}. `}
                         {isRetryingAutomatically && automaticRetryDelaySeconds
                           ? `We will retry automatically in about ${automaticRetryDelaySeconds} seconds.`
                           : 'We will retry automatically.'}

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -1,5 +1,5 @@
 import {
-  Center, Flex, Loader, Space, Text,
+  Button, Center, Flex, Group, Loader, Space, Text,
 } from '@mantine/core';
 import {
   useEffect, useState, useCallback, useMemo, useRef,
@@ -13,7 +13,11 @@ import { download } from './downloader/DownloadTidy';
 import { useStudyId } from '../routes/utils';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
 import { useStoreDispatch, useStoreActions } from '../store/store';
-import { getStudyEndFinalizeState } from './StudyEnd.utils';
+import {
+  createStudyEndFinalizeLoop,
+  DEFAULT_STUDY_END_FINALIZE_STATE,
+  StudyEndFinalizeLoopState,
+} from './StudyEnd.utils';
 
 export function StudyEnd() {
   const studyConfig = useStudyConfig();
@@ -24,8 +28,9 @@ export function StudyEnd() {
   const isAnalysis = useIsAnalysis();
 
   const [completed, setCompleted] = useState(false);
-  const [finalizeError, setFinalizeError] = useState<string | null>(null);
+  const [finalizeState, setFinalizeState] = useState<StudyEndFinalizeLoopState>(DEFAULT_STUDY_END_FINALIZE_STATE);
   const storageEngineRef = useRef(storageEngine);
+  const finalizeLoopRef = useRef<ReturnType<typeof createStudyEndFinalizeLoop> | null>(null);
 
   useEffect(() => {
     storageEngineRef.current = storageEngine;
@@ -34,59 +39,25 @@ export function StudyEnd() {
   useEffect(() => {
     // Don't save to the storage engine in analysis
     if (!isAnalysis) {
-      let cancelled = false;
-      let timeoutId: NodeJS.Timeout | null = null;
-      const verifyLoop = async () => {
-        if (cancelled) {
-          return;
-        }
-
-        const engine = storageEngineRef.current;
-        if (!engine) {
-          timeoutId = setTimeout(() => {
-            verifyLoop();
-          }, 2000);
-          return;
-        }
-
-        try {
-          const result = await engine.finalizeParticipant();
-
-          const nextFinalizeState = getStudyEndFinalizeState(result);
-          if (nextFinalizeState.completed) {
-            setFinalizeError(null);
-            setCompleted(true);
-            dispatch(setParticipantCompleted(true));
-            return;
-          }
-
-          if (!nextFinalizeState.shouldRetry) {
-            setFinalizeError(nextFinalizeState.error);
-            return;
-          }
-
-          setFinalizeError(nextFinalizeState.error);
-        } catch (error) {
+      const finalizeLoop = createStudyEndFinalizeLoop({
+        getStorageEngine: () => storageEngineRef.current,
+        onComplete: () => {
+          setFinalizeState(DEFAULT_STUDY_END_FINALIZE_STATE);
+          setCompleted(true);
+          dispatch(setParticipantCompleted(true));
+        },
+        onStateChange: setFinalizeState,
+        onUnexpectedError: (error) => {
           console.error('An error occurred while verifying completion', error);
-          setFinalizeError('An error occurred while uploading your answers.');
-          return;
-        }
+        },
+      });
 
-        if (!cancelled) {
-          timeoutId = setTimeout(() => {
-            verifyLoop();
-          }, 2000);
-        }
-      };
-
-      verifyLoop();
+      finalizeLoopRef.current = finalizeLoop;
+      finalizeLoop.start();
 
       return () => {
-        cancelled = true;
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = null;
-        }
+        finalizeLoopRef.current = null;
+        finalizeLoop.cancel();
       };
     }
 
@@ -102,21 +73,52 @@ export function StudyEnd() {
   const [participantData, setParticipantData] = useState<ParticipantData | null>();
   const [participantId, setParticipantId] = useState('');
   const baseFilename = studyConfig.studyMetadata.title.replace(' ', '_');
-  useEffect(() => {
-    async function fetchParticipantId() {
-      if (storageEngine) {
-        const _participantId = await storageEngine.getCurrentParticipantId();
-        const _participantData = await storageEngine.getParticipantData();
 
-        setParticipantId(_participantId);
-        setParticipantData(_participantData);
-      }
+  const refreshParticipantData = useCallback(async () => {
+    if (storageEngine) {
+      const participantDataSnapshot = storageEngine.getCurrentParticipantDataSnapshot();
+      const [_participantId, _participantData] = await Promise.all([
+        storageEngine.getCurrentParticipantId(),
+        participantDataSnapshot ? Promise.resolve(participantDataSnapshot) : storageEngine.getParticipantData(),
+      ]);
+
+      setParticipantId(_participantId);
+      setParticipantData(_participantData);
+      return {
+        participantId: _participantId,
+        participantData: _participantData,
+      };
     }
-    fetchParticipantId();
+
+    return {
+      participantId: '',
+      participantData: null,
+    };
   }, [storageEngine]);
+
+  useEffect(() => {
+    refreshParticipantData();
+  }, [refreshParticipantData]);
+
   const downloadParticipant = useCallback(async () => {
-    download(JSON.stringify(participantData, null, 2), `${baseFilename}_${participantId}.json`);
-  }, [baseFilename, participantData, participantId]);
+    const latestParticipant = await refreshParticipantData();
+    const participantDataToDownload = latestParticipant.participantData || participantData;
+    const participantIdToDownload = latestParticipant.participantId || participantId;
+
+    if (!participantDataToDownload || !participantIdToDownload) {
+      return;
+    }
+
+    download(JSON.stringify(participantDataToDownload, null, 2), `${baseFilename}_${participantIdToDownload}.json`);
+  }, [baseFilename, participantData, participantId, refreshParticipantData]);
+
+  const handleDownloadParticipant = useCallback(() => {
+    downloadParticipant();
+  }, [downloadParticipant]);
+
+  const retryFinalize = useCallback(() => {
+    finalizeLoopRef.current?.retryNow();
+  }, []);
 
   const autoDownload = studyConfig.uiConfig.autoDownloadStudy || false;
   const autoDownloadDelay = autoDownload
@@ -185,6 +187,17 @@ export function StudyEnd() {
     };
   }, [completed, isAnalysis, studyConfig.uiConfig]);
 
+  const {
+    error: finalizeError,
+    failedAttemptCount,
+    isRetryingAutomatically,
+    manualRetryRequired,
+    retryDelayMs,
+  } = finalizeState;
+  const showRetryNotice = failedAttemptCount > 0;
+  const downloadUnavailable = !participantId || participantData === null || participantData === undefined;
+  const automaticRetryDelaySeconds = retryDelayMs ? Math.ceil(retryDelayMs / 1000) : null;
+
   return (
     <Center style={{ height: '100%' }}>
       <Flex direction="column">
@@ -195,18 +208,59 @@ export function StudyEnd() {
           : (
             <>
               <Text size="xl" display="block">
-                {finalizeError
-                  ? 'We hit an error while uploading your answers.'
-                  : 'Please wait while your answers are uploaded.'}
+                {manualRetryRequired
+                  ? 'We could not confirm your upload after 3 attempts.'
+                  : showRetryNotice
+                    ? 'We hit an issue while uploading your answers. Retrying automatically...'
+                    : 'Please wait while your answers are uploaded.'}
               </Text>
               <Space h="lg" />
-              {finalizeError
-                ? <Text c="red" maw={520}>{`${finalizeError} Please keep this page open and contact the study administrator if the issue persists.`}</Text>
-                : (
-                  <Center>
-                    <Loader color="blue" />
-                  </Center>
-                )}
+              {manualRetryRequired
+                ? (
+                  <>
+                    <Text c="red" maw={560}>
+                      {finalizeError || 'The upload confirmation is taking longer than expected.'}
+                      {' '}
+                      You can try the upload again, or download your participant data and submit it manually to the study designer.
+                    </Text>
+                    {participantId
+                      ? (
+                        <>
+                          <Space h="sm" />
+                          <Text size="sm" c="dimmed">{`Participant ID: ${participantId}`}</Text>
+                        </>
+                      )
+                      : null}
+                    <Space h="lg" />
+                    <Group>
+                      <Button onClick={retryFinalize}>Retry Upload</Button>
+                      <Button variant="default" onClick={handleDownloadParticipant} disabled={downloadUnavailable}>
+                        Download Participant Data
+                      </Button>
+                    </Group>
+                  </>
+                )
+                : showRetryNotice
+                  ? (
+                    <>
+                      <Text c={finalizeError ? 'red' : undefined} maw={560}>
+                        {finalizeError || 'The upload confirmation is taking longer than expected.'}
+                        {' '}
+                        {isRetryingAutomatically && automaticRetryDelaySeconds
+                          ? `We will retry automatically in about ${automaticRetryDelaySeconds} seconds.`
+                          : 'We will retry automatically.'}
+                      </Text>
+                      <Space h="lg" />
+                      <Center>
+                        <Loader color="blue" />
+                      </Center>
+                    </>
+                  )
+                  : (
+                    <Center>
+                      <Loader color="blue" />
+                    </Center>
+                  )}
             </>
           )}
       </Flex>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -112,10 +112,6 @@ export function StudyEnd() {
     download(JSON.stringify(participantDataToDownload, null, 2), `${baseFilename}_${participantIdToDownload}.json`);
   }, [baseFilename, participantData, participantId, refreshParticipantData]);
 
-  const handleDownloadParticipant = useCallback(() => {
-    downloadParticipant();
-  }, [downloadParticipant]);
-
   const retryFinalize = useCallback(() => {
     finalizeLoopRef.current?.retryNow();
   }, []);
@@ -192,6 +188,7 @@ export function StudyEnd() {
     failedAttemptCount,
     isRetryingAutomatically,
     manualRetryRequired,
+    retryAllowed,
     retryDelayMs,
   } = finalizeState;
   const showRetryNotice = failedAttemptCount > 0;
@@ -210,7 +207,9 @@ export function StudyEnd() {
             <>
               <Text size="xl" display="block">
                 {manualRetryRequired
-                  ? 'We could not confirm your upload after 3 attempts.'
+                  ? retryAllowed
+                    ? 'We could not confirm your upload after 3 attempts.'
+                    : 'Your responses were saved, but we could not upload all recorded media from this tab.'
                   : showRetryNotice
                     ? 'We hit an issue while uploading your answers. Retrying automatically...'
                     : 'Please wait while your answers are uploaded.'}
@@ -222,7 +221,9 @@ export function StudyEnd() {
                     <Text c="red" maw={560}>
                       {finalizeError || 'The upload confirmation is taking longer than expected.'}
                       {' '}
-                      You can try the upload again, or download your participant data and submit it manually to the study designer.
+                      {retryAllowed
+                        ? 'You can try the upload again, or download your participant data and submit it manually to the study designer.'
+                        : 'You can download your participant data and send it to the study designer, but the recorded media from this tab cannot be re-uploaded now.'}
                     </Text>
                     {participantId
                       ? (
@@ -234,8 +235,10 @@ export function StudyEnd() {
                       : null}
                     <Space h="lg" />
                     <Group>
-                      <Button onClick={retryFinalize}>Retry Upload</Button>
-                      <Button variant="default" onClick={handleDownloadParticipant} disabled={downloadUnavailable}>
+                      {retryAllowed
+                        ? <Button onClick={retryFinalize}>Retry Upload</Button>
+                        : null}
+                      <Button variant="default" onClick={downloadParticipant} disabled={downloadUnavailable}>
                         Download Participant Data
                       </Button>
                     </Group>

--- a/src/components/StudyEnd.utils.spec.ts
+++ b/src/components/StudyEnd.utils.spec.ts
@@ -43,6 +43,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: false,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: null,
     });
   });
@@ -79,6 +80,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 1,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: 2000,
     });
     expect(finalizeParticipant).toHaveBeenCalledTimes(1);
@@ -97,6 +99,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: false,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: null,
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -125,6 +128,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 1,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: 2000,
     });
 
@@ -136,6 +140,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 2,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: 5000,
     });
 
@@ -147,6 +152,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 3,
       isRetryingAutomatically: false,
       manualRetryRequired: true,
+      retryAllowed: true,
       retryDelayMs: null,
     });
     expect(finalizeParticipant).toHaveBeenCalledTimes(3);
@@ -165,6 +171,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: false,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: null,
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
@@ -193,6 +200,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: 2000,
     });
 
@@ -205,6 +213,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: 2000,
     });
 
@@ -217,6 +226,7 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: 2000,
     });
 
@@ -229,8 +239,44 @@ describe('StudyEnd utils', () => {
       failedAttemptCount: 0,
       isRetryingAutomatically: false,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs: null,
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('stops immediately on a non-retryable finalize error', async () => {
+    const finalizeParticipant = vi.fn()
+      .mockResolvedValueOnce({
+        status: 'error',
+        message: 'Recorded media upload failed',
+        retryable: false,
+      } satisfies FinalizeParticipantResult);
+    const onComplete = vi.fn();
+    const onStateChange = vi.fn();
+
+    const finalizeLoop = createStudyEndFinalizeLoop({
+      getStorageEngine: () => ({ finalizeParticipant } as unknown as StorageEngine),
+      onComplete,
+      onStateChange,
+    });
+
+    finalizeLoop.start();
+    await flushPromises();
+
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: 'Recorded media upload failed',
+      failedAttemptCount: 1,
+      isRetryingAutomatically: false,
+      manualRetryRequired: true,
+      retryAllowed: false,
+      retryDelayMs: null,
+    });
+
+    vi.advanceTimersByTime(30000);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/src/components/StudyEnd.utils.spec.ts
+++ b/src/components/StudyEnd.utils.spec.ts
@@ -1,32 +1,172 @@
 import {
+  afterEach,
+  beforeEach,
   describe,
   expect,
   test,
+  vi,
 } from 'vitest';
-import { getStudyEndFinalizeState } from './StudyEnd.utils';
+import { FinalizeParticipantResult, StorageEngine } from '../storage/engines/types';
+import {
+  createStudyEndFinalizeLoop,
+  DEFAULT_STUDY_END_FINALIZE_STATE,
+} from './StudyEnd.utils';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+
+  return {
+    promise: new Promise<T>((res) => {
+      resolve = res;
+    }),
+    resolve,
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('StudyEnd utils', () => {
-  test('maps retry responses to a retryable loading state', () => {
-    expect(getStudyEndFinalizeState({ status: 'retry' })).toEqual({
-      completed: false,
-      shouldRetry: true,
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('exports the default finalize loop state', () => {
+    expect(DEFAULT_STUDY_END_FINALIZE_STATE).toEqual({
       error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: false,
+      manualRetryRequired: false,
+      retryDelayMs: null,
     });
   });
 
-  test('maps complete responses to a completed state', () => {
-    expect(getStudyEndFinalizeState({ status: 'complete' })).toEqual({
-      completed: true,
-      shouldRetry: false,
-      error: null,
+  test('retries after an error with backoff and without starting overlapping finalize requests', async () => {
+    const firstAttempt = createDeferred<FinalizeParticipantResult>();
+    const finalizeParticipant = vi.fn()
+      .mockImplementationOnce(() => firstAttempt.promise)
+      .mockResolvedValueOnce({ status: 'complete' });
+    const onComplete = vi.fn();
+    const onStateChange = vi.fn();
+
+    const finalizeLoop = createStudyEndFinalizeLoop({
+      getStorageEngine: () => ({ finalizeParticipant } as unknown as StorageEngine),
+      onComplete,
+      onStateChange,
     });
+
+    finalizeLoop.start();
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10000);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(1);
+
+    firstAttempt.resolve({ status: 'error', message: 'Temporary failure' });
+    await flushPromises();
+
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: 'Temporary failure',
+      failedAttemptCount: 1,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs: 2000,
+    });
+    expect(finalizeParticipant).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1999);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(2);
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: false,
+      manualRetryRequired: false,
+      retryDelayMs: null,
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  test('maps error responses to a terminal error state', () => {
-    expect(getStudyEndFinalizeState({ status: 'error', message: 'Upload failed' })).toEqual({
-      completed: false,
-      shouldRetry: false,
-      error: 'Upload failed',
+  test('stops automatic retries after the third failed attempt until retryNow is called', async () => {
+    const finalizeParticipant = vi.fn()
+      .mockResolvedValueOnce({ status: 'error', message: 'First failure' })
+      .mockResolvedValueOnce({ status: 'error', message: 'Second failure' })
+      .mockResolvedValueOnce({ status: 'error', message: 'Third failure' })
+      .mockResolvedValueOnce({ status: 'complete' });
+    const onComplete = vi.fn();
+    const onStateChange = vi.fn();
+
+    const finalizeLoop = createStudyEndFinalizeLoop({
+      getStorageEngine: () => ({ finalizeParticipant } as unknown as StorageEngine),
+      onComplete,
+      onStateChange,
     });
+
+    finalizeLoop.start();
+    await flushPromises();
+
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: 'First failure',
+      failedAttemptCount: 1,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs: 2000,
+    });
+
+    vi.advanceTimersByTime(2000);
+    await flushPromises();
+
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: 'Second failure',
+      failedAttemptCount: 2,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs: 5000,
+    });
+
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: 'Third failure',
+      failedAttemptCount: 3,
+      isRetryingAutomatically: false,
+      manualRetryRequired: true,
+      retryDelayMs: null,
+    });
+    expect(finalizeParticipant).toHaveBeenCalledTimes(3);
+
+    vi.advanceTimersByTime(30000);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(3);
+
+    finalizeLoop.retryNow();
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(4);
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: false,
+      manualRetryRequired: false,
+      retryDelayMs: null,
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/StudyEnd.utils.spec.ts
+++ b/src/components/StudyEnd.utils.spec.ts
@@ -1,0 +1,32 @@
+import {
+  describe,
+  expect,
+  test,
+} from 'vitest';
+import { getStudyEndFinalizeState } from './StudyEnd.utils';
+
+describe('StudyEnd utils', () => {
+  test('maps retry responses to a retryable loading state', () => {
+    expect(getStudyEndFinalizeState({ status: 'retry' })).toEqual({
+      completed: false,
+      shouldRetry: true,
+      error: null,
+    });
+  });
+
+  test('maps complete responses to a completed state', () => {
+    expect(getStudyEndFinalizeState({ status: 'complete' })).toEqual({
+      completed: true,
+      shouldRetry: false,
+      error: null,
+    });
+  });
+
+  test('maps error responses to a terminal error state', () => {
+    expect(getStudyEndFinalizeState({ status: 'error', message: 'Upload failed' })).toEqual({
+      completed: false,
+      shouldRetry: false,
+      error: 'Upload failed',
+    });
+  });
+});

--- a/src/components/StudyEnd.utils.spec.ts
+++ b/src/components/StudyEnd.utils.spec.ts
@@ -169,4 +169,68 @@ describe('StudyEnd utils', () => {
     });
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
+
+  test('treats retry as a neutral syncing state without consuming the failure budget', async () => {
+    const finalizeParticipant = vi.fn()
+      .mockResolvedValueOnce({ status: 'retry' })
+      .mockResolvedValueOnce({ status: 'retry' })
+      .mockResolvedValueOnce({ status: 'retry' })
+      .mockResolvedValueOnce({ status: 'complete' });
+    const onComplete = vi.fn();
+    const onStateChange = vi.fn();
+
+    const finalizeLoop = createStudyEndFinalizeLoop({
+      getStorageEngine: () => ({ finalizeParticipant } as unknown as StorageEngine),
+      onComplete,
+      onStateChange,
+    });
+
+    finalizeLoop.start();
+    await flushPromises();
+
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs: 2000,
+    });
+
+    vi.advanceTimersByTime(2000);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(2);
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs: 2000,
+    });
+
+    vi.advanceTimersByTime(2000);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(3);
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs: 2000,
+    });
+
+    vi.advanceTimersByTime(2000);
+    await flushPromises();
+
+    expect(finalizeParticipant).toHaveBeenCalledTimes(4);
+    expect(onStateChange).toHaveBeenLastCalledWith({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: false,
+      manualRetryRequired: false,
+      retryDelayMs: null,
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/StudyEnd.utils.ts
+++ b/src/components/StudyEnd.utils.ts
@@ -5,6 +5,7 @@ export type StudyEndFinalizeLoopState = {
   failedAttemptCount: number;
   isRetryingAutomatically: boolean;
   manualRetryRequired: boolean;
+  retryAllowed: boolean;
   retryDelayMs: number | null;
 };
 
@@ -24,8 +25,11 @@ export const DEFAULT_STUDY_END_FINALIZE_STATE: StudyEndFinalizeLoopState = {
   failedAttemptCount: 0,
   isRetryingAutomatically: false,
   manualRetryRequired: false,
+  retryAllowed: true,
   retryDelayMs: null,
 };
+
+const DEFAULT_FINALIZE_ERROR_MESSAGE = 'An error occurred while uploading your answers.';
 
 export function getStudyEndRetryDelayMs(failedAttemptCount: number) {
   if (failedAttemptCount <= 1) {
@@ -66,6 +70,7 @@ export function createStudyEndFinalizeLoop({
       failedAttemptCount: 0,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs,
     });
   };
@@ -90,6 +95,7 @@ export function createStudyEndFinalizeLoop({
         failedAttemptCount,
         isRetryingAutomatically: false,
         manualRetryRequired: true,
+        retryAllowed: true,
         retryDelayMs: null,
       });
       return;
@@ -101,10 +107,22 @@ export function createStudyEndFinalizeLoop({
       failedAttemptCount,
       isRetryingAutomatically: true,
       manualRetryRequired: false,
+      retryAllowed: true,
       retryDelayMs,
     });
 
     scheduleRetry(retryDelayMs);
+  };
+
+  const handleTerminalFailure = (error: string | null) => {
+    emitState({
+      error,
+      failedAttemptCount: 1,
+      isRetryingAutomatically: false,
+      manualRetryRequired: true,
+      retryAllowed: false,
+      retryDelayMs: null,
+    });
   };
 
   const handleRetryablePendingState = () => {
@@ -142,14 +160,19 @@ export function createStudyEndFinalizeLoop({
         return;
       }
 
-      handleRetryableFailure(result.message || 'An error occurred while uploading your answers.');
+      if (result.retryable === false) {
+        handleTerminalFailure(result.message || DEFAULT_FINALIZE_ERROR_MESSAGE);
+        return;
+      }
+
+      handleRetryableFailure(result.message || DEFAULT_FINALIZE_ERROR_MESSAGE);
     } catch (error) {
       if (cancelled) {
         return;
       }
 
       onUnexpectedError?.(error);
-      handleRetryableFailure('An error occurred while uploading your answers.');
+      handleRetryableFailure(DEFAULT_FINALIZE_ERROR_MESSAGE);
     } finally {
       finalizeRequestInFlight = false;
     }

--- a/src/components/StudyEnd.utils.ts
+++ b/src/components/StudyEnd.utils.ts
@@ -60,6 +60,16 @@ export function createStudyEndFinalizeLoop({
     onStateChange(nextState);
   };
 
+  const emitAutomaticRetryState = (retryDelayMs: number) => {
+    emitState({
+      error: null,
+      failedAttemptCount: 0,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs,
+    });
+  };
+
   const scheduleRetry = (retryDelayMs: number) => {
     if (cancelled || timeoutId) {
       return;
@@ -97,6 +107,12 @@ export function createStudyEndFinalizeLoop({
     scheduleRetry(retryDelayMs);
   };
 
+  const handleRetryablePendingState = () => {
+    const retryDelayMs = getRetryDelayMs(1);
+    emitAutomaticRetryState(retryDelayMs);
+    scheduleRetry(retryDelayMs);
+  };
+
   verifyLoop = async () => {
     if (cancelled || finalizeRequestInFlight) {
       return;
@@ -118,6 +134,11 @@ export function createStudyEndFinalizeLoop({
       if (result.status === 'complete') {
         emitState(DEFAULT_STUDY_END_FINALIZE_STATE);
         onComplete();
+        return;
+      }
+
+      if (result.status === 'retry') {
+        handleRetryablePendingState();
         return;
       }
 

--- a/src/components/StudyEnd.utils.ts
+++ b/src/components/StudyEnd.utils.ts
@@ -1,0 +1,25 @@
+import { FinalizeParticipantResult } from '../storage/engines/types';
+
+export function getStudyEndFinalizeState(result: FinalizeParticipantResult) {
+  if (result.status === 'complete') {
+    return {
+      completed: true,
+      shouldRetry: false,
+      error: null,
+    };
+  }
+
+  if (result.status === 'error') {
+    return {
+      completed: false,
+      shouldRetry: false,
+      error: result.message || 'An error occurred while uploading your answers.',
+    };
+  }
+
+  return {
+    completed: false,
+    shouldRetry: true,
+    error: null,
+  };
+}

--- a/src/components/StudyEnd.utils.ts
+++ b/src/components/StudyEnd.utils.ts
@@ -1,25 +1,163 @@
-import { FinalizeParticipantResult } from '../storage/engines/types';
+import { StorageEngine } from '../storage/engines/types';
 
-export function getStudyEndFinalizeState(result: FinalizeParticipantResult) {
-  if (result.status === 'complete') {
-    return {
-      completed: true,
-      shouldRetry: false,
-      error: null,
-    };
+export type StudyEndFinalizeLoopState = {
+  error: string | null;
+  failedAttemptCount: number;
+  isRetryingAutomatically: boolean;
+  manualRetryRequired: boolean;
+  retryDelayMs: number | null;
+};
+
+type StudyEndFinalizeLoopOptions = {
+  getStorageEngine: () => StorageEngine | undefined;
+  onComplete: () => void;
+  onStateChange: (state: StudyEndFinalizeLoopState) => void;
+  onUnexpectedError?: (error: unknown) => void;
+  maxAutomaticRetryAttempts?: number;
+  getRetryDelayMs?: (failedAttemptCount: number) => number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+};
+
+export const DEFAULT_STUDY_END_FINALIZE_STATE: StudyEndFinalizeLoopState = {
+  error: null,
+  failedAttemptCount: 0,
+  isRetryingAutomatically: false,
+  manualRetryRequired: false,
+  retryDelayMs: null,
+};
+
+export function getStudyEndRetryDelayMs(failedAttemptCount: number) {
+  if (failedAttemptCount <= 1) {
+    return 2000;
   }
 
-  if (result.status === 'error') {
-    return {
-      completed: false,
-      shouldRetry: false,
-      error: result.message || 'An error occurred while uploading your answers.',
-    };
+  if (failedAttemptCount === 2) {
+    return 5000;
   }
+
+  return 10000;
+}
+
+export function createStudyEndFinalizeLoop({
+  getStorageEngine,
+  onComplete,
+  onStateChange,
+  onUnexpectedError,
+  maxAutomaticRetryAttempts = 3,
+  getRetryDelayMs = getStudyEndRetryDelayMs,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+}: StudyEndFinalizeLoopOptions) {
+  let cancelled = false;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let finalizeRequestInFlight = false;
+  let loopState = DEFAULT_STUDY_END_FINALIZE_STATE;
+  let verifyLoop: () => Promise<void>;
+
+  const emitState = (nextState: StudyEndFinalizeLoopState) => {
+    loopState = nextState;
+    onStateChange(nextState);
+  };
+
+  const scheduleRetry = (retryDelayMs: number) => {
+    if (cancelled || timeoutId) {
+      return;
+    }
+
+    timeoutId = setTimeoutFn(() => {
+      timeoutId = null;
+      verifyLoop();
+    }, retryDelayMs);
+  };
+
+  const handleRetryableFailure = (error: string | null) => {
+    const failedAttemptCount = loopState.failedAttemptCount + 1;
+
+    if (failedAttemptCount >= maxAutomaticRetryAttempts) {
+      emitState({
+        error,
+        failedAttemptCount,
+        isRetryingAutomatically: false,
+        manualRetryRequired: true,
+        retryDelayMs: null,
+      });
+      return;
+    }
+
+    const retryDelayMs = getRetryDelayMs(failedAttemptCount);
+    emitState({
+      error,
+      failedAttemptCount,
+      isRetryingAutomatically: true,
+      manualRetryRequired: false,
+      retryDelayMs,
+    });
+
+    scheduleRetry(retryDelayMs);
+  };
+
+  verifyLoop = async () => {
+    if (cancelled || finalizeRequestInFlight) {
+      return;
+    }
+
+    const storageEngine = getStorageEngine();
+    if (!storageEngine) {
+      scheduleRetry(getStudyEndRetryDelayMs(1));
+      return;
+    }
+
+    finalizeRequestInFlight = true;
+    try {
+      const result = await storageEngine.finalizeParticipant();
+      if (cancelled) {
+        return;
+      }
+
+      if (result.status === 'complete') {
+        emitState(DEFAULT_STUDY_END_FINALIZE_STATE);
+        onComplete();
+        return;
+      }
+
+      handleRetryableFailure(result.message || 'An error occurred while uploading your answers.');
+    } catch (error) {
+      if (cancelled) {
+        return;
+      }
+
+      onUnexpectedError?.(error);
+      handleRetryableFailure('An error occurred while uploading your answers.');
+    } finally {
+      finalizeRequestInFlight = false;
+    }
+  };
 
   return {
-    completed: false,
-    shouldRetry: true,
-    error: null,
+    start() {
+      verifyLoop();
+    },
+    retryNow() {
+      if (cancelled || finalizeRequestInFlight) {
+        return;
+      }
+
+      if (timeoutId) {
+        clearTimeoutFn(timeoutId);
+        timeoutId = null;
+      }
+
+      emitState(DEFAULT_STUDY_END_FINALIZE_STATE);
+      verifyLoop();
+    },
+    cancel() {
+      cancelled = true;
+
+      if (timeoutId) {
+        clearTimeoutFn(timeoutId);
+        timeoutId = null;
+      }
+    },
   };
 }

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -32,7 +32,7 @@ import {
   useStoreDispatch, useStoreSelector, useStoreActions, useFlatSequence,
 } from '../../store/store';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
-import { calculateProgressData } from '../../storage/engines/utils';
+import { calculateProgressData } from '../../storage/engines/utils/storageEngineHelpers';
 import { PREFIX } from '../../utils/Prefix';
 import { getNewParticipant } from '../../utils/nextParticipant';
 import { RecordingAudioWaveform } from './RecordingAudioWaveform';

--- a/src/components/settings/GlobalSettings.tsx
+++ b/src/components/settings/GlobalSettings.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '../../store/hooks/useAuth';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { StoredUser } from '../../storage/engines/types';
 import { signIn } from '../../Login';
-import { isCloudStorageEngine } from '../../storage/engines/utils';
+import { isCloudStorageEngine } from '../../storage/engines/utils/storageEngineHelpers';
 import { SupabaseStorageEngine } from '../../storage/engines/SupabaseStorageEngine';
 
 export function GlobalSettings() {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -265,6 +265,35 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     await updateDoc(participantSequenceAssignmentDoc, firebaseUpdatedFields);
   }
 
+  protected async _getSequenceAssignment(participantId: string) {
+    if (this.studyId === undefined) {
+      throw new Error('Study ID is not set');
+    }
+
+    const sequenceAssignmentDoc = doc(this.studyCollection, 'sequenceAssignment');
+    const sequenceAssignmentCollection = collection(
+      sequenceAssignmentDoc,
+      'sequenceAssignment',
+    );
+    const participantSequenceAssignmentDoc = doc(
+      sequenceAssignmentCollection,
+      participantId,
+    );
+
+    const participantSequenceAssignment = await getDoc(participantSequenceAssignmentDoc);
+    if (!participantSequenceAssignment.exists()) {
+      return null;
+    }
+
+    const data = participantSequenceAssignment.data();
+    return {
+      ...data,
+      timestamp: data.timestamp instanceof Timestamp ? data.timestamp.toMillis() : data.timestamp,
+      createdTime: data.createdTime instanceof Timestamp ? data.createdTime.toMillis() : data.createdTime,
+      completed: data.completed instanceof Timestamp ? data.completed.toMillis() : data.completed,
+    } as SequenceAssignment;
+  }
+
   protected async _completeCurrentParticipantRealtime() {
     await this.verifyStudyDatabase();
     if (!this.currentParticipantId) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -96,6 +96,17 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
   }
 
+  protected async _getSequenceAssignment(participantId: string) {
+    await this.verifyStudyDatabase();
+    if (this.studyId === undefined) {
+      throw new Error('Study ID is not set');
+    }
+
+    const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
+    const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
+    return sequenceAssignments[participantId] || null;
+  }
+
   protected async _completeCurrentParticipantRealtime() {
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -201,6 +201,30 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .eq('docId', sequenceAssignmentPath);
   }
 
+  protected async _getSequenceAssignment(participantId: string) {
+    await this.verifyStudyDatabase();
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+
+    const { data, error } = await this.supabase
+      .from('revisit')
+      .select('data, createdAt')
+      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('docId', `sequenceAssignment_${participantId}`)
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return {
+      ...data.data,
+      timestamp: data.data.withServerTimestamp ? new Date(data.createdAt).getTime() : data.data.timestamp,
+      createdTime: new Date(data.createdAt).getTime(),
+    } as SequenceAssignment;
+  }
+
   protected async _completeCurrentParticipantRealtime() {
     await this.verifyStudyDatabase();
     if (!this.currentParticipantId) {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -5,6 +5,10 @@ import { StudyConfig } from '../../parser/types';
 import { ParticipantMetadata, Sequence } from '../../store/types';
 import { ParticipantData } from '../types';
 import { hash, isParticipantData } from './utils/storageEngineHelpers';
+import {
+  answeredParticipantAnswerMetadataMatches,
+  getAnsweredParticipantAnswerMetadata,
+} from './utils/participantAnswerMetadata';
 import { shouldPreferCachedParticipantData } from './utils/participantDataRecovery';
 import { RevisitNotification } from '../../utils/notifications';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
@@ -123,41 +127,12 @@ export type FinalizeParticipantResult = {
   message?: string;
 };
 
-type AnsweredParticipantAnswerMetadata = {
-  key: string;
-  endTime: number;
-};
-
 function normalizeError(error: unknown) {
   return error instanceof Error ? error : new Error(String(error));
 }
 
 function cloneParticipantDataSnapshot(participantData: ParticipantData) {
   return structuredClone(participantData);
-}
-
-function getAnsweredParticipantAnswerMetadata(answers: ParticipantData['answers']): AnsweredParticipantAnswerMetadata[] {
-  return Object.entries(answers)
-    .filter(([, answer]) => answer.endTime > -1)
-    .map(([key, answer]) => ({
-      key,
-      endTime: answer.endTime,
-    }))
-    .sort((a, b) => a.key.localeCompare(b.key));
-}
-
-function answeredParticipantAnswerMetadataMatches(
-  localAnswers: AnsweredParticipantAnswerMetadata[],
-  persistedAnswers: AnsweredParticipantAnswerMetadata[],
-) {
-  if (localAnswers.length !== persistedAnswers.length) {
-    return false;
-  }
-
-  return localAnswers.every(
-    (answer, index) => answer.key === persistedAnswers[index].key
-      && answer.endTime === persistedAnswers[index].endTime,
-  );
 }
 
 export abstract class StorageEngine {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -879,6 +879,14 @@ export abstract class StorageEngine {
     return isParticipantData(participantData) ? participantData : null;
   }
 
+  getCurrentParticipantDataSnapshot() {
+    if (!this.participantData) {
+      return null;
+    }
+
+    return cloneParticipantDataSnapshot(this.participantData);
+  }
+
   // Gets the participant tags for the current participant.
   async getParticipantTags(): Promise<string[]> {
     await this.verifyStudyDatabase();

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -5,6 +5,7 @@ import { StudyConfig } from '../../parser/types';
 import { ParticipantMetadata, Sequence } from '../../store/types';
 import { ParticipantData } from '../types';
 import { hash, isParticipantData } from './utils';
+import { shouldPreferCachedParticipantData } from './utils/participantDataRecovery';
 import { RevisitNotification } from '../../utils/notifications';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
 import {
@@ -192,7 +193,11 @@ export abstract class StorageEngine {
 
   private pendingAssetUploads = new Map<string, Promise<void>>();
 
+  private pendingAssetOperations = new Set<Promise<unknown>>();
+
   private assetUploadError: Error | null = null;
+
+  private assetUploadActivityVersion = 0;
 
   constructor(engine: typeof this.engine, testing: boolean) {
     this.engine = engine;
@@ -352,6 +357,48 @@ export abstract class StorageEngine {
     return await this.__throttleVerifyStudyDatabase();
   }
 
+  private getParticipantDataSnapshotStorageKey(participantId: string) {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+
+    return `${this.collectionPrefix}${this.studyId}/participants/${participantId}/localParticipantData`;
+  }
+
+  private async cacheParticipantDataSnapshot(snapshot: ParticipantData, participantId?: string) {
+    const targetParticipantId = participantId || this.currentParticipantId;
+    if (!this.studyId || !targetParticipantId) {
+      return;
+    }
+
+    try {
+      await this.participantStore.setItem(
+        this.getParticipantDataSnapshotStorageKey(targetParticipantId),
+        cloneParticipantDataSnapshot(snapshot),
+      );
+    } catch (error) {
+      console.warn('Failed to cache participant data locally:', error);
+    }
+  }
+
+  private async getCachedParticipantDataSnapshot(participantId?: string) {
+    const targetParticipantId = participantId || this.currentParticipantId;
+    if (!this.studyId || !targetParticipantId) {
+      return null;
+    }
+
+    try {
+      const cachedParticipantData = await this.participantStore.getItem<ParticipantData>(
+        this.getParticipantDataSnapshotStorageKey(targetParticipantId),
+      );
+
+      return isParticipantData(cachedParticipantData) ? cachedParticipantData : null;
+    } catch (error) {
+      console.warn('Failed to read cached participant data:', error);
+      return null;
+    }
+  }
+
   private clearPendingParticipantDataWriteTimer() {
     if (this.pendingParticipantDataWriteTimer) {
       clearTimeout(this.pendingParticipantDataWriteTimer);
@@ -438,14 +485,15 @@ export abstract class StorageEngine {
   protected async persistCurrentParticipantData(
     options: { immediate?: boolean; cache?: boolean } = {},
   ) {
-    await this.verifyStudyDatabase();
-
     if (!this.currentParticipantId || this.participantData === undefined) {
       throw new Error('Participant not initialized');
     }
 
     const snapshot = cloneParticipantDataSnapshot(this.participantData);
     const { immediate = false, cache = false } = options;
+
+    await this.cacheParticipantDataSnapshot(snapshot, this.currentParticipantId);
+    await this.verifyStudyDatabase();
 
     if (!immediate) {
       this.scheduleParticipantDataWrite(snapshot, cache);
@@ -486,10 +534,52 @@ export abstract class StorageEngine {
     return this.assetUploadError;
   }
 
+  private noteAssetUploadActivity() {
+    this.assetUploadActivityVersion += 1;
+  }
+
+  private async waitForAssetUploadIdleWindow() {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  private trackAssetOperation<T>(operation: () => Promise<T>) {
+    this.noteAssetUploadActivity();
+
+    const operationPromise = operation()
+      .catch((error) => {
+        this.recordAssetUploadError(error);
+        throw this.getAssetUploadError();
+      })
+      .finally(() => {
+        this.pendingAssetOperations.delete(operationPromise);
+        this.noteAssetUploadActivity();
+      });
+
+    this.pendingAssetOperations.add(operationPromise);
+
+    return operationPromise;
+  }
+
   private async waitForPendingAssetUploads() {
-    const uploadPromises = Array.from(this.pendingAssetUploads.values());
+    const uploadPromises = [
+      ...this.pendingAssetUploads.values(),
+      ...this.pendingAssetOperations,
+    ];
     if (uploadPromises.length === 0) {
-      return this.getAssetUploadError();
+      const activityVersion = this.assetUploadActivityVersion;
+      await this.waitForAssetUploadIdleWindow();
+
+      if (
+        this.pendingAssetUploads.size === 0
+        && this.pendingAssetOperations.size === 0
+        && this.assetUploadActivityVersion === activityVersion
+      ) {
+        return this.getAssetUploadError();
+      }
+
+      return this.waitForPendingAssetUploads();
     }
 
     const results = await Promise.allSettled(uploadPromises);
@@ -499,7 +589,7 @@ export abstract class StorageEngine {
       this.recordAssetUploadError(rejectedUpload.reason);
     }
 
-    return this.getAssetUploadError();
+    return this.waitForPendingAssetUploads();
   }
 
   async getStageData(studyId: string): Promise<StageData> {
@@ -786,6 +876,7 @@ export abstract class StorageEngine {
       `participants/${this.currentParticipantId}`,
       'participantData',
     );
+    const cachedParticipant = await this.getCachedParticipantDataSnapshot(this.currentParticipantId);
 
     if (this.studyId === undefined) {
       throw new Error('Study ID is not set');
@@ -796,9 +887,18 @@ export abstract class StorageEngine {
     const stageData = await this.getStageData(this.studyId);
     const currentStage = stageData.currentStage.stageName;
 
+    if (
+      cachedParticipant
+      && (!isParticipantData(participant) || shouldPreferCachedParticipantData(cachedParticipant, participant))
+    ) {
+      this.participantData = cachedParticipant;
+      return cachedParticipant;
+    }
+
     if (isParticipantData(participant)) {
       // Participant already initialized
       this.participantData = participant;
+      await this.cacheParticipantDataSnapshot(participant, this.currentParticipantId);
       return participant;
     }
     // Initialize participant
@@ -824,6 +924,8 @@ export abstract class StorageEngine {
 
     if (modes.dataCollectionEnabled) {
       await this.persistCurrentParticipantData({ immediate: true });
+    } else {
+      await this.cacheParticipantDataSnapshot(this.participantData, this.currentParticipantId);
     }
 
     return this.participantData;
@@ -876,7 +978,30 @@ export abstract class StorageEngine {
       'participantData',
     );
 
-    return isParticipantData(participantData) ? participantData : null;
+    if (isParticipantData(participantData)) {
+      const targetParticipantId = participantId || this.currentParticipantId;
+      const cachedParticipantData = targetParticipantId === this.currentParticipantId
+        ? await this.getCachedParticipantDataSnapshot(targetParticipantId)
+        : null;
+
+      if (
+        cachedParticipantData
+        && shouldPreferCachedParticipantData(cachedParticipantData, participantData)
+      ) {
+        return cachedParticipantData;
+      }
+
+      if (targetParticipantId === this.currentParticipantId) {
+        await this.cacheParticipantDataSnapshot(participantData, targetParticipantId);
+      }
+      return participantData;
+    }
+
+    if (!participantId || participantId === this.currentParticipantId) {
+      return await this.getCachedParticipantDataSnapshot(participantId);
+    }
+
+    return null;
   }
 
   getCurrentParticipantDataSnapshot() {
@@ -1101,6 +1226,7 @@ export abstract class StorageEngine {
       answers,
     };
 
+    await this.cacheParticipantDataSnapshot(this.participantData, this.currentParticipantId);
     this.scheduleParticipantDataWrite(this.participantData);
   }
 
@@ -1299,14 +1425,16 @@ export abstract class StorageEngine {
     blob: Blob,
     taskName: string,
   ) {
-    if (this.studyId === undefined) {
-      throw new Error('Study ID is not set');
-    }
-    const modes = await this.getModes(this.studyId);
-    if (!modes.dataCollectionEnabled) {
-      throw new Error('Data collection is disabled for this study');
-    }
-    return this.saveAsset('audio', blob, taskName);
+    return this.trackAssetOperation(async () => {
+      if (this.studyId === undefined) {
+        throw new Error('Study ID is not set');
+      }
+      const modes = await this.getModes(this.studyId);
+      if (!modes.dataCollectionEnabled) {
+        throw new Error('Data collection is disabled for this study');
+      }
+      return this.saveAsset('audio', blob, taskName);
+    });
   }
 
   // Gets the screen recording for a specific task and participantId.
@@ -1323,14 +1451,16 @@ export abstract class StorageEngine {
     blob: Blob,
     taskName: string,
   ) {
-    if (this.studyId === undefined) {
-      throw new Error('Study ID is not set');
-    }
-    const modes = await this.getModes(this.studyId);
-    if (!modes.dataCollectionEnabled) {
-      throw new Error('Data collection is disabled for this study');
-    }
-    return this.saveAsset('screenRecording', blob, taskName);
+    return this.trackAssetOperation(async () => {
+      if (this.studyId === undefined) {
+        throw new Error('Study ID is not set');
+      }
+      const modes = await this.getModes(this.studyId);
+      if (!modes.dataCollectionEnabled) {
+        throw new Error('Data collection is disabled for this study');
+      }
+      return this.saveAsset('screenRecording', blob, taskName);
+    });
   }
 
   // Gets the sequence array from the storage engine.
@@ -1358,7 +1488,9 @@ export abstract class StorageEngine {
     this.participantDataWriteChain = Promise.resolve();
     this.participantDataWriteError = null;
     this.pendingAssetUploads.clear();
+    this.pendingAssetOperations.clear();
     this.assetUploadError = null;
+    this.assetUploadActivityVersion = 0;
     this.participantData = undefined;
     if (this.studyId) {
       await this.clearCurrentParticipantId();

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -1276,6 +1276,29 @@ export abstract class StorageEngine {
     const localAnsweredAnswers = getAnsweredParticipantAnswerMetadata(this.participantData.answers);
     const persistedAnsweredAnswers = getAnsweredParticipantAnswerMetadata(persistedParticipantData.answers);
 
+    if (localAnsweredAnswers.length === 0 && persistedAnsweredAnswers.length === 0) {
+      this.participantData.completed = true;
+
+      try {
+        await this.persistCurrentParticipantData({ immediate: true, cache: true });
+        await this._completeCurrentParticipantRealtime();
+      } catch (error) {
+        return {
+          status: 'error',
+          message: normalizeError(error).message,
+        };
+      }
+
+      const completedParticipantData = await this.getParticipantData();
+      const sequenceAssignment = await this._getSequenceAssignment(this.currentParticipantId);
+
+      if (completedParticipantData?.completed && sequenceAssignment?.completed) {
+        return { status: 'complete' };
+      }
+
+      return { status: 'retry' };
+    }
+
     if (localAnsweredAnswers.length === 0 || persistedAnsweredAnswers.length === 0) {
       return { status: 'retry' };
     }

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -568,7 +568,7 @@ export abstract class StorageEngine {
     return operationPromise;
   }
 
-  private async waitForPendingAssetUploads() {
+  private async waitForPendingAssetUploads(): Promise<Error | null> {
     const uploadPromises = [
       ...this.pendingAssetUploads.values(),
       ...this.pendingAssetOperations,

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -195,7 +195,7 @@ export abstract class StorageEngine {
 
   private pendingAssetOperations = new Set<Promise<unknown>>();
 
-  private assetUploadError: Error | null = null;
+  private failedAssetUploads = new Map<string, Error>();
 
   private assetUploadActivityVersion = 0;
 
@@ -526,12 +526,16 @@ export abstract class StorageEngine {
     }
   }
 
-  private recordAssetUploadError(error: unknown) {
-    this.assetUploadError = normalizeError(error);
+  private recordAssetUploadError(assetKey: string, error: unknown) {
+    this.failedAssetUploads.set(assetKey, normalizeError(error));
+  }
+
+  private clearAssetUploadError(assetKey: string) {
+    this.failedAssetUploads.delete(assetKey);
   }
 
   private getAssetUploadError() {
-    return this.assetUploadError;
+    return this.failedAssetUploads.values().next().value || null;
   }
 
   private noteAssetUploadActivity() {
@@ -544,13 +548,15 @@ export abstract class StorageEngine {
     });
   }
 
-  private trackAssetOperation<T>(operation: () => Promise<T>) {
+  private trackAssetOperation<T>(assetKey: string, operation: () => Promise<T>) {
     this.noteAssetUploadActivity();
+    this.clearAssetUploadError(assetKey);
 
     const operationPromise = operation()
       .catch((error) => {
-        this.recordAssetUploadError(error);
-        throw this.getAssetUploadError();
+        const normalizedError = normalizeError(error);
+        this.recordAssetUploadError(assetKey, normalizedError);
+        throw normalizedError;
       })
       .finally(() => {
         this.pendingAssetOperations.delete(operationPromise);
@@ -582,12 +588,7 @@ export abstract class StorageEngine {
       return this.waitForPendingAssetUploads();
     }
 
-    const results = await Promise.allSettled(uploadPromises);
-    const rejectedUpload = results.find((result) => result.status === 'rejected');
-
-    if (rejectedUpload?.status === 'rejected') {
-      this.recordAssetUploadError(rejectedUpload.reason);
-    }
+    await Promise.allSettled(uploadPromises);
 
     return this.waitForPendingAssetUploads();
   }
@@ -1404,12 +1405,12 @@ export abstract class StorageEngine {
     const participantKey = `${prefix}/${this.currentParticipantId}`;
     const uploadPromise = (async () => {
       try {
-        this.assetUploadError = null;
         await this._pushToStorage(participantKey, taskName, blob);
         await this._cacheStorageObject(participantKey, taskName);
       } catch (error) {
-        this.recordAssetUploadError(error);
-        throw this.assetUploadError;
+        const normalizedError = normalizeError(error);
+        this.recordAssetUploadError(assetKey, normalizedError);
+        throw normalizedError;
       } finally {
         this.pendingAssetUploads.delete(assetKey);
       }
@@ -1425,7 +1426,7 @@ export abstract class StorageEngine {
     blob: Blob,
     taskName: string,
   ) {
-    return this.trackAssetOperation(async () => {
+    return this.trackAssetOperation(`audio/${taskName}`, async () => {
       if (this.studyId === undefined) {
         throw new Error('Study ID is not set');
       }
@@ -1451,7 +1452,7 @@ export abstract class StorageEngine {
     blob: Blob,
     taskName: string,
   ) {
-    return this.trackAssetOperation(async () => {
+    return this.trackAssetOperation(`screenRecording/${taskName}`, async () => {
       if (this.studyId === undefined) {
         throw new Error('Study ID is not set');
       }
@@ -1489,7 +1490,7 @@ export abstract class StorageEngine {
     this.participantDataWriteError = null;
     this.pendingAssetUploads.clear();
     this.pendingAssetOperations.clear();
-    this.assetUploadError = null;
+    this.failedAssetUploads.clear();
     this.assetUploadActivityVersion = 0;
     this.participantData = undefined;
     if (this.studyId) {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -125,6 +125,7 @@ export type SnapshotDocContent = Record<string, { name: string; }>;
 export type FinalizeParticipantResult = {
   status: 'complete' | 'retry' | 'error';
   message?: string;
+  retryable?: boolean;
 };
 
 function normalizeError(error: unknown) {
@@ -1261,12 +1262,6 @@ export abstract class StorageEngine {
     }
 
     const assetUploadError = await this.waitForPendingAssetUploads();
-    if (assetUploadError) {
-      return {
-        status: 'error',
-        message: assetUploadError.message,
-      };
-    }
 
     const persistedParticipantData = await this.getParticipantData();
     if (!persistedParticipantData || !this.participantData) {
@@ -1276,8 +1271,8 @@ export abstract class StorageEngine {
     const localAnsweredAnswers = getAnsweredParticipantAnswerMetadata(this.participantData.answers);
     const persistedAnsweredAnswers = getAnsweredParticipantAnswerMetadata(persistedParticipantData.answers);
 
-    if (localAnsweredAnswers.length === 0 && persistedAnsweredAnswers.length === 0) {
-      this.participantData.completed = true;
+    const completeParticipant = async (): Promise<FinalizeParticipantResult> => {
+      this.participantData!.completed = true;
 
       try {
         await this.persistCurrentParticipantData({ immediate: true, cache: true });
@@ -1290,13 +1285,25 @@ export abstract class StorageEngine {
       }
 
       const completedParticipantData = await this.getParticipantData();
-      const sequenceAssignment = await this._getSequenceAssignment(this.currentParticipantId);
+      const sequenceAssignment = await this._getSequenceAssignment(this.currentParticipantId!);
 
       if (completedParticipantData?.completed && sequenceAssignment?.completed) {
+        if (assetUploadError) {
+          return {
+            status: 'error',
+            message: assetUploadError.message,
+            retryable: false,
+          };
+        }
+
         return { status: 'complete' };
       }
 
       return { status: 'retry' };
+    };
+
+    if (localAnsweredAnswers.length === 0 && persistedAnsweredAnswers.length === 0) {
+      return completeParticipant();
     }
 
     if (localAnsweredAnswers.length === 0 || persistedAnsweredAnswers.length === 0) {
@@ -1307,26 +1314,7 @@ export abstract class StorageEngine {
       return { status: 'retry' };
     }
 
-    this.participantData.completed = true;
-
-    try {
-      await this.persistCurrentParticipantData({ immediate: true, cache: true });
-      await this._completeCurrentParticipantRealtime();
-    } catch (error) {
-      return {
-        status: 'error',
-        message: normalizeError(error).message,
-      };
-    }
-
-    const completedParticipantData = await this.getParticipantData();
-    const sequenceAssignment = await this._getSequenceAssignment(this.currentParticipantId);
-
-    if (completedParticipantData?.completed && sequenceAssignment?.completed) {
-      return { status: 'complete' };
-    }
-
-    return { status: 'retry' };
+    return completeParticipant();
   }
 
   // Verifies if the current participant has completed the study.

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -117,6 +117,48 @@ export type ActionResponse =
 // Represents a snapshot name item with an original name and an optional alternate (renamed) name.
 export type SnapshotDocContent = Record<string, { name: string; }>;
 
+export type FinalizeParticipantResult = {
+  status: 'complete' | 'retry' | 'error';
+  message?: string;
+};
+
+type AnsweredParticipantAnswerMetadata = {
+  key: string;
+  endTime: number;
+};
+
+function normalizeError(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function cloneParticipantDataSnapshot(participantData: ParticipantData) {
+  return structuredClone(participantData);
+}
+
+function getAnsweredParticipantAnswerMetadata(answers: ParticipantData['answers']): AnsweredParticipantAnswerMetadata[] {
+  return Object.entries(answers)
+    .filter(([, answer]) => answer.endTime > -1)
+    .map(([key, answer]) => ({
+      key,
+      endTime: answer.endTime,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function answeredParticipantAnswerMetadataMatches(
+  localAnswers: AnsweredParticipantAnswerMetadata[],
+  persistedAnswers: AnsweredParticipantAnswerMetadata[],
+) {
+  if (localAnswers.length !== persistedAnswers.length) {
+    return false;
+  }
+
+  return localAnswers.every(
+    (answer, index) => answer.key === persistedAnswers[index].key
+      && answer.endTime === persistedAnswers[index].endTime,
+  );
+}
+
 export abstract class StorageEngine {
   protected engine: 'localStorage' | 'supabase' | 'firebase';
 
@@ -136,8 +178,21 @@ export abstract class StorageEngine {
 
   protected participantData: ParticipantData | undefined;
 
-  // Ids of assets (eg. audio/screen recording) being uploaded.
-  protected uploadingAssetIds: string[] = [];
+  protected participantDataWriteDelayMs = 3000;
+
+  private pendingParticipantDataWrite:
+  | { participantId: string; snapshot: ParticipantData; cache: boolean }
+  | undefined;
+
+  private pendingParticipantDataWriteTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private participantDataWriteChain: Promise<void> = Promise.resolve();
+
+  private participantDataWriteError: Error | null = null;
+
+  private pendingAssetUploads = new Map<string, Promise<void>>();
+
+  private assetUploadError: Error | null = null;
 
   constructor(engine: typeof this.engine, testing: boolean) {
     this.engine = engine;
@@ -196,6 +251,9 @@ export abstract class StorageEngine {
     participantId: string,
     updatedFields: Partial<SequenceAssignment>,
   ): Promise<void>;
+
+  // Gets a single sequence assignment for the given participantId.
+  protected abstract _getSequenceAssignment(participantId: string): Promise<SequenceAssignment | null>;
 
   // Sets the participant to completed in the sequence assignments in the realtime database.
   protected abstract _completeCurrentParticipantRealtime(): Promise<void>;
@@ -284,8 +342,6 @@ export abstract class StorageEngine {
     10000,
   );
 
-  private __throttleSaveAnswers = throttle(async () => { await this._saveAnswers(); }, 3000);
-
   /*
   * HIGHER-LEVEL METHODS
   * These methods are used by the application to interact with the storage engine and provide consistent behavior across different storage engines.
@@ -294,6 +350,156 @@ export abstract class StorageEngine {
   // Verify study database using provided primitive from storage engine with a throttle of 10 seconds.
   protected async verifyStudyDatabase() {
     return await this.__throttleVerifyStudyDatabase();
+  }
+
+  private clearPendingParticipantDataWriteTimer() {
+    if (this.pendingParticipantDataWriteTimer) {
+      clearTimeout(this.pendingParticipantDataWriteTimer);
+      this.pendingParticipantDataWriteTimer = null;
+    }
+  }
+
+  private recordParticipantDataWriteError(error: unknown) {
+    this.participantDataWriteError = normalizeError(error);
+  }
+
+  private consumeParticipantDataWriteError() {
+    const error = this.participantDataWriteError;
+    this.participantDataWriteError = null;
+    return error;
+  }
+
+  private async enqueueParticipantDataWrite(
+    participantId: string,
+    snapshot: ParticipantData,
+    cache: boolean,
+  ) {
+    const write = async () => {
+      this.participantDataWriteError = null;
+      try {
+        await this._pushToStorage(
+          `participants/${participantId}`,
+          'participantData',
+          snapshot,
+        );
+
+        if (cache) {
+          await this._cacheStorageObject(
+            `participants/${participantId}`,
+            'participantData',
+          );
+        }
+      } catch (error) {
+        this.recordParticipantDataWriteError(error);
+        throw this.participantDataWriteError;
+      }
+    };
+
+    const queuedWrite = this.participantDataWriteChain
+      .catch(() => undefined)
+      .then(write);
+
+    this.participantDataWriteChain = queuedWrite
+      .then(() => undefined)
+      .catch(() => undefined);
+
+    return queuedWrite;
+  }
+
+  private scheduleParticipantDataWrite(snapshot: ParticipantData, cache: boolean = false) {
+    if (!this.currentParticipantId) {
+      throw new Error('Participant not initialized');
+    }
+
+    this.pendingParticipantDataWrite = {
+      participantId: this.currentParticipantId,
+      snapshot: cloneParticipantDataSnapshot(snapshot),
+      cache,
+    };
+
+    this.clearPendingParticipantDataWriteTimer();
+    this.pendingParticipantDataWriteTimer = setTimeout(() => {
+      const pendingWrite = this.pendingParticipantDataWrite;
+      this.pendingParticipantDataWrite = undefined;
+      this.pendingParticipantDataWriteTimer = null;
+
+      if (!pendingWrite) {
+        return;
+      }
+
+      this.enqueueParticipantDataWrite(
+        pendingWrite.participantId,
+        pendingWrite.snapshot,
+        pendingWrite.cache,
+      ).catch(() => undefined);
+    }, this.participantDataWriteDelayMs);
+  }
+
+  protected async persistCurrentParticipantData(
+    options: { immediate?: boolean; cache?: boolean } = {},
+  ) {
+    await this.verifyStudyDatabase();
+
+    if (!this.currentParticipantId || this.participantData === undefined) {
+      throw new Error('Participant not initialized');
+    }
+
+    const snapshot = cloneParticipantDataSnapshot(this.participantData);
+    const { immediate = false, cache = false } = options;
+
+    if (!immediate) {
+      this.scheduleParticipantDataWrite(snapshot, cache);
+      return;
+    }
+
+    this.clearPendingParticipantDataWriteTimer();
+    this.pendingParticipantDataWrite = undefined;
+    await this.enqueueParticipantDataWrite(this.currentParticipantId, snapshot, cache);
+  }
+
+  async flushPendingParticipantData() {
+    this.clearPendingParticipantDataWriteTimer();
+
+    if (this.pendingParticipantDataWrite) {
+      const pendingWrite = this.pendingParticipantDataWrite;
+      this.pendingParticipantDataWrite = undefined;
+      await this.enqueueParticipantDataWrite(
+        pendingWrite.participantId,
+        pendingWrite.snapshot,
+        pendingWrite.cache,
+      );
+    }
+
+    await this.participantDataWriteChain;
+
+    const error = this.consumeParticipantDataWriteError();
+    if (error) {
+      throw error;
+    }
+  }
+
+  private recordAssetUploadError(error: unknown) {
+    this.assetUploadError = normalizeError(error);
+  }
+
+  private getAssetUploadError() {
+    return this.assetUploadError;
+  }
+
+  private async waitForPendingAssetUploads() {
+    const uploadPromises = Array.from(this.pendingAssetUploads.values());
+    if (uploadPromises.length === 0) {
+      return this.getAssetUploadError();
+    }
+
+    const results = await Promise.allSettled(uploadPromises);
+    const rejectedUpload = results.find((result) => result.status === 'rejected');
+
+    if (rejectedUpload?.status === 'rejected') {
+      this.recordAssetUploadError(rejectedUpload.reason);
+    }
+
+    return this.getAssetUploadError();
   }
 
   async getStageData(studyId: string): Promise<StageData> {
@@ -617,11 +823,7 @@ export abstract class StorageEngine {
     };
 
     if (modes.dataCollectionEnabled) {
-      await this._pushToStorage(
-        `participants/${this.currentParticipantId}`,
-        'participantData',
-        this.participantData,
-      );
+      await this.persistCurrentParticipantData({ immediate: true });
     }
 
     return this.participantData;
@@ -697,11 +899,7 @@ export abstract class StorageEngine {
     }
     this.participantData.participantTags = [...new Set([...this.participantData.participantTags, ...tags])];
 
-    await this._pushToStorage(
-      `participants/${this.currentParticipantId}`,
-      'participantData',
-      this.participantData,
-    );
+    await this.persistCurrentParticipantData({ immediate: true });
   }
 
   // Removes participant tags from the current participant.
@@ -713,11 +911,7 @@ export abstract class StorageEngine {
     }
     this.participantData.participantTags = this.participantData.participantTags.filter((tag) => !tags.includes(tag));
 
-    await this._pushToStorage(
-      `participants/${this.currentParticipantId}`,
-      'participantData',
-      this.participantData,
-    );
+    await this.persistCurrentParticipantData({ immediate: true });
   }
 
   // Updates the participant's stored search params.
@@ -730,11 +924,7 @@ export abstract class StorageEngine {
 
     this.participantData.searchParams = searchParams;
 
-    await this._pushToStorage(
-      `participants/${this.currentParticipantId}`,
-      'participantData',
-      this.participantData,
-    );
+    await this.persistCurrentParticipantData({ immediate: true });
   }
 
   async updateStudyCondition(condition: string | string[]) {
@@ -756,11 +946,7 @@ export abstract class StorageEngine {
     const parsedConditions = parseConditionParam(condition);
     this.participantData.conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
 
-    await this._pushToStorage(
-      `participants/${this.currentParticipantId}`,
-      'participantData',
-      this.participantData,
-    );
+    await this.persistCurrentParticipantData({ immediate: true });
 
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
@@ -890,24 +1076,7 @@ export abstract class StorageEngine {
     };
   }
 
-  // The actual logic to save the answers to storage, called by the throttled saveAnswers method
-  protected async _saveAnswers() {
-    await this.verifyStudyDatabase();
-
-    if (!this.currentParticipantId || this.participantData === undefined) {
-      throw new Error('Participant not initialized');
-    }
-
-    // Push the updated participant data to firebase
-    await this._pushToStorage(
-      `participants/${this.currentParticipantId}`,
-      'participantData',
-      this.participantData,
-    );
-  }
-
-  // Save the answer into the local participant data and then call the throttled saveAnswers method.
-  // The throttled method calls _saveAnswers which is the actual logic to save the answers to storage
+  // Save the answer into the local participant data and queue a debounced write to storage.
   async saveAnswers(answers: ParticipantData['answers']) {
     if (!this.currentParticipantId || this.participantData === undefined) {
       throw new Error('Participant not initialized');
@@ -924,7 +1093,7 @@ export abstract class StorageEngine {
       answers,
     };
 
-    await this.__throttleSaveAnswers(answers);
+    this.scheduleParticipantDataWrite(this.participantData);
   }
 
   // Updates the progress data in the sequence assignment
@@ -936,37 +1105,23 @@ export abstract class StorageEngine {
       throw new Error('Study ID is not set');
     }
 
-    if (this.getEngine() !== 'firebase') {
-      return;
-    }
-
     const targetParticipantId = participantId || this.currentParticipantId;
     if (!targetParticipantId) {
       throw new Error('Participant not initialized');
     }
 
-    const sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
-    const existingAssignment = sequenceAssignments.find(
-      (assignment) => assignment.participantId === targetParticipantId,
-    );
+    const existingAssignment = await this._getSequenceAssignment(targetParticipantId);
 
     if (existingAssignment) {
-      // Ensure backward compatibility by providing default values if fields don't exist
-      const updatedAssignment: SequenceAssignment = {
-        ...existingAssignment,
-        total: existingAssignment.total ?? progressData.total,
-        answered: existingAssignment.answered ?? progressData.answered,
-        isDynamic: existingAssignment.isDynamic ?? progressData.isDynamic,
-      };
-      updatedAssignment.total = progressData.total;
-      updatedAssignment.answered = progressData.answered;
-      updatedAssignment.isDynamic = progressData.isDynamic;
-      await this._createSequenceAssignment(targetParticipantId, updatedAssignment, false);
+      await this._updateSequenceAssignmentFields(targetParticipantId, {
+        total: progressData.total,
+        answered: progressData.answered,
+        isDynamic: progressData.isDynamic,
+      });
     }
   }
 
-  // Verifies if the current participant has completed the study. Checks that the throttled answers are saved and marks the participant as complete if so.
-  async verifyCompletion() {
+  async finalizeParticipant(): Promise<FinalizeParticipantResult> {
     await this.verifyStudyDatabase();
 
     if (!this.studyId) {
@@ -977,47 +1132,74 @@ export abstract class StorageEngine {
       throw new Error('Participant not initialized');
     }
 
-    // Get the participantData
-    const participantData = await this.getParticipantData();
-    if (!participantData) {
+    const modes = await this.getModes(this.studyId);
+
+    if (!modes.dataCollectionEnabled) {
+      if (this.participantData) {
+        this.participantData.completed = true;
+      }
+      return { status: 'complete' };
+    }
+
+    try {
+      await this.flushPendingParticipantData();
+    } catch (error) {
+      return {
+        status: 'error',
+        message: normalizeError(error).message,
+      };
+    }
+
+    const assetUploadError = await this.waitForPendingAssetUploads();
+    if (assetUploadError) {
+      return {
+        status: 'error',
+        message: assetUploadError.message,
+      };
+    }
+
+    const persistedParticipantData = await this.getParticipantData();
+    if (!persistedParticipantData || !this.participantData) {
       throw new Error('Participant not initialized');
     }
 
-    // Check for remaining assets uploads
-    const hasUploadsRemaining = this.uploadingAssetIds.length > 0;
-    if (hasUploadsRemaining) {
-      return false;
+    const localAnsweredAnswers = getAnsweredParticipantAnswerMetadata(this.participantData.answers);
+    const persistedAnsweredAnswers = getAnsweredParticipantAnswerMetadata(persistedParticipantData.answers);
+
+    if (localAnsweredAnswers.length === 0 || persistedAnsweredAnswers.length === 0) {
+      return { status: 'retry' };
     }
 
-    if (participantData.completed) {
-      return true;
+    if (!answeredParticipantAnswerMetadataMatches(localAnsweredAnswers, persistedAnsweredAnswers)) {
+      return { status: 'retry' };
     }
 
-    // Get modes
-    const modes = await this.getModes(this.studyId);
+    this.participantData.completed = true;
 
-    const serverEndTime = Object.values(participantData.answers).map((answer) => answer.endTime).reduce((a, b) => Math.max(a, b), 0);
-    const localEndTime = Object.values(this.participantData?.answers || {}).map((answer) => answer.endTime).reduce((a, b) => Math.max(a, b), 0);
-    if (this.participantData && serverEndTime === localEndTime) {
-      this.participantData.completed = true;
-      if (modes.dataCollectionEnabled) {
-        await this._completeCurrentParticipantRealtime();
-
-        await this._pushToStorage(
-          `participants/${this.currentParticipantId}`,
-          'participantData',
-          this.participantData,
-        );
-        await this._cacheStorageObject(
-          `participants/${this.currentParticipantId}`,
-          'participantData',
-        );
-      }
-
-      return true;
+    try {
+      await this.persistCurrentParticipantData({ immediate: true, cache: true });
+      await this._completeCurrentParticipantRealtime();
+    } catch (error) {
+      return {
+        status: 'error',
+        message: normalizeError(error).message,
+      };
     }
 
-    return false;
+    const completedParticipantData = await this.getParticipantData();
+    const sequenceAssignment = await this._getSequenceAssignment(this.currentParticipantId);
+
+    if (completedParticipantData?.completed && sequenceAssignment?.completed) {
+      return { status: 'complete' };
+    }
+
+    return { status: 'retry' };
+  }
+
+  // Verifies if the current participant has completed the study.
+  async verifyCompletion() {
+    const result = await this.finalizeParticipant();
+    return result.status === 'complete';
   }
 
   async getAsset(url: string | null) {
@@ -1086,13 +1268,22 @@ export abstract class StorageEngine {
   ) {
     const assetKey = `${prefix}/${taskName}`;
     const participantKey = `${prefix}/${this.currentParticipantId}`;
+    const uploadPromise = (async () => {
+      try {
+        this.assetUploadError = null;
+        await this._pushToStorage(participantKey, taskName, blob);
+        await this._cacheStorageObject(participantKey, taskName);
+      } catch (error) {
+        this.recordAssetUploadError(error);
+        throw this.assetUploadError;
+      } finally {
+        this.pendingAssetUploads.delete(assetKey);
+      }
+    })();
 
-    this.uploadingAssetIds.push(assetKey);
+    this.pendingAssetUploads.set(assetKey, uploadPromise);
 
-    await this._pushToStorage(participantKey, taskName, blob);
-    await this._cacheStorageObject(participantKey, taskName);
-
-    this.uploadingAssetIds = this.uploadingAssetIds.filter((id) => id !== assetKey);
+    await uploadPromise;
   }
 
   // Saves the audio stream to the storage engine. This method is used to save the audio recorded data from a MediaRecorder stream.
@@ -1154,6 +1345,12 @@ export abstract class StorageEngine {
   }
 
   protected async __testingReset() {
+    this.clearPendingParticipantDataWriteTimer();
+    this.pendingParticipantDataWrite = undefined;
+    this.participantDataWriteChain = Promise.resolve();
+    this.participantDataWriteError = null;
+    this.pendingAssetUploads.clear();
+    this.assetUploadError = null;
     this.participantData = undefined;
     if (this.studyId) {
       await this.clearCurrentParticipantId();

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { StudyConfig } from '../../parser/types';
 import { ParticipantMetadata, Sequence } from '../../store/types';
 import { ParticipantData } from '../types';
-import { hash, isParticipantData } from './utils';
+import { hash, isParticipantData } from './utils/storageEngineHelpers';
 import { shouldPreferCachedParticipantData } from './utils/participantDataRecovery';
 import { RevisitNotification } from '../../utils/notifications';
 import { parseConditionParam } from '../../utils/handleConditionLogic';

--- a/src/storage/engines/utils/participantAnswerMetadata.ts
+++ b/src/storage/engines/utils/participantAnswerMetadata.ts
@@ -1,0 +1,32 @@
+import { ParticipantData } from '../../types';
+
+export type AnsweredParticipantAnswerMetadata = {
+  key: string;
+  endTime: number;
+};
+
+export function getAnsweredParticipantAnswerMetadata(
+  answers: ParticipantData['answers'],
+): AnsweredParticipantAnswerMetadata[] {
+  return Object.entries(answers)
+    .filter(([, answer]) => answer.endTime > -1)
+    .map(([key, answer]) => ({
+      key,
+      endTime: answer.endTime,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function answeredParticipantAnswerMetadataMatches(
+  localAnswers: AnsweredParticipantAnswerMetadata[],
+  persistedAnswers: AnsweredParticipantAnswerMetadata[],
+) {
+  if (localAnswers.length !== persistedAnswers.length) {
+    return false;
+  }
+
+  return localAnswers.every(
+    (answer, index) => answer.key === persistedAnswers[index].key
+      && answer.endTime === persistedAnswers[index].endTime,
+  );
+}

--- a/src/storage/engines/utils/participantDataRecovery.spec.ts
+++ b/src/storage/engines/utils/participantDataRecovery.spec.ts
@@ -1,0 +1,130 @@
+import {
+  describe,
+  expect,
+  test,
+} from 'vitest';
+import { Sequence, StoredAnswer } from '../../../store/types';
+import { ParticipantData } from '../../types';
+import { shouldPreferCachedParticipantData } from './participantDataRecovery';
+
+const baseSequence: Sequence = {
+  id: 'root',
+  orderPath: 'root',
+  order: 'fixed',
+  components: ['intro'],
+  skip: [],
+};
+
+function makeStoredAnswer(identifier: string, endTime: number): StoredAnswer {
+  return {
+    answer: { response: `answer-${endTime}` },
+    identifier,
+    componentName: 'intro',
+    trialOrder: '0',
+    incorrectAnswers: {},
+    startTime: endTime - 10,
+    endTime,
+    provenanceGraph: {
+      aboveStimulus: undefined,
+      belowStimulus: undefined,
+      stimulus: undefined,
+      sidebar: undefined,
+    },
+    windowEvents: [],
+    timedOut: false,
+    helpButtonClickedCount: 0,
+    parameters: {},
+    correctAnswer: [],
+    optionOrders: {},
+    questionOrders: {},
+  };
+}
+
+function makeParticipantData(overrides: Partial<ParticipantData> = {}): ParticipantData {
+  return {
+    participantId: 'participant-1',
+    participantConfigHash: 'config-1',
+    sequence: baseSequence,
+    participantIndex: 1,
+    answers: {},
+    searchParams: {},
+    metadata: {
+      userAgent: 'test-agent',
+      resolution: { width: 1920, height: 1080 },
+      language: 'en-US',
+      ip: '127.0.0.1',
+    },
+    completed: false,
+    rejected: false,
+    participantTags: [],
+    stage: 'DEFAULT',
+    createdTime: 1,
+    ...overrides,
+  };
+}
+
+describe('shouldPreferCachedParticipantData', () => {
+  test('prefers cached participant data when cached completion is newer', () => {
+    const remoteParticipantData = makeParticipantData({
+      completed: false,
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+    });
+    const cachedParticipantData = makeParticipantData({
+      completed: true,
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+    });
+
+    expect(shouldPreferCachedParticipantData(cachedParticipantData, remoteParticipantData)).toBe(true);
+  });
+
+  test('prefers cached participant data when it has more answered questions', () => {
+    const remoteParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+    });
+    const cachedParticipantData = makeParticipantData({
+      answers: {
+        intro_0: makeStoredAnswer('intro_0', 100),
+        intro_1: makeStoredAnswer('intro_1', 200),
+      },
+    });
+
+    expect(shouldPreferCachedParticipantData(cachedParticipantData, remoteParticipantData)).toBe(true);
+  });
+
+  test('prefers cached participant data when answered questions are newer', () => {
+    const remoteParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+    });
+    const cachedParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 200) },
+    });
+
+    expect(shouldPreferCachedParticipantData(cachedParticipantData, remoteParticipantData)).toBe(true);
+  });
+
+  test('keeps remote participant data when answer metadata matches', () => {
+    const remoteParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+    });
+    const cachedParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+      participantTags: ['cached-only-tag'],
+    });
+
+    expect(shouldPreferCachedParticipantData(cachedParticipantData, remoteParticipantData)).toBe(false);
+  });
+
+  test('keeps remote participant data when cached differences are only non-answer fields', () => {
+    const remoteParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+      searchParams: { source: 'remote' },
+    });
+    const cachedParticipantData = makeParticipantData({
+      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
+      searchParams: { source: 'cached' },
+      stage: 'FOLLOW_UP',
+    });
+
+    expect(shouldPreferCachedParticipantData(cachedParticipantData, remoteParticipantData)).toBe(false);
+  });
+});

--- a/src/storage/engines/utils/participantDataRecovery.ts
+++ b/src/storage/engines/utils/participantDataRecovery.ts
@@ -1,33 +1,8 @@
 import { ParticipantData } from '../../types';
-
-type AnsweredParticipantAnswerMetadata = {
-  key: string;
-  endTime: number;
-};
-
-function getAnsweredParticipantAnswerMetadata(answers: ParticipantData['answers']): AnsweredParticipantAnswerMetadata[] {
-  return Object.entries(answers)
-    .filter(([, answer]) => answer.endTime > -1)
-    .map(([key, answer]) => ({
-      key,
-      endTime: answer.endTime,
-    }))
-    .sort((a, b) => a.key.localeCompare(b.key));
-}
-
-function answeredParticipantAnswerMetadataMatches(
-  localAnswers: AnsweredParticipantAnswerMetadata[],
-  persistedAnswers: AnsweredParticipantAnswerMetadata[],
-) {
-  if (localAnswers.length !== persistedAnswers.length) {
-    return false;
-  }
-
-  return localAnswers.every(
-    (answer, index) => answer.key === persistedAnswers[index].key
-      && answer.endTime === persistedAnswers[index].endTime,
-  );
-}
+import {
+  answeredParticipantAnswerMetadataMatches,
+  getAnsweredParticipantAnswerMetadata,
+} from './participantAnswerMetadata';
 
 export function shouldPreferCachedParticipantData(
   cachedParticipantData: ParticipantData,

--- a/src/storage/engines/utils/participantDataRecovery.ts
+++ b/src/storage/engines/utils/participantDataRecovery.ts
@@ -1,0 +1,54 @@
+import { ParticipantData } from '../../types';
+
+type AnsweredParticipantAnswerMetadata = {
+  key: string;
+  endTime: number;
+};
+
+function getAnsweredParticipantAnswerMetadata(answers: ParticipantData['answers']): AnsweredParticipantAnswerMetadata[] {
+  return Object.entries(answers)
+    .filter(([, answer]) => answer.endTime > -1)
+    .map(([key, answer]) => ({
+      key,
+      endTime: answer.endTime,
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function answeredParticipantAnswerMetadataMatches(
+  localAnswers: AnsweredParticipantAnswerMetadata[],
+  persistedAnswers: AnsweredParticipantAnswerMetadata[],
+) {
+  if (localAnswers.length !== persistedAnswers.length) {
+    return false;
+  }
+
+  return localAnswers.every(
+    (answer, index) => answer.key === persistedAnswers[index].key
+      && answer.endTime === persistedAnswers[index].endTime,
+  );
+}
+
+export function shouldPreferCachedParticipantData(
+  cachedParticipantData: ParticipantData,
+  remoteParticipantData: ParticipantData,
+) {
+  if (cachedParticipantData.completed !== remoteParticipantData.completed) {
+    return cachedParticipantData.completed;
+  }
+
+  const cachedAnsweredAnswers = getAnsweredParticipantAnswerMetadata(cachedParticipantData.answers);
+  const remoteAnsweredAnswers = getAnsweredParticipantAnswerMetadata(remoteParticipantData.answers);
+
+  if (answeredParticipantAnswerMetadataMatches(cachedAnsweredAnswers, remoteAnsweredAnswers)) {
+    return false;
+  }
+
+  if (cachedAnsweredAnswers.length !== remoteAnsweredAnswers.length) {
+    return cachedAnsweredAnswers.length > remoteAnsweredAnswers.length;
+  }
+
+  return cachedAnsweredAnswers.some(
+    (answer, index) => answer.endTime > remoteAnsweredAnswers[index].endTime,
+  );
+}

--- a/src/storage/engines/utils/storageEngineHelpers.ts
+++ b/src/storage/engines/utils/storageEngineHelpers.ts
@@ -1,6 +1,6 @@
-import { ParticipantData } from '../types';
-import type { CloudStorageEngine, StorageEngine } from './types';
-import { StudyConfig } from '../../parser/types';
+import { ParticipantData } from '../../types';
+import type { CloudStorageEngine, StorageEngine } from '../types';
+import { StudyConfig } from '../../../parser/types';
 
 export async function hash(input: string) {
   const msgUint8 = new TextEncoder().encode(input);

--- a/src/storage/tests/analysis-config.spec.ts
+++ b/src/storage/tests/analysis-config.spec.ts
@@ -4,7 +4,7 @@ import {
 import { StudyConfig } from '../../parser/types';
 import testConfigSimple from './testConfigSimple.json';
 import testConfigSimple2 from './testConfigSimple2.json';
-import { hash } from '../engines/utils';
+import { hash } from '../engines/utils/storageEngineHelpers';
 import { buildConfigRows, ConfigInfo } from '../../analysis/individualStudy/config/utils';
 import { downloadConfigFile, downloadConfigFilesZip } from '../../utils/handleDownloadFiles';
 import { ConfigDiffModal } from '../../analysis/individualStudy/config/ConfigDiffModal';

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -799,6 +799,16 @@ describe.each([
     const finalizeResult = await finalizePromise;
     expect(finalizeResult.status).toBe('error');
     expect(finalizeResult.message).toContain('Asset upload failed');
+    expect(finalizeResult.retryable).toBe(false);
+
+    const participantData = await storageEngine.getParticipantData();
+    expect(participantData).toBeDefined();
+    expect(participantData!.completed).toBe(true);
+
+    const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantData!.participantId);
+    expect(sequenceAssignment).toBeDefined();
+    expect(sequenceAssignment!.completed).not.toBeNull();
   });
 
   test('finalizeParticipant does not mask a failed asset upload after a later successful upload', async () => {
@@ -834,6 +844,16 @@ describe.each([
     const finalizeResult = await storageEngine.finalizeParticipant();
     expect(finalizeResult.status).toBe('error');
     expect(finalizeResult.message).toContain('Asset upload failed');
+    expect(finalizeResult.retryable).toBe(false);
+
+    const participantData = await storageEngine.getParticipantData();
+    expect(participantData).toBeDefined();
+    expect(participantData!.completed).toBe(true);
+
+    const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantData!.participantId);
+    expect(sequenceAssignment).toBeDefined();
+    expect(sequenceAssignment!.completed).not.toBeNull();
   });
 
   test('finalizeParticipant succeeds after a transient realtime completion failure', async () => {

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -8,9 +8,9 @@ import testConfigSimple from './testConfigSimple.json';
 import testConfigSimple2 from './testConfigSimple2.json';
 import { generateSequenceArray } from '../../utils/handleRandomSequences';
 import { hash } from '../engines/utils';
-import { Sequence } from '../../store/types';
+import { Sequence, StoredAnswer } from '../../store/types';
 import { LocalStorageEngine } from '../engines/LocalStorageEngine';
-import { StorageEngine } from '../engines/types';
+import { StorageEngine, StorageObject, StorageObjectType } from '../engines/types';
 import { filterSequenceByCondition } from '../../utils/handleConditionLogic';
 // import { SupabaseStorageEngine } from '../engines/SupabaseStorageEngine';
 
@@ -88,6 +88,131 @@ function getConditionalBlockOrder(sequence: Sequence, condition: string): string
   }
 
   return conditionalBlock.components as string[];
+}
+
+function makeStoredAnswer(identifier: string, endTime: number): StoredAnswer {
+  return {
+    answer: { response: `answer-${endTime}` },
+    identifier,
+    componentName: 'intro',
+    trialOrder: '0',
+    incorrectAnswers: {},
+    startTime: endTime - 10,
+    endTime,
+    provenanceGraph: {
+      aboveStimulus: undefined,
+      belowStimulus: undefined,
+      stimulus: undefined,
+      sidebar: undefined,
+    },
+    windowEvents: [],
+    timedOut: false,
+    helpButtonClickedCount: 0,
+    parameters: {},
+    correctAnswer: [],
+    optionOrders: {},
+    questionOrders: {},
+  };
+}
+
+class DelayedLocalStorageEngine extends LocalStorageEngine {
+  private holdParticipantDataWrite = false;
+
+  private releaseParticipantDataWrite: (() => void) | null = null;
+
+  private participantDataWriteHeld = Promise.resolve();
+
+  private resolveParticipantDataWriteHeld: (() => void) | null = null;
+
+  private holdAssetUpload = false;
+
+  private failHeldAssetUpload = false;
+
+  private releaseAssetUpload: (() => void) | null = null;
+
+  private assetUploadHeld = Promise.resolve();
+
+  private resolveAssetUploadHeld: (() => void) | null = null;
+
+  constructor(testing: boolean = false) {
+    super(testing);
+    this.participantDataWriteDelayMs = 0;
+  }
+
+  holdNextParticipantDataWrite() {
+    this.holdParticipantDataWrite = true;
+    this.participantDataWriteHeld = new Promise<void>((resolve) => {
+      this.resolveParticipantDataWriteHeld = resolve;
+    });
+  }
+
+  releaseHeldParticipantDataWrite() {
+    this.releaseParticipantDataWrite?.();
+    this.releaseParticipantDataWrite = null;
+  }
+
+  waitForHeldParticipantDataWrite() {
+    return this.participantDataWriteHeld;
+  }
+
+  holdNextAssetUpload(options: { fail?: boolean } = {}) {
+    this.holdAssetUpload = true;
+    this.failHeldAssetUpload = options.fail ?? false;
+    this.assetUploadHeld = new Promise<void>((resolve) => {
+      this.resolveAssetUploadHeld = resolve;
+    });
+  }
+
+  releaseHeldAssetUpload() {
+    this.releaseAssetUpload?.();
+    this.releaseAssetUpload = null;
+  }
+
+  waitForHeldAssetUpload() {
+    return this.assetUploadHeld;
+  }
+
+  protected override async _pushToStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    objectToUpload: StorageObject<T>,
+  ) {
+    const isParticipantDataWrite = type === 'participantData' && prefix.startsWith('participants/');
+    const isAssetUpload = objectToUpload instanceof Blob
+      && (prefix.startsWith('audio/') || prefix.startsWith('screenRecording/'));
+
+    if (isParticipantDataWrite && this.holdParticipantDataWrite) {
+      this.holdParticipantDataWrite = false;
+      this.resolveParticipantDataWriteHeld?.();
+      this.resolveParticipantDataWriteHeld = null;
+      await new Promise<void>((resolve) => {
+        this.releaseParticipantDataWrite = resolve;
+      });
+    }
+
+    if (isAssetUpload && this.holdAssetUpload) {
+      const shouldFail = this.failHeldAssetUpload;
+      this.holdAssetUpload = false;
+      this.failHeldAssetUpload = false;
+      this.resolveAssetUploadHeld?.();
+      this.resolveAssetUploadHeld = null;
+
+      await new Promise<void>((resolve, reject) => {
+        this.releaseAssetUpload = () => {
+          this.releaseAssetUpload = null;
+
+          if (shouldFail) {
+            reject(new Error('Asset upload failed'));
+            return;
+          }
+
+          resolve();
+        };
+      });
+    }
+
+    await super._pushToStorage(prefix, type, objectToUpload);
+  }
 }
 
 describe.each([
@@ -499,7 +624,126 @@ describe.each([
 
   // saveAnswers test
 
-  // verifyCompletion test
+  test('saveAnswers coalesces to the latest answer and finalizeParticipant persists completed state after delayed writes', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const identifier = 'intro_0';
+
+    delayedStorageEngine.holdNextParticipantDataWrite();
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+
+    const firstWritePromise = storageEngine.flushPendingParticipantData();
+    await delayedStorageEngine.waitForHeldParticipantDataWrite();
+
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 200),
+    });
+
+    const finalizePromise = storageEngine.finalizeParticipant();
+
+    delayedStorageEngine.releaseHeldParticipantDataWrite();
+
+    await firstWritePromise;
+
+    const finalizeResult = await finalizePromise;
+    expect(finalizeResult.status).toBe('complete');
+
+    const participantData = await storageEngine.getParticipantData();
+    expect(participantData).toBeDefined();
+    expect(participantData!.answers[identifier].endTime).toBe(200);
+    expect(participantData!.completed).toBe(true);
+  });
+
+  test('updateProgressData preserves completion when progress is updated after completion', async () => {
+    const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const { participantId } = participantSession;
+    const identifier = 'intro_0';
+
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+    await storageEngine.flushPendingParticipantData();
+
+    const finalizeResult = await storageEngine.finalizeParticipant();
+    expect(finalizeResult.status).toBe('complete');
+
+    let sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    let sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantId);
+    expect(sequenceAssignment).toBeDefined();
+    expect(sequenceAssignment!.completed).not.toBeNull();
+    const completedTime = sequenceAssignment!.completed;
+
+    await storageEngine.updateProgressData({
+      total: 29,
+      answered: ['intro', 'late-progress'],
+      isDynamic: false,
+    });
+
+    sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantId);
+    expect(sequenceAssignment).toBeDefined();
+    expect(sequenceAssignment!.completed).toBe(completedTime);
+    expect(sequenceAssignment!.total).toBe(29);
+    expect(sequenceAssignment!.answered).toEqual(['intro', 'late-progress']);
+  });
+
+  test('finalizeParticipant returns retry when there are no answered questions', async () => {
+    const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const finalizeResult = await storageEngine.finalizeParticipant();
+    expect(finalizeResult.status).toBe('retry');
+
+    const participantData = await storageEngine.getParticipantData(participantSession.participantId);
+    expect(participantData).toBeDefined();
+    expect(participantData!.completed).toBe(false);
+
+    const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantSession.participantId);
+    expect(sequenceAssignment).toBeDefined();
+    expect(sequenceAssignment!.completed).toBeNull();
+  });
+
+  test('finalizeParticipant waits for pending asset uploads and returns an error when an upload fails', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const identifier = 'intro_0';
+
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+    await storageEngine.flushPendingParticipantData();
+
+    delayedStorageEngine.holdNextAssetUpload({ fail: true });
+
+    const assetUploadPromise = storageEngine
+      .saveAudioRecording(new Blob(['audio'], { type: 'audio/webm' }), identifier)
+      .catch(() => undefined);
+    await delayedStorageEngine.waitForHeldAssetUpload();
+
+    const finalizePromise = storageEngine.finalizeParticipant();
+
+    delayedStorageEngine.releaseHeldAssetUpload();
+
+    await assetUploadPromise;
+
+    const finalizeResult = await finalizePromise;
+    expect(finalizeResult.status).toBe('error');
+    expect(finalizeResult.message).toContain('Asset upload failed');
+  });
 
   // getAudio and saveAudio untestable due to browser-specific implementation
 

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -7,7 +7,7 @@ import { ParticipantMetadata, StudyConfig } from '../../parser/types';
 import testConfigSimple from './testConfigSimple.json';
 import testConfigSimple2 from './testConfigSimple2.json';
 import { generateSequenceArray } from '../../utils/handleRandomSequences';
-import { hash } from '../engines/utils';
+import { hash } from '../engines/utils/storageEngineHelpers';
 import { Sequence, StoredAnswer } from '../../store/types';
 import { LocalStorageEngine } from '../engines/LocalStorageEngine';
 import { StorageEngine, StorageObject, StorageObjectType } from '../engines/types';
@@ -134,6 +134,8 @@ class DelayedLocalStorageEngine extends LocalStorageEngine {
 
   private resolveAssetUploadHeld: (() => void) | null = null;
 
+  private failRealtimeCompletionAttempts = 0;
+
   constructor(testing: boolean = false) {
     super(testing);
     this.participantDataWriteDelayMs = 0;
@@ -170,6 +172,10 @@ class DelayedLocalStorageEngine extends LocalStorageEngine {
 
   waitForHeldAssetUpload() {
     return this.assetUploadHeld;
+  }
+
+  failNextRealtimeCompletionAttempt() {
+    this.failRealtimeCompletionAttempts += 1;
   }
 
   protected override async _pushToStorage<T extends StorageObjectType>(
@@ -211,7 +217,20 @@ class DelayedLocalStorageEngine extends LocalStorageEngine {
       });
     }
 
+    if (isAssetUpload) {
+      return;
+    }
+
     await super._pushToStorage(prefix, type, objectToUpload);
+  }
+
+  protected override async _completeCurrentParticipantRealtime() {
+    if (this.failRealtimeCompletionAttempts > 0) {
+      this.failRealtimeCompletionAttempts -= 1;
+      throw new Error('Realtime completion update failed');
+    }
+
+    await super._completeCurrentParticipantRealtime();
   }
 }
 
@@ -662,6 +681,43 @@ describe.each([
     expect(participantData!.completed).toBe(true);
   });
 
+  test('initializeParticipantSession recovers the latest local participant data while remote writes are pending', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const identifier = 'intro_0';
+
+    delayedStorageEngine.holdNextParticipantDataWrite();
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+
+    await delayedStorageEngine.waitForHeldParticipantDataWrite();
+
+    const recoveredStorageEngine = new LocalStorageEngine(true);
+    await recoveredStorageEngine.connect();
+    await recoveredStorageEngine.initializeStudyDb(studyId);
+
+    const recoveredParticipantSession = await recoveredStorageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+    );
+
+    expect(recoveredParticipantSession.answers[identifier].endTime).toBe(100);
+
+    delayedStorageEngine.releaseHeldParticipantDataWrite();
+    await storageEngine.flushPendingParticipantData();
+
+    // @ts-expect-error using protected method for testing
+    await recoveredStorageEngine._testingReset(studyId);
+  });
+
   test('updateProgressData preserves completion when progress is updated after completion', async () => {
     const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
     const { participantId } = participantSession;
@@ -743,6 +799,130 @@ describe.each([
     const finalizeResult = await finalizePromise;
     expect(finalizeResult.status).toBe('error');
     expect(finalizeResult.message).toContain('Asset upload failed');
+  });
+
+  test('finalizeParticipant succeeds after a transient realtime completion failure', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const identifier = 'intro_0';
+
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+    await storageEngine.flushPendingParticipantData();
+
+    delayedStorageEngine.failNextRealtimeCompletionAttempt();
+
+    const firstFinalizeResult = await storageEngine.finalizeParticipant();
+    expect(firstFinalizeResult.status).toBe('error');
+    expect(firstFinalizeResult.message).toContain('Realtime completion update failed');
+
+    const retryFinalizeResult = await storageEngine.finalizeParticipant();
+    expect(retryFinalizeResult.status).toBe('complete');
+
+    const participantData = await storageEngine.getParticipantData(participantSession.participantId);
+    expect(participantData).toBeDefined();
+    expect(participantData!.completed).toBe(true);
+
+    const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const sequenceAssignment = sequenceAssignments.find(
+      (assignment) => assignment.participantId === participantSession.participantId,
+    );
+    expect(sequenceAssignment).toBeDefined();
+    expect(sequenceAssignment!.completed).not.toBeNull();
+  });
+
+  test('finalizeParticipant waits for a high-latency asset upload before completing', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const identifier = 'intro_0';
+
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+    await storageEngine.flushPendingParticipantData();
+
+    delayedStorageEngine.holdNextAssetUpload();
+
+    const assetUploadPromise = storageEngine.saveAudioRecording(
+      new Blob(['audio'], { type: 'audio/webm' }),
+      identifier,
+    );
+    await delayedStorageEngine.waitForHeldAssetUpload();
+
+    const finalizePromise = storageEngine.finalizeParticipant();
+    let finalizeSettled = false;
+    finalizePromise.finally(() => {
+      finalizeSettled = true;
+    });
+
+    await Promise.resolve();
+    expect(finalizeSettled).toBe(false);
+
+    delayedStorageEngine.releaseHeldAssetUpload();
+
+    await assetUploadPromise;
+
+    const finalizeResult = await finalizePromise;
+    expect(finalizeResult.status).toBe('complete');
+  });
+
+  test('finalizeParticipant waits for asset uploads that start after finalization begins', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const identifier = 'intro_0';
+
+    await storageEngine.saveAnswers({
+      [identifier]: makeStoredAnswer(identifier, 100),
+    });
+    await storageEngine.flushPendingParticipantData();
+
+    delayedStorageEngine.holdNextAssetUpload();
+
+    const finalizePromise = storageEngine.finalizeParticipant();
+    let finalizeSettled = false;
+    finalizePromise.finally(() => {
+      finalizeSettled = true;
+    });
+
+    let lateAssetUploadPromise: Promise<void> | undefined;
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        lateAssetUploadPromise = storageEngine.saveAudioRecording(
+          new Blob(['audio'], { type: 'audio/webm' }),
+          identifier,
+        );
+        resolve();
+      }, 0);
+    });
+
+    await delayedStorageEngine.waitForHeldAssetUpload();
+    expect(finalizeSettled).toBe(false);
+
+    delayedStorageEngine.releaseHeldAssetUpload();
+
+    await lateAssetUploadPromise;
+
+    const finalizeResult = await finalizePromise;
+    expect(finalizeResult.status).toBe('complete');
   });
 
   // getAudio and saveAudio untestable due to browser-specific implementation

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -801,6 +801,41 @@ describe.each([
     expect(finalizeResult.message).toContain('Asset upload failed');
   });
 
+  test('finalizeParticipant does not mask a failed asset upload after a later successful upload', async () => {
+    storageEngine = new DelayedLocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    sequenceArray = await generateSequenceArray(configSimple);
+    await storageEngine.setSequenceArray(sequenceArray);
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    const delayedStorageEngine = storageEngine as DelayedLocalStorageEngine;
+    const firstIdentifier = 'intro_0';
+    const secondIdentifier = 'intro_1';
+
+    await storageEngine.saveAnswers({
+      [firstIdentifier]: makeStoredAnswer(firstIdentifier, 100),
+    });
+    await storageEngine.flushPendingParticipantData();
+
+    delayedStorageEngine.holdNextAssetUpload({ fail: true });
+    const failedAssetUploadPromise = storageEngine
+      .saveAudioRecording(new Blob(['first-audio'], { type: 'audio/webm' }), firstIdentifier)
+      .catch(() => undefined);
+    await delayedStorageEngine.waitForHeldAssetUpload();
+    delayedStorageEngine.releaseHeldAssetUpload();
+    await failedAssetUploadPromise;
+
+    await storageEngine.saveAudioRecording(
+      new Blob(['second-audio'], { type: 'audio/webm' }),
+      secondIdentifier,
+    );
+
+    const finalizeResult = await storageEngine.finalizeParticipant();
+    expect(finalizeResult.status).toBe('error');
+    expect(finalizeResult.message).toContain('Asset upload failed');
+  });
+
   test('finalizeParticipant succeeds after a transient realtime completion failure', async () => {
     storageEngine = new DelayedLocalStorageEngine(true);
     await storageEngine.connect();

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -751,20 +751,20 @@ describe.each([
     expect(sequenceAssignment!.answered).toEqual(['intro', 'late-progress']);
   });
 
-  test('finalizeParticipant returns retry when there are no answered questions', async () => {
+  test('finalizeParticipant completes when there are no answered questions', async () => {
     const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
 
     const finalizeResult = await storageEngine.finalizeParticipant();
-    expect(finalizeResult.status).toBe('retry');
+    expect(finalizeResult.status).toBe('complete');
 
     const participantData = await storageEngine.getParticipantData(participantSession.participantId);
     expect(participantData).toBeDefined();
-    expect(participantData!.completed).toBe(false);
+    expect(participantData!.completed).toBe(true);
 
     const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
     const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantSession.participantId);
     expect(sequenceAssignment).toBeDefined();
-    expect(sequenceAssignment!.completed).toBeNull();
+    expect(sequenceAssignment!.completed).not.toBeNull();
   });
 
   test('finalizeParticipant waits for pending asset uploads and returns an error when an upload fails', async () => {

--- a/src/storage/tests/primitives.spec.ts
+++ b/src/storage/tests/primitives.spec.ts
@@ -6,7 +6,7 @@ import testConfigSimple from './testConfigSimple.json';
 import { generateSequenceArray } from '../../utils/handleRandomSequences';
 import { LocalStorageEngine } from '../engines/LocalStorageEngine';
 import { StorageEngine, cleanupModes } from '../engines/types';
-import { hash } from '../engines/utils';
+import { hash } from '../engines/utils/storageEngineHelpers';
 
 // import { SupabaseStorageEngine } from '../engines/SupabaseStorageEngine';
 

--- a/src/store/hooks/useAuth.tsx
+++ b/src/store/hooks/useAuth.tsx
@@ -6,7 +6,7 @@ import {
 import { LoadingOverlay } from '@mantine/core';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { StoredUser, UserWrapped } from '../../storage/engines/types';
-import { isCloudStorageEngine } from '../../storage/engines/utils';
+import { isCloudStorageEngine } from '../../storage/engines/utils/storageEngineHelpers';
 import { SupabaseStorageEngine } from '../../storage/engines/SupabaseStorageEngine';
 
 // Defines default AuthContextValue

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -60,7 +60,7 @@ export function useNextStep() {
   const startTime = useMemo(() => Date.now(), [funcIndex, currentStep]);
 
   const windowEvents = useWindowEvents();
-  const goToNextStep = useCallback(async (collectData = true) => {
+  const goToNextStep = useCallback((collectData = true) => {
     try {
       if (typeof currentStep !== 'number') {
         return;
@@ -97,19 +97,14 @@ export function useNextStep() {
         const answersToPersist = { ...answers, [identifier]: toSave };
 
         if (storageEngine) {
-          try {
-            // Force the answers to be up to date before saving.
-            // Await the local snapshot write before navigating away.
-            await storageEngine.saveAnswers(answersToPersist);
-          } catch (error) {
-            console.error('Failed to save participant answers before advancing', error);
+          storageEngine.saveAnswers(answersToPersist).catch((error) => {
+            console.error('Failed to save participant answers', error);
             showNotification({
               title: 'Failed to Save Response',
               message: 'Your response could not be saved. Please check your connection and try again.',
               color: 'red',
             });
-            return;
-          }
+          });
         }
 
         storeDispatch(setReactiveAnswers({}));

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -23,6 +23,7 @@ import {
 import { decryptIndex, encryptIndex } from '../../utils/encryptDecryptIndex';
 import { useIsAnalysis } from './useIsAnalysis';
 import { componentAnswersAreCorrect } from '../../utils/correctAnswer';
+import { showNotification } from '../../utils/notifications';
 
 function checkAllAnswersCorrect(answers: StoredAnswer['answer'], componentId: string, componentConfig: IndividualComponent | InheritedComponent, studyConfig: StudyConfig) {
   const componentName = componentId.slice(0, componentId.lastIndexOf('_'));
@@ -80,7 +81,7 @@ export function useNextStep() {
   const startTime = useMemo(() => Date.now(), [funcIndex, currentStep]);
 
   const windowEvents = useWindowEvents();
-  const goToNextStep = useCallback((collectData = true) => {
+  const goToNextStep = useCallback(async (collectData = true) => {
     if (typeof currentStep !== 'number') {
       return;
     }
@@ -115,11 +116,24 @@ export function useNextStep() {
           ...toSave,
         }),
       );
-      // Update database
+      const answersToPersist = { ...answers, [identifier]: toSave };
+
       if (storageEngine) {
-        // Force the answers to be up to date before saving
-        storageEngine.saveAnswers({ ...answers, [identifier]: toSave });
+        try {
+          // Force the answers to be up to date before saving.
+          // Await the local snapshot write before navigating away.
+          await storageEngine.saveAnswers(answersToPersist);
+        } catch (error) {
+          console.error('Failed to save participant answers before advancing', error);
+          showNotification({
+            title: 'Failed to Save Response',
+            message: 'Your response could not be saved. Please check your connection and try again.',
+            color: 'red',
+          });
+          return;
+        }
       }
+
       storeDispatch(setReactiveAnswers({}));
       storeDispatch(setMatrixAnswersCheckbox(null));
       storeDispatch(setMatrixAnswersRadio(null));

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -82,149 +82,158 @@ export function useNextStep() {
 
   const windowEvents = useWindowEvents();
   const goToNextStep = useCallback(async (collectData = true) => {
-    if (typeof currentStep !== 'number') {
-      return;
-    }
-    // Get answer from across the 3 response blocks and the provenance graph
-    const trialValidationCopy = structuredClone(trialValidation[identifier]);
-    const answer = trialValidationCopy ? Object.values(trialValidationCopy).reduce((acc, curr) => {
-      if (Object.hasOwn(curr, 'values')) {
-        return { ...acc, ...(curr as ValidationStatus).values };
+    try {
+      if (typeof currentStep !== 'number') {
+        return;
       }
-      return acc;
-    }, {}) as StoredAnswer['answer'] : {};
-    const { provenanceGraph } = trialValidationCopy || {};
-    const endTime = Date.now();
-
-    const { componentName } = storedAnswer;
-
-    // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
-    const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
-
-    if (dataCollectionEnabled && (storedAnswer.endTime === -1 || clickedPrevious)) {
-      const toSave = {
-        ...storedAnswer,
-        answer: collectData ? answer : {},
-        startTime,
-        endTime,
-        provenanceGraph,
-        windowEvents: currentWindowEvents,
-        timedOut: !collectData,
-      };
-      storeDispatch(
-        saveTrialAnswer({
-          ...toSave,
-        }),
-      );
-      const answersToPersist = { ...answers, [identifier]: toSave };
-
-      if (storageEngine) {
-        try {
-          // Force the answers to be up to date before saving.
-          // Await the local snapshot write before navigating away.
-          await storageEngine.saveAnswers(answersToPersist);
-        } catch (error) {
-          console.error('Failed to save participant answers before advancing', error);
-          showNotification({
-            title: 'Failed to Save Response',
-            message: 'Your response could not be saved. Please check your connection and try again.',
-            color: 'red',
-          });
-          return;
+      // Get answer from across the 3 response blocks and the provenance graph
+      const trialValidationCopy = structuredClone(trialValidation[identifier]);
+      const answer = trialValidationCopy ? Object.values(trialValidationCopy).reduce((acc, curr) => {
+        if (Object.hasOwn(curr, 'values')) {
+          return { ...acc, ...(curr as ValidationStatus).values };
         }
-      }
+        return acc;
+      }, {}) as StoredAnswer['answer'] : {};
+      const { provenanceGraph } = trialValidationCopy || {};
+      const endTime = Date.now();
 
-      storeDispatch(setReactiveAnswers({}));
-      storeDispatch(setMatrixAnswersCheckbox(null));
-      storeDispatch(setMatrixAnswersRadio(null));
-      storeDispatch(setRankingAnswers(null));
-    }
+      const { componentName } = storedAnswer;
 
-    let nextStep = currentStep + 1;
+      // Get current window events. Splice empties the array and returns the removed elements, which handles clearing the array
+      const currentWindowEvents = windowEvents && 'current' in windowEvents && windowEvents.current ? windowEvents.current.splice(0, windowEvents.current.length) : [];
 
-    // Traverse through the sequence to find the block the current component is in
-    const blocksForStep = findBlockForStep(sequence, currentStep);
+      if (dataCollectionEnabled && (storedAnswer.endTime === -1 || clickedPrevious)) {
+        const toSave = {
+          ...storedAnswer,
+          answer: collectData ? answer : {},
+          startTime,
+          endTime,
+          provenanceGraph,
+          windowEvents: currentWindowEvents,
+          timedOut: !collectData,
+        };
+        storeDispatch(
+          saveTrialAnswer({
+            ...toSave,
+          }),
+        );
+        const answersToPersist = { ...answers, [identifier]: toSave };
 
-    // If the current component is in a block that has a skip block (or is nested in a block that has a skip block), we need to check if the skip block should be triggered
-    const hasSkipBlock = blocksForStep !== null && (blocksForStep.some((block) => block.currentBlock.skip && block.currentBlock.skip.length > 0));
-
-    // Get the answers with the new answer added, since above is dispatching and async, but we need it synchronously
-    const answersWithNewAnswer = {
-      ...answers,
-      [identifier]: {
-        answer,
-        startTime,
-        endTime,
-        provenanceGraph,
-        windowEvents: currentWindowEvents,
-      },
-    };
-
-    // Check if the skip block should be triggered
-    if (hasSkipBlock) {
-      const skipConditions = [
-        ...blocksForStep.flatMap((block) => (block.currentBlock.skip ? block.currentBlock.skip.map((condition) => ({ ...condition, firstIndex: block.firstIndex, lastIndex: block.lastIndex })) : [])),
-      ];
-
-      // Loop over all conditions, use `.some()` to stop early if the condition is met
-      skipConditions.some((condition) => {
-        let conditionIsTriggered = false;
-
-        const validationCandidates = Object.fromEntries(Object.entries(answersWithNewAnswer).filter(([key]) => {
-          const componentIndex = parseInt(key.slice(key.lastIndexOf('_') + 1), 10);
-          return componentIndex >= condition.firstIndex && componentIndex <= currentStep;
-        })) as unknown as StoredAnswer;
-
-        // Slim down the validationCandidates to only include the skip condition's component
-        const componentsToCheck = condition.check !== 'block' ? Object.entries(validationCandidates).filter(([key]) => key.slice(0, key.lastIndexOf('_')) === condition.name) : Object.entries(validationCandidates);
-
-        // Make sure componentsToCheck array is well-formed
-        if (componentsToCheck.length === 0) {
-          return false;
-        }
-        if (componentsToCheck.some(([_, responseObj]) => !responseObj)) {
-          throw new Error(`There are components with missing response objects for the skip condition: ${JSON.stringify(condition, null, 2)}`);
-        }
-
-        if (condition.check === 'response' || condition.check === 'responses') {
-          const [componentId, response] = componentsToCheck[0]; // We will only check the first component that matches the condition
-
-          // For a response check, we only need to check the specified response
-          if (condition.check === 'response') {
-            conditionIsTriggered = condition.comparison === 'equal' ? condition.value === response.answer[condition.responseId] : condition.value !== response.answer[condition.responseId];
-          } else {
-            // Check that the response is matches the correct answer
-            conditionIsTriggered = !checkAllAnswersCorrect(response.answer, componentId, studyConfig.components[componentId.slice(0, componentId.lastIndexOf('_'))], studyConfig);
+        if (storageEngine) {
+          try {
+            // Force the answers to be up to date before saving.
+            // Await the local snapshot write before navigating away.
+            await storageEngine.saveAnswers(answersToPersist);
+          } catch (error) {
+            console.error('Failed to save participant answers before advancing', error);
+            showNotification({
+              title: 'Failed to Save Response',
+              message: 'Your response could not be saved. Please check your connection and try again.',
+              color: 'red',
+            });
+            return;
           }
-        } else if (condition.check === 'block' || condition.check === 'repeatedComponent') {
-          // If we have less than numCorrect or numIncorrect, there's no point in checking the condition
-          if (componentsToCheck.length < condition.value) {
+        }
+
+        storeDispatch(setReactiveAnswers({}));
+        storeDispatch(setMatrixAnswersCheckbox(null));
+        storeDispatch(setMatrixAnswersRadio(null));
+        storeDispatch(setRankingAnswers(null));
+      }
+
+      let nextStep = currentStep + 1;
+
+      // Traverse through the sequence to find the block the current component is in
+      const blocksForStep = findBlockForStep(sequence, currentStep);
+
+      // If the current component is in a block that has a skip block (or is nested in a block that has a skip block), we need to check if the skip block should be triggered
+      const hasSkipBlock = blocksForStep !== null && (blocksForStep.some((block) => block.currentBlock.skip && block.currentBlock.skip.length > 0));
+
+      // Get the answers with the new answer added, since above is dispatching and async, but we need it synchronously
+      const answersWithNewAnswer = {
+        ...answers,
+        [identifier]: {
+          answer,
+          startTime,
+          endTime,
+          provenanceGraph,
+          windowEvents: currentWindowEvents,
+        },
+      };
+
+      // Check if the skip block should be triggered
+      if (hasSkipBlock) {
+        const skipConditions = [
+          ...blocksForStep.flatMap((block) => (block.currentBlock.skip ? block.currentBlock.skip.map((condition) => ({ ...condition, firstIndex: block.firstIndex, lastIndex: block.lastIndex })) : [])),
+        ];
+
+        // Loop over all conditions, use `.some()` to stop early if the condition is met
+        skipConditions.some((condition) => {
+          let conditionIsTriggered = false;
+
+          const validationCandidates = Object.fromEntries(Object.entries(answersWithNewAnswer).filter(([key]) => {
+            const componentIndex = parseInt(key.slice(key.lastIndexOf('_') + 1), 10);
+            return componentIndex >= condition.firstIndex && componentIndex <= currentStep;
+          })) as unknown as StoredAnswer;
+
+          // Slim down the validationCandidates to only include the skip condition's component
+          const componentsToCheck = condition.check !== 'block' ? Object.entries(validationCandidates).filter(([key]) => key.slice(0, key.lastIndexOf('_')) === condition.name) : Object.entries(validationCandidates);
+
+          // Make sure componentsToCheck array is well-formed
+          if (componentsToCheck.length === 0) {
             return false;
           }
+          if (componentsToCheck.some(([_, responseObj]) => !responseObj)) {
+            throw new Error(`There are components with missing response objects for the skip condition: ${JSON.stringify(condition, null, 2)}`);
+          }
 
-          // Check the candidates and count the number of correct and incorrect answers
-          const correctAnswers = componentsToCheck.map(([_componentName, responseObj]) => checkAllAnswersCorrect(responseObj.answer, _componentName, studyConfig.components[componentName.slice(0, componentName.lastIndexOf('_'))], studyConfig));
-          const numCorrect = correctAnswers.filter((correct) => correct).length;
-          const numIncorrect = correctAnswers.length - numCorrect;
+          if (condition.check === 'response' || condition.check === 'responses') {
+            const [componentId, response] = componentsToCheck[0]; // We will only check the first component that matches the condition
 
-          // Check if the number of correct and incorrect answers match the condition
-          conditionIsTriggered = (condition.condition === 'numCorrect' && numCorrect === condition.value) || (condition.condition === 'numIncorrect' && numIncorrect === condition.value);
-        }
+            // For a response check, we only need to check the specified response
+            if (condition.check === 'response') {
+              conditionIsTriggered = condition.comparison === 'equal' ? condition.value === response.answer[condition.responseId] : condition.value !== response.answer[condition.responseId];
+            } else {
+              // Check that the response is matches the correct answer
+              conditionIsTriggered = !checkAllAnswersCorrect(response.answer, componentId, studyConfig.components[componentId.slice(0, componentId.lastIndexOf('_'))], studyConfig);
+            }
+          } else if (condition.check === 'block' || condition.check === 'repeatedComponent') {
+            // If we have less than numCorrect or numIncorrect, there's no point in checking the condition
+            if (componentsToCheck.length < condition.value) {
+              return false;
+            }
 
-        if (conditionIsTriggered) {
-          const nextStepIndex = participantSequence.indexOf(condition.to);
-          const nextStepBlockIndex = nextStepIndex === -1 ? findIndexOfBlock(sequence, condition.to) : -1;
-          nextStep = nextStepIndex === -1 ? nextStepBlockIndex : nextStepIndex;
-          return true;
-        }
-        return false;
+            // Check the candidates and count the number of correct and incorrect answers
+            const correctAnswers = componentsToCheck.map(([_componentName, responseObj]) => checkAllAnswersCorrect(responseObj.answer, _componentName, studyConfig.components[componentName.slice(0, componentName.lastIndexOf('_'))], studyConfig));
+            const numCorrect = correctAnswers.filter((correct) => correct).length;
+            const numIncorrect = correctAnswers.length - numCorrect;
+
+            // Check if the number of correct and incorrect answers match the condition
+            conditionIsTriggered = (condition.condition === 'numCorrect' && numCorrect === condition.value) || (condition.condition === 'numIncorrect' && numIncorrect === condition.value);
+          }
+
+          if (conditionIsTriggered) {
+            const nextStepIndex = participantSequence.indexOf(condition.to);
+            const nextStepBlockIndex = nextStepIndex === -1 ? findIndexOfBlock(sequence, condition.to) : -1;
+            nextStep = nextStepIndex === -1 ? nextStepBlockIndex : nextStepIndex;
+            return true;
+          }
+          return false;
+        });
+      }
+
+      if (funcIndex) {
+        navigate(`/${studyId}/${encryptIndex(currentStep)}/${encryptIndex(decryptIndex(funcIndex) + 1)}${window.location.search}`);
+      } else {
+        navigate(`/${studyId}/${encryptIndex(nextStep)}${window.location.search}`);
+      }
+    } catch (error) {
+      console.error('Failed to advance to next step', error);
+      showNotification({
+        title: 'Failed to Advance',
+        message: 'Something went wrong while processing your response. Please try again.',
+        color: 'red',
       });
-    }
-
-    if (funcIndex) {
-      navigate(`/${studyId}/${encryptIndex(currentStep)}/${encryptIndex(decryptIndex(funcIndex) + 1)}${window.location.search}`);
-    } else {
-      navigate(`/${studyId}/${encryptIndex(nextStep)}${window.location.search}`);
     }
   }, [currentStep, trialValidation, identifier, storedAnswer, windowEvents, dataCollectionEnabled, clickedPrevious, sequence, answers, startTime, funcIndex, storeDispatch, saveTrialAnswer, storageEngine, setReactiveAnswers, setMatrixAnswersCheckbox, setMatrixAnswersRadio, setRankingAnswers, studyConfig, participantSequence, navigate, studyId]);
 


### PR DESCRIPTION
### Does this PR close any open issues?
Towards #1182

### Give a longer description of what this PR addresses and why it's needed
This PR makes study completion robust under high latency and slow uploads by replacing the old throttled answer-save path with a serialized participant-data write queue and an explicit finalizeParticipant() flow. Completion now waits for pending participant-data writes and asset uploads, verifies local and persisted answers match, rejects false zero-answer completions, and only marks a participant complete once storage and realtime state are both confirmed.

It also fixes realtime progress updates so they patch only progress fields instead of rewriting the full sequence-assignment document, which prevents late progress writes from clobbering completion state or causing answered-count drift. On the UI side, the study end screen now uses the explicit finalization result to retry only while writes are still converging and to show a terminal error message when uploads actually fail.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
No


### Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/216

- [x] Done
- [ ] N/A