### PR TITLE
Fix UI break when user rejects mic permission

### DIFF
--- a/public/libraries/calvi/config.json
+++ b/public/libraries/calvi/config.json
@@ -5,7 +5,7 @@
   "reference": "Lily W. Ge, Yuan Cui, and Matthew Kay. 2023. CALVI: Critical Thinking Assessment for Literacy in Visualizations. In Proceedings of the 2023 CHI Conference on Human Factors in Computing Systems (CHI '23). Association for Computing Machinery, New York, NY, USA, Article 815, 1-18.",
   "components": {
     "N1": {
-      "description": "Audio test",
+      "description": "Visitors at Movie Theaters in 2001",
       "type": "image",
       "path": "libraries/calvi/assets/questions/normal/N1.jpg",
       "nextButtonLocation": "sidebar",

--- a/public/libraries/mic-check/config.json
+++ b/public/libraries/mic-check/config.json
@@ -8,6 +8,7 @@
       "path": "libraries/mic-check/assets/AudioTest.tsx",
       "nextButtonLocation": "belowStimulus",
       "nextButtonText": "Continue",
+      "recordAudio": true,
       "response": [
         {
           "id": "audioTest",

--- a/public/libraries/screen-recording/config.json
+++ b/public/libraries/screen-recording/config.json
@@ -8,13 +8,15 @@
       "path": "libraries/screen-recording/assets/ScreenRecording.tsx",
       "nextButtonLocation": "belowStimulus",
       "nextButtonText": "Continue",
-      "recordAudio": false,
-      "response": [{
-        "hidden": true,
-        "type": "reactive",
-        "id": "screenRecordingPermission",
-        "prompt": "Screen recording enabled"
-      }]
+      "recordScreen": true,
+      "response": [
+        {
+          "hidden": true,
+          "type": "reactive",
+          "id": "screenRecordingPermission",
+          "prompt": "Screen recording enabled"
+        }
+      ]
     }
   },
   "sequences": {}

--- a/public/library-screen-recording/config.json
+++ b/public/library-screen-recording/config.json
@@ -17,7 +17,8 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": false
+    "withSidebar": false,
+    "recordScreen": true
   },
   "importedLibraries": [
     "screen-recording"

--- a/public/library-screen-recording/config.json
+++ b/public/library-screen-recording/config.json
@@ -17,8 +17,7 @@
     "contactEmail": "",
     "logoPath": "revisitAssets/revisitLogoSquare.svg",
     "withProgressBar": true,
-    "withSidebar": false,
-    "recordScreen": true
+    "withSidebar": false
   },
   "importedLibraries": [
     "screen-recording"

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -119,6 +119,7 @@ export function AllTasksTimeline({
       const isCorrect = componentAnswersAreCorrect(answer.answer, answer.correctAnswer, resolvedComponent?.response);
       const hasCorrect = !!((resolvedComponent && resolvedComponent.correctAnswer) || answer.correctAnswer.length > 0);
       const hasAudio = resolvedComponent?.recordAudio ?? studyConfig?.uiConfig?.recordAudio ?? false;
+      const hasScreenRecording = resolvedComponent?.recordScreen ?? studyConfig?.uiConfig?.recordScreen ?? false;
 
       return {
         line: <SingleTaskLabelLines key={name} labelHeight={currentHeight * LABEL_GAP} height={maxHeight} xScale={scale} scaleStart={scaleStart} />,
@@ -147,7 +148,7 @@ export function AllTasksTimeline({
             )}
           >
             <g>
-              <SingleTask incomplete={answer.startTime === 0} isCorrect={isCorrect} hasCorrect={hasCorrect} hasAudio={hasAudio} key={name} labelHeight={currentHeight * LABEL_GAP} height={maxHeight} name={name} xScale={scale} scaleStart={scaleStart} scaleEnd={scaleEnd} trialOrder={answer.trialOrder} participantId={participantData.participantId} studyId={studyId} condition={conditionParam} />
+              <SingleTask incomplete={answer.startTime === 0} isCorrect={isCorrect} hasCorrect={hasCorrect} hasAudio={hasAudio} hasScreenRecording={hasScreenRecording} key={name} labelHeight={currentHeight * LABEL_GAP} height={maxHeight} name={name} xScale={scale} scaleStart={scaleStart} scaleEnd={scaleEnd} trialOrder={answer.trialOrder} participantId={participantData.participantId} studyId={studyId} condition={conditionParam} />
             </g>
           </Tooltip>),
       };

--- a/src/analysis/individualStudy/replay/SingleTask.tsx
+++ b/src/analysis/individualStudy/replay/SingleTask.tsx
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 
 import { useResizeObserver } from '@mantine/hooks';
 import {
-  IconCheck, IconMicrophone, IconProgress, IconX,
+  IconCheck, IconDeviceDesktop, IconMicrophone, IconProgress, IconX,
 } from '@tabler/icons-react';
 import { useNavigateToTrial } from '../../../utils/useNavigateToTrial';
 
@@ -24,6 +24,7 @@ export function SingleTask({
   isCorrect,
   hasCorrect,
   hasAudio,
+  hasScreenRecording,
   scaleStart,
   scaleEnd,
   incomplete,
@@ -39,6 +40,7 @@ export function SingleTask({
   isCorrect: boolean,
   hasCorrect: boolean,
   hasAudio: boolean,
+  hasScreenRecording: boolean,
   scaleStart: number,
   scaleEnd: number,
   incomplete: boolean,
@@ -52,7 +54,7 @@ export function SingleTask({
   const [ref, { width: labelWidth }] = useResizeObserver();
 
   const navigateToTrial = useNavigateToTrial();
-  const iconCount = (incomplete || hasCorrect ? 1 : 0) + (hasAudio ? 1 : 0);
+  const iconCount = (incomplete || hasCorrect ? 1 : 0) + (hasAudio ? 1 : 0) + (hasScreenRecording ? 1 : 0);
   const iconsWidth = iconCount * (ICON_SIZE + ICON_GAP);
 
   return (
@@ -93,6 +95,12 @@ export function SingleTask({
             <Text lineClamp={1} ref={ref} mx={0} style={{ width: 'fit-content', fontWeight: 600 }} size="12px">
               {name}
             </Text>
+            {hasScreenRecording && (
+              <IconDeviceDesktop
+                color="orange"
+                size="14"
+              />
+            )}
             {hasAudio && (
               <IconMicrophone
                 color="orange"

--- a/src/components/interface/AppHeader.spec.tsx
+++ b/src/components/interface/AppHeader.spec.tsx
@@ -1,0 +1,187 @@
+import { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { AppHeader } from './AppHeader';
+
+let mockedRecordingContext = {
+  isScreenRecording: false,
+  isAudioRecording: false,
+  setIsMuted: vi.fn(),
+  isMuted: false,
+  clickToRecord: false,
+  isSpeakingWhileMuted: false,
+  showMutedWarning: false,
+  audioRecordingError: null as string | null,
+  currentComponentHasAudioRecording: false,
+  audioStatus: 'idle' as 'idle' | 'pending' | 'recording' | 'denied',
+};
+
+const mockedStudyConfig = {
+  studyMetadata: { title: 'Test Study' },
+  uiConfig: {
+    logoPath: 'logo.png',
+    withProgressBar: false,
+    showTitle: true,
+  },
+  components: {},
+  studyRules: undefined,
+};
+
+vi.mock('@mantine/core', () => ({
+  ActionIcon: ({ children, ...props }: { children: ReactNode }) => <button type="button" {...props}>{children}</button>,
+  AppShell: { Header: ({ children }: { children: ReactNode }) => <div>{children}</div> },
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Button: ({ children, ...props }: { children: ReactNode }) => <button type="button" {...props}>{children}</button>,
+  Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Grid: Object.assign(
+    ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    { Col: ({ children }: { children: ReactNode }) => <div>{children}</div> },
+  ),
+  Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Image: ({ alt }: { alt: string }) => <img alt={alt} />,
+  Menu: Object.assign(
+    ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    {
+      Target: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      Dropdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      Item: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    },
+  ),
+  Progress: () => <div>progress</div>,
+  Space: () => <div />,
+  Title: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+  Tooltip: ({ children, label }: { children: ReactNode; label?: ReactNode }) => (
+    <div>
+      {children}
+      {label ? <span>{label}</span> : null}
+    </div>
+  ),
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('@tabler/icons-react', () => ({
+  IconChartHistogram: () => <span>chart</span>,
+  IconDotsVertical: () => <span>dots</span>,
+  IconMail: () => <span>mail</span>,
+  IconMicrophone: () => <span>mic</span>,
+  IconMicrophoneOff: () => <span>mic-off</span>,
+  IconSchema: () => <span>schema</span>,
+  IconUserPlus: () => <span>user-plus</span>,
+}));
+
+vi.mock('react-router', () => ({
+  useHref: () => '/test-study',
+  useParams: () => ({}),
+}));
+
+vi.mock('../../routes/utils', () => ({
+  useCurrentComponent: () => 'componentA',
+  useCurrentStep: () => 0,
+  useStudyId: () => 'test-study',
+}));
+
+vi.mock('../../store/store', () => ({
+  useStoreDispatch: () => vi.fn(),
+  useStoreSelector: (selector: (state: {
+    config: typeof mockedStudyConfig;
+    answers: Record<string, never>;
+    storageEngineFailedToConnect: boolean;
+  }) => unknown) => selector({
+    config: mockedStudyConfig,
+    answers: {},
+    storageEngineFailedToConnect: false,
+  }),
+  useStoreActions: () => ({
+    toggleShowHelpText: vi.fn(),
+    toggleStudyBrowser: vi.fn(),
+    incrementHelpCounter: vi.fn(),
+    setAlertModal: vi.fn(),
+  }),
+  useFlatSequence: () => [],
+}));
+
+vi.mock('../../storage/storageEngineHooks', () => ({
+  useStorageEngine: () => ({
+    storageEngine: {
+      updateProgressData: vi.fn().mockResolvedValue(undefined),
+    },
+  }),
+}));
+
+vi.mock('../../utils/handleComponentInheritance', () => ({
+  studyComponentToIndividualComponent: () => ({}),
+}));
+
+vi.mock('../../store/hooks/useRecording', () => ({
+  useRecordingContext: () => mockedRecordingContext,
+}));
+
+vi.mock('../../utils/notifications', () => ({
+  hideNotification: vi.fn(),
+  showNotification: vi.fn(() => 'notification-id'),
+}));
+
+vi.mock('../../utils/recordingWarnings', () => ({
+  getMutedInstruction: () => 'Muted warning',
+}));
+
+vi.mock('../../utils/useDeviceRules', () => ({
+  useDeviceRules: () => ({
+    isBrowserAllowed: true,
+    isDeviceAllowed: true,
+    isInputAllowed: true,
+    isDisplayAllowed: true,
+  }),
+}));
+
+vi.mock('./RecordingAudioWaveform', () => ({
+  RecordingAudioWaveform: () => <div>waveform</div>,
+}));
+
+describe('AppHeader', () => {
+  beforeEach(() => {
+    mockedRecordingContext = {
+      isScreenRecording: false,
+      isAudioRecording: false,
+      setIsMuted: vi.fn(),
+      isMuted: false,
+      clickToRecord: false,
+      isSpeakingWhileMuted: false,
+      showMutedWarning: false,
+      audioRecordingError: null,
+      currentComponentHasAudioRecording: false,
+      audioStatus: 'idle',
+    };
+  });
+
+  test('shows disabled mic state when audio permission is denied before recording starts', () => {
+    mockedRecordingContext = {
+      ...mockedRecordingContext,
+      currentComponentHasAudioRecording: true,
+      audioRecordingError: 'Microphone permission denied or not supported.',
+      audioStatus: 'denied',
+    };
+
+    const html = renderToStaticMarkup(<AppHeader developmentModeEnabled={false} dataCollectionEnabled />);
+
+    expect(html).toContain('Microphone error');
+    expect(html).toContain('Microphone permission denied or not supported.');
+    expect(html).toContain('mic-off');
+  });
+
+  test('shows pending mic state before audio permission is granted', () => {
+    mockedRecordingContext = {
+      ...mockedRecordingContext,
+      currentComponentHasAudioRecording: true,
+      audioStatus: 'pending',
+    };
+
+    const html = renderToStaticMarkup(<AppHeader developmentModeEnabled={false} dataCollectionEnabled />);
+
+    expect(html).toContain('Microphone pending');
+    expect(html).toContain('Microphone not enabled yet');
+    expect(html).toContain('mic-off');
+  });
+});

--- a/src/components/interface/AppHeader.spec.tsx
+++ b/src/components/interface/AppHeader.spec.tsx
@@ -5,6 +5,8 @@ import {
 } from 'vitest';
 import { AppHeader } from './AppHeader';
 
+let mockedCurrentComponent = 'componentA';
+
 let mockedRecordingContext = {
   isScreenRecording: false,
   isAudioRecording: false,
@@ -78,7 +80,7 @@ vi.mock('react-router', () => ({
 }));
 
 vi.mock('../../routes/utils', () => ({
-  useCurrentComponent: () => 'componentA',
+  useCurrentComponent: () => mockedCurrentComponent,
   useCurrentStep: () => 0,
   useStudyId: () => 'test-study',
 }));
@@ -143,6 +145,7 @@ vi.mock('./RecordingAudioWaveform', () => ({
 
 describe('AppHeader', () => {
   beforeEach(() => {
+    mockedCurrentComponent = 'componentA';
     mockedRecordingContext = {
       isScreenRecording: false,
       isAudioRecording: false,
@@ -187,6 +190,32 @@ describe('AppHeader', () => {
     expect(html).toContain('Microphone pending');
     expect(html).toContain('Microphone not enabled yet');
     expect(html).toContain('mic-off');
+  });
+
+  test('hides stale mic error outside audio and permission pages', () => {
+    mockedRecordingContext = {
+      ...mockedRecordingContext,
+      audioRecordingError: 'Microphone permission denied',
+      audioStatus: 'denied',
+    };
+
+    const html = renderToStaticMarkup(<AppHeader developmentModeEnabled={false} dataCollectionEnabled />);
+
+    expect(html).not.toContain('Microphone error');
+    expect(html).not.toContain('Microphone permission denied');
+  });
+
+  test('shows mic error on the screen recording permission page', () => {
+    mockedCurrentComponent = '$screen-recording.components.screenRecordingPermission';
+    mockedRecordingContext = {
+      ...mockedRecordingContext,
+      audioRecordingError: 'Microphone permission denied',
+      audioStatus: 'denied',
+    };
+
+    const html = renderToStaticMarkup(<AppHeader developmentModeEnabled={false} dataCollectionEnabled />);
+
+    expect(html).toContain('Microphone permission denied');
   });
 
   test('shows screen recording error in the header', () => {

--- a/src/components/interface/AppHeader.spec.tsx
+++ b/src/components/interface/AppHeader.spec.tsx
@@ -13,6 +13,7 @@ let mockedRecordingContext = {
   clickToRecord: false,
   isSpeakingWhileMuted: false,
   showMutedWarning: false,
+  screenRecordingError: null as string | null,
   audioRecordingError: null as string | null,
   currentComponentHasAudioRecording: false,
   audioStatus: 'idle' as 'idle' | 'pending' | 'recording' | 'denied',
@@ -150,6 +151,7 @@ describe('AppHeader', () => {
       clickToRecord: false,
       isSpeakingWhileMuted: false,
       showMutedWarning: false,
+      screenRecordingError: null,
       audioRecordingError: null,
       currentComponentHasAudioRecording: false,
       audioStatus: 'idle',
@@ -159,21 +161,23 @@ describe('AppHeader', () => {
   test('shows disabled mic state when audio permission is denied before recording starts', () => {
     mockedRecordingContext = {
       ...mockedRecordingContext,
+      clickToRecord: true,
       currentComponentHasAudioRecording: true,
-      audioRecordingError: 'Microphone permission denied or not supported.',
+      audioRecordingError: 'Microphone permission denied',
       audioStatus: 'denied',
     };
 
     const html = renderToStaticMarkup(<AppHeader developmentModeEnabled={false} dataCollectionEnabled />);
 
     expect(html).toContain('Microphone error');
-    expect(html).toContain('Microphone permission denied or not supported.');
+    expect(html).toContain('Microphone permission denied');
     expect(html).toContain('mic-off');
   });
 
   test('shows pending mic state before audio permission is granted', () => {
     mockedRecordingContext = {
       ...mockedRecordingContext,
+      clickToRecord: true,
       currentComponentHasAudioRecording: true,
       audioStatus: 'pending',
     };
@@ -183,5 +187,16 @@ describe('AppHeader', () => {
     expect(html).toContain('Microphone pending');
     expect(html).toContain('Microphone not enabled yet');
     expect(html).toContain('mic-off');
+  });
+
+  test('shows screen recording error in the header', () => {
+    mockedRecordingContext = {
+      ...mockedRecordingContext,
+      screenRecordingError: 'Recording permission denied',
+    };
+
+    const html = renderToStaticMarkup(<AppHeader developmentModeEnabled={false} dataCollectionEnabled />);
+
+    expect(html).toContain('Recording permission denied');
   });
 });

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -90,7 +90,16 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
   const lastProgressRef = useRef<number>(0);
 
   const {
-    isScreenRecording, isAudioRecording, setIsMuted, isMuted, clickToRecord, isSpeakingWhileMuted, showMutedWarning, audioRecordingError,
+    isScreenRecording,
+    isAudioRecording,
+    setIsMuted,
+    isMuted,
+    clickToRecord,
+    isSpeakingWhileMuted,
+    showMutedWarning,
+    audioRecordingError,
+    currentComponentHasAudioRecording,
+    audioStatus,
   } = useRecordingContext();
   const {
     isBrowserAllowed,
@@ -100,6 +109,8 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
   } = useDeviceRules(studyConfig.studyRules);
   const hasUnmetDeviceRequirement = developmentModeEnabled
     && (!isBrowserAllowed || !isDeviceAllowed || !isInputAllowed || !isDisplayAllowed);
+  const showAudioStatus = currentComponentHasAudioRecording || isAudioRecording || audioStatus !== 'idle';
+  const showRecordingStatus = showAudioStatus || isScreenRecording;
 
   useEffect(() => {
     if (!(isMuted && isSpeakingWhileMuted)) return undefined;
@@ -195,31 +206,37 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
 
         <Grid.Col span={4}>
           <Group wrap="nowrap" justify="right">
-            {(isAudioRecording || isScreenRecording) && (
+            {showRecordingStatus && (
 
               <Group ml="xl" gap={20} wrap="nowrap">
                 <Text c="red">
-                  {((isAudioRecording && !isMuted && !audioRecordingError) || (isScreenRecording)) && 'Recording'}
+                  {((audioStatus === 'recording' && !isMuted) || (isScreenRecording)) && 'Recording'}
                   {isScreenRecording && ' screen'}
-                  {isScreenRecording && isAudioRecording && !isMuted && !audioRecordingError && ' and'}
-                  {isAudioRecording && !isMuted && !audioRecordingError && ' audio'}
+                  {isScreenRecording && audioStatus === 'recording' && !isMuted && ' and'}
+                  {audioStatus === 'recording' && !isMuted && ' audio'}
                 </Text>
-                {isAudioRecording && !isMuted && !audioRecordingError && <RecordingAudioWaveform />}
-                {isAudioRecording && (audioRecordingError ? (
+                {audioStatus === 'recording' && !isMuted && <RecordingAudioWaveform />}
+                {showAudioStatus && (audioStatus === 'denied' ? (
                   <Tooltip label={audioRecordingError}>
-                    <ActionIcon variant="light" size="md" aria-label="Microphone error" data-disabled aria-disabled tabIndex={-1}>
+                    <ActionIcon color="red" variant="light" size="md" aria-label="Microphone error" data-disabled aria-disabled tabIndex={-1}>
+                      <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
+                    </ActionIcon>
+                  </Tooltip>
+                ) : audioStatus === 'pending' ? (
+                  <Tooltip label="Microphone not enabled yet">
+                    <ActionIcon color="gray" variant="light" size="md" aria-label="Microphone pending" data-disabled aria-disabled tabIndex={-1}>
                       <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
                     </ActionIcon>
                   </Tooltip>
                 ) : clickToRecord ? (
                   <Tooltip label={showMutedWarning ? 'You are still muted. Press and hold to unmute.' : 'Press and hold to unmute.'} opened={showMutedWarning || undefined}>
-                    <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} variant="light" size="md" aria-label="Click and hold to unmute microphone" onMouseDown={() => setIsMuted(false)} onMouseUp={() => setIsMuted(true)} onTouchStart={() => setIsMuted(false)} onTouchEnd={() => setIsMuted(true)}>
+                    <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} color="blue" variant="light" size="md" aria-label="Click and hold to unmute microphone" onMouseDown={() => setIsMuted(false)} onMouseUp={() => setIsMuted(true)} onTouchStart={() => setIsMuted(false)} onTouchEnd={() => setIsMuted(true)}>
                       {isMuted ? <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} /> : <IconMicrophone style={{ width: '70%', height: '70%' }} stroke={1.5} />}
                     </ActionIcon>
                   </Tooltip>
                 ) : (
                   <Tooltip label={showMutedWarning ? 'You are still muted. Press to unmute.' : `Press to ${isMuted ? 'unmute' : 'mute'}`} opened={showMutedWarning || undefined}>
-                    <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} variant="light" size="md" aria-label={isMuted ? 'Unmute microphone' : 'Mute microphone'} onClick={() => setIsMuted(!isMuted)}>
+                    <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} color="blue" variant="light" size="md" aria-label={isMuted ? 'Unmute microphone' : 'Mute microphone'} onClick={() => setIsMuted(!isMuted)}>
                       {isMuted ? <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} /> : <IconMicrophone style={{ width: '70%', height: '70%' }} stroke={1.5} />}
                     </ActionIcon>
                   </Tooltip>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -90,7 +90,7 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
   const lastProgressRef = useRef<number>(0);
 
   const {
-    isScreenRecording, isAudioRecording, setIsMuted, isMuted, clickToRecord, isSpeakingWhileMuted, showMutedWarning,
+    isScreenRecording, isAudioRecording, setIsMuted, isMuted, clickToRecord, isSpeakingWhileMuted, showMutedWarning, audioRecordingError,
   } = useRecordingContext();
   const {
     isBrowserAllowed,
@@ -199,13 +199,19 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
 
               <Group ml="xl" gap={20} wrap="nowrap">
                 <Text c="red">
-                  {((isAudioRecording && !isMuted) || (isScreenRecording)) && 'Recording'}
+                  {((isAudioRecording && !isMuted && !audioRecordingError) || (isScreenRecording)) && 'Recording'}
                   {isScreenRecording && ' screen'}
-                  {isScreenRecording && isAudioRecording && !isMuted && ' and'}
-                  {isAudioRecording && !isMuted && ' audio'}
+                  {isScreenRecording && isAudioRecording && !isMuted && !audioRecordingError && ' and'}
+                  {isAudioRecording && !isMuted && !audioRecordingError && ' audio'}
                 </Text>
-                {isAudioRecording && !isMuted && <RecordingAudioWaveform />}
-                {clickToRecord ? (
+                {isAudioRecording && !isMuted && !audioRecordingError && <RecordingAudioWaveform />}
+                {isAudioRecording && (audioRecordingError ? (
+                  <Tooltip label={audioRecordingError}>
+                    <ActionIcon variant="light" size="md" aria-label="Microphone error" data-disabled>
+                      <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
+                    </ActionIcon>
+                  </Tooltip>
+                ) : clickToRecord ? (
                   <Tooltip label={showMutedWarning ? 'You are still muted. Press and hold to unmute.' : 'Press and hold to unmute.'} opened={showMutedWarning || undefined}>
                     <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} variant="light" size="md" aria-label="Click and hold to unmute microphone" onMouseDown={() => setIsMuted(false)} onMouseUp={() => setIsMuted(true)} onTouchStart={() => setIsMuted(false)} onTouchEnd={() => setIsMuted(true)}>
                       {isMuted ? <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} /> : <IconMicrophone style={{ width: '70%', height: '70%' }} stroke={1.5} />}
@@ -217,7 +223,7 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
                       {isMuted ? <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} /> : <IconMicrophone style={{ width: '70%', height: '70%' }} stroke={1.5} />}
                     </ActionIcon>
                   </Tooltip>
-                )}
+                ))}
               </Group>
             )}
             {storageEngineFailedToConnect && <Tooltip multiline withArrow arrowSize={6} w={300} label="Failed to connect to the storage engine. Study data will not be saved. Check your connection or restart the app."><Badge size="lg" color="red">Storage Disconnected</Badge></Tooltip>}

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -207,7 +207,7 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
                 {isAudioRecording && !isMuted && !audioRecordingError && <RecordingAudioWaveform />}
                 {isAudioRecording && (audioRecordingError ? (
                   <Tooltip label={audioRecordingError}>
-                    <ActionIcon variant="light" size="md" aria-label="Microphone error" data-disabled>
+                    <ActionIcon variant="light" size="md" aria-label="Microphone error" data-disabled aria-disabled tabIndex={-1}>
                       <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
                     </ActionIcon>
                   </Tooltip>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -97,6 +97,7 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
     clickToRecord,
     isSpeakingWhileMuted,
     showMutedWarning,
+    screenRecordingError,
     audioRecordingError,
     currentComponentHasAudioRecording,
     audioStatus,
@@ -110,7 +111,16 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
   const hasUnmetDeviceRequirement = developmentModeEnabled
     && (!isBrowserAllowed || !isDeviceAllowed || !isInputAllowed || !isDisplayAllowed);
   const showAudioStatus = currentComponentHasAudioRecording || isAudioRecording || audioStatus !== 'idle';
-  const showRecordingStatus = showAudioStatus || isScreenRecording;
+  const showRecordingStatus = showAudioStatus || isScreenRecording || !!screenRecordingError;
+  const isAudioActivelyRecording = audioStatus === 'recording' && !isMuted;
+  let recordingLabel = '';
+  if (isScreenRecording && isAudioActivelyRecording) {
+    recordingLabel = 'Recording screen and audio';
+  } else if (isScreenRecording) {
+    recordingLabel = 'Recording screen';
+  } else if (isAudioActivelyRecording) {
+    recordingLabel = 'Recording audio';
+  }
 
   useEffect(() => {
     if (!(isMuted && isSpeakingWhileMuted)) return undefined;
@@ -209,34 +219,23 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
             {showRecordingStatus && (
 
               <Group ml="xl" gap={20} wrap="nowrap">
-                <Text c="red">
-                  {((audioStatus === 'recording' && !isMuted) || (isScreenRecording)) && 'Recording'}
-                  {isScreenRecording && ' screen'}
-                  {isScreenRecording && audioStatus === 'recording' && !isMuted && ' and'}
-                  {audioStatus === 'recording' && !isMuted && ' audio'}
-                </Text>
+                {recordingLabel && <Text c="red" size="sm">{recordingLabel}</Text>}
+                {screenRecordingError && <Text c="red" size="sm" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{screenRecordingError}</Text>}
+                {audioStatus === 'denied' && audioRecordingError && <Text c="red" size="sm" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{audioRecordingError}</Text>}
                 {audioStatus === 'recording' && !isMuted && <RecordingAudioWaveform />}
-                {showAudioStatus && (audioStatus === 'denied' ? (
-                  <Tooltip label={audioRecordingError}>
-                    <ActionIcon color="red" variant="light" size="md" aria-label="Microphone error" data-disabled aria-disabled tabIndex={-1}>
-                      <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
-                    </ActionIcon>
-                  </Tooltip>
+                {clickToRecord && showAudioStatus && (audioStatus === 'denied' ? (
+                  <ActionIcon color="red" variant="light" size="md" aria-label="Microphone error" data-disabled aria-disabled tabIndex={-1}>
+                    <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
+                  </ActionIcon>
                 ) : audioStatus === 'pending' ? (
                   <Tooltip label="Microphone not enabled yet">
                     <ActionIcon color="gray" variant="light" size="md" aria-label="Microphone pending" data-disabled aria-disabled tabIndex={-1}>
                       <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} />
                     </ActionIcon>
                   </Tooltip>
-                ) : clickToRecord ? (
+                ) : (
                   <Tooltip label={showMutedWarning ? 'You are still muted. Press and hold to unmute.' : 'Press and hold to unmute.'} opened={showMutedWarning || undefined}>
                     <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} color="blue" variant="light" size="md" aria-label="Click and hold to unmute microphone" onMouseDown={() => setIsMuted(false)} onMouseUp={() => setIsMuted(true)} onTouchStart={() => setIsMuted(false)} onTouchEnd={() => setIsMuted(true)}>
-                      {isMuted ? <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} /> : <IconMicrophone style={{ width: '70%', height: '70%' }} stroke={1.5} />}
-                    </ActionIcon>
-                  </Tooltip>
-                ) : (
-                  <Tooltip label={showMutedWarning ? 'You are still muted. Press to unmute.' : `Press to ${isMuted ? 'unmute' : 'mute'}`} opened={showMutedWarning || undefined}>
-                    <ActionIcon className={showMutedWarning ? classes.micBlink : undefined} color="blue" variant="light" size="md" aria-label={isMuted ? 'Unmute microphone' : 'Mute microphone'} onClick={() => setIsMuted(!isMuted)}>
                       {isMuted ? <IconMicrophoneOff style={{ width: '70%', height: '70%' }} stroke={1.5} /> : <IconMicrophone style={{ width: '70%', height: '70%' }} stroke={1.5} />}
                     </ActionIcon>
                   </Tooltip>

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -110,7 +110,10 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
   } = useDeviceRules(studyConfig.studyRules);
   const hasUnmetDeviceRequirement = developmentModeEnabled
     && (!isBrowserAllowed || !isDeviceAllowed || !isInputAllowed || !isDisplayAllowed);
-  const showAudioStatus = currentComponentHasAudioRecording || isAudioRecording || audioStatus !== 'idle';
+  const isScreenRecordingPermission = currentComponent === '$screen-recording.components.screenRecordingPermission';
+  const showAudioStatus = currentComponentHasAudioRecording
+    || isAudioRecording
+    || (isScreenRecordingPermission && audioStatus !== 'idle');
   const showRecordingStatus = showAudioStatus || isScreenRecording || !!screenRecordingError;
   const isAudioActivelyRecording = audioStatus === 'recording' && !isMuted;
   let recordingLabel = '';

--- a/src/components/interface/RecordingAudioWaveform.tsx
+++ b/src/components/interface/RecordingAudioWaveform.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@mantine/core';
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect } from 'react';
 
 export function RecordingAudioWaveform({
   width = 60,
@@ -22,8 +22,6 @@ export function RecordingAudioWaveform({
   const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const animationFrameIdRef = useRef<number>(0);
   const mediaStreamRef = useRef<MediaStream | null>(null);
-
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let lastTime = 0;
@@ -110,11 +108,6 @@ export function RecordingAudioWaveform({
         animationFrameIdRef.current = requestAnimationFrame(draw);
       } catch (err) {
         console.error('Error accessing microphone:', err);
-        if (err instanceof Error) {
-          setError(`Error accessing microphone: ${err.message}. Please grant permission.`);
-        } else {
-          setError('An unknown error occurred while accessing the microphone.');
-        }
       }
     };
 
@@ -139,7 +132,6 @@ export function RecordingAudioWaveform({
 
   return (
     <Flex>
-      {error && <p style={{ color: 'red', maxWidth: `${width}px` }}>{error}</p>}
       <canvas ref={canvasRef} />
     </Flex>
   );

--- a/src/public/libraries/mic-check/assets/AudioTest.tsx
+++ b/src/public/libraries/mic-check/assets/AudioTest.tsx
@@ -1,5 +1,5 @@
 import {
-  Center, Stack, Text,
+  Box, Title,
 } from '@mantine/core';
 import {
   useEffect,
@@ -57,20 +57,47 @@ export function AudioTest({ setAnswer }: StimulusParams<undefined>) {
   }, [setAnswer]);
 
   return (
-    <Center style={{ height: '70%', width: '100%' }}>
-      <Stack>
-        <Text ta="center">
-          Please allow us to access your microphone. There may be a popup in your browser window asking for access, click accept.
-        </Text>
-        <Text ta="center">
-          Once we can confirm that your microphone is on and we hear you say something, the continue button will become available.
-        </Text>
-        <Text ta="center" style={{ fontWeight: 700 }}>
-          If you are not comfortable or able to speak English during this study, please return the study.
-        </Text>
-        <Center><RecordingAudioWaveform height={200} width={400} /></Center>
-      </Stack>
-    </Center>
+    <Box p="md">
+      <Title order={1} size="h2">
+        Audio Recording Permission
+      </Title>
+
+      <p>
+        This study requires recording of your
+        {' '}
+        <strong>audio</strong>
+        . If you&apos;re not comfortable, you may exit and return the study.
+      </p>
+      <p>Follow the steps below to grant microphone access and confirm that your audio is working.</p>
+
+      <ol>
+        <li>
+          <strong>Please allow us to access your microphone.</strong>
+          {' '}
+          There may be a popup in your browser window asking for access. Click allow to continue.
+        </li>
+        <li>
+          <strong>Speak</strong>
+          {' '}
+          into your microphone to check if audio is working.
+          <Box h={200} w={400} bd="1px solid #ccc" mt="sm">
+            <RecordingAudioWaveform height={200} width={400} />
+          </Box>
+        </li>
+      </ol>
+
+      <strong>Note:</strong>
+      <ul>
+        <li>
+          Once we can confirm that your microphone is on and we hear you say something, the
+          {' '}
+          <b>Continue</b>
+          {' '}
+          button will become available.
+        </li>
+        <li>If you are not comfortable or able to speak English during this study, please return the study.</li>
+      </ul>
+    </Box>
   );
 }
 

--- a/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
+++ b/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
@@ -8,12 +8,14 @@ import { RecordingAudioWaveform } from '../../../../components/interface/Recordi
 
 function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
   const {
-    recordAudio,
+    studyHasAudioRecording,
     recordVideoRef,
     startScreenCapture: startCapture,
     stopScreenCapture: stopCapture,
     isScreenCapturing: screenCapturing,
+    isAudioCapturing: audioCapturing,
     screenRecordingError: error,
+    audioRecordingError,
     audioMediaStream,
   } = useRecordingContext();
 
@@ -22,13 +24,13 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
 
   useEffect(() => {
     setAnswer({
-      status: screenCapturing && (recordAudio ? audioCapturingSuccess : true),
+      status: screenCapturing && (studyHasAudioRecording ? audioCapturingSuccess : true),
       provenanceGraph: undefined,
       answers: {
         screenRecordingPermission: screenCapturing,
       },
     });
-  }, [screenCapturing, audioCapturingSuccess, setAnswer, recordAudio]);
+  }, [screenCapturing, audioCapturingSuccess, setAnswer, studyHasAudioRecording]);
 
   useEffect(() => {
     if (!screenCapturing) {
@@ -78,12 +80,12 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
     <Box p="md">
       <Title order={1} size="h2">
         Screen
-        {recordAudio && ' and Audio'}
+        {studyHasAudioRecording && ' and Audio'}
         {' '}
         Recording Permission
       </Title>
 
-      {recordAudio ? (
+      {studyHasAudioRecording ? (
         <>
           {/* Record both screen and audio */}
           <p>
@@ -113,7 +115,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
                 muted
                 style={{ width: '400px', border: '1px solid #ccc', marginTop: '1rem' }}
               />
-              {error && <p style={{ color: 'red' }}>{error}</p>}
+              {(error || audioRecordingError) && <p style={{ color: 'red' }}>{error || audioRecordingError}</p>}
               <p><i>Note: Please make sure you are recording the correct tab or window. Otherwise, stop and re-share the correct one.</i></p>
 
             </li>
@@ -121,7 +123,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
               <strong>Speak</strong>
               {' '}
               into your microphone to check if audio is working.
-              {(recordAudio && screenCapturing) ? <Box h={200} w={400} bd="1px solid #ccc"><RecordingAudioWaveform height={200} width={400} /></Box> : <Box h={200} w={400} bd="1px solid #ccc" />}
+              {audioCapturing ? <Box h={200} w={400} bd="1px solid #ccc"><RecordingAudioWaveform height={200} width={400} /></Box> : <Box h={200} w={400} bd="1px solid #ccc" />}
             </li>
           </ol>
           <strong>Note:</strong>

--- a/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
+++ b/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
@@ -14,8 +14,6 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
     stopScreenCapture: stopCapture,
     isScreenCapturing: screenCapturing,
     isAudioCapturing: audioCapturing,
-    screenRecordingError: error,
-    audioRecordingError,
     audioMediaStream,
   } = useRecordingContext();
 
@@ -115,8 +113,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
                 muted
                 style={{ width: '400px', border: '1px solid #ccc', marginTop: '1rem' }}
               />
-              {(error || audioRecordingError) && <p style={{ color: 'red' }}>{error || audioRecordingError}</p>}
-              <p><i>Note: Please make sure you are recording the correct tab or window. Otherwise, stop and re-share the correct one.</i></p>
+              <p><i>Please make sure you are recording the correct tab or window. Otherwise, stop and re-share the correct one.</i></p>
 
             </li>
             <li>
@@ -160,8 +157,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
             muted
             style={{ width: '400px', border: '1px solid #ccc', marginTop: '1rem' }}
           />
-          {error && <p style={{ color: 'red' }}>{error}</p>}
-          <p><i>Note: Please make sure you are recording the correct tab or window. Otherwise, stop and re-share the correct one.</i></p>
+          <p><i>Please make sure you are recording the correct tab or window. Otherwise, stop and re-share the correct one.</i></p>
 
           <strong>Note:</strong>
           <ul>

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -26,6 +26,7 @@ export function useRecording() {
 
   const recordVideoRef = useRef<HTMLVideoElement>(null);
   const [screenRecordingError, setRecordingError] = useState<string | null>(null);
+  const [audioRecordingError, setAudioRecordingError] = useState<string | null>(null);
   const [isScreenRecording, setIsScreenRecording] = useState(false);
   const [isAudioRecording, setIsAudioRecording] = useState(false);
   const [screenWithAudioRecording, setScreenWithAudioRecording] = useState(false);
@@ -152,7 +153,7 @@ export function useRecording() {
     const audioRecorder = (currentComponentHasAudioRecording && audioMediaStream.current) ? new MediaRecorder(audioMediaStream.current) : null;
     audioMediaRecorder.current = audioRecorder;
 
-    let chunks : Blob[] = [];
+    let chunks: Blob[] = [];
     mediaRecorder.addEventListener('dataavailable', (event: BlobEvent) => {
       if (event.data && event.data.size > 0) {
         chunks.push(event.data);
@@ -266,7 +267,7 @@ export function useRecording() {
       const recorder = new MediaRecorder(s);
       audioMediaRecorder.current = recorder;
 
-      let chunks : Blob[] = [];
+      let chunks: Blob[] = [];
 
       recorder.addEventListener('start', () => {
         chunks = [];
@@ -287,6 +288,10 @@ export function useRecording() {
       });
 
       recorder.start();
+      setAudioRecordingError(null);
+    }).catch((err) => {
+      console.error('Error accessing microphone:', err);
+      setAudioRecordingError('Microphone permission denied or not supported.');
     });
 
     setIsAudioRecording(true);
@@ -315,7 +320,7 @@ export function useRecording() {
       startAudioRecording(identifier);
     }
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentComponent, identifier, currentComponentHasAudioRecording]);
 
   // For study with screen recording
@@ -491,6 +496,7 @@ export function useRecording() {
     startScreenRecording,
     stopScreenRecording,
     screenRecordingError,
+    audioRecordingError,
     isScreenRecording,
     isAudioRecording,
     isScreenCapturing,

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -289,12 +289,12 @@ export function useRecording() {
 
       recorder.start();
       setAudioRecordingError(null);
+      setIsAudioRecording(true);
     }).catch((err) => {
       console.error('Error accessing microphone:', err);
       setAudioRecordingError('Microphone permission denied or not supported.');
+      setIsAudioRecording(false);
     });
-
-    setIsAudioRecording(true);
   }, [storageEngine, isMuted]);
 
   // For study with just audio recording

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -488,6 +488,8 @@ export function useRecording() {
   return {
     recordVideoRef,
     studyHasScreenRecording,
+    studyHasAudioRecording,
+    currentComponentHasAudioRecording,
     isMuted,
     setIsMuted,
     recordAudio,
@@ -509,6 +511,13 @@ export function useRecording() {
     isRejected,
     isSpeakingWhileMuted,
     showMutedWarning,
+    audioStatus: audioRecordingError
+      ? 'denied'
+      : isAudioRecording
+        ? 'recording'
+        : currentComponentHasAudioRecording
+          ? 'pending'
+          : 'idle',
   };
 }
 

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -292,7 +292,7 @@ export function useRecording() {
       setIsAudioRecording(true);
     }).catch((err) => {
       console.error('Error accessing microphone:', err);
-      setAudioRecordingError('Microphone permission denied or not supported.');
+      setAudioRecordingError('Microphone permission denied');
       setIsAudioRecording(false);
     });
   }, [storageEngine, isMuted]);
@@ -352,6 +352,9 @@ export function useRecording() {
       document.title = `RECORD THIS TAB: ${pageTitle}`;
 
       try {
+        setRecordingError(null);
+        setAudioRecordingError(null);
+
         const screenStream = studyHasScreenRecording ? await navigator.mediaDevices.getDisplayMedia({
           video: { displaySurface: 'browser', ...(recordScreenFPS ? { frameRate: { ideal: recordScreenFPS } } : {}) },
           audio: false,
@@ -363,10 +366,18 @@ export function useRecording() {
 
         screenMediaStream.current = screenStream;
 
-        const micStream = studyHasAudioRecording ? await navigator.mediaDevices.getUserMedia({
-          audio: true,
-          video: false,
-        }) : null;
+        let micStream: MediaStream | null = null;
+        if (studyHasAudioRecording) {
+          try {
+            micStream = await navigator.mediaDevices.getUserMedia({
+              audio: true,
+              video: false,
+            });
+          } catch (err) {
+            console.error('Error accessing microphone:', err);
+            setAudioRecordingError('Microphone permission denied');
+          }
+        }
 
         audioMediaStream.current = micStream;
 
@@ -398,11 +409,10 @@ export function useRecording() {
         setIsAudioCapturing(micStream !== null);
         setIsMediaCapturing(screenStream !== null || micStream !== null);
         setScreenCaptureStarted(true);
-        setScreenWithAudioRecording(!!recordAudio);
-        setRecordingError(null);
+        setScreenWithAudioRecording(micStream !== null && !!recordAudio);
       } catch (err) {
         console.error('Error accessing screen:', err);
-        setRecordingError('Recording permission denied or not supported.');
+        setRecordingError('Recording permission denied');
       } finally {
         document.title = pageTitle;
       }


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1171 

### Give a longer description of what this PR addresses and why it's needed
- Fix the UI break when the user rejects mic permission
- Make the mic icon disabled when the user rejects permission
- Fix `library-mic-check` and `library-screen-recording` `config.json` files
- Fix the `library-calvi` question description, which had the wrong description
- Add screen recording icon to timeline as well

### Provide pictures/videos of the behavior before and after these changes (optional)
**Fix the UI break when the user rejects mic permission**
Before

<img width="897" height="369" alt="Screenshot 2026-04-10 at 1 00 04 PM" src="https://github.com/user-attachments/assets/caf8361e-6bb9-4eec-8b19-4280be693cb0" />

After

<img width="1720" height="932" alt="Screenshot 2026-05-11 at 10 52 45 PM" src="https://github.com/user-attachments/assets/ca702f3d-1bb5-44a9-ac61-3118f4284447" />


**Add screen recording icon to timeline as well**

<img width="711" height="109" alt="Screenshot 2026-04-10 at 1 32 51 PM" src="https://github.com/user-attachments/assets/7011cd9a-2a4f-42b5-b75d-790904e86505" />


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [ ] Done
- [x] N/A