### PR TITLE
Stabilize participant completion and study end submission flow

### DIFF
--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react';
 import { useResizeObserver } from '@mantine/hooks';
 import { AppHeader } from '../interface/AppHeader';
-import { GlobalConfig, ParticipantData, StudyConfig } from '../../parser/types';
+import { GlobalConfig, ParticipantDataWithStatus, StudyConfig } from '../../parser/types';
 import { getStudyConfig, resolveConfigKey } from '../../utils/fetchConfig';
 import { LiveMonitorView } from './LiveMonitor/LiveMonitorView';
 import { SummaryView } from './summary/SummaryView';
@@ -37,7 +37,7 @@ import { ConfigView } from './config/ConfigView';
 
 const TABLE_HEADER_HEIGHT = 37; // Height of the tabs header
 
-function sortByStartTime(a: ParticipantData, b: ParticipantData) {
+function sortByStartTime(a: ParticipantDataWithStatus, b: ParticipantDataWithStatus) {
   const aStartTimes = Object.values(a.answers).map((answer) => answer.startTime).filter((startTime) => startTime !== undefined).sort();
   const bStartTimes = Object.values(b.answers).map((answer) => answer.startTime).filter((startTime) => startTime !== undefined).sort();
   if (aStartTimes.length === 0 || bStartTimes.length === 0) {
@@ -52,7 +52,11 @@ function sortByStartTime(a: ParticipantData, b: ParticipantData) {
   return bStartTimes[0] - aStartTimes[0];
 }
 
-async function getParticipantsData(studyConfig: StudyConfig | undefined, storageEngine: StorageEngine | undefined, studyId: string | undefined): Promise<Record<number, ParticipantData>> {
+async function getParticipantsData(
+  studyConfig: StudyConfig | undefined,
+  storageEngine: StorageEngine | undefined,
+  studyId: string | undefined,
+): Promise<ParticipantDataWithStatus[]> {
   if (studyId && storageEngine) {
     await storageEngine.initializeStudyDb(studyId);
   }
@@ -71,7 +75,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   const [selectedStages, setSelectedStages] = useState<string[]>(['ALL']);
   const [availableStages, setAvailableStages] = useState<{ value: string; label: string }[]>([{ value: 'ALL', label: 'ALL' }]);
   const [stageColors, setStageColors] = useState<Record<string, string>>({});
-  const [selectedParticipants, setSelectedParticipants] = useState<ParticipantData[]>([]);
+  const [selectedParticipants, setSelectedParticipants] = useState<ParticipantDataWithStatus[]>([]);
   const [selectedConfigs, setSelectedConfigs] = useState<string[]>(['ALL']);
   const [availableConfigs, setAvailableConfigs] = useState<{ value: string; label: string }[]>([{ value: 'ALL', label: 'ALL' }]);
   const [allConfigs, setAllConfigs] = useState<Record<string, StudyConfig>>({});

--- a/src/analysis/individualStudy/management/DataManagementItem.tsx
+++ b/src/analysis/individualStudy/management/DataManagementItem.tsx
@@ -8,7 +8,7 @@ import { useStorageEngine } from '../../../storage/storageEngineHooks';
 import { showNotification, RevisitNotification } from '../../../utils/notifications';
 import { DownloadButtons } from '../../../components/downloader/DownloadButtons';
 import { ActionResponse, SnapshotDocContent } from '../../../storage/engines/types';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 
 type SnapshotAction =
   | { type: 'create', archive: boolean }
@@ -17,7 +17,7 @@ type SnapshotAction =
   | { type: 'deleteSnapshot', snapshot: string }
   | { type: 'deleteLive' };
 
-export function DataManagementItem({ studyId, refresh }: { studyId: string, refresh: () => Promise<Record<number, ParticipantData>> }) {
+export function DataManagementItem({ studyId, refresh }: { studyId: string, refresh: () => Promise<ParticipantDataWithStatus[]> }) {
   const [modalArchiveOpened, setModalArchiveOpened] = useState<boolean>(false);
   const [modalDeleteSnapshotOpened, setModalDeleteSnapshotOpened] = useState<boolean>(false);
   const [modalRenameSnapshotOpened, setModalRenameSnapshotOpened] = useState<boolean>(false);

--- a/src/analysis/individualStudy/management/ManageView.tsx
+++ b/src/analysis/individualStudy/management/ManageView.tsx
@@ -4,9 +4,9 @@ import {
 import { DataManagementItem } from './DataManagementItem';
 import { RevisitModesItem } from './RevisitModesItem';
 import { StageManagementItem } from './StageManagementItem';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 
-export function ManageView({ studyId, refresh }: { studyId: string, refresh: () => Promise<Record<number, ParticipantData>> }) {
+export function ManageView({ studyId, refresh }: { studyId: string, refresh: () => Promise<ParticipantDataWithStatus[]> }) {
   return (
     <Stack gap="lg" w="60%" mx="auto">
       <Paper shadow="sm" p="lg" radius="md" withBorder>

--- a/src/analysis/individualStudy/stats/StatsView.tsx
+++ b/src/analysis/individualStudy/stats/StatsView.tsx
@@ -3,7 +3,7 @@ import {
 } from '@mantine/core';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { TrialVisualization } from './TrialVisualization';
 import { StepsPanel } from '../../../components/interface/StepsPanel';
@@ -17,7 +17,7 @@ export function StatsView(
     studyId,
   }: {
     studyConfig: StudyConfig;
-    visibleParticipants: ParticipantData[];
+    visibleParticipants: ParticipantDataWithStatus[];
     studyId?: string;
   },
 ) {

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Paper, Title } from '@mantine/core';
 // eslint-disable-next-line camelcase
 import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from 'mantine-react-table';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { getComponentStats, convertNumberToString } from './utils';
 import { ComponentData } from '../../types';
@@ -11,7 +11,7 @@ export function ComponentStats({
   visibleParticipants,
   studyConfig,
 }: {
-  visibleParticipants: ParticipantData[];
+  visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
 }) {
   const componentData: ComponentData[] = useMemo(() => getComponentStats(visibleParticipants, studyConfig), [visibleParticipants, studyConfig]);

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Paper, Title } from '@mantine/core';
 // eslint-disable-next-line camelcase
 import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from 'mantine-react-table';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { getResponseStats, convertNumberToString } from './utils';
 import { ResponseData } from '../../types';
@@ -11,7 +11,7 @@ export function ResponseStats({
   visibleParticipants,
   studyConfig,
 }: {
-  visibleParticipants: ParticipantData[];
+  visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
 }) {
   const responseData: ResponseData[] = useMemo(() => getResponseStats(visibleParticipants, studyConfig), [visibleParticipants, studyConfig]);

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -1,6 +1,6 @@
 import { Stack, Group } from '@mantine/core';
 import { useMemo } from 'react';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { OverviewStats } from './OverviewStats';
 import { ComponentStats } from './ComponentStats';
@@ -12,7 +12,7 @@ export function SummaryView({
   studyConfig,
   studyId,
 }: {
-  visibleParticipants: ParticipantData[];
+  visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
   studyId?: string;
 }) {

--- a/src/analysis/individualStudy/summary/utils.test.ts
+++ b/src/analysis/individualStudy/summary/utils.test.ts
@@ -7,7 +7,7 @@ import {
   getComponentStats,
   getResponseStats,
 } from './utils';
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 
@@ -35,7 +35,7 @@ vi.mock('../../../utils/handleComponentInheritance', () => ({
 }));
 
 // Helper function to create mock participant data
-function createMockParticipant(overrides: Partial<ParticipantData> & { participantId: string }): ParticipantData {
+function createMockParticipant(overrides: Partial<ParticipantDataWithStatus> & { participantId: string }): ParticipantDataWithStatus {
   const { participantId, ...rest } = overrides;
   return {
     participantId,

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -1,4 +1,4 @@
-import { ParticipantData } from '../../../storage/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
 import { getCleanedDuration } from '../../../utils/getCleanedDuration';
 import {
   ComponentData, OverviewData, ParticipantCounts, ResponseData,
@@ -8,7 +8,11 @@ import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { getMatrixAnswerOptions } from '../../../utils/responseOptions';
 
-function filterParticipants(visibleParticipants: ParticipantData[], componentName?: string, excludeRejected?: boolean): ParticipantData[] {
+function filterParticipants(
+  visibleParticipants: ParticipantDataWithStatus[],
+  componentName?: string,
+  excludeRejected?: boolean,
+): ParticipantDataWithStatus[] {
   return visibleParticipants.filter((participant) => {
     // Filter out rejected participants if excludeRejected is true
     const isNotRejected = !excludeRejected || !participant.rejected;
@@ -20,7 +24,7 @@ function filterParticipants(visibleParticipants: ParticipantData[], componentNam
   });
 }
 
-function calculateParticipantCounts(visibleParticipants: ParticipantData[], componentName?: string): ParticipantCounts {
+function calculateParticipantCounts(visibleParticipants: ParticipantDataWithStatus[], componentName?: string): ParticipantCounts {
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, false);
 
   const participantCounts: ParticipantCounts = {
@@ -34,7 +38,7 @@ function calculateParticipantCounts(visibleParticipants: ParticipantData[], comp
   return participantCounts;
 }
 
-function calculateDateStats(visibleParticipants: ParticipantData[], componentName?: string): { startDate: Date | null; endDate: Date | null } {
+function calculateDateStats(visibleParticipants: ParticipantDataWithStatus[], componentName?: string): { startDate: Date | null; endDate: Date | null } {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
   const answers = filteredParticipants
@@ -54,7 +58,7 @@ function calculateDateStats(visibleParticipants: ParticipantData[], componentNam
   };
 }
 
-function calculateTimeStats(visibleParticipants: ParticipantData[], componentName?: string): { avgTime: number; avgCleanTime: number; participantsWithInvalidCleanTimeCount: number } {
+function calculateTimeStats(visibleParticipants: ParticipantDataWithStatus[], componentName?: string): { avgTime: number; avgCleanTime: number; participantsWithInvalidCleanTimeCount: number } {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
 
@@ -91,7 +95,10 @@ function calculateTimeStats(visibleParticipants: ParticipantData[], componentNam
   };
 }
 
-function calculateCorrectnessStats(visibleParticipants: ParticipantData[], componentName?: string): number {
+function calculateCorrectnessStats(
+  visibleParticipants: ParticipantDataWithStatus[],
+  componentName?: string,
+): number {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
   const answers = filteredParticipants
@@ -166,7 +173,10 @@ export function convertNumberToString(number: number | Date | null, type: 'date'
   return 'N/A';
 }
 
-export function getOverviewStats(visibleParticipants: ParticipantData[], componentName?: string): OverviewData {
+export function getOverviewStats(
+  visibleParticipants: ParticipantDataWithStatus[],
+  componentName?: string,
+): OverviewData {
   const timeStats = calculateTimeStats(visibleParticipants, componentName);
   const dateStats = calculateDateStats(visibleParticipants, componentName);
   const calculatedCounts = calculateParticipantCounts(visibleParticipants, componentName);
@@ -184,7 +194,7 @@ export function getOverviewStats(visibleParticipants: ParticipantData[], compone
   return overviewData;
 }
 
-export function getComponentStats(visibleParticipants: ParticipantData[], studyConfig: StudyConfig): ComponentData[] {
+export function getComponentStats(visibleParticipants: ParticipantDataWithStatus[], studyConfig: StudyConfig): ComponentData[] {
   // Get all component names from the current study
   const componentNames = Object.keys(studyConfig.components);
   const componentData: ComponentData[] = componentNames.map((name) => {
@@ -202,7 +212,7 @@ export function getComponentStats(visibleParticipants: ParticipantData[], studyC
   return componentData;
 }
 
-export function getResponseStats(visibleParticipants: ParticipantData[], studyConfig: StudyConfig): ResponseData[] {
+export function getResponseStats(visibleParticipants: ParticipantDataWithStatus[], studyConfig: StudyConfig): ResponseData[] {
   // Get all responses for each component
   const responseData: ResponseData[] = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
     const component = studyComponentToIndividualComponent(componentConfig, studyConfig);

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -14,7 +14,7 @@ import {
 } from '@tabler/icons-react';
 
 import {
-  ParticipantData, StoredAnswer, StudyConfig,
+  ParticipantDataWithStatus, StoredAnswer, StudyConfig,
 } from '../../../parser/types';
 import { ParticipantRejectModal } from '../ParticipantRejectModal';
 import { participantName } from '../../../utils/participantName';
@@ -42,14 +42,14 @@ export function TableView({
   selectedParticipants,
   onSelectionChange,
 }: {
-  visibleParticipants: ParticipantData[];
+  visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
   allConfigs: Record<string, StudyConfig>;
-  refresh: () => Promise<Record<number, ParticipantData>>;
+  refresh: () => Promise<ParticipantDataWithStatus[]>;
   width: number;
   stageColors: Record<string, string>;
-  selectedParticipants: ParticipantData[];
-  onSelectionChange: (participants: ParticipantData[]) => void;
+  selectedParticipants: ParticipantDataWithStatus[];
+  onSelectionChange: (participants: ParticipantDataWithStatus[]) => void;
 }) {
   const { studyId } = useParams();
   const [checked, setChecked] = useState<MrtRowSelectionState>({});
@@ -57,7 +57,7 @@ export function TableView({
   useEffect(() => {
     const newSelectedParticipants = Object.keys(checked).filter((v) => checked[v])
       .map((participantId) => visibleParticipants.find((p) => p.participantId === participantId))
-      .filter((p) => p !== undefined) as ParticipantData[];
+      .filter((p) => p !== undefined) as ParticipantDataWithStatus[];
     onSelectionChange(newSelectedParticipants);
   }, [checked, visibleParticipants, onSelectionChange]);
 
@@ -73,19 +73,19 @@ export function TableView({
     setTimeout(() => setCopied(null), 2000);
   };
 
-  const columns = useMemo<MrtColumnDef<ParticipantData>[]>(() => {
+  const columns = useMemo<MrtColumnDef<ParticipantDataWithStatus>[]>(() => {
     const hasCondition = visibleParticipants.some((participant) => participant.conditions ?? participant.searchParams?.condition);
 
     return [
       {
-        accessorFn: (row: ParticipantData) => {
+        accessorFn: (row: ParticipantDataWithStatus) => {
           const incompleteEntries = Object.entries(row.answers || {}).filter((e) => e[1].startTime === 0);
 
           return { percent: (Object.entries(row.answers).length - incompleteEntries.length) / (getSequenceFlatMap(row.sequence).length - 1), completed: row.completed, rejected: row.rejected };
         },
         header: 'Status',
         size: 100,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantData, { percent: number, completed: boolean, rejected: ParticipantData['rejected'] }> }) => {
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, { percent: number, completed: boolean, rejected: ParticipantDataWithStatus['rejected'] }> }) => {
           const cellValue = cell.getValue();
           return (
             cellValue.rejected ? (
@@ -121,7 +121,7 @@ export function TableView({
         accessorKey: 'stage',
         header: 'Stage',
         size: 100,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantData, string> }) => {
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, string> }) => {
           const stageName = cell.getValue();
           if (!stageName || stageName === '') {
             return (
@@ -149,7 +149,7 @@ export function TableView({
       {
         accessorKey: 'participantId',
         header: 'ID',
-        Cell: ({ row }: { row: { original: ParticipantData } }) => (
+        Cell: ({ row }: { row: { original: ParticipantDataWithStatus } }) => (
           <Flex align="center">
             <Text size="sm">{row.original.participantId}</Text>
             <Tooltip label={copied === row.original.participantId ? 'Copied' : 'Copy ID'}>
@@ -166,14 +166,14 @@ export function TableView({
       },
       ...(studyConfig.uiConfig.participantNameField ? [
         {
-          accessorFn: (row: ParticipantData) => participantName(row, studyConfig),
+          accessorFn: (row: ParticipantDataWithStatus) => participantName(row, studyConfig),
           header: 'Name',
           size: 100,
         },
       ] : []),
       ...(hasCondition ? [
         {
-          accessorFn: (row: ParticipantData) => {
+          accessorFn: (row: ParticipantDataWithStatus) => {
             const { conditions } = row;
             if (Array.isArray(conditions) && conditions.length > 0) {
               return conditions.join(',');
@@ -185,10 +185,10 @@ export function TableView({
         },
       ] : []),
       {
-        accessorFn: (row: ParticipantData) => new Date(Math.max(...Object.values<StoredAnswer>(row.answers).filter((data) => data.endTime > 0).map((s) => s.endTime)) - Math.min(...Object.values<StoredAnswer>(row.answers).filter((data) => data.startTime > 0).map((s) => s.startTime))),
+        accessorFn: (row: ParticipantDataWithStatus) => new Date(Math.max(...Object.values<StoredAnswer>(row.answers).filter((data) => data.endTime > 0).map((s) => s.endTime)) - Math.min(...Object.values<StoredAnswer>(row.answers).filter((data) => data.startTime > 0).map((s) => s.startTime))),
         header: 'Duration',
         size: 120,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantData, Date> }) => (
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, Date> }) => (
           !Number.isNaN(cell.getValue()) ? (
             <Badge
               variant="light"
@@ -204,16 +204,18 @@ export function TableView({
 
       },
       {
-        accessorFn: (row: ParticipantData) => new Date(Math.min(...Object.values<StoredAnswer>(row.answers).filter((data) => data.startTime > 0).map((s) => s.startTime))),
+        accessorFn: (row: ParticipantDataWithStatus) => new Date(Math.min(...Object.values<StoredAnswer>(row.answers).filter((data) => data.startTime > 0).map((s) => s.startTime))),
         header: 'Start Time',
         size: 150,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantData, Date> }) => (formatDate(cell.getValue() as Date)),
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, Date> }) => (formatDate(cell.getValue() as Date)),
       },
       {
-        accessorFn: (row: ParticipantData) => Object.values(row.answers).filter((answer) => answer.correctAnswer.length > 0 && answer.endTime > 0).map((answer) => componentAnswersAreCorrect(answer.answer, answer.correctAnswer)),
+        accessorFn: (row: ParticipantDataWithStatus) => Object.values(row.answers)
+          .filter((answer) => answer.correctAnswer.length > 0 && answer.endTime > 0)
+          .map((answer) => componentAnswersAreCorrect(answer.answer, answer.correctAnswer)),
         header: 'Correct Answers',
         size: 160,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantData, boolean[]> }) => (
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, boolean[]> }) => (
           <Group gap={4}>
             <Badge
               variant="light"
@@ -241,7 +243,7 @@ export function TableView({
         accessorKey: 'metadata',
         header: 'Metadata',
         size: 200,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantData, ParticipantData['metadata']> }) => <MetaCell metaData={cell.getValue()} />,
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, ParticipantDataWithStatus['metadata']> }) => <MetaCell metaData={cell.getValue()} />,
       },
     ];
   }, [studyConfig, stageColors, copied, visibleParticipants]);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -172,6 +172,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           allowUrlOverride: modes.developmentModeEnabled,
         });
         const filteredParticipantSequence = filterSequenceByCondition(participantSession.sequence, effectiveStudyCondition);
+        const participantCompleted = await storageEngine.getParticipantCompletionStatus(participantSession.participantId);
         // Initialize the redux stores
         const newStore = await studyStoreCreator(
           canonicalStudyId,
@@ -181,7 +182,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           participantSession.answers,
           modes,
           participantSession.participantId,
-          participantSession.completed,
+          participantCompleted,
           false,
           participantSession.participantConfigHash !== activeHash,
         );

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -48,6 +48,7 @@ export function StepRenderer() {
   const showStudyBrowser = useStoreSelector((state) => state.showStudyBrowser);
   const modes = useStoreSelector((state) => state.modes);
   const isCompleted = useStoreSelector((state) => state.completed);
+  const isSubmittingFinal = useStoreSelector((state) => state.isSubmittingFinal);
 
   const screenRecording = useRecording();
   const replay = useReplay();
@@ -148,8 +149,9 @@ export function StepRenderer() {
       developmentModeEnabled,
       isCompleted,
       dataCollectionEnabled,
+      isSubmittingFinal,
     ),
-    [isAnalysis, currentComponent, developmentModeEnabled, isCompleted, dataCollectionEnabled],
+    [isAnalysis, currentComponent, developmentModeEnabled, isCompleted, dataCollectionEnabled, isSubmittingFinal],
   );
 
   const [hasAudio, setHasAudio] = useState<boolean>();

--- a/src/components/StudyEnd.spec.tsx
+++ b/src/components/StudyEnd.spec.tsx
@@ -1,12 +1,19 @@
 import { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
+  beforeEach,
   describe,
   expect,
   test,
   vi,
 } from 'vitest';
 import { StudyEnd } from './StudyEnd';
+
+const mockState = {
+  modes: {
+    dataCollectionEnabled: true,
+  },
+};
 
 vi.mock('@mantine/core', () => ({
   Button: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
@@ -50,9 +57,14 @@ vi.mock('../store/hooks/useIsAnalysis', () => ({
 
 vi.mock('../store/store', () => ({
   useStoreDispatch: () => vi.fn(),
+  useStoreSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
   useStoreActions: () => ({
     setParticipantCompleted: vi.fn((value: boolean) => ({
       type: 'setParticipantCompleted',
+      payload: value,
+    })),
+    setIsSubmittingFinal: vi.fn((value: boolean) => ({
+      type: 'setIsSubmittingFinal',
       payload: value,
     })),
   }),
@@ -63,7 +75,19 @@ vi.mock('./downloader/DownloadTidy', () => ({
 }));
 
 describe('StudyEnd', () => {
-  test('renders the study end message', () => {
+  beforeEach(() => {
+    mockState.modes.dataCollectionEnabled = true;
+  });
+
+  test('renders the upload spinner while data collection is enabled', () => {
+    const html = renderToStaticMarkup(<StudyEnd />);
+    expect(html).toContain('Please wait while your answers are uploaded.');
+    expect(html).toContain('Loading');
+  });
+
+  test('renders the study end message immediately when data collection is disabled', () => {
+    mockState.modes.dataCollectionEnabled = false;
+
     const html = renderToStaticMarkup(<StudyEnd />);
     expect(html).toContain('Study complete');
   });

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -10,9 +10,8 @@ import { useDisableBrowserBack } from '../utils/useDisableBrowserBack';
 import { useStorageEngine } from '../storage/storageEngineHooks';
 import { ParticipantData } from '../storage/types';
 import { download } from './downloader/DownloadTidy';
-import { useStudyId } from '../routes/utils';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
-import { useStoreDispatch, useStoreActions } from '../store/store';
+import { useStoreDispatch, useStoreActions, useStoreSelector } from '../store/store';
 import {
   createStudyEndFinalizeLoop,
   DEFAULT_STUDY_END_FINALIZE_STATE,
@@ -23,9 +22,10 @@ export function StudyEnd() {
   const studyConfig = useStudyConfig();
   const { storageEngine } = useStorageEngine();
   const dispatch = useStoreDispatch();
-  const { setParticipantCompleted } = useStoreActions();
+  const { setParticipantCompleted, setIsSubmittingFinal } = useStoreActions();
 
   const isAnalysis = useIsAnalysis();
+  const dataCollectionEnabled = useStoreSelector((state) => state.modes.dataCollectionEnabled);
 
   const [completed, setCompleted] = useState(false);
   const [finalizeState, setFinalizeState] = useState<StudyEndFinalizeLoopState>(DEFAULT_STUDY_END_FINALIZE_STATE);
@@ -45,6 +45,7 @@ export function StudyEnd() {
           setFinalizeState(DEFAULT_STUDY_END_FINALIZE_STATE);
           setCompleted(true);
           dispatch(setParticipantCompleted(true));
+          dispatch(setIsSubmittingFinal(false));
         },
         onStateChange: setFinalizeState,
         onUnexpectedError: (error) => {
@@ -52,17 +53,20 @@ export function StudyEnd() {
         },
       });
 
+      dispatch(setIsSubmittingFinal(true));
       finalizeLoopRef.current = finalizeLoop;
       finalizeLoop.start();
 
       return () => {
         finalizeLoopRef.current = null;
         finalizeLoop.cancel();
+        dispatch(setIsSubmittingFinal(false));
       };
     }
 
     setCompleted(true);
     dispatch(setParticipantCompleted(true));
+    dispatch(setIsSubmittingFinal(false));
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -143,18 +147,6 @@ export function StudyEnd() {
     }
     return () => { };
   }, [autoDownload, completed, delayCounter, downloadParticipant]);
-
-  const studyId = useStudyId();
-  const [dataCollectionEnabled, setDataCollectionEnabled] = useState(false);
-  useEffect(() => {
-    const checkDataCollectionEnabled = async () => {
-      if (storageEngine) {
-        const modes = await storageEngine.getModes(studyId);
-        setDataCollectionEnabled(modes.dataCollectionEnabled);
-      }
-    };
-    checkDataCollectionEnabled();
-  }, [storageEngine, studyId]);
 
   const processedStudyEndMsg = useMemo(() => {
     const { studyEndMsg, urlParticipantIdParam } = studyConfig.uiConfig;

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -7,17 +7,17 @@ import {
 import { useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { DownloadTidy, download } from './DownloadTidy';
-import { ParticipantData } from '../../storage/types';
+import { ParticipantDataWithStatus } from '../../storage/types';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { downloadParticipantsAudioZip, downloadParticipantsScreenRecordingZip } from '../../utils/handleDownloadFiles';
 
-type ParticipantDataFetcher = ParticipantData[] | (() => Promise<ParticipantData[]>);
+type ParticipantDataFetcher = ParticipantDataWithStatus[] | (() => Promise<ParticipantDataWithStatus[]>);
 
 export function DownloadButtons({
   visibleParticipants, studyId, gap, fileName, hasAudio, hasScreenRecording,
 }: { visibleParticipants: ParticipantDataFetcher; studyId: string, gap?: string, fileName?: string | null; hasAudio?: boolean; hasScreenRecording?: boolean; }) {
   const [openDownload, { open, close }] = useDisclosure(false);
-  const [participants, setParticipants] = useState<ParticipantData[]>([]);
+  const [participants, setParticipants] = useState<ParticipantDataWithStatus[]>([]);
   const [loadingAudio, setLoadingAudio] = useState(false);
   const [loadingScreenRecording, setLoadingScreenRecording] = useState(false);
   const { storageEngine } = useStorageEngine();

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -17,7 +17,7 @@ import {
   IconBrandPython, IconLayoutColumns, IconTableExport, IconX,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
-import { ParticipantData } from '../../storage/types';
+import { ParticipantDataWithStatus } from '../../storage/types';
 import { Prettify, StudyConfig } from '../../parser/types';
 import { StorageEngine } from '../../storage/engines/types';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
@@ -99,7 +99,12 @@ export function download(graph: string, filename: string) {
   downloadAnchorNode.remove();
 }
 
-function participantDataToRows(participant: ParticipantData, properties: Property[], studyConfig: StudyConfig, transcripts?: Record<string, string | null>): [TidyRow[], string[]] {
+function participantDataToRows(
+  participant: ParticipantDataWithStatus,
+  properties: Property[],
+  studyConfig: StudyConfig,
+  transcripts?: Record<string, string | null>,
+): [TidyRow[], string[]] {
   const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (Object.entries(participant.answers).length)) * 100).toFixed(2);
   const newHeaders = new Set<string>();
   const participantConditions = parseConditionParam(participant.conditions ?? participant.searchParams?.condition);
@@ -237,7 +242,7 @@ function participantDataToRows(participant: ParticipantData, properties: Propert
 
 async function getTableData(
   selectedProperties: Property[],
-  data: ParticipantData[],
+  data: ParticipantDataWithStatus[],
   storageEngine: StorageEngine | undefined,
   studyId: string,
   hasAudio?: boolean,
@@ -303,7 +308,7 @@ export function DownloadTidy({
   opened: boolean;
   close: () => void;
   filename: string;
-  data: ParticipantData[];
+  data: ParticipantDataWithStatus[];
   studyId: string;
   hasAudio?: boolean;
 }) {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,4 +1,4 @@
-export type { ParticipantData } from '../storage/types';
+export type { ParticipantData, ParticipantDataWithStatus } from '../storage/types';
 export type { StoredAnswer, ParticipantMetadata } from '../store/types';
 
 /**

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -3,12 +3,8 @@ import throttle from 'lodash.throttle';
 import { v4 as uuidv4 } from 'uuid';
 import { StudyConfig } from '../../parser/types';
 import { ParticipantMetadata, Sequence } from '../../store/types';
-import { ParticipantData } from '../types';
+import { ParticipantData, ParticipantDataWithStatus } from '../types';
 import { hash, isParticipantData } from './utils/storageEngineHelpers';
-import {
-  answeredParticipantAnswerMetadataMatches,
-  getAnsweredParticipantAnswerMetadata,
-} from './utils/participantAnswerMetadata';
 import { shouldPreferCachedParticipantData } from './utils/participantDataRecovery';
 import { RevisitNotification } from '../../utils/notifications';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
@@ -892,7 +888,6 @@ export abstract class StorageEngine {
       searchParams,
       conditions,
       metadata,
-      completed: false,
       rejected: false,
       participantTags: [],
       stage: currentStage,
@@ -1147,9 +1142,12 @@ export abstract class StorageEngine {
   }
 
   // Gets all participant IDs for the current studyId or a provided studyId.
-  async getAllParticipantsData(studyId: string) {
+  async getAllParticipantsData(studyId: string): Promise<ParticipantDataWithStatus[]> {
     const participantIds = await this.getAllParticipantIds(studyId);
-    const participantsData: ParticipantData[] = [];
+    const sequenceAssignments = await this.getAllSequenceAssignments(studyId);
+    const completedByParticipantId = new Map(
+      sequenceAssignments.map((assignment) => [assignment.participantId, assignment.completed !== null]),
+    );
 
     const participantPulls = participantIds.map(async (participantId) => {
       const participantData = await this._getFromStorage(
@@ -1159,13 +1157,16 @@ export abstract class StorageEngine {
       );
 
       if (isParticipantData(participantData)) {
-        participantsData.push(participantData);
+        return {
+          ...participantData,
+          completed: completedByParticipantId.get(participantId) ?? false,
+        } satisfies ParticipantDataWithStatus;
       }
+      return null;
     });
 
-    await Promise.all(participantPulls);
-
-    return participantsData;
+    const participantsData = await Promise.all(participantPulls);
+    return participantsData.filter((participant): participant is ParticipantDataWithStatus => participant !== null);
   }
 
   async getParticipantsStatusCounts(studyId: string) {
@@ -1232,26 +1233,27 @@ export abstract class StorageEngine {
     }
   }
 
-  async finalizeParticipant(): Promise<FinalizeParticipantResult> {
-    await this.verifyStudyDatabase();
+  async getParticipantCompletionStatus(participantId?: string, studyId?: string): Promise<boolean> {
+    const studyIdToUse = this.studyId || studyId;
+    const participantIdToUse = participantId || this.currentParticipantId;
 
-    if (!this.studyId) {
+    if (!studyIdToUse) {
       throw new Error('Study not initialized');
     }
 
-    if (!this.currentParticipantId) {
+    if (!participantIdToUse) {
       throw new Error('Participant not initialized');
     }
 
-    const modes = await this.getModes(this.studyId);
+    const sequenceAssignments = await this.getAllSequenceAssignments(studyIdToUse);
+    const sequenceAssignment = sequenceAssignments.find(
+      (assignment) => assignment.participantId === participantIdToUse,
+    );
 
-    if (!modes.dataCollectionEnabled) {
-      if (this.participantData) {
-        this.participantData.completed = true;
-      }
-      return { status: 'complete' };
-    }
+    return sequenceAssignment ? sequenceAssignment.completed !== null : false;
+  }
 
+  async finalizeParticipant(): Promise<FinalizeParticipantResult> {
     try {
       await this.flushPendingParticipantData();
     } catch (error) {
@@ -1263,64 +1265,42 @@ export abstract class StorageEngine {
 
     const assetUploadError = await this.waitForPendingAssetUploads();
 
-    const persistedParticipantData = await this.getParticipantData();
-    if (!persistedParticipantData || !this.participantData) {
+    if (!this.studyId) {
+      throw new Error('Study not initialized');
+    }
+
+    if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
 
-    const localAnsweredAnswers = getAnsweredParticipantAnswerMetadata(this.participantData.answers);
-    const persistedAnsweredAnswers = getAnsweredParticipantAnswerMetadata(persistedParticipantData.answers);
-
-    const completeParticipant = async (): Promise<FinalizeParticipantResult> => {
-      this.participantData!.completed = true;
-
-      try {
-        await this.persistCurrentParticipantData({ immediate: true, cache: true });
-        await this._completeCurrentParticipantRealtime();
-      } catch (error) {
-        return {
-          status: 'error',
-          message: normalizeError(error).message,
-        };
-      }
-
-      const completedParticipantData = await this.getParticipantData();
-      const sequenceAssignment = await this._getSequenceAssignment(this.currentParticipantId!);
-
-      if (completedParticipantData?.completed && sequenceAssignment?.completed) {
-        if (assetUploadError) {
-          return {
-            status: 'error',
-            message: assetUploadError.message,
-            retryable: false,
-          };
-        }
-
-        return { status: 'complete' };
-      }
-
-      return { status: 'retry' };
-    };
-
-    if (localAnsweredAnswers.length === 0 && persistedAnsweredAnswers.length === 0) {
-      return completeParticipant();
+    const modes = await this.getModes(this.studyId);
+    if (!modes.dataCollectionEnabled) {
+      return { status: 'complete' };
     }
 
-    if (localAnsweredAnswers.length === 0 || persistedAnsweredAnswers.length === 0) {
-      return { status: 'retry' };
+    const alreadyCompleted = await this.getParticipantCompletionStatus();
+    if (alreadyCompleted) {
+      return { status: 'complete' };
     }
 
-    if (!answeredParticipantAnswerMetadataMatches(localAnsweredAnswers, persistedAnsweredAnswers)) {
-      return { status: 'retry' };
+    if (assetUploadError) {
+      return {
+        status: 'error',
+        message: assetUploadError.message,
+        retryable: false,
+      };
     }
 
-    return completeParticipant();
-  }
+    try {
+      await this._completeCurrentParticipantRealtime();
+    } catch (error) {
+      return {
+        status: 'error',
+        message: normalizeError(error).message,
+      };
+    }
 
-  // Verifies if the current participant has completed the study.
-  async verifyCompletion() {
-    const result = await this.finalizeParticipant();
-    return result.status === 'complete';
+    return { status: 'complete' };
   }
 
   async getAsset(url: string | null) {
@@ -1392,7 +1372,13 @@ export abstract class StorageEngine {
     const uploadPromise = (async () => {
       try {
         await this._pushToStorage(participantKey, taskName, blob);
-        await this._cacheStorageObject(participantKey, taskName);
+        this.clearAssetUploadError(assetKey);
+
+        try {
+          await this._cacheStorageObject(participantKey, taskName);
+        } catch (error) {
+          console.warn(`Failed to update cache headers for asset ${assetKey}:`, error);
+        }
       } catch (error) {
         const normalizedError = normalizeError(error);
         this.recordAssetUploadError(assetKey, normalizedError);

--- a/src/storage/engines/utils/participantDataRecovery.spec.ts
+++ b/src/storage/engines/utils/participantDataRecovery.spec.ts
@@ -54,7 +54,6 @@ function makeParticipantData(overrides: Partial<ParticipantData> = {}): Particip
       language: 'en-US',
       ip: '127.0.0.1',
     },
-    completed: false,
     rejected: false,
     participantTags: [],
     stage: 'DEFAULT',
@@ -64,19 +63,6 @@ function makeParticipantData(overrides: Partial<ParticipantData> = {}): Particip
 }
 
 describe('shouldPreferCachedParticipantData', () => {
-  test('prefers cached participant data when cached completion is newer', () => {
-    const remoteParticipantData = makeParticipantData({
-      completed: false,
-      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
-    });
-    const cachedParticipantData = makeParticipantData({
-      completed: true,
-      answers: { intro_0: makeStoredAnswer('intro_0', 100) },
-    });
-
-    expect(shouldPreferCachedParticipantData(cachedParticipantData, remoteParticipantData)).toBe(true);
-  });
-
   test('prefers cached participant data when it has more answered questions', () => {
     const remoteParticipantData = makeParticipantData({
       answers: { intro_0: makeStoredAnswer('intro_0', 100) },

--- a/src/storage/engines/utils/participantDataRecovery.ts
+++ b/src/storage/engines/utils/participantDataRecovery.ts
@@ -8,10 +8,6 @@ export function shouldPreferCachedParticipantData(
   cachedParticipantData: ParticipantData,
   remoteParticipantData: ParticipantData,
 ) {
-  if (cachedParticipantData.completed !== remoteParticipantData.completed) {
-    return cachedParticipantData.completed;
-  }
-
   const cachedAnsweredAnswers = getAnsweredParticipantAnswerMetadata(cachedParticipantData.answers);
   const remoteAnsweredAnswers = getAnsweredParticipantAnswerMetadata(remoteParticipantData.answers);
 

--- a/src/storage/tests/analysis-live-monitor.spec.ts
+++ b/src/storage/tests/analysis-live-monitor.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { SequenceAssignment } from '../engines/types';
-import { ParticipantData } from '../types';
+import { ParticipantDataWithStatus } from '../types';
 import { getFilteredParticipantProgress, groupParticipantProgress } from '../../analysis/individualStudy/LiveMonitor/LiveMonitorView';
 
 function makeAssignment(partial: Partial<SequenceAssignment> & Pick<SequenceAssignment, 'participantId'>): SequenceAssignment {
@@ -19,7 +19,9 @@ function makeAssignment(partial: Partial<SequenceAssignment> & Pick<SequenceAssi
   };
 }
 
-function makeParticipant(partial: Partial<ParticipantData> & Pick<ParticipantData, 'participantId'>): ParticipantData {
+function makeParticipant(
+  partial: Partial<ParticipantDataWithStatus> & Pick<ParticipantDataWithStatus, 'participantId'>,
+): ParticipantDataWithStatus {
   return {
     participantId: partial.participantId,
     participantConfigHash: partial.participantConfigHash ?? 'hash',
@@ -48,7 +50,7 @@ function makeParticipant(partial: Partial<ParticipantData> & Pick<ParticipantDat
 }
 
 function getParticipantViewIds(
-  participants: ParticipantData[],
+  participants: ParticipantDataWithStatus[],
   includedParticipants: string[],
   selectedStages: string[],
 ): string[] {
@@ -107,7 +109,7 @@ describe('analysis live monitor', () => {
       }),
     ];
 
-    const participants: ParticipantData[] = [
+    const participants: ParticipantDataWithStatus[] = [
       makeParticipant({
         participantId: 'p1', completed: false, rejected: false, stage: 'S1',
       }),

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -314,7 +314,6 @@ describe.each([
     expect(participantData!.searchParams).toEqual({});
     expect(participantData!.conditions).toBeUndefined();
     expect(participantData!.metadata).toEqual(participantMetadata);
-    expect(participantData!.completed).toBe(false);
     expect(participantData!.rejected).toBe(false);
     expect(participantData!.participantTags).toEqual([]);
   });
@@ -641,9 +640,50 @@ describe.each([
 
   // getParticipantStatusCounts test
 
-  // saveAnswers test
+  test('flushPendingParticipantData persists the newest queued answers snapshot', async () => {
+    const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
 
-  test('saveAnswers coalesces to the latest answer and finalizeParticipant persists completed state after delayed writes', async () => {
+    const firstAnswers = {
+      intro_0: {
+        identifier: 'intro_0',
+        componentName: 'intro',
+        trialOrder: '0',
+        answer: { response: 'first' },
+        correctAnswer: [],
+        incorrectAnswers: {},
+        startTime: 10,
+        endTime: 20,
+        provenanceGraph: {
+          sidebar: undefined,
+          aboveStimulus: undefined,
+          belowStimulus: undefined,
+          stimulus: undefined,
+        },
+        windowEvents: [],
+        timedOut: false,
+        helpButtonClickedCount: 0,
+        parameters: {},
+        optionOrders: {},
+        questionOrders: {},
+      },
+    };
+    const secondAnswers = {
+      intro_0: {
+        ...firstAnswers.intro_0,
+        answer: { response: 'second' },
+        endTime: 30,
+      },
+    };
+
+    await storageEngine.saveAnswers(firstAnswers);
+    await storageEngine.saveAnswers(secondAnswers);
+    await storageEngine.flushPendingParticipantData();
+
+    const participantData = await storageEngine.getParticipantData(participantSession.participantId);
+    expect(participantData?.answers).toEqual(secondAnswers);
+  });
+
+  test('saveAnswers coalesces to the latest answer and finalizeParticipant persists completion after delayed writes', async () => {
     storageEngine = new DelayedLocalStorageEngine(true);
     await storageEngine.connect();
     await storageEngine.initializeStudyDb(studyId);
@@ -678,7 +718,12 @@ describe.each([
     const participantData = await storageEngine.getParticipantData();
     expect(participantData).toBeDefined();
     expect(participantData!.answers[identifier].endTime).toBe(200);
-    expect(participantData!.completed).toBe(true);
+
+    const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const sequenceAssignment = sequenceAssignments.find(
+      (assignment) => assignment.participantId === participantData!.participantId,
+    );
+    expect(sequenceAssignment?.completed).not.toBeNull();
   });
 
   test('initializeParticipantSession recovers the latest local participant data while remote writes are pending', async () => {
@@ -759,7 +804,6 @@ describe.each([
 
     const participantData = await storageEngine.getParticipantData(participantSession.participantId);
     expect(participantData).toBeDefined();
-    expect(participantData!.completed).toBe(true);
 
     const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
     const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantSession.participantId);
@@ -803,12 +847,11 @@ describe.each([
 
     const participantData = await storageEngine.getParticipantData();
     expect(participantData).toBeDefined();
-    expect(participantData!.completed).toBe(true);
 
     const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
     const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantData!.participantId);
     expect(sequenceAssignment).toBeDefined();
-    expect(sequenceAssignment!.completed).not.toBeNull();
+    expect(sequenceAssignment!.completed).toBeNull();
   });
 
   test('finalizeParticipant does not mask a failed asset upload after a later successful upload', async () => {
@@ -848,12 +891,11 @@ describe.each([
 
     const participantData = await storageEngine.getParticipantData();
     expect(participantData).toBeDefined();
-    expect(participantData!.completed).toBe(true);
 
     const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
     const sequenceAssignment = sequenceAssignments.find((assignment) => assignment.participantId === participantData!.participantId);
     expect(sequenceAssignment).toBeDefined();
-    expect(sequenceAssignment!.completed).not.toBeNull();
+    expect(sequenceAssignment!.completed).toBeNull();
   });
 
   test('finalizeParticipant succeeds after a transient realtime completion failure', async () => {
@@ -883,7 +925,6 @@ describe.each([
 
     const participantData = await storageEngine.getParticipantData(participantSession.participantId);
     expect(participantData).toBeDefined();
-    expect(participantData!.completed).toBe(true);
 
     const sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
     const sequenceAssignment = sequenceAssignments.find(

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -61,8 +61,6 @@ export interface ParticipantData {
   searchParams: Record<string, string>;
   /** Metadata of a participant's browser, resolution, language, and IP. */
   metadata: ParticipantMetadata
-  /** Whether the participant has completed the study. */
-  completed: boolean;
   /** Whether the participant has been rejected and the reason. */
   rejected: {
     reason: string;
@@ -76,4 +74,9 @@ export interface ParticipantData {
   conditions?: string[];
   /** Time that the participant registered for the study in epoch milliseconds. */
   createdTime?: number;
+}
+
+export interface ParticipantDataWithStatus extends ParticipantData {
+  /** Whether the participant has completed the study. Derived from sequence assignment status. */
+  completed: boolean;
 }

--- a/src/store/hooks/useNextStep.spec.tsx
+++ b/src/store/hooks/useNextStep.spec.tsx
@@ -1,0 +1,225 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import { useNextStep } from './useNextStep';
+
+const mockNavigate = vi.fn();
+const mockShowNotification = vi.fn();
+const mockSaveAnswers = vi.fn();
+const mockSaveTrialAnswer = vi.fn((payload) => ({ type: 'saveTrialAnswer', payload }));
+const mockSetReactiveAnswers = vi.fn((payload) => ({ type: 'setReactiveAnswers', payload }));
+const mockSetMatrixAnswersCheckbox = vi.fn((payload) => ({ type: 'setMatrixAnswersCheckbox', payload }));
+const mockSetMatrixAnswersRadio = vi.fn((payload) => ({ type: 'setMatrixAnswersRadio', payload }));
+const mockSetRankingAnswers = vi.fn((payload) => ({ type: 'setRankingAnswers', payload }));
+
+let mockStoredAnswer: {
+  answer: Record<string, string>;
+  componentName: string;
+  identifier: string;
+  trialOrder: string;
+  incorrectAnswers: Record<string, string>;
+  startTime: number;
+  endTime: number;
+  provenanceGraph: {
+    aboveStimulus: undefined;
+    belowStimulus: undefined;
+    stimulus: undefined;
+    sidebar: undefined;
+  };
+  windowEvents: never[];
+  timedOut: boolean;
+  helpButtonClickedCount: number;
+  parameters: Record<string, string>;
+  correctAnswer: never[];
+  optionOrders: Record<string, string>;
+  questionOrders: Record<string, string>;
+};
+
+let mockAnswers: Record<string, unknown>;
+let capturedGoToNextStep: ((collectData?: boolean) => Promise<void>) | undefined;
+
+const mockDispatch = vi.fn((action) => {
+  if (action.type === 'saveTrialAnswer') {
+    mockStoredAnswer.endTime = action.payload.endTime;
+    mockAnswers = {
+      ...mockAnswers,
+      [action.payload.identifier]: action.payload,
+    };
+  }
+});
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ funcIndex: undefined }),
+}));
+
+vi.mock('../store', () => ({
+  useStoreSelector: (selector: (state: {
+    trialValidation: Record<string, unknown>;
+    sequence: {
+      id: string;
+      orderPath: string;
+      order: 'fixed';
+      components: string[];
+      skip: never[];
+    };
+    answers: Record<string, unknown>;
+    modes: { dataCollectionEnabled: boolean };
+    clickedPrevious: boolean;
+  }) => unknown) => selector({
+    trialValidation: {
+      intro_0: {
+        response: {
+          values: {
+            response: 'saved-answer',
+          },
+        },
+      },
+    },
+    sequence: {
+      id: 'root',
+      orderPath: 'root',
+      order: 'fixed',
+      components: ['intro'],
+      skip: [],
+    },
+    answers: mockAnswers,
+    modes: { dataCollectionEnabled: true },
+    clickedPrevious: false,
+  }),
+  useStoreActions: () => ({
+    saveTrialAnswer: mockSaveTrialAnswer,
+    setReactiveAnswers: mockSetReactiveAnswers,
+    setMatrixAnswersRadio: mockSetMatrixAnswersRadio,
+    setMatrixAnswersCheckbox: mockSetMatrixAnswersCheckbox,
+    setRankingAnswers: mockSetRankingAnswers,
+  }),
+  useStoreDispatch: () => mockDispatch,
+  useAreResponsesValid: () => true,
+  useFlatSequence: () => ['intro'],
+}));
+
+vi.mock('../../routes/utils', () => ({
+  useCurrentIdentifier: () => 'intro_0',
+  useCurrentStep: () => 0,
+  useStudyId: () => 'study-1',
+}));
+
+vi.mock('../../storage/storageEngineHooks', () => ({
+  useStorageEngine: () => ({
+    storageEngine: {
+      saveAnswers: mockSaveAnswers,
+    },
+  }),
+}));
+
+vi.mock('./useStoredAnswer', () => ({
+  useStoredAnswer: () => mockStoredAnswer,
+}));
+
+vi.mock('./useWindowEvents', () => ({
+  useWindowEvents: () => ({ current: [] }),
+}));
+
+vi.mock('./useStudyConfig', () => ({
+  useStudyConfig: () => ({
+    components: {
+      intro: {},
+    },
+  }),
+}));
+
+vi.mock('./useIsAnalysis', () => ({
+  useIsAnalysis: () => false,
+}));
+
+vi.mock('../../utils/notifications', () => ({
+  showNotification: (...args: unknown[]) => mockShowNotification(...args),
+}));
+
+function HookHarness() {
+  capturedGoToNextStep = useNextStep().goToNextStep;
+  return null;
+}
+
+describe('useNextStep', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockNavigate.mockReset();
+    mockShowNotification.mockReset();
+    mockSaveAnswers.mockReset();
+    mockSaveTrialAnswer.mockClear();
+    mockSetReactiveAnswers.mockClear();
+    mockSetMatrixAnswersCheckbox.mockClear();
+    mockSetMatrixAnswersRadio.mockClear();
+    mockSetRankingAnswers.mockClear();
+    mockDispatch.mockClear();
+    mockAnswers = {};
+    mockStoredAnswer = {
+      answer: {},
+      componentName: 'intro',
+      identifier: 'intro_0',
+      trialOrder: '0',
+      incorrectAnswers: {},
+      startTime: 0,
+      endTime: -1,
+      provenanceGraph: {
+        aboveStimulus: undefined,
+        belowStimulus: undefined,
+        stimulus: undefined,
+        sidebar: undefined,
+      },
+      windowEvents: [],
+      timedOut: false,
+      helpButtonClickedCount: 0,
+      parameters: {},
+      correctAnswer: [],
+      optionOrders: {},
+      questionOrders: {},
+    };
+    capturedGoToNextStep = undefined;
+
+    vi.stubGlobal('window', {
+      location: { search: '' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('retries persistence on the next click after a save failure', async () => {
+    mockSaveAnswers
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce(undefined);
+
+    renderToStaticMarkup(<HookHarness />);
+
+    expect(capturedGoToNextStep).toBeDefined();
+
+    await capturedGoToNextStep?.();
+
+    expect(mockSaveAnswers).toHaveBeenCalledTimes(1);
+    expect(mockSaveTrialAnswer).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockShowNotification).toHaveBeenCalledWith({
+      title: 'Failed to Save Response',
+      message: 'Your response could not be saved. Please check your connection and try again.',
+      color: 'red',
+    });
+    expect(mockStoredAnswer.endTime).toBe(-1);
+
+    await capturedGoToNextStep?.();
+
+    expect(mockSaveAnswers).toHaveBeenCalledTimes(2);
+    expect(mockSaveTrialAnswer).toHaveBeenCalledTimes(1);
+    expect(mockStoredAnswer.endTime).toBeGreaterThan(-1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/hooks/useNextStep.spec.tsx
+++ b/src/store/hooks/useNextStep.spec.tsx
@@ -194,7 +194,7 @@ describe('useNextStep', () => {
     vi.restoreAllMocks();
   });
 
-  test('retries persistence on the next click after a save failure', async () => {
+  test('continues locally and shows an error when persistence fails', async () => {
     mockSaveAnswers
       .mockRejectedValueOnce(new Error('write failed'))
       .mockResolvedValueOnce(undefined);
@@ -204,22 +204,23 @@ describe('useNextStep', () => {
     expect(capturedGoToNextStep).toBeDefined();
 
     await capturedGoToNextStep?.();
+    await Promise.resolve();
 
     expect(mockSaveAnswers).toHaveBeenCalledTimes(1);
-    expect(mockSaveTrialAnswer).not.toHaveBeenCalled();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockSaveTrialAnswer).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockShowNotification).toHaveBeenCalledWith({
       title: 'Failed to Save Response',
       message: 'Your response could not be saved. Please check your connection and try again.',
       color: 'red',
     });
-    expect(mockStoredAnswer.endTime).toBe(-1);
+    expect(mockStoredAnswer.endTime).toBeGreaterThan(-1);
 
     await capturedGoToNextStep?.();
 
-    expect(mockSaveAnswers).toHaveBeenCalledTimes(2);
+    expect(mockSaveAnswers).toHaveBeenCalledTimes(1);
     expect(mockSaveTrialAnswer).toHaveBeenCalledTimes(1);
     expect(mockStoredAnswer.endTime).toBeGreaterThan(-1);
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -112,11 +112,6 @@ export function useNextStep() {
           windowEvents: currentWindowEvents,
           timedOut: !collectData,
         };
-        storeDispatch(
-          saveTrialAnswer({
-            ...toSave,
-          }),
-        );
         const answersToPersist = { ...answers, [identifier]: toSave };
 
         if (storageEngine) {
@@ -135,6 +130,11 @@ export function useNextStep() {
           }
         }
 
+        storeDispatch(
+          saveTrialAnswer({
+            ...toSave,
+          }),
+        );
         storeDispatch(setReactiveAnswers({}));
         storeDispatch(setMatrixAnswersCheckbox(null));
         storeDispatch(setMatrixAnswersRadio(null));

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -133,6 +133,7 @@ export async function studyStoreCreator(
     participantId,
     funcSequence: {},
     completed,
+    isSubmittingFinal: false,
     clickedPrevious: false,
     storageEngineFailedToConnect,
     isStalledConfig,
@@ -368,6 +369,9 @@ export async function studyStoreCreator(
       },
       setParticipantCompleted(state, { payload }: PayloadAction<boolean>) {
         state.completed = payload;
+      },
+      setIsSubmittingFinal(state, { payload }: PayloadAction<boolean>) {
+        state.isSubmittingFinal = payload;
       },
       setClickedPrevious(state, { payload }: PayloadAction<boolean>) {
         state.clickedPrevious = payload;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -185,6 +185,7 @@ export interface StoreState {
   rankingAnswers: Record<string, Record<string, string>>;
   funcSequence: Record<string, string[]>;
   completed: boolean;
+  isSubmittingFinal: boolean;
   clickedPrevious: boolean;
   storageEngineFailedToConnect: boolean;
   isStalledConfig: boolean;

--- a/src/utils/closeTabConfirmation.spec.ts
+++ b/src/utils/closeTabConfirmation.spec.ts
@@ -5,13 +5,14 @@ import { handleBeforeUnload, shouldConfirmTabClose } from './closeTabConfirmatio
 
 describe('closeTabConfirmation', () => {
   test('shouldConfirmTabClose handles trial and end states based on completion and modes', () => {
-    expect(shouldConfirmTabClose(false, 'trial', false, false, true)).toBe(true);
-    expect(shouldConfirmTabClose(false, 'trial', true, false, true)).toBe(false);
-    expect(shouldConfirmTabClose(true, 'trial', false, false, true)).toBe(false);
+    expect(shouldConfirmTabClose(false, 'trial', false, false, true, false)).toBe(true);
+    expect(shouldConfirmTabClose(false, 'trial', true, false, true, false)).toBe(false);
+    expect(shouldConfirmTabClose(true, 'trial', false, false, true, false)).toBe(false);
 
-    expect(shouldConfirmTabClose(false, 'end', false, false, true)).toBe(true);
-    expect(shouldConfirmTabClose(false, 'end', false, true, true)).toBe(false);
-    expect(shouldConfirmTabClose(false, 'end', false, false, false)).toBe(false);
+    expect(shouldConfirmTabClose(false, 'end', false, false, true, false)).toBe(true);
+    expect(shouldConfirmTabClose(false, 'end', false, true, true, false)).toBe(false);
+    expect(shouldConfirmTabClose(false, 'end', false, false, false, false)).toBe(false);
+    expect(shouldConfirmTabClose(false, 'end', false, true, false, true)).toBe(true);
   });
 
   test('handleBeforeUnload sets browser confirmation fields', () => {

--- a/src/utils/closeTabConfirmation.ts
+++ b/src/utils/closeTabConfirmation.ts
@@ -4,13 +4,14 @@ export function shouldConfirmTabClose(
   developmentModeEnabled: boolean,
   isCompleted: boolean,
   dataCollectionEnabled: boolean,
+  isSubmittingFinal: boolean,
 ): boolean {
   if (isAnalysis || developmentModeEnabled) {
     return false;
   }
 
   if (currentComponent === 'end') {
-    return dataCollectionEnabled && !isCompleted;
+    return isSubmittingFinal || (dataCollectionEnabled && !isCompleted);
   }
 
   return true;

--- a/src/utils/handleConditionLogic.spec.ts
+++ b/src/utils/handleConditionLogic.spec.ts
@@ -54,7 +54,6 @@ const participantData: ParticipantData = {
     language: '',
     ip: null,
   },
-  completed: false,
   rejected: false,
   participantTags: [],
   stage: 'test-sequence-condition',


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #

### Give a longer description of what this PR addresses and why it's needed
This PR fixes two related issues in participant finalization.

First, it moves completion status to the source of truth in sequence assignments instead of storing it on ParticipantData. Analysis, downloads, and table views now use a ParticipantDataWithStatus shape so completed/in-progress state reflects the realtime assignment status consistently.

Second, it hardens the study end flow. The end screen now keeps the app in a final-submission state while completion is being finalized, preserves the unload warning during that window, and removes the end-card flicker caused by locally refetching dataCollectionEnabled and treating its initial value as “disabled.” The end view now uses the already-loaded store mode instead.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...

### Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/216

- [ ] Done
- [ ] N/A