### PR TITLE
Fix study summary (stats, config)

### DIFF
--- a/src/analysis/individualStudy/LiveMonitor/LiveMonitorView.tsx
+++ b/src/analysis/individualStudy/LiveMonitor/LiveMonitorView.tsx
@@ -235,7 +235,7 @@ export function LiveMonitorView({
             </Text>
             <Group gap="xs">
               <Badge color="green" variant="light" size="sm">
-                {filteredParticipantProgress.filter((p) => p.isCompleted).length}
+                {filteredParticipantProgress.filter((p) => p.isCompleted && !p.isRejected).length}
                 {' '}
                 Completed
               </Badge>

--- a/src/analysis/individualStudy/LiveMonitor/LiveMonitorView.tsx
+++ b/src/analysis/individualStudy/LiveMonitor/LiveMonitorView.tsx
@@ -38,7 +38,7 @@ export function getFilteredParticipantProgress(
       };
     })
     .filter(({ isCompleted, isRejected, assignment }) => {
-      const status = isRejected ? 'rejected' : (isCompleted ? 'completed' : 'inprogress');
+      const status = isRejected ? 'rejected' : (isCompleted ? 'completed' : 'inProgress');
       const statusMatch = includedParticipants.includes(status);
       const stageMatch = selectedStages.includes('ALL') || selectedStages.includes(assignment.stage || '');
 

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -144,19 +144,14 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   }, [selectedParticipants]);
 
   const showStoredCountMismatch = useMemo(() => {
-    const includesAllParticipantStatuses = includedParticipants.length === 3
-      && includedParticipants.includes('completed')
-      && includedParticipants.includes('inprogress')
-      && includedParticipants.includes('rejected');
     const hasStageFilter = !(selectedStages.length === 1 && selectedStages[0] === 'ALL');
     const hasConfigFilter = !(selectedConfigs.length === 1 && selectedConfigs[0] === 'ALL');
     const hasConditionFilter = availableConditions.length > 0 && !(selectedConditions.length === 1 && selectedConditions[0] === 'ALL');
 
-    return includesAllParticipantStatuses
-      && !hasStageFilter
+    return !hasStageFilter
       && !hasConfigFilter
       && !hasConditionFilter;
-  }, [includedParticipants, selectedStages, selectedConfigs, selectedConditions, availableConditions.length]);
+  }, [selectedStages, selectedConfigs, selectedConditions, availableConditions.length]);
 
   const mismatchComparisonParticipantCounts = useMemo((): ParticipantCounts => ({
     total: participantCounts.completed + participantCounts.inprogress + participantCounts.rejected,

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -558,8 +558,8 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 <Tabs.Tab value="stats" leftSection={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
                 <Tooltip
                   label={!isFirebaseEngine
-                    ? 'Coding is only available when using Firebase with audio recording enabled.'
-                    : 'Coding is only available for studies with audio recording enabled.'}
+                    ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config'
+                    : 'Think aloud coding is only available for studies with audio recording enabled in your study config'}
                   disabled={codingEnabled}
                 >
                   <span>
@@ -567,7 +567,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                   </span>
                 </Tooltip>
                 <Tooltip
-                  label="Live Monitor is only available when using Firebase."
+                  label="Live Monitor is only available when using Firebase"
                   disabled={liveMonitorEnabled}
                 >
                   <span>
@@ -603,8 +603,8 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     <Center>
                       <Text c="dimmed">
                         {!isFirebaseEngine
-                          ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config.'
-                          : 'Think aloud coding is only available for studies with audio recording enabled in your study config.'}
+                          ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config'
+                          : 'Think aloud coding is only available for studies with audio recording enabled in your study config'}
                       </Text>
                     </Center>
                   )}
@@ -614,7 +614,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                   ? <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />
                   : (
                     <Center>
-                      <Text c="dimmed">Live Monitor is only available when using Firebase.</Text>
+                      <Text c="dimmed">Live Monitor is only available when using Firebase</Text>
                     </Center>
                   )}
               </Tabs.Panel>

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -1,5 +1,5 @@
 import {
-  Alert, AppShell, Center, Checkbox, Container, Flex, Group, LoadingOverlay, Stack, Tabs, Text, Title, MultiSelect,
+  Alert, AppShell, Badge, Center, Checkbox, Container, Flex, Group, LoadingOverlay, Stack, Tabs, Text, Title, MultiSelect, Tooltip,
 } from '@mantine/core';
 import { useNavigate, useParams } from 'react-router';
 import {
@@ -53,6 +53,10 @@ function sortByStartTime(a: ParticipantDataWithStatus, b: ParticipantDataWithSta
   return bStartTimes[0] - aStartTimes[0];
 }
 
+function getParticipantConditions(participant: Pick<ParticipantDataWithStatus, 'conditions' | 'searchParams'>) {
+  return parseConditionParam(participant.conditions ?? participant.searchParams?.condition);
+}
+
 async function getParticipantsData(
   studyConfig: StudyConfig | undefined,
   storageEngine: StorageEngine | undefined,
@@ -65,6 +69,14 @@ async function getParticipantsData(
   if (!studyConfig || !storageEngine || !studyId) return [];
 
   return await storageEngine.getAllParticipantsData(studyId);
+}
+
+async function getCurrentConfigHashForStudy(
+  storageEngine: StorageEngine | undefined,
+  studyId: string | undefined,
+): Promise<string | null> {
+  if (!storageEngine || !studyId) return null;
+  return storageEngine.getCurrentConfigHash(studyId);
 }
 
 export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig; }) {
@@ -102,6 +114,10 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   // 0-1 percentage of scroll height
 
   const { value: expData, execute, status } = useAsync(getParticipantsData, [studyConfig, storageEngine, canonicalStudyId ?? undefined]);
+  const { value: currentConfigHashValue } = useAsync(
+    getCurrentConfigHashForStudy,
+    storageEngine && canonicalStudyId ? [storageEngine, canonicalStudyId] : null,
+  );
 
   const participantCounts = useMemo(() => {
     if (!expData) return { completed: 0, inprogress: 0, rejected: 0 };
@@ -121,7 +137,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     const conditionFiltered = selectedConditions.includes('ALL')
       ? stageFiltered
       : stageFiltered.filter((d) => {
-        const conds = parseConditionParam(d.conditions ?? d.searchParams?.condition);
+        const conds = getParticipantConditions(d);
         const normalizedConds = conds.length > 0 ? conds : ['default'];
         return normalizedConds.some((c) => selectedConditions.includes(c));
       });
@@ -160,6 +176,34 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     rejected: participantCounts.rejected,
   }), [participantCounts]);
 
+  const currentConfigHash = currentConfigHashValue ?? undefined;
+  const isFirebaseEngine = storageEngine?.getEngine() === 'firebase';
+  const codingEnabled = isFirebaseEngine && hasAudioRecording;
+  const liveMonitorEnabled = isFirebaseEngine;
+
+  const currentConfigLabel = useMemo(() => {
+    if (!currentConfigHash) return undefined;
+    const currentConfig = allConfigs[currentConfigHash];
+    if (!currentConfig) return undefined;
+    return `${currentConfig.studyMetadata.version} - ${currentConfigHash.slice(0, 6)}`;
+  }, [allConfigs, currentConfigHash]);
+
+  const configSelectData = useMemo(() => {
+    const decoratedOptions = availableConfigs.map((configOption) => ({
+      ...configOption,
+    }));
+
+    const allOption = decoratedOptions.find((configOption) => configOption.value === 'ALL');
+    const currentOption = decoratedOptions.find((configOption) => configOption.value === currentConfigHash);
+    const remainingOptions = decoratedOptions.filter((configOption) => configOption.value !== 'ALL' && configOption.value !== currentConfigHash);
+
+    return [
+      ...(allOption ? [allOption] : []),
+      ...(currentOption ? [currentOption] : []),
+      ...remainingOptions,
+    ];
+  }, [availableConfigs, currentConfigHash]);
+
   const visibleParticipants = useMemo(() => {
     if (!expData) return [];
     const expList = Object.values(expData);
@@ -184,7 +228,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     const conditionFiltered = selectedConditions.includes('ALL')
       ? stageFiltered
       : stageFiltered.filter((d) => {
-        const conds = parseConditionParam(d.conditions ?? d.searchParams?.condition);
+        const conds = getParticipantConditions(d);
         const normalizedConds = conds.length > 0 ? conds : ['default'];
         return normalizedConds.some((c) => selectedConditions.includes(c));
       });
@@ -224,9 +268,13 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       const participantData = expData ? Object.values(expData) : [];
       const participantConfig = [...new Set(
         participantData.map((participant) => participant.participantConfigHash),
-      )];
+      )].filter((hash): hash is string => Boolean(hash));
 
-      const fetchedConfigs = await storageEngine.getAllConfigsFromHash(participantConfig, canonicalStudyId);
+      const configHashesToLoad = currentConfigHash
+        ? [...new Set([currentConfigHash, ...participantConfig])]
+        : participantConfig;
+
+      const fetchedConfigs = await storageEngine.getAllConfigsFromHash(configHashesToLoad, canonicalStudyId);
 
       const configOptions = Object.entries(fetchedConfigs)
         .map(([hash, config]) => ({
@@ -240,15 +288,14 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       setAvailableConfigs([{ value: 'ALL', label: 'ALL' }]);
       setAllConfigs({});
     }
-  }, [canonicalStudyId, storageEngine, expData]);
+  }, [canonicalStudyId, storageEngine, expData, currentConfigHash]);
 
   const allConditions = useMemo(() => {
     if (!expData) return [];
     const conditionSet = new Set<string>();
     Object.values(expData).forEach((participant) => {
-      const parsedConditions = parseConditionParam(participant.conditions ?? participant.searchParams?.condition);
-      const normalizedConditions = parsedConditions.length > 0 ? parsedConditions : ['default'];
-      normalizedConditions.forEach((condition) => conditionSet.add(condition));
+      const participantConditions = getParticipantConditions(participant);
+      participantConditions.forEach((condition) => conditionSet.add(condition));
     });
     return Array.from(conditionSet).sort();
   }, [expData]);
@@ -375,8 +422,35 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
               <Flex direction="row" align="center" gap="xs">
                 <Text size="sm" fw={500}>Config:</Text>
                 <MultiSelect
-                  data={availableConfigs}
+                  data={configSelectData}
                   value={selectedConfigs}
+                  renderOption={({ option }) => (
+                    <Flex align="center" gap="xs" wrap="nowrap" w="100%">
+                      <Text
+                        size="sm"
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {option.label}
+                      </Text>
+                      {option.value === currentConfigHash && (
+                        <Badge
+                          size="xs"
+                          variant="light"
+                          px={6}
+                          py={0}
+                          style={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+                        >
+                          Current
+                        </Badge>
+                      )}
+                    </Flex>
+                  )}
                   onChange={(values) => {
                     if (values.includes('ALL') && !selectedConfigs.includes('ALL')) {
                       setSelectedConfigs(['ALL']);
@@ -479,10 +553,24 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 <Tabs.Tab value="summary" leftSection={<IconChartPie size={16} />}>Study Summary</Tabs.Tab>
                 <Tabs.Tab value="table" leftSection={<IconTable size={16} />}>Participant View</Tabs.Tab>
                 <Tabs.Tab value="stats" leftSection={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
-                <Tabs.Tab value="tagging" leftSection={<IconTags size={16} />}>Coding</Tabs.Tab>
-                {storageEngine?.getEngine() === 'firebase' && (
-                  <Tabs.Tab value="live-monitor" leftSection={<IconDashboard size={16} />}>Live Monitor</Tabs.Tab>
-                )}
+                <Tooltip
+                  label={!isFirebaseEngine
+                    ? 'Coding is only available when using Firebase and when audio recording is enabled in your study config.'
+                    : 'Coding is only available for studies with audio recording enabled in your study config.'}
+                  disabled={codingEnabled}
+                >
+                  <span>
+                    <Tabs.Tab value="tagging" leftSection={<IconTags size={16} />} disabled={!codingEnabled}>Coding</Tabs.Tab>
+                  </span>
+                </Tooltip>
+                <Tooltip
+                  label="Live Monitor is only available when using Firebase."
+                  disabled={liveMonitorEnabled}
+                >
+                  <span>
+                    <Tabs.Tab value="live-monitor" leftSection={<IconDashboard size={16} />} disabled={!liveMonitorEnabled}>Live Monitor</Tabs.Tab>
+                  </span>
+                </Tooltip>
                 <Tabs.Tab value="config" leftSection={<IconFileCode size={16} />}>Config</Tabs.Tab>
                 <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin}>Manage</Tabs.Tab>
               </Tabs.List>
@@ -495,6 +583,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     studyId={canonicalStudyId ?? undefined}
                     showStoredCountMismatch={showStoredCountMismatch}
                     comparisonParticipantCounts={mismatchComparisonParticipantCounts}
+                    currentConfigLabel={currentConfigLabel}
                   />
                 )}
               </Tabs.Panel>
@@ -505,15 +594,29 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel value="tagging" pt="xs">
-                {studyConfig && storageEngine?.getEngine() === 'firebase' ? <ThinkAloudAnalysis visibleParticipants={visibleParticipants} storageEngine={storageEngine as FirebaseStorageEngine} /> : <Center>Think aloud coding is only available when using Firebase.</Center>}
+                {studyConfig && codingEnabled
+                  ? <ThinkAloudAnalysis visibleParticipants={visibleParticipants} storageEngine={storageEngine as FirebaseStorageEngine} />
+                  : (
+                    <Center>
+                      <Text c="dimmed">
+                        {!isFirebaseEngine
+                          ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config.'
+                          : 'Think aloud coding is only available for studies with audio recording enabled in your study config.'}
+                      </Text>
+                    </Center>
+                  )}
               </Tabs.Panel>
-              {storageEngine?.getEngine() === 'firebase' && (
-                <Tabs.Panel style={{ overflow: 'auto' }} value="live-monitor" pt="xs">
-                  {studyConfig && <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />}
-                </Tabs.Panel>
-              )}
+              <Tabs.Panel style={{ overflow: 'auto' }} value="live-monitor" pt="xs">
+                {studyConfig && liveMonitorEnabled
+                  ? <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />
+                  : (
+                    <Center>
+                      <Text c="dimmed">Live Monitor is only available when using Firebase.</Text>
+                    </Center>
+                  )}
+              </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="config" pt="xs">
-                {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
+                {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} currentConfigHash={currentConfigHash} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="manage" pt="xs">
                 {canonicalStudyId && user.isAdmin ? <ManageView studyId={canonicalStudyId} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -30,6 +30,7 @@ import { StorageEngine } from '../../storage/engines/types';
 import { DownloadButtons } from '../../components/downloader/DownloadButtons';
 import { useStudyRecordings } from '../../utils/useStudyRecordings';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
+import { ParticipantCounts } from '../types';
 import 'mantine-react-table/styles.css';
 import { ThinkAloudAnalysis } from './thinkAloud/ThinkAloudAnalysis';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
@@ -141,6 +142,28 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       rejected: selectedParticipants.filter((d) => d.rejected).length,
     };
   }, [selectedParticipants]);
+
+  const showStoredCountMismatch = useMemo(() => {
+    const includesAllParticipantStatuses = includedParticipants.length === 3
+      && includedParticipants.includes('completed')
+      && includedParticipants.includes('inprogress')
+      && includedParticipants.includes('rejected');
+    const hasStageFilter = !(selectedStages.length === 1 && selectedStages[0] === 'ALL');
+    const hasConfigFilter = !(selectedConfigs.length === 1 && selectedConfigs[0] === 'ALL');
+    const hasConditionFilter = availableConditions.length > 0 && !(selectedConditions.length === 1 && selectedConditions[0] === 'ALL');
+
+    return includesAllParticipantStatuses
+      && !hasStageFilter
+      && !hasConfigFilter
+      && !hasConditionFilter;
+  }, [includedParticipants, selectedStages, selectedConfigs, selectedConditions, availableConditions.length]);
+
+  const mismatchComparisonParticipantCounts = useMemo((): ParticipantCounts => ({
+    total: participantCounts.completed + participantCounts.inprogress + participantCounts.rejected,
+    completed: participantCounts.completed,
+    inProgress: participantCounts.inprogress,
+    rejected: participantCounts.rejected,
+  }), [participantCounts]);
 
   const visibleParticipants = useMemo(() => {
     if (!expData) return [];
@@ -469,13 +492,22 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin}>Manage</Tabs.Tab>
               </Tabs.List>
               <Tabs.Panel style={{ overflow: 'auto' }} value="summary" pt="xs">
-                {studyConfig && <SummaryView studyConfig={studyConfig} visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
+                {studyConfig && (
+                  <SummaryView
+                    studyConfig={studyConfig}
+                    visibleParticipants={visibleParticipants}
+                    allConfigs={allConfigs}
+                    studyId={canonicalStudyId ?? undefined}
+                    showStoredCountMismatch={showStoredCountMismatch}
+                    comparisonParticipantCounts={mismatchComparisonParticipantCounts}
+                  />
+                )}
               </Tabs.Panel>
               <Tabs.Panel style={{ height: `calc(100% - ${TABLE_HEADER_HEIGHT}px)` }} value="table" pt="xs">
                 {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="stats" pt="xs">
-                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
+                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel value="tagging" pt="xs">
                 {studyConfig && storageEngine?.getEngine() === 'firebase' ? <ThinkAloudAnalysis visibleParticipants={visibleParticipants} storageEngine={storageEngine as FirebaseStorageEngine} /> : <Center>Think aloud coding is only available when using Firebase.</Center>}

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -169,11 +169,17 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     const hasStageFilter = !(selectedStages.length === 1 && selectedStages[0] === 'ALL');
     const hasConfigFilter = !(selectedConfigs.length === 1 && selectedConfigs[0] === 'ALL');
     const hasConditionFilter = availableConditions.length > 0 && !(selectedConditions.length === 1 && selectedConditions[0] === 'ALL');
+    const hasParticipantStatusFilter = !(
+      includedParticipants.includes('completed')
+      && includedParticipants.includes('inprogress')
+      && includedParticipants.includes('rejected')
+    );
 
     return !hasStageFilter
       && !hasConfigFilter
-      && !hasConditionFilter;
-  }, [selectedStages, selectedConfigs, selectedConditions, availableConditions.length]);
+      && !hasConditionFilter
+      && !hasParticipantStatusFilter;
+  }, [selectedStages, selectedConfigs, selectedConditions, availableConditions.length, includedParticipants]);
 
   const mismatchComparisonParticipantCounts = useMemo((): ParticipantCounts => ({
     total: participantCounts.completed + participantCounts.inprogress + participantCounts.rejected,

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -29,7 +29,7 @@ import { useAsync } from '../../store/hooks/useAsync';
 import { StorageEngine } from '../../storage/engines/types';
 import { DownloadButtons } from '../../components/downloader/DownloadButtons';
 import { useStudyRecordings } from '../../utils/useStudyRecordings';
-import { parseConditionParam } from '../../utils/handleConditionLogic';
+import { getSequenceConditions, parseConditionParam } from '../../utils/handleConditionLogic';
 import { ParticipantCounts } from '../types';
 import 'mantine-react-table/styles.css';
 import { ThinkAloudAnalysis } from './thinkAloud/ThinkAloudAnalysis';
@@ -118,6 +118,10 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     getCurrentConfigHashForStudy,
     storageEngine && canonicalStudyId ? [storageEngine, canonicalStudyId] : null,
   );
+  const studyUsesConditions = useMemo(
+    () => (studyConfig ? getSequenceConditions(studyConfig.sequence).length > 0 : false),
+    [studyConfig],
+  );
 
   const participantCounts = useMemo(() => {
     if (!expData) return { completed: 0, inprogress: 0, rejected: 0 };
@@ -138,8 +142,10 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       ? stageFiltered
       : stageFiltered.filter((d) => {
         const conds = getParticipantConditions(d);
-        const normalizedConds = conds.length > 0 ? conds : ['default'];
-        return normalizedConds.some((c) => selectedConditions.includes(c));
+        if (studyUsesConditions && selectedConditions.includes('default') && conds.length === 0) {
+          return true;
+        }
+        return conds.some((c) => selectedConditions.includes(c));
       });
 
     return {
@@ -147,7 +153,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       inprogress: conditionFiltered.filter((d) => !d.rejected && !d.completed).length,
       rejected: conditionFiltered.filter((d) => d.rejected).length,
     };
-  }, [expData, selectedStages, selectedConfigs, selectedConditions]);
+  }, [expData, selectedStages, selectedConfigs, selectedConditions, studyUsesConditions]);
 
   const selectedParticipantCounts = useMemo(() => {
     if (selectedParticipants.length === 0) return { completed: 0, inprogress: 0, rejected: 0 };
@@ -229,12 +235,14 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       ? stageFiltered
       : stageFiltered.filter((d) => {
         const conds = getParticipantConditions(d);
-        const normalizedConds = conds.length > 0 ? conds : ['default'];
-        return normalizedConds.some((c) => selectedConditions.includes(c));
+        if (studyUsesConditions && selectedConditions.includes('default') && conds.length === 0) {
+          return true;
+        }
+        return conds.some((c) => selectedConditions.includes(c));
       });
 
     return conditionFiltered.sort(sortByStartTime);
-  }, [expData, includedParticipants, selectedStages, selectedConfigs, selectedConditions]);
+  }, [expData, includedParticipants, selectedStages, selectedConfigs, selectedConditions, studyUsesConditions]);
 
   // Load available stages
   const loadStages = useCallback(async () => {
@@ -295,10 +303,13 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     const conditionSet = new Set<string>();
     Object.values(expData).forEach((participant) => {
       const participantConditions = getParticipantConditions(participant);
+      if (studyUsesConditions && participantConditions.length === 0) {
+        conditionSet.add('default');
+      }
       participantConditions.forEach((condition) => conditionSet.add(condition));
     });
     return Array.from(conditionSet).sort();
-  }, [expData]);
+  }, [expData, studyUsesConditions]);
 
   // Load configs and clear selection when dependencies change
   useEffect(() => {

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -30,7 +30,6 @@ import { StorageEngine } from '../../storage/engines/types';
 import { DownloadButtons } from '../../components/downloader/DownloadButtons';
 import { useStudyRecordings } from '../../utils/useStudyRecordings';
 import { getSequenceConditions, parseConditionParam } from '../../utils/handleConditionLogic';
-import { ParticipantCounts } from '../types';
 import 'mantine-react-table/styles.css';
 import { ThinkAloudAnalysis } from './thinkAloud/ThinkAloudAnalysis';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
@@ -83,7 +82,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   const { studyId: routeStudyId } = useParams();
   const [studyConfig, setStudyConfig] = useState<StudyConfig | undefined>(undefined);
 
-  const [includedParticipants, setIncludedParticipants] = useState<string[]>(['completed', 'inprogress', 'rejected']);
+  const [includedParticipants, setIncludedParticipants] = useState<string[]>(['completed', 'inProgress', 'rejected']);
 
   const [selectedStages, setSelectedStages] = useState<string[]>(['ALL']);
   const [availableStages, setAvailableStages] = useState<{ value: string; label: string }[]>([{ value: 'ALL', label: 'ALL' }]);
@@ -124,7 +123,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   );
 
   const participantCounts = useMemo(() => {
-    if (!expData) return { completed: 0, inprogress: 0, rejected: 0 };
+    if (!expData) return { completed: 0, inProgress: 0, rejected: 0 };
     const expList = Object.values(expData);
 
     // Apply config filter before counting
@@ -150,17 +149,17 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
 
     return {
       completed: conditionFiltered.filter((d) => !d.rejected && d.completed).length,
-      inprogress: conditionFiltered.filter((d) => !d.rejected && !d.completed).length,
+      inProgress: conditionFiltered.filter((d) => !d.rejected && !d.completed).length,
       rejected: conditionFiltered.filter((d) => d.rejected).length,
     };
   }, [expData, selectedStages, selectedConfigs, selectedConditions, studyUsesConditions]);
 
   const selectedParticipantCounts = useMemo(() => {
-    if (selectedParticipants.length === 0) return { completed: 0, inprogress: 0, rejected: 0 };
+    if (selectedParticipants.length === 0) return { completed: 0, inProgress: 0, rejected: 0 };
 
     return {
       completed: selectedParticipants.filter((d) => !d.rejected && d.completed).length,
-      inprogress: selectedParticipants.filter((d) => !d.rejected && !d.completed).length,
+      inProgress: selectedParticipants.filter((d) => !d.rejected && !d.completed).length,
       rejected: selectedParticipants.filter((d) => d.rejected).length,
     };
   }, [selectedParticipants]);
@@ -169,24 +168,11 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     const hasStageFilter = !(selectedStages.length === 1 && selectedStages[0] === 'ALL');
     const hasConfigFilter = !(selectedConfigs.length === 1 && selectedConfigs[0] === 'ALL');
     const hasConditionFilter = availableConditions.length > 0 && !(selectedConditions.length === 1 && selectedConditions[0] === 'ALL');
-    const hasParticipantStatusFilter = !(
-      includedParticipants.includes('completed')
-      && includedParticipants.includes('inprogress')
-      && includedParticipants.includes('rejected')
-    );
 
     return !hasStageFilter
       && !hasConfigFilter
-      && !hasConditionFilter
-      && !hasParticipantStatusFilter;
-  }, [selectedStages, selectedConfigs, selectedConditions, availableConditions.length, includedParticipants]);
-
-  const mismatchComparisonParticipantCounts = useMemo((): ParticipantCounts => ({
-    total: participantCounts.completed + participantCounts.inprogress + participantCounts.rejected,
-    completed: participantCounts.completed,
-    inProgress: participantCounts.inprogress,
-    rejected: participantCounts.rejected,
-  }), [participantCounts]);
+      && !hasConditionFilter;
+  }, [selectedStages, selectedConfigs, selectedConditions, availableConditions.length]);
 
   const currentConfigHash = currentConfigHashValue ?? undefined;
   const isFirebaseEngine = storageEngine?.getEngine() === 'firebase';
@@ -221,7 +207,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     const expList = Object.values(expData);
 
     const comp = includedParticipants.includes('completed') ? expList.filter((d) => !d.rejected && d.completed) : [];
-    const prog = includedParticipants.includes('inprogress') ? expList.filter((d) => !d.rejected && !d.completed) : [];
+    const prog = includedParticipants.includes('inProgress') ? expList.filter((d) => !d.rejected && !d.completed) : [];
     const rej = includedParticipants.includes('rejected') ? expList.filter((d) => d.rejected) : [];
 
     const statusFiltered = [...comp, ...prog, ...rej];
@@ -536,10 +522,10 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                       size="sm"
                     />
                     <Checkbox
-                      value="inprogress"
+                      value="inProgress"
                       label={selectedParticipants.length > 0
-                        ? `In Progress (${selectedParticipantCounts.inprogress} of ${participantCounts.inprogress})`
-                        : `In Progress (${participantCounts.inprogress})`}
+                        ? `In Progress (${selectedParticipantCounts.inProgress} of ${participantCounts.inProgress})`
+                        : `In Progress (${participantCounts.inProgress})`}
                       size="sm"
                     />
                     <Checkbox
@@ -572,8 +558,8 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 <Tabs.Tab value="stats" leftSection={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
                 <Tooltip
                   label={!isFirebaseEngine
-                    ? 'Coding is only available when using Firebase and when audio recording is enabled in your study config.'
-                    : 'Coding is only available for studies with audio recording enabled in your study config.'}
+                    ? 'Coding is only available when using Firebase with audio recording enabled.'
+                    : 'Coding is only available for studies with audio recording enabled.'}
                   disabled={codingEnabled}
                 >
                   <span>
@@ -599,7 +585,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     allConfigs={allConfigs}
                     studyId={canonicalStudyId ?? undefined}
                     showStoredCountMismatch={showStoredCountMismatch}
-                    comparisonParticipantCounts={mismatchComparisonParticipantCounts}
+                    includedParticipants={includedParticipants}
                     currentConfigLabel={currentConfigLabel}
                   />
                 )}
@@ -608,7 +594,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="stats" pt="xs">
-                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} studyId={canonicalStudyId ?? undefined} />}
+                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel value="tagging" pt="xs">
                 {studyConfig && codingEnabled

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -594,7 +594,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="stats" pt="xs">
-                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} />}
+                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} studyId={canonicalStudyId ?? undefined} />}
               </Tabs.Panel>
               <Tabs.Panel value="tagging" pt="xs">
                 {studyConfig && codingEnabled

--- a/src/analysis/individualStudy/config/ConfigView.tsx
+++ b/src/analysis/individualStudy/config/ConfigView.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 import {
-  Button, Flex, Space, Text, Tooltip, Group, Modal, ActionIcon, Loader, Stack, Paper, Box,
+  Badge, Button, Flex, Space, Text, Tooltip, Group, Modal, ActionIcon, Loader, Stack, Paper, Box,
 } from '@mantine/core';
 import {
   useCallback, useEffect, useMemo, useState,
@@ -20,9 +20,11 @@ import { ConfigDiffModal } from './ConfigDiffModal';
 export function ConfigView({
   visibleParticipants,
   studyId,
+  currentConfigHash,
 }: {
   visibleParticipants: ParticipantData[];
   studyId?: string;
+  currentConfigHash?: string;
 }) {
   const [checked, setChecked] = useState<MrtRowSelectionState>({});
   const { storageEngine } = useStorageEngine();
@@ -41,7 +43,12 @@ export function ConfigView({
 
     const fetchConfigs = async () => {
       try {
-        const allConfigHashes = [...new Set(visibleParticipants.map((participant) => participant.participantConfigHash))];
+        const participantConfigHashes = visibleParticipants
+          .map((participant) => participant.participantConfigHash)
+          .filter((hash): hash is string => Boolean(hash));
+        const allConfigHashes = currentConfigHash
+          ? [...new Set([currentConfigHash, ...participantConfigHashes])]
+          : [...new Set(participantConfigHashes)];
         const fetchedConfigs = await storageEngine.getAllConfigsFromHash(allConfigHashes, studyId);
         const rows = buildConfigRows(fetchedConfigs, visibleParticipants);
         setConfigs(rows);
@@ -53,7 +60,7 @@ export function ConfigView({
     };
 
     fetchConfigs();
-  }, [visibleParticipants, storageEngine, studyId]);
+  }, [visibleParticipants, storageEngine, studyId, currentConfigHash]);
 
   const handleViewConfig = useCallback((hash: string) => {
     const selectedConfig = configs.find((config) => config.hash === hash) || null;
@@ -110,7 +117,12 @@ export function ConfigView({
       header: 'Version',
       size: 70,
       Cell: ({ row }: { row: { original: ConfigInfo } }) => (
-        <Text>{row.original.version}</Text>
+        <Group gap="xs">
+          <Text size="sm">{row.original.version}</Text>
+          {row.original.hash === currentConfigHash && (
+            <Badge size="xs" variant="light">Current</Badge>
+          )}
+        </Group>
       ),
     },
     {
@@ -119,7 +131,7 @@ export function ConfigView({
       size: 70,
       Cell: ({ row }: { row: { original: ConfigInfo } }) => (
         <Flex align="center" gap="xs">
-          <Text>
+          <Text size="sm">
             {row.original.hash.slice(0, 6)}
             ...
           </Text>
@@ -179,7 +191,7 @@ export function ConfigView({
         </Flex>
       ),
     },
-  ], [handleDownloadConfig, handleViewConfig, handleCopyHash, copied]);
+  ], [handleDownloadConfig, handleViewConfig, handleCopyHash, copied, currentConfigHash]);
 
   const table = useMantineReactTable({
     columns,

--- a/src/analysis/individualStudy/stats/StatsView.tsx
+++ b/src/analysis/individualStudy/stats/StatsView.tsx
@@ -14,24 +14,26 @@ export function StatsView(
   {
     studyConfig,
     visibleParticipants,
+    allConfigs,
     studyId,
   }: {
     studyConfig: StudyConfig;
     visibleParticipants: ParticipantDataWithStatus[];
+    allConfigs: Record<string, StudyConfig>;
     studyId?: string;
   },
 ) {
   const { trialId } = useParams();
 
   const overviewData = useMemo(
-    () => (trialId && trialId !== 'end' ? getOverviewStats(visibleParticipants, trialId, studyConfig) : null),
-    [studyConfig, visibleParticipants, trialId],
+    () => (trialId && trialId !== 'end' ? getOverviewStats(visibleParticipants, trialId, studyConfig, allConfigs) : null),
+    [studyConfig, visibleParticipants, trialId, allConfigs],
   );
 
   return (
     <>
       {overviewData && (
-        <OverviewStats overviewData={overviewData} studyId={studyId} />
+        <OverviewStats overviewData={overviewData} studyId={studyId} showStoredCountMismatch={false} />
       )}
       <Paper shadow="sm" p="md" mt="md" withBorder>
         {

--- a/src/analysis/individualStudy/stats/StatsView.tsx
+++ b/src/analysis/individualStudy/stats/StatsView.tsx
@@ -14,20 +14,18 @@ export function StatsView(
   {
     studyConfig,
     visibleParticipants,
-    allConfigs,
     studyId,
   }: {
     studyConfig: StudyConfig;
     visibleParticipants: ParticipantDataWithStatus[];
-    allConfigs: Record<string, StudyConfig>;
     studyId?: string;
   },
 ) {
   const { trialId } = useParams();
 
   const overviewData = useMemo(
-    () => (trialId && trialId !== 'end' ? getOverviewStats(visibleParticipants, trialId, studyConfig, allConfigs) : null),
-    [studyConfig, visibleParticipants, trialId, allConfigs],
+    () => (trialId && trialId !== 'end' ? getOverviewStats(visibleParticipants, trialId) : null),
+    [visibleParticipants, trialId],
   );
 
   return (

--- a/src/analysis/individualStudy/stats/StatsView.tsx
+++ b/src/analysis/individualStudy/stats/StatsView.tsx
@@ -14,18 +14,20 @@ export function StatsView(
   {
     studyConfig,
     visibleParticipants,
+    allConfigs,
     studyId,
   }: {
     studyConfig: StudyConfig;
     visibleParticipants: ParticipantDataWithStatus[];
+    allConfigs: Record<string, StudyConfig>;
     studyId?: string;
   },
 ) {
   const { trialId } = useParams();
 
   const overviewData = useMemo(
-    () => (trialId && trialId !== 'end' ? getOverviewStats(visibleParticipants, trialId) : null),
-    [visibleParticipants, trialId],
+    () => (trialId && trialId !== 'end' ? getOverviewStats(visibleParticipants, trialId, studyConfig, allConfigs) : null),
+    [studyConfig, visibleParticipants, trialId, allConfigs],
   );
 
   return (

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -91,7 +91,6 @@ export function ComponentStats({
       {
         accessorKey: 'component',
         header: 'Component',
-        size: 200,
         Cell: ({ row }) => renderComponentNameCell(row, currentConfigLabel),
       },
       {

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -10,11 +10,16 @@ import { ComponentData } from '../../types';
 export function ComponentStats({
   visibleParticipants,
   studyConfig,
+  allConfigs,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
+  allConfigs: Record<string, StudyConfig>;
 }) {
-  const componentData: ComponentData[] = useMemo(() => getComponentStats(visibleParticipants, studyConfig), [visibleParticipants, studyConfig]);
+  const componentData: ComponentData[] = useMemo(
+    () => getComponentStats(visibleParticipants, studyConfig, allConfigs),
+    [visibleParticipants, studyConfig, allConfigs],
+  );
 
   // eslint-disable-next-line camelcase
   const columns = useMemo<MRT_ColumnDef<ComponentData>[]>(

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -1,40 +1,108 @@
 import { useMemo } from 'react';
-import { Paper, Title } from '@mantine/core';
-// eslint-disable-next-line camelcase
-import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from 'mantine-react-table';
+import {
+  Badge, Flex, Paper, Text, Title,
+} from '@mantine/core';
+import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef as MrtColumnDef } from 'mantine-react-table';
 import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
-import { getComponentStats, convertNumberToString } from './utils';
+import { getComponentStats, getComponentStatsForConfigs, convertNumberToString } from './utils';
 import { ComponentData } from '../../types';
+
+function renderComponentNameCell(
+  row: { original: ComponentData },
+  currentConfigLabel?: string,
+) {
+  const configs = row.original.configs ?? [];
+  const hasCurrentConfig = currentConfigLabel ? configs.includes(currentConfigLabel) : false;
+  const hasOutdatedConfig = configs.length > 0 && !hasCurrentConfig;
+
+  return (
+    <Flex align="center" gap={6} wrap="nowrap">
+      <Text size="sm">{row.original.component}</Text>
+      {hasOutdatedConfig && (
+        <Badge size="xs" variant="light" color="gray">Outdated</Badge>
+      )}
+    </Flex>
+  );
+}
+
+function renderConfigListCell(
+  row: { original: ComponentData },
+  currentConfigLabel?: string,
+) {
+  return (
+    <Flex
+      align="center"
+      gap={6}
+      wrap="nowrap"
+      style={{ whiteSpace: 'nowrap', minWidth: 'max-content' }}
+    >
+      {(row.original.configs ?? []).map((config, index, configs) => (
+        <Flex
+          key={config}
+          align="center"
+          gap={4}
+          wrap="nowrap"
+          style={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+        >
+          <Text size="sm">{config}</Text>
+          {config === currentConfigLabel ? (
+            <Badge
+              size="xs"
+              variant="light"
+              px={6}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+            >
+              Current
+            </Badge>
+          ) : null}
+          {index < configs.length - 1 && (
+            <Text size="sm" c="dimmed" style={{ flexShrink: 0 }}>,</Text>
+          )}
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
 
 export function ComponentStats({
   visibleParticipants,
   studyConfig,
   allConfigs,
+  selectedConfigRows,
+  currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
   allConfigs: Record<string, StudyConfig>;
+  selectedConfigRows: Array<{ configHash: string; configLabel: string; studyConfig: StudyConfig }>;
+  currentConfigLabel?: string;
 }) {
+  const useSelectedConfigRows = selectedConfigRows.length > 0;
   const componentData: ComponentData[] = useMemo(
-    () => getComponentStats(visibleParticipants, studyConfig, allConfigs),
-    [visibleParticipants, studyConfig, allConfigs],
+    () => (useSelectedConfigRows
+      ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
+      : getComponentStats(visibleParticipants, studyConfig, allConfigs)),
+    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows],
   );
 
-  // eslint-disable-next-line camelcase
-  const columns = useMemo<MRT_ColumnDef<ComponentData>[]>(
+  const columns = useMemo<MrtColumnDef<ComponentData>[]>(
     () => [
       {
         accessorKey: 'component',
         header: 'Component',
+        size: 200,
+        Cell: ({ row }) => renderComponentNameCell(row, currentConfigLabel),
       },
       {
         accessorKey: 'participants',
         header: 'Participants',
+        size: 50,
       },
       {
         accessorKey: 'avgTime',
         header: 'Avg Time',
+        size: 50,
         Cell: ({ cell }) => {
           const value = cell.getValue<number>();
           return convertNumberToString(value, 'time');
@@ -43,6 +111,7 @@ export function ComponentStats({
       {
         accessorKey: 'avgCleanTime',
         header: 'Avg Clean Time',
+        size: 50,
         Cell: ({ cell }) => {
           const value = cell.getValue<number>();
           return convertNumberToString(value, 'time');
@@ -51,21 +120,24 @@ export function ComponentStats({
       {
         accessorKey: 'correctness',
         header: 'Correctness',
+        size: 50,
         Cell: ({ cell }) => {
           const value = cell.getValue<number>();
           return convertNumberToString(value, 'correctness');
         },
       },
+      ...(useSelectedConfigRows ? [{
+        accessorKey: 'configs',
+        header: 'Configs',
+        Cell: ({ row }) => renderConfigListCell(row, currentConfigLabel),
+      } satisfies MrtColumnDef<ComponentData>] : []),
     ],
-    [],
+    [useSelectedConfigRows, currentConfigLabel],
   );
 
   const table = useMantineReactTable({
     columns,
     data: componentData,
-    initialState: {
-      sorting: [{ id: 'component.index', desc: false }],
-    },
     mantinePaperProps: {
       style: { overflow: 'hidden' },
     },

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -107,13 +107,11 @@ function renderConfigListCell(
 export function ComponentStats({
   visibleParticipants,
   studyConfig,
-  allConfigs,
   selectedConfigRows,
   currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
-  allConfigs: Record<string, StudyConfig>;
   selectedConfigRows: Array<{ configHash: string; configLabel: string; studyConfig: StudyConfig }>;
   currentConfigLabel?: string;
 }) {
@@ -122,8 +120,8 @@ export function ComponentStats({
   const componentData: ComponentData[] = useMemo(
     () => {
       const rows = useSelectedConfigRows
-        ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
-        : getComponentStats(visibleParticipants, studyConfig, allConfigs);
+        ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows)
+        : getComponentStats(visibleParticipants, studyConfig);
       // Outdated rows are always pinned below current rows; user sort applies within each group
       return [...rows].sort((a, b) => {
         const aOutdated = isComponentOutdated(a, currentConfigLabel) ? 1 : 0;
@@ -141,7 +139,7 @@ export function ComponentStats({
         return 0;
       });
     },
-    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
+    [visibleParticipants, studyConfig, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
   );
 
   const columns = useMemo<MrtColumnDef<ComponentData>[]>(
@@ -187,6 +185,7 @@ export function ComponentStats({
       ...(useSelectedConfigRows ? [{
         accessorKey: 'configs',
         header: 'Configs',
+        enableSorting: false,
         Cell: ({ row }) => renderConfigListCell(row, currentConfigLabel),
       } satisfies MrtColumnDef<ComponentData>] : []),
     ],

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -69,6 +69,13 @@ function renderConfigListCell(
   row: { original: ComponentData },
   currentConfigLabel?: string,
 ) {
+  // Pin the current config to the front; preserve relative order otherwise.
+  const sortedConfigs = (row.original.configs ?? []).slice().sort((a, b) => {
+    if (a === currentConfigLabel) return -1;
+    if (b === currentConfigLabel) return 1;
+    return 0;
+  });
+
   return (
     <Flex
       align="center"
@@ -76,7 +83,7 @@ function renderConfigListCell(
       wrap="nowrap"
       style={{ whiteSpace: 'nowrap', minWidth: 'max-content' }}
     >
-      {(row.original.configs ?? []).map((config, index, configs) => (
+      {sortedConfigs.map((config, index, configs) => (
         <Flex
           key={config}
           align="center"
@@ -107,11 +114,13 @@ function renderConfigListCell(
 export function ComponentStats({
   visibleParticipants,
   studyConfig,
+  allConfigs,
   selectedConfigRows,
   currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
+  allConfigs: Record<string, StudyConfig>;
   selectedConfigRows: Array<{ configHash: string; configLabel: string; studyConfig: StudyConfig }>;
   currentConfigLabel?: string;
 }) {
@@ -120,8 +129,8 @@ export function ComponentStats({
   const componentData: ComponentData[] = useMemo(
     () => {
       const rows = useSelectedConfigRows
-        ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows)
-        : getComponentStats(visibleParticipants, studyConfig);
+        ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
+        : getComponentStats(visibleParticipants, studyConfig, allConfigs);
       // Outdated rows are always pinned below current rows; user sort applies within each group
       return [...rows].sort((a, b) => {
         const aOutdated = isComponentOutdated(a, currentConfigLabel) ? 1 : 0;
@@ -139,7 +148,7 @@ export function ComponentStats({
         return 0;
       });
     },
-    [visibleParticipants, studyConfig, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
+    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
   );
 
   const columns = useMemo<MrtColumnDef<ComponentData>[]>(

--- a/src/analysis/individualStudy/summary/ComponentStats.tsx
+++ b/src/analysis/individualStudy/summary/ComponentStats.tsx
@@ -1,12 +1,38 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
-  Badge, Flex, Paper, Text, Title,
+  Badge, Flex, Paper, Text, Title, Tooltip,
 } from '@mantine/core';
-import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef as MrtColumnDef } from 'mantine-react-table';
+import {
+  MantineReactTable,
+  useMantineReactTable,
+  type MRT_ColumnDef as MrtColumnDef,
+  type MRT_SortingState as MrtSortingState,
+} from 'mantine-react-table';
 import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { getComponentStats, getComponentStatsForConfigs, convertNumberToString } from './utils';
 import { ComponentData } from '../../types';
+
+function isComponentOutdated(row: ComponentData, currentConfigLabel?: string) {
+  const configs = row.configs ?? [];
+  if (!currentConfigLabel || configs.length === 0) return false;
+  return !configs.includes(currentConfigLabel);
+}
+
+function compareValues(aVal: unknown, bVal: unknown): number {
+  if (typeof aVal === 'number' && typeof bVal === 'number') {
+    const aNaN = Number.isNaN(aVal);
+    const bNaN = Number.isNaN(bVal);
+    if (aNaN && bNaN) return 0;
+    if (aNaN) return 1;
+    if (bNaN) return -1;
+    return aVal - bVal;
+  }
+  if (typeof aVal === 'string' && typeof bVal === 'string') {
+    return aVal.localeCompare(bVal);
+  }
+  return 0;
+}
 
 function renderComponentNameCell(
   row: { original: ComponentData },
@@ -17,10 +43,23 @@ function renderComponentNameCell(
   const hasOutdatedConfig = configs.length > 0 && !hasCurrentConfig;
 
   return (
-    <Flex align="center" gap={6} wrap="nowrap">
-      <Text size="sm">{row.original.component}</Text>
+    <Flex align="center" gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+      <Tooltip label={row.original.component} withinPortal>
+        <Text
+          size="sm"
+          style={{
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            minWidth: 0,
+            flex: 1,
+          }}
+        >
+          {row.original.component}
+        </Text>
+      </Tooltip>
       {hasOutdatedConfig && (
-        <Badge size="xs" variant="light" color="gray">Outdated</Badge>
+        <Badge size="xs" variant="light" color="gray" style={{ flexShrink: 0 }}>Outdated</Badge>
       )}
     </Flex>
   );
@@ -79,11 +118,30 @@ export function ComponentStats({
   currentConfigLabel?: string;
 }) {
   const useSelectedConfigRows = selectedConfigRows.length > 0;
+  const [sorting, setSorting] = useState<MrtSortingState>([]);
   const componentData: ComponentData[] = useMemo(
-    () => (useSelectedConfigRows
-      ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
-      : getComponentStats(visibleParticipants, studyConfig, allConfigs)),
-    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows],
+    () => {
+      const rows = useSelectedConfigRows
+        ? getComponentStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
+        : getComponentStats(visibleParticipants, studyConfig, allConfigs);
+      // Outdated rows are always pinned below current rows; user sort applies within each group
+      return [...rows].sort((a, b) => {
+        const aOutdated = isComponentOutdated(a, currentConfigLabel) ? 1 : 0;
+        const bOutdated = isComponentOutdated(b, currentConfigLabel) ? 1 : 0;
+        if (aOutdated !== bOutdated) return aOutdated - bOutdated;
+
+        for (let i = 0; i < sorting.length; i += 1) {
+          const sort = sorting[i];
+          const cmp = compareValues(
+            a[sort.id as keyof ComponentData],
+            b[sort.id as keyof ComponentData],
+          );
+          if (cmp !== 0) return sort.desc ? -cmp : cmp;
+        }
+        return 0;
+      });
+    },
+    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
   );
 
   const columns = useMemo<MrtColumnDef<ComponentData>[]>(
@@ -91,6 +149,7 @@ export function ComponentStats({
       {
         accessorKey: 'component',
         header: 'Component',
+        size: 200,
         Cell: ({ row }) => renderComponentNameCell(row, currentConfigLabel),
       },
       {
@@ -137,6 +196,9 @@ export function ComponentStats({
   const table = useMantineReactTable({
     columns,
     data: componentData,
+    manualSorting: true,
+    state: { sorting },
+    onSortingChange: setSorting,
     mantinePaperProps: {
       style: { overflow: 'hidden' },
     },

--- a/src/analysis/individualStudy/summary/OverviewStats.tsx
+++ b/src/analysis/individualStudy/summary/OverviewStats.tsx
@@ -4,7 +4,7 @@ import {
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { convertNumberToString } from './utils';
-import { OverviewData } from '../../types';
+import { OverviewData, ParticipantCounts } from '../../types';
 import { useStorageEngine } from '../../../storage/storageEngineHooks';
 import { useAsync } from '../../../store/hooks/useAsync';
 import { StorageEngine } from '../../../storage/engines/types';
@@ -17,9 +17,13 @@ async function getStoredParticipantCounts(storageEngine: StorageEngine, studyId:
 export function OverviewStats({
   overviewData,
   studyId,
+  showStoredCountMismatch = false,
+  comparisonParticipantCounts,
 }: {
   overviewData: OverviewData;
   studyId?: string;
+  showStoredCountMismatch?: boolean;
+  comparisonParticipantCounts?: ParticipantCounts;
 }) {
   // Check if there are participants with invalid clean time (e.g. due to a window events bug)
   const hasExcluded = overviewData && overviewData.participantsWithInvalidCleanTimeCount > 0;
@@ -27,25 +31,30 @@ export function OverviewStats({
   const { storageEngine } = useStorageEngine();
 
   // Get the stored participant counts from the storage engine
-  const { value: storedCounts } = useAsync(getStoredParticipantCounts, storageEngine && studyId ? [storageEngine, studyId] : null);
+  const { value: storedCounts } = useAsync(
+    getStoredParticipantCounts,
+    showStoredCountMismatch && storageEngine && studyId ? [storageEngine, studyId] : null,
+  );
+
+  const mismatchComparisonCounts = comparisonParticipantCounts ?? overviewData.participantCounts;
 
   const mismatchDetails = useMemo(() => {
-    if (!storedCounts) return null;
+    if (!showStoredCountMismatch || !storedCounts) return null;
     return {
       completed: {
         current: storedCounts.completed,
-        calculated: overviewData.participantCounts.completed,
+        calculated: mismatchComparisonCounts.completed,
       },
       inProgress: {
         current: storedCounts.inProgress,
-        calculated: overviewData.participantCounts.inProgress,
+        calculated: mismatchComparisonCounts.inProgress,
       },
       rejected: {
         current: storedCounts.rejected,
-        calculated: overviewData.participantCounts.rejected,
+        calculated: mismatchComparisonCounts.rejected,
       },
     };
-  }, [overviewData, storedCounts]);
+  }, [mismatchComparisonCounts, showStoredCountMismatch, storedCounts]);
 
   // Check if the stored participant counts match the calculated participant counts
   const hasMismatch = (type: 'completed' | 'inProgress' | 'rejected') => {

--- a/src/analysis/individualStudy/summary/OverviewStats.tsx
+++ b/src/analysis/individualStudy/summary/OverviewStats.tsx
@@ -4,7 +4,7 @@ import {
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { convertNumberToString } from './utils';
-import { OverviewData, ParticipantCounts } from '../../types';
+import { OverviewData } from '../../types';
 import { useStorageEngine } from '../../../storage/storageEngineHooks';
 import { useAsync } from '../../../store/hooks/useAsync';
 import { StorageEngine } from '../../../storage/engines/types';
@@ -18,12 +18,12 @@ export function OverviewStats({
   overviewData,
   studyId,
   showStoredCountMismatch = false,
-  comparisonParticipantCounts,
+  includedParticipants = ['completed', 'inProgress', 'rejected'],
 }: {
   overviewData: OverviewData;
   studyId?: string;
   showStoredCountMismatch?: boolean;
-  comparisonParticipantCounts?: ParticipantCounts;
+  includedParticipants?: string[];
 }) {
   // Check if there are participants with invalid clean time (e.g. due to a window events bug)
   const hasExcluded = overviewData && overviewData.participantsWithInvalidCleanTimeCount > 0;
@@ -36,25 +36,23 @@ export function OverviewStats({
     showStoredCountMismatch && storageEngine && studyId ? [storageEngine, studyId] : null,
   );
 
-  const mismatchComparisonCounts = comparisonParticipantCounts ?? overviewData.participantCounts;
-
   const mismatchDetails = useMemo(() => {
     if (!showStoredCountMismatch || !storedCounts) return null;
     return {
       completed: {
-        current: storedCounts.completed,
-        calculated: mismatchComparisonCounts.completed,
+        current: includedParticipants.includes('completed') ? storedCounts.completed : 0,
+        calculated: overviewData.participantCounts.completed,
       },
       inProgress: {
-        current: storedCounts.inProgress,
-        calculated: mismatchComparisonCounts.inProgress,
+        current: includedParticipants.includes('inProgress') ? storedCounts.inProgress : 0,
+        calculated: overviewData.participantCounts.inProgress,
       },
       rejected: {
-        current: storedCounts.rejected,
-        calculated: mismatchComparisonCounts.rejected,
+        current: includedParticipants.includes('rejected') ? storedCounts.rejected : 0,
+        calculated: overviewData.participantCounts.rejected,
       },
     };
-  }, [mismatchComparisonCounts, showStoredCountMismatch, storedCounts]);
+  }, [overviewData.participantCounts, showStoredCountMismatch, storedCounts, includedParticipants]);
 
   // Check if the stored participant counts match the calculated participant counts
   const hasMismatch = (type: 'completed' | 'inProgress' | 'rejected') => {

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -107,13 +107,11 @@ function renderResponseConfigListCell(
 export function ResponseStats({
   visibleParticipants,
   studyConfig,
-  allConfigs,
   selectedConfigRows,
   currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
-  allConfigs: Record<string, StudyConfig>;
   selectedConfigRows: Array<{ configHash: string; configLabel: string; studyConfig: StudyConfig }>;
   currentConfigLabel?: string;
 }) {
@@ -122,8 +120,8 @@ export function ResponseStats({
   const responseData: ResponseData[] = useMemo(
     () => {
       const rows = useSelectedConfigRows
-        ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
-        : getResponseStats(visibleParticipants, studyConfig, allConfigs);
+        ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows)
+        : getResponseStats(visibleParticipants, studyConfig);
       // Outdated rows are always pinned below current rows; user sort applies within each group
       return [...rows].sort((a, b) => {
         const aOutdated = isResponseOutdated(a, currentConfigLabel) ? 1 : 0;
@@ -141,7 +139,7 @@ export function ResponseStats({
         return 0;
       });
     },
-    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
+    [visibleParticipants, studyConfig, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
   );
 
   const columns = useMemo<MrtColumnDef<ResponseData>[]>(() => [
@@ -177,6 +175,7 @@ export function ResponseStats({
     ...(useSelectedConfigRows ? [{
       accessorKey: 'configs',
       header: 'Configs',
+      enableSorting: false,
       Cell: ({ row }) => renderResponseConfigListCell(row, currentConfigLabel),
     } satisfies MrtColumnDef<ResponseData>] : []),
   ], [useSelectedConfigRows, currentConfigLabel]);

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -1,60 +1,132 @@
 import { useMemo } from 'react';
-import { Paper, Title } from '@mantine/core';
-// eslint-disable-next-line camelcase
-import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef } from 'mantine-react-table';
+import {
+  Badge, Flex, Paper, Text, Title,
+} from '@mantine/core';
+import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef as MrtColumnDef } from 'mantine-react-table';
 import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
-import { getResponseStats, convertNumberToString } from './utils';
+import { getResponseStats, getResponseStatsForConfigs, convertNumberToString } from './utils';
 import { ResponseData } from '../../types';
+
+function renderResponseComponentCell(
+  row: { original: ResponseData },
+  currentConfigLabel?: string,
+) {
+  const configs = row.original.configs ?? [];
+  const hasCurrentConfig = currentConfigLabel ? configs.includes(currentConfigLabel) : false;
+  const hasOutdatedConfig = configs.length > 0 && !hasCurrentConfig;
+
+  return (
+    <Flex align="center" gap={6} wrap="nowrap">
+      <Text size="sm">{row.original.component}</Text>
+      {hasOutdatedConfig && (
+        <Badge size="xs" variant="light" color="gray">Outdated</Badge>
+      )}
+    </Flex>
+  );
+}
+
+function renderResponseConfigListCell(
+  row: { original: ResponseData },
+  currentConfigLabel?: string,
+) {
+  return (
+    <Flex
+      align="center"
+      gap={6}
+      wrap="nowrap"
+      style={{ whiteSpace: 'nowrap', minWidth: 'max-content' }}
+    >
+      {(row.original.configs ?? []).map((config, index, configs) => (
+        <Flex
+          key={config}
+          align="center"
+          gap={4}
+          wrap="nowrap"
+          style={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+        >
+          <Text size="sm">{config}</Text>
+          {config === currentConfigLabel ? (
+            <Badge
+              size="xs"
+              variant="light"
+              px={6}
+              style={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+            >
+              Current
+            </Badge>
+          ) : null}
+          {index < configs.length - 1 && (
+            <Text size="sm" c="dimmed" style={{ flexShrink: 0 }}>,</Text>
+          )}
+        </Flex>
+      ))}
+    </Flex>
+  );
+}
 
 export function ResponseStats({
   visibleParticipants,
   studyConfig,
   allConfigs,
+  selectedConfigRows,
+  currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
   allConfigs: Record<string, StudyConfig>;
+  selectedConfigRows: Array<{ configHash: string; configLabel: string; studyConfig: StudyConfig }>;
+  currentConfigLabel?: string;
 }) {
+  const useSelectedConfigRows = selectedConfigRows.length > 0;
   const responseData: ResponseData[] = useMemo(
-    () => getResponseStats(visibleParticipants, studyConfig, allConfigs),
-    [visibleParticipants, studyConfig, allConfigs],
+    () => (useSelectedConfigRows
+      ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
+      : getResponseStats(visibleParticipants, studyConfig, allConfigs)),
+    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows],
   );
 
-  // eslint-disable-next-line camelcase
-  const columns = useMemo<MRT_ColumnDef<ResponseData>[]>(() => [
+  const columns = useMemo<MrtColumnDef<ResponseData>[]>(() => [
     {
       accessorKey: 'component',
       header: 'Component',
+      size: 200,
+      Cell: ({ row }) => renderResponseComponentCell(row, currentConfigLabel),
     },
     {
       accessorKey: 'type',
       header: 'Type',
+      size: 50,
     },
     {
       accessorKey: 'question',
       header: 'Question',
+      size: 200,
     },
     {
       accessorKey: 'options',
       header: 'Options',
+      size: 200,
     },
     {
       accessorKey: 'correctness',
       header: 'Correctness',
+      size: 50,
       Cell: ({ cell }) => {
         const value = cell.getValue<number>();
         return convertNumberToString(value, 'correctness');
       },
     },
-  ], []);
+    ...(useSelectedConfigRows ? [{
+      accessorKey: 'configs',
+      header: 'Configs',
+      Cell: ({ row }) => renderResponseConfigListCell(row, currentConfigLabel),
+    } satisfies MrtColumnDef<ResponseData>] : []),
+  ], [useSelectedConfigRows, currentConfigLabel]);
 
   const table = useMantineReactTable({
     columns,
     data: responseData,
-    initialState: {
-      sorting: [{ id: 'component.index', desc: true }],
-    },
     mantinePaperProps: {
       style: { overflow: 'hidden' },
     },

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -69,6 +69,13 @@ function renderResponseConfigListCell(
   row: { original: ResponseData },
   currentConfigLabel?: string,
 ) {
+  // Pin the current config to the front; preserve relative order otherwise.
+  const sortedConfigs = (row.original.configs ?? []).slice().sort((a, b) => {
+    if (a === currentConfigLabel) return -1;
+    if (b === currentConfigLabel) return 1;
+    return 0;
+  });
+
   return (
     <Flex
       align="center"
@@ -76,7 +83,7 @@ function renderResponseConfigListCell(
       wrap="nowrap"
       style={{ whiteSpace: 'nowrap', minWidth: 'max-content' }}
     >
-      {(row.original.configs ?? []).map((config, index, configs) => (
+      {sortedConfigs.map((config, index, configs) => (
         <Flex
           key={config}
           align="center"
@@ -107,11 +114,13 @@ function renderResponseConfigListCell(
 export function ResponseStats({
   visibleParticipants,
   studyConfig,
+  allConfigs,
   selectedConfigRows,
   currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
+  allConfigs: Record<string, StudyConfig>;
   selectedConfigRows: Array<{ configHash: string; configLabel: string; studyConfig: StudyConfig }>;
   currentConfigLabel?: string;
 }) {
@@ -120,8 +129,8 @@ export function ResponseStats({
   const responseData: ResponseData[] = useMemo(
     () => {
       const rows = useSelectedConfigRows
-        ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows)
-        : getResponseStats(visibleParticipants, studyConfig);
+        ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
+        : getResponseStats(visibleParticipants, studyConfig, allConfigs);
       // Outdated rows are always pinned below current rows; user sort applies within each group
       return [...rows].sort((a, b) => {
         const aOutdated = isResponseOutdated(a, currentConfigLabel) ? 1 : 0;
@@ -139,7 +148,7 @@ export function ResponseStats({
         return 0;
       });
     },
-    [visibleParticipants, studyConfig, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
+    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
   );
 
   const columns = useMemo<MrtColumnDef<ResponseData>[]>(() => [

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -1,12 +1,38 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
-  Badge, Flex, Paper, Text, Title,
+  Badge, Flex, Paper, Text, Title, Tooltip,
 } from '@mantine/core';
-import { MantineReactTable, useMantineReactTable, type MRT_ColumnDef as MrtColumnDef } from 'mantine-react-table';
+import {
+  MantineReactTable,
+  useMantineReactTable,
+  type MRT_ColumnDef as MrtColumnDef,
+  type MRT_SortingState as MrtSortingState,
+} from 'mantine-react-table';
 import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
 import { getResponseStats, getResponseStatsForConfigs, convertNumberToString } from './utils';
 import { ResponseData } from '../../types';
+
+function isResponseOutdated(row: ResponseData, currentConfigLabel?: string) {
+  const configs = row.configs ?? [];
+  if (!currentConfigLabel || configs.length === 0) return false;
+  return !configs.includes(currentConfigLabel);
+}
+
+function compareValues(aVal: unknown, bVal: unknown): number {
+  if (typeof aVal === 'number' && typeof bVal === 'number') {
+    const aNaN = Number.isNaN(aVal);
+    const bNaN = Number.isNaN(bVal);
+    if (aNaN && bNaN) return 0;
+    if (aNaN) return 1;
+    if (bNaN) return -1;
+    return aVal - bVal;
+  }
+  if (typeof aVal === 'string' && typeof bVal === 'string') {
+    return aVal.localeCompare(bVal);
+  }
+  return 0;
+}
 
 function renderResponseComponentCell(
   row: { original: ResponseData },
@@ -17,10 +43,23 @@ function renderResponseComponentCell(
   const hasOutdatedConfig = configs.length > 0 && !hasCurrentConfig;
 
   return (
-    <Flex align="center" gap={6} wrap="nowrap">
-      <Text size="sm">{row.original.component}</Text>
+    <Flex align="center" gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+      <Tooltip label={row.original.component} withinPortal>
+        <Text
+          size="sm"
+          style={{
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            minWidth: 0,
+            flex: 1,
+          }}
+        >
+          {row.original.component}
+        </Text>
+      </Tooltip>
       {hasOutdatedConfig && (
-        <Badge size="xs" variant="light" color="gray">Outdated</Badge>
+        <Badge size="xs" variant="light" color="gray" style={{ flexShrink: 0 }}>Outdated</Badge>
       )}
     </Flex>
   );
@@ -79,11 +118,30 @@ export function ResponseStats({
   currentConfigLabel?: string;
 }) {
   const useSelectedConfigRows = selectedConfigRows.length > 0;
+  const [sorting, setSorting] = useState<MrtSortingState>([]);
   const responseData: ResponseData[] = useMemo(
-    () => (useSelectedConfigRows
-      ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
-      : getResponseStats(visibleParticipants, studyConfig, allConfigs)),
-    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows],
+    () => {
+      const rows = useSelectedConfigRows
+        ? getResponseStatsForConfigs(visibleParticipants, selectedConfigRows, allConfigs)
+        : getResponseStats(visibleParticipants, studyConfig, allConfigs);
+      // Outdated rows are always pinned below current rows; user sort applies within each group
+      return [...rows].sort((a, b) => {
+        const aOutdated = isResponseOutdated(a, currentConfigLabel) ? 1 : 0;
+        const bOutdated = isResponseOutdated(b, currentConfigLabel) ? 1 : 0;
+        if (aOutdated !== bOutdated) return aOutdated - bOutdated;
+
+        for (let i = 0; i < sorting.length; i += 1) {
+          const sort = sorting[i];
+          const cmp = compareValues(
+            a[sort.id as keyof ResponseData],
+            b[sort.id as keyof ResponseData],
+          );
+          if (cmp !== 0) return sort.desc ? -cmp : cmp;
+        }
+        return 0;
+      });
+    },
+    [visibleParticipants, studyConfig, allConfigs, useSelectedConfigRows, selectedConfigRows, currentConfigLabel, sorting],
   );
 
   const columns = useMemo<MrtColumnDef<ResponseData>[]>(() => [
@@ -126,6 +184,9 @@ export function ResponseStats({
   const table = useMantineReactTable({
     columns,
     data: responseData,
+    manualSorting: true,
+    state: { sorting },
+    onSortingChange: setSorting,
     mantinePaperProps: {
       style: { overflow: 'hidden' },
     },

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -90,7 +90,6 @@ export function ResponseStats({
     {
       accessorKey: 'component',
       header: 'Component',
-      size: 200,
       Cell: ({ row }) => renderResponseComponentCell(row, currentConfigLabel),
     },
     {

--- a/src/analysis/individualStudy/summary/ResponseStats.tsx
+++ b/src/analysis/individualStudy/summary/ResponseStats.tsx
@@ -10,11 +10,16 @@ import { ResponseData } from '../../types';
 export function ResponseStats({
   visibleParticipants,
   studyConfig,
+  allConfigs,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
+  allConfigs: Record<string, StudyConfig>;
 }) {
-  const responseData: ResponseData[] = useMemo(() => getResponseStats(visibleParticipants, studyConfig), [visibleParticipants, studyConfig]);
+  const responseData: ResponseData[] = useMemo(
+    () => getResponseStats(visibleParticipants, studyConfig, allConfigs),
+    [visibleParticipants, studyConfig, allConfigs],
+  );
 
   // eslint-disable-next-line camelcase
   const columns = useMemo<MRT_ColumnDef<ResponseData>[]>(() => [

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -6,7 +6,6 @@ import { OverviewStats } from './OverviewStats';
 import { ComponentStats } from './ComponentStats';
 import { ResponseStats } from './ResponseStats';
 import { getOverviewStats } from './utils';
-import { ParticipantCounts } from '../../types';
 
 export function SummaryView({
   visibleParticipants,
@@ -14,7 +13,7 @@ export function SummaryView({
   allConfigs,
   studyId,
   showStoredCountMismatch,
-  comparisonParticipantCounts,
+  includedParticipants,
   currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
@@ -22,12 +21,12 @@ export function SummaryView({
   allConfigs: Record<string, StudyConfig>;
   studyId?: string;
   showStoredCountMismatch: boolean;
-  comparisonParticipantCounts?: ParticipantCounts;
+  includedParticipants: string[];
   currentConfigLabel?: string;
 }) {
   const overviewData = useMemo(
-    () => getOverviewStats(visibleParticipants, undefined, studyConfig, allConfigs),
-    [visibleParticipants, studyConfig, allConfigs],
+    () => getOverviewStats(visibleParticipants),
+    [visibleParticipants],
   );
 
   const selectedConfigRows = useMemo(() => {
@@ -56,20 +55,18 @@ export function SummaryView({
         overviewData={overviewData}
         studyId={studyId}
         showStoredCountMismatch={showStoredCountMismatch}
-        comparisonParticipantCounts={comparisonParticipantCounts}
+        includedParticipants={includedParticipants}
       />
       <Group align="flex-start" gap="md" grow>
         <ComponentStats
           visibleParticipants={visibleParticipants}
           studyConfig={studyConfig}
-          allConfigs={allConfigs}
           selectedConfigRows={selectedConfigRows}
           currentConfigLabel={currentConfigLabel}
         />
         <ResponseStats
           visibleParticipants={visibleParticipants}
           studyConfig={studyConfig}
-          allConfigs={allConfigs}
           selectedConfigRows={selectedConfigRows}
           currentConfigLabel={currentConfigLabel}
         />

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -25,27 +25,28 @@ export function SummaryView({
   currentConfigLabel?: string;
 }) {
   const overviewData = useMemo(
-    () => getOverviewStats(visibleParticipants),
-    [visibleParticipants],
+    () => getOverviewStats(visibleParticipants, undefined, studyConfig, allConfigs),
+    [visibleParticipants, studyConfig, allConfigs],
   );
 
   const selectedConfigRows = useMemo(() => {
     const visibleConfigHashes = [...new Set(visibleParticipants.map((participant) => participant.participantConfigHash))];
 
-    return visibleConfigHashes.flatMap((configHash) => {
-      const config = allConfigs[configHash];
-      if (!config) {
-        return [];
-      }
+    const resolved = visibleConfigHashes.map((configHash) => ({
+      configHash,
+      config: allConfigs[configHash],
+    }));
+    if (resolved.some(({ config }) => !config)) {
+      return [];
+    }
 
+    return resolved.map(({ configHash, config }) => {
       const version = config.studyMetadata?.version;
-      return [
-        {
-          configHash,
-          configLabel: version ? `${version} - ${configHash.slice(0, 6)}` : configHash.slice(0, 6),
-          studyConfig: config,
-        },
-      ];
+      return {
+        configHash,
+        configLabel: version ? `${version} - ${configHash.slice(0, 6)}` : configHash.slice(0, 6),
+        studyConfig: config,
+      };
     });
   }, [visibleParticipants, allConfigs]);
 
@@ -61,12 +62,14 @@ export function SummaryView({
         <ComponentStats
           visibleParticipants={visibleParticipants}
           studyConfig={studyConfig}
+          allConfigs={allConfigs}
           selectedConfigRows={selectedConfigRows}
           currentConfigLabel={currentConfigLabel}
         />
         <ResponseStats
           visibleParticipants={visibleParticipants}
           studyConfig={studyConfig}
+          allConfigs={allConfigs}
           selectedConfigRows={selectedConfigRows}
           currentConfigLabel={currentConfigLabel}
         />

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -31,17 +31,22 @@ export function SummaryView({
   );
 
   const selectedConfigRows = useMemo(() => {
-    const visibleConfigHashes = [...new Set(visibleParticipants.map((participant) => participant.participantConfigHash))]
-      .filter((hash) => hash in allConfigs);
+    const visibleConfigHashes = [...new Set(visibleParticipants.map((participant) => participant.participantConfigHash))];
 
-    return visibleConfigHashes.map((configHash) => {
+    return visibleConfigHashes.flatMap((configHash) => {
       const config = allConfigs[configHash];
-      const version = config?.studyMetadata?.version;
-      return {
-        configHash,
-        configLabel: version ? `${version} - ${configHash.slice(0, 6)}` : configHash.slice(0, 6),
-        studyConfig: config,
-      };
+      if (!config) {
+        return [];
+      }
+
+      const version = config.studyMetadata?.version;
+      return [
+        {
+          configHash,
+          configLabel: version ? `${version} - ${configHash.slice(0, 6)}` : configHash.slice(0, 6),
+          studyConfig: config,
+        },
+      ];
     });
   }, [visibleParticipants, allConfigs]);
 

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -6,27 +6,39 @@ import { OverviewStats } from './OverviewStats';
 import { ComponentStats } from './ComponentStats';
 import { ResponseStats } from './ResponseStats';
 import { getOverviewStats } from './utils';
+import { ParticipantCounts } from '../../types';
 
 export function SummaryView({
   visibleParticipants,
   studyConfig,
+  allConfigs,
   studyId,
+  showStoredCountMismatch,
+  comparisonParticipantCounts,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
+  allConfigs: Record<string, StudyConfig>;
   studyId?: string;
+  showStoredCountMismatch: boolean;
+  comparisonParticipantCounts?: ParticipantCounts;
 }) {
   const overviewData = useMemo(
-    () => getOverviewStats(visibleParticipants, undefined, studyConfig),
-    [visibleParticipants, studyConfig],
+    () => getOverviewStats(visibleParticipants, undefined, studyConfig, allConfigs),
+    [visibleParticipants, studyConfig, allConfigs],
   );
 
   return (
     <Stack gap="md">
-      <OverviewStats overviewData={overviewData} studyId={studyId} />
+      <OverviewStats
+        overviewData={overviewData}
+        studyId={studyId}
+        showStoredCountMismatch={showStoredCountMismatch}
+        comparisonParticipantCounts={comparisonParticipantCounts}
+      />
       <Group align="flex-start" gap="md" grow>
-        <ComponentStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} />
-        <ResponseStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} />
+        <ComponentStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} />
+        <ResponseStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} />
       </Group>
     </Stack>
   );

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -15,6 +15,7 @@ export function SummaryView({
   studyId,
   showStoredCountMismatch,
   comparisonParticipantCounts,
+  currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
@@ -22,11 +23,27 @@ export function SummaryView({
   studyId?: string;
   showStoredCountMismatch: boolean;
   comparisonParticipantCounts?: ParticipantCounts;
+  currentConfigLabel?: string;
 }) {
   const overviewData = useMemo(
     () => getOverviewStats(visibleParticipants, undefined, studyConfig, allConfigs),
     [visibleParticipants, studyConfig, allConfigs],
   );
+
+  const selectedConfigRows = useMemo(() => {
+    const visibleConfigHashes = [...new Set(visibleParticipants.map((participant) => participant.participantConfigHash))]
+      .filter((hash) => hash in allConfigs);
+
+    return visibleConfigHashes.map((configHash) => {
+      const config = allConfigs[configHash];
+      const version = config?.studyMetadata?.version;
+      return {
+        configHash,
+        configLabel: version ? `${version} - ${configHash.slice(0, 6)}` : configHash.slice(0, 6),
+        studyConfig: config,
+      };
+    });
+  }, [visibleParticipants, allConfigs]);
 
   return (
     <Stack gap="md">
@@ -37,8 +54,20 @@ export function SummaryView({
         comparisonParticipantCounts={comparisonParticipantCounts}
       />
       <Group align="flex-start" gap="md" grow>
-        <ComponentStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} />
-        <ResponseStats visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} />
+        <ComponentStats
+          visibleParticipants={visibleParticipants}
+          studyConfig={studyConfig}
+          allConfigs={allConfigs}
+          selectedConfigRows={selectedConfigRows}
+          currentConfigLabel={currentConfigLabel}
+        />
+        <ResponseStats
+          visibleParticipants={visibleParticipants}
+          studyConfig={studyConfig}
+          allConfigs={allConfigs}
+          selectedConfigRows={selectedConfigRows}
+          currentConfigLabel={currentConfigLabel}
+        />
       </Group>
     </Stack>
   );

--- a/src/analysis/individualStudy/summary/utils.test.ts
+++ b/src/analysis/individualStudy/summary/utils.test.ts
@@ -570,6 +570,38 @@ describe('utils.tsx', () => {
         expect(result.avgTime).toBe(10);
       });
 
+      it('should include finished answers from in-progress participants in overview time calculations', () => {
+        const participants = [
+          createMockParticipant({
+            participantId: '1',
+            completed: true,
+            answers: {
+              comp1_1: createMockAnswer({
+                componentName: 'comp1',
+                startTime: 0,
+                endTime: 10000,
+              }),
+            },
+          }),
+          createMockParticipant({
+            participantId: '2',
+            completed: false,
+            answers: {
+              comp1_1: createMockAnswer({
+                componentName: 'comp1',
+                startTime: 0,
+                endTime: 40000,
+              }),
+            },
+          }),
+        ];
+
+        const result = getOverviewStats(participants);
+
+        expect(result.participantCounts.inProgress).toBe(1);
+        expect(result.avgTime).toBe(25);
+      });
+
       it('should count participants with invalid clean time', () => {
         const participants = [
           createMockParticipant({
@@ -600,6 +632,39 @@ describe('utils.tsx', () => {
         const result = getOverviewStats(participants);
 
         expect(result.participantsWithInvalidCleanTimeCount).toBe(1);
+      });
+
+      it('should exclude participants with invalid clean time from avgCleanTime', () => {
+        const participants = [
+          createMockParticipant({
+            participantId: '1',
+            completed: true,
+            answers: {
+              comp1_1: createMockAnswer({
+                componentName: 'comp1',
+                startTime: 0,
+                endTime: 10000,
+                invalidCleanTime: true,
+              }),
+            },
+          }),
+          createMockParticipant({
+            participantId: '2',
+            completed: true,
+            answers: {
+              comp1_1: createMockAnswer({
+                componentName: 'comp1',
+                startTime: 0,
+                endTime: 10000,
+              }),
+            },
+          }),
+        ];
+
+        const result = getOverviewStats(participants);
+
+        expect(result.participantsWithInvalidCleanTimeCount).toBe(1);
+        expect(result.avgCleanTime).toBe(9);
       });
 
       it('should return NaN for avgTime when no valid answers exist', () => {
@@ -1451,6 +1516,44 @@ describe('utils.tsx', () => {
       expect(comp2Stats?.avgTime).toBe(5);
     });
 
+    it('should include finished component answers from in-progress participants in component time calculations', () => {
+      const participants = [
+        createMockParticipant({
+          participantId: '1',
+          completed: true,
+          answers: {
+            comp1_1: createMockAnswer({
+              componentName: 'comp1',
+              startTime: 1,
+              endTime: 10001,
+            }),
+          },
+        }),
+        createMockParticipant({
+          participantId: '2',
+          completed: false,
+          answers: {
+            comp1_1: createMockAnswer({
+              componentName: 'comp1',
+              startTime: 1,
+              endTime: 30001,
+            }),
+          },
+        }),
+      ];
+
+      const studyConfig = {
+        components: {
+          comp1: { response: [] },
+        },
+      } as unknown as StudyConfig;
+
+      const result = getComponentStats(participants, studyConfig);
+
+      expect(result[0].participants).toBe(2);
+      expect(result[0].avgTime).toBe(20);
+    });
+
     it('should return participant count for each component', () => {
       const participants = [
         createMockParticipant({
@@ -1540,7 +1643,7 @@ describe('utils.tsx', () => {
       expect(result[0].correctness).toBe(100);
     });
 
-    it('should resolve component correctness with each participant config hash', () => {
+    it('should use each participant config hash when calculating correctness', () => {
       const participants = [
         createMockParticipant({
           participantId: '1',
@@ -1551,8 +1654,8 @@ describe('utils.tsx', () => {
               componentName: 'comp1',
               startTime: 1,
               endTime: 10000,
-              answer: { q1: ['B', 'A'] },
-              correctAnswer: [{ id: 'q1', answer: ['A', 'B'] }],
+              answer: { q1: ['b', 'a'] },
+              correctAnswer: [{ id: 'q1', answer: ['a', 'b'] }],
             }),
           },
         }),
@@ -1565,39 +1668,33 @@ describe('utils.tsx', () => {
               componentName: 'comp1',
               startTime: 1,
               endTime: 10000,
-              answer: { q1: ['B', 'A'] },
-              correctAnswer: [{ id: 'q1', answer: ['A', 'B'] }],
+              answer: { q1: ['b', 'a'] },
+              correctAnswer: [{ id: 'q1', answer: ['a', 'b'] }],
             }),
           },
         }),
       ];
 
-      const currentStudyConfig = {
+      const studyConfig = {
         components: {
-          comp1: {
-            response: [{ id: 'q1', type: 'radio' }],
-          },
+          comp1: { response: [{ id: 'q1', type: 'radio' }] },
         },
       } as unknown as StudyConfig;
 
       const allConfigs = {
         'config-a': {
           components: {
-            comp1: {
-              response: [{ id: 'q1', type: 'checkbox' }],
-            },
+            comp1: { response: [{ id: 'q1', type: 'checkbox' }] },
           },
         },
         'config-b': {
           components: {
-            comp1: {
-              response: [{ id: 'q1', type: 'radio' }],
-            },
+            comp1: { response: [{ id: 'q1', type: 'radio' }] },
           },
         },
       } as unknown as Record<string, StudyConfig>;
 
-      const result = getComponentStats(participants, currentStudyConfig, allConfigs);
+      const result = getComponentStats(participants, studyConfig, allConfigs);
 
       expect(result[0].correctness).toBe(50);
     });

--- a/src/analysis/individualStudy/summary/utils.test.ts
+++ b/src/analysis/individualStudy/summary/utils.test.ts
@@ -5,7 +5,9 @@ import {
   convertNumberToString,
   getOverviewStats,
   getComponentStats,
+  getComponentStatsForConfigs,
   getResponseStats,
+  getResponseStatsForConfigs,
 } from './utils';
 import { ParticipantDataWithStatus } from '../../../storage/types';
 import { StudyConfig } from '../../../parser/types';
@@ -1889,6 +1891,59 @@ describe('utils.tsx', () => {
       expect(comp1Stats.avgTime).toBe(10);
       expect(comp1Stats.correctness).toBe(100);
     });
+
+    it('should merge matching component rows across selected configs and collect config labels', () => {
+      const participants = [
+        createMockParticipant({
+          participantId: '1',
+          participantConfigHash: 'config-a',
+          completed: true,
+          answers: {
+            intro_1: createMockAnswer({
+              componentName: 'introduction',
+              startTime: 1,
+              endTime: 1001,
+            }),
+          },
+        }),
+        createMockParticipant({
+          participantId: '2',
+          participantConfigHash: 'config-b',
+          completed: true,
+          answers: {
+            intro_1: createMockAnswer({
+              componentName: 'introduction',
+              startTime: 1,
+              endTime: 2001,
+            }),
+          },
+        }),
+      ];
+
+      const configA = {
+        components: {
+          introduction: { response: [] },
+        },
+      } as unknown as StudyConfig;
+
+      const configB = {
+        components: {
+          introduction: { response: [] },
+        },
+      } as unknown as StudyConfig;
+
+      const result = getComponentStatsForConfigs(participants, [
+        { configHash: 'config-a', configLabel: 'pilot - aaaaaa', studyConfig: configA },
+        { configHash: 'config-b', configLabel: 'pilot - bbbbbb', studyConfig: configB },
+      ], {
+        'config-a': configA,
+        'config-b': configB,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].component).toBe('introduction');
+      expect(result[0].configs).toEqual(['pilot - aaaaaa', 'pilot - bbbbbb']);
+    });
   });
 
   // ============================================
@@ -2003,6 +2058,40 @@ describe('utils.tsx', () => {
         const result = getResponseStats(participants, studyConfig);
 
         expect(result[0].correctness).toBe(100);
+      });
+
+      it('should merge matching response rows across selected configs and collect config labels', () => {
+        const configA = {
+          components: {
+            survey: {
+              response: [
+                { type: 'radio', prompt: 'Q1', options: ['A', 'B'] },
+              ],
+            },
+          },
+        } as unknown as StudyConfig;
+
+        const configB = {
+          components: {
+            survey: {
+              response: [
+                { type: 'radio', prompt: 'Q1', options: ['A', 'B'] },
+              ],
+            },
+          },
+        } as unknown as StudyConfig;
+
+        const result = getResponseStatsForConfigs([], [
+          { configHash: 'config-a', configLabel: 'pilot - aaaaaa', studyConfig: configA },
+          { configHash: 'config-b', configLabel: 'pilot - bbbbbb', studyConfig: configB },
+        ], {
+          'config-a': configA,
+          'config-b': configB,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].component).toBe('survey');
+        expect(result[0].configs).toEqual(['pilot - aaaaaa', 'pilot - bbbbbb']);
       });
     });
 

--- a/src/analysis/individualStudy/summary/utils.test.ts
+++ b/src/analysis/individualStudy/summary/utils.test.ts
@@ -26,26 +26,30 @@ vi.mock('../../../utils/getCleanedDuration', () => ({
 }));
 
 vi.mock('../../../utils/correctAnswer', () => ({
-  componentAnswersAreCorrect: vi.fn((
-    userAnswers: Record<string, unknown>,
-    correctAnswers: Array<{ id: string; answer: unknown }>,
-    responses?: Array<{ id: string; type?: string }>,
+  responseAnswerIsCorrect: vi.fn((
+    userAnswer: unknown,
+    correctAnswer: unknown,
+    acceptableLow?: number,
+    acceptableHigh?: number,
+    options?: { ignoreArrayOrder?: boolean },
   ) => {
-    if (!correctAnswers || correctAnswers.length === 0) return true;
-    return correctAnswers.every((ca) => {
-      const userAnswer = userAnswers[ca.id];
-      const response = responses?.find((entry) => entry.id === ca.id);
-
-      if (Array.isArray(userAnswer) && Array.isArray(ca.answer)) {
-        if (response?.type === 'checkbox' || response?.type === 'dropdown') {
-          return [...userAnswer].sort().join('|') === [...ca.answer].sort().join('|');
-        }
-
-        return userAnswer.join('|') === ca.answer.join('|');
+    if (Array.isArray(userAnswer) && Array.isArray(correctAnswer)) {
+      // Match real responseAnswerIsCorrect: default is sort-and-compare unless caller opts out.
+      if ((options?.ignoreArrayOrder ?? true) === false) {
+        return userAnswer.join('|') === correctAnswer.join('|');
       }
+      return [...userAnswer].sort().join('|') === [...correctAnswer].sort().join('|');
+    }
 
-      return userAnswer === ca.answer;
-    });
+    if (acceptableLow !== undefined || acceptableHigh !== undefined) {
+      const num = Number(userAnswer);
+      if (Number.isNaN(num)) return userAnswer === correctAnswer;
+      if (acceptableLow !== undefined && num < acceptableLow) return false;
+      if (acceptableHigh !== undefined && num > acceptableHigh) return false;
+      return true;
+    }
+
+    return userAnswer === correctAnswer;
   }),
 }));
 
@@ -910,8 +914,8 @@ describe('utils.tsx', () => {
 
         const result = getOverviewStats(participants);
 
-        // Mock returns false for component (all-or-nothing), so 0%
-        expect(result.correctness).toBe(0);
+        // Per-response evaluation: q1 and q3 correct, q2 wrong → 2 correct out of 3
+        expect(result.correctness).toBeCloseTo((2 / 3) * 100, 5);
       });
 
       it('should aggregate correctness across multiple participants with multiple questions', () => {
@@ -1683,22 +1687,11 @@ describe('utils.tsx', () => {
         },
       } as unknown as StudyConfig;
 
-      const allConfigs = {
-        'config-a': {
-          components: {
-            comp1: { response: [{ id: 'q1', type: 'checkbox' }] },
-          },
-        },
-        'config-b': {
-          components: {
-            comp1: { response: [{ id: 'q1', type: 'radio' }] },
-          },
-        },
-      } as unknown as Record<string, StudyConfig>;
+      const result = getComponentStats(participants, studyConfig);
 
-      const result = getComponentStats(participants, studyConfig, allConfigs);
-
-      expect(result[0].correctness).toBe(50);
+      // Both participants submit ['b', 'a'] vs correct ['a', 'b']. Array comparison
+      // defaults to sort-and-compare → both count as correct → 100%.
+      expect(result[0].correctness).toBe(100);
     });
 
     it('should return NaN stats for components with no participant data', () => {
@@ -1935,10 +1928,7 @@ describe('utils.tsx', () => {
       const result = getComponentStatsForConfigs(participants, [
         { configHash: 'config-a', configLabel: 'pilot - aaaaaa', studyConfig: configA },
         { configHash: 'config-b', configLabel: 'pilot - bbbbbb', studyConfig: configB },
-      ], {
-        'config-a': configA,
-        'config-b': configB,
-      });
+      ]);
 
       expect(result).toHaveLength(1);
       expect(result[0].component).toBe('introduction');
@@ -2084,10 +2074,7 @@ describe('utils.tsx', () => {
         const result = getResponseStatsForConfigs([], [
           { configHash: 'config-a', configLabel: 'pilot - aaaaaa', studyConfig: configA },
           { configHash: 'config-b', configLabel: 'pilot - bbbbbb', studyConfig: configB },
-        ], {
-          'config-a': configA,
-          'config-b': configB,
-        });
+        ]);
 
         expect(result).toHaveLength(1);
         expect(result[0].component).toBe('survey');

--- a/src/analysis/individualStudy/summary/utils.test.ts
+++ b/src/analysis/individualStudy/summary/utils.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../../utils/getCleanedDuration', () => ({
 }));
 
 vi.mock('../../../utils/correctAnswer', () => ({
+  shouldIgnoreArrayOrder: vi.fn((response?: { type?: string }) => response?.type === 'checkbox' || response?.type === 'dropdown'),
   responseAnswerIsCorrect: vi.fn((
     userAnswer: unknown,
     correctAnswer: unknown,
@@ -1687,11 +1688,25 @@ describe('utils.tsx', () => {
         },
       } as unknown as StudyConfig;
 
-      const result = getComponentStats(participants, studyConfig);
+      const allConfigs = {
+        'config-a': {
+          components: {
+            comp1: { response: [{ id: 'q1', type: 'checkbox' }] },
+          },
+        },
+        'config-b': {
+          components: {
+            comp1: { response: [{ id: 'q1', type: 'radio' }] },
+          },
+        },
+      } as unknown as Record<string, StudyConfig>;
 
-      // Both participants submit ['b', 'a'] vs correct ['a', 'b']. Array comparison
-      // defaults to sort-and-compare → both count as correct → 100%.
-      expect(result[0].correctness).toBe(100);
+      const result = getComponentStats(participants, studyConfig, allConfigs);
+
+      // P1 (config-a, checkbox): array order ignored → ['b','a'] sorted == ['a','b'] sorted → correct
+      // P2 (config-b, radio): array order strict → ['b','a'] !== ['a','b'] → wrong
+      // → 1/2 = 50%
+      expect(result[0].correctness).toBe(50);
     });
 
     it('should return NaN stats for components with no participant data', () => {
@@ -1928,7 +1943,10 @@ describe('utils.tsx', () => {
       const result = getComponentStatsForConfigs(participants, [
         { configHash: 'config-a', configLabel: 'pilot - aaaaaa', studyConfig: configA },
         { configHash: 'config-b', configLabel: 'pilot - bbbbbb', studyConfig: configB },
-      ]);
+      ], {
+        'config-a': configA,
+        'config-b': configB,
+      });
 
       expect(result).toHaveLength(1);
       expect(result[0].component).toBe('introduction');
@@ -2074,7 +2092,10 @@ describe('utils.tsx', () => {
         const result = getResponseStatsForConfigs([], [
           { configHash: 'config-a', configLabel: 'pilot - aaaaaa', studyConfig: configA },
           { configHash: 'config-b', configLabel: 'pilot - bbbbbb', studyConfig: configB },
-        ]);
+        ], {
+          'config-a': configA,
+          'config-b': configB,
+        });
 
         expect(result).toHaveLength(1);
         expect(result[0].component).toBe('survey');

--- a/src/analysis/individualStudy/summary/utils.test.ts
+++ b/src/analysis/individualStudy/summary/utils.test.ts
@@ -24,9 +24,26 @@ vi.mock('../../../utils/getCleanedDuration', () => ({
 }));
 
 vi.mock('../../../utils/correctAnswer', () => ({
-  componentAnswersAreCorrect: vi.fn((userAnswers: Record<string, unknown>, correctAnswers: Array<{ id: string; answer: unknown }>) => {
+  componentAnswersAreCorrect: vi.fn((
+    userAnswers: Record<string, unknown>,
+    correctAnswers: Array<{ id: string; answer: unknown }>,
+    responses?: Array<{ id: string; type?: string }>,
+  ) => {
     if (!correctAnswers || correctAnswers.length === 0) return true;
-    return correctAnswers.every((ca) => userAnswers[ca.id] === ca.answer);
+    return correctAnswers.every((ca) => {
+      const userAnswer = userAnswers[ca.id];
+      const response = responses?.find((entry) => entry.id === ca.id);
+
+      if (Array.isArray(userAnswer) && Array.isArray(ca.answer)) {
+        if (response?.type === 'checkbox' || response?.type === 'dropdown') {
+          return [...userAnswer].sort().join('|') === [...ca.answer].sort().join('|');
+        }
+
+        return userAnswer.join('|') === ca.answer.join('|');
+      }
+
+      return userAnswer === ca.answer;
+    });
   }),
 }));
 
@@ -1135,6 +1152,47 @@ describe('utils.tsx', () => {
         expect(result.avgTime).toBe(15);
       });
 
+      it('should use total study duration per participant in study overview stats', () => {
+        const participants = [
+          createMockParticipant({
+            participantId: '1',
+            completed: true,
+            answers: {
+              comp1_1: createMockAnswer({
+                componentName: 'comp1',
+                startTime: 1,
+                endTime: 10001,
+              }),
+              comp2_1: createMockAnswer({
+                componentName: 'comp2',
+                startTime: 10001,
+                endTime: 30001,
+              }),
+            },
+          }),
+          createMockParticipant({
+            participantId: '2',
+            completed: true,
+            answers: {
+              comp1_1: createMockAnswer({
+                componentName: 'comp1',
+                startTime: 1,
+                endTime: 5001,
+              }),
+              comp2_1: createMockAnswer({
+                componentName: 'comp2',
+                startTime: 5001,
+                endTime: 15001,
+              }),
+            },
+          }),
+        ];
+
+        const result = getOverviewStats(participants);
+
+        expect(result.avgTime).toBe(22.5);
+      });
+
       it('should handle all participants being rejected', () => {
         const participants = [
           createMockParticipant({
@@ -1480,6 +1538,68 @@ describe('utils.tsx', () => {
       const result = getComponentStats(participants, studyConfig);
 
       expect(result[0].correctness).toBe(100);
+    });
+
+    it('should resolve component correctness with each participant config hash', () => {
+      const participants = [
+        createMockParticipant({
+          participantId: '1',
+          participantConfigHash: 'config-a',
+          completed: true,
+          answers: {
+            comp1_1: createMockAnswer({
+              componentName: 'comp1',
+              startTime: 1,
+              endTime: 10000,
+              answer: { q1: ['B', 'A'] },
+              correctAnswer: [{ id: 'q1', answer: ['A', 'B'] }],
+            }),
+          },
+        }),
+        createMockParticipant({
+          participantId: '2',
+          participantConfigHash: 'config-b',
+          completed: true,
+          answers: {
+            comp1_1: createMockAnswer({
+              componentName: 'comp1',
+              startTime: 1,
+              endTime: 10000,
+              answer: { q1: ['B', 'A'] },
+              correctAnswer: [{ id: 'q1', answer: ['A', 'B'] }],
+            }),
+          },
+        }),
+      ];
+
+      const currentStudyConfig = {
+        components: {
+          comp1: {
+            response: [{ id: 'q1', type: 'radio' }],
+          },
+        },
+      } as unknown as StudyConfig;
+
+      const allConfigs = {
+        'config-a': {
+          components: {
+            comp1: {
+              response: [{ id: 'q1', type: 'checkbox' }],
+            },
+          },
+        },
+        'config-b': {
+          components: {
+            comp1: {
+              response: [{ id: 'q1', type: 'radio' }],
+            },
+          },
+        },
+      } as unknown as Record<string, StudyConfig>;
+
+      const result = getComponentStats(participants, currentStudyConfig, allConfigs);
+
+      expect(result[0].correctness).toBe(50);
     });
 
     it('should return NaN stats for components with no participant data', () => {

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -84,7 +84,18 @@ function calculateDateStats(visibleParticipants: ParticipantDataWithStatus[], co
   };
 }
 
-function calculateTimeStats(visibleParticipants: ParticipantDataWithStatus[], componentName?: string): { avgTime: number; avgCleanTime: number; participantsWithInvalidCleanTimeCount: number } {
+function calculateTimeStats(
+  visibleParticipants: ParticipantDataWithStatus[],
+  componentName?: string,
+): {
+  avgTime: number;
+  avgCleanTime: number;
+  participantsWithInvalidCleanTimeCount: number;
+  totalTimeSum: number;
+  totalTimeCount: number;
+  totalCleanTimeSum: number;
+  totalCleanTimeCount: number;
+} {
   // Time stats use any non-rejected participant who has finished the relevant answer(s).
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
 
@@ -131,6 +142,10 @@ function calculateTimeStats(visibleParticipants: ParticipantDataWithStatus[], co
     avgTime: time.count > 0 ? time.totalTimeSum / time.count : NaN,
     avgCleanTime: time.cleanCount > 0 ? time.cleanTimeSum / time.cleanCount : NaN,
     participantsWithInvalidCleanTimeCount,
+    totalTimeSum: time.totalTimeSum,
+    totalTimeCount: time.count,
+    totalCleanTimeSum: time.cleanTimeSum,
+    totalCleanTimeCount: time.cleanCount,
   };
 }
 
@@ -139,7 +154,7 @@ function calculateCorrectnessStats(
   componentName?: string,
   studyConfig?: StudyConfig,
   allConfigs: Record<string, StudyConfig> = {},
-): number {
+): { correctness: number; correctCount: number; totalQuestionCount: number } {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
   const participantAnswers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
@@ -148,7 +163,11 @@ function calculateCorrectnessStats(
 
   const hasCorrectAnswer = participantAnswers.some(({ answer }) => answer.correctAnswer && answer.correctAnswer.length > 0);
   if (!hasCorrectAnswer) {
-    return NaN;
+    return {
+      correctness: NaN,
+      correctCount: 0,
+      totalQuestionCount: 0,
+    };
   }
 
   let totalQuestions = 0;
@@ -172,7 +191,11 @@ function calculateCorrectnessStats(
     }
   });
 
-  return totalQuestions > 0 ? (correctSum / totalQuestions) * 100 : NaN;
+  return {
+    correctness: totalQuestions > 0 ? (correctSum / totalQuestions) * 100 : NaN,
+    correctCount: correctSum,
+    totalQuestionCount: totalQuestions,
+  };
 }
 
 function getResponseOptions(response: Response): string {
@@ -238,7 +261,7 @@ export function getOverviewStats(
     avgTime: timeStats.avgTime,
     avgCleanTime: timeStats.avgCleanTime,
     participantsWithInvalidCleanTimeCount: timeStats.participantsWithInvalidCleanTimeCount,
-    correctness: calculateCorrectnessStats(visibleParticipants, componentName, studyConfig, allConfigs),
+    correctness: calculateCorrectnessStats(visibleParticipants, componentName, studyConfig, allConfigs).correctness,
   };
 
   return overviewData;
@@ -248,18 +271,39 @@ export function getComponentStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
   allConfigs: Record<string, StudyConfig> = {},
-): ComponentData[] {
+): Array<ComponentData & {
+  timeSum: number;
+  timeCount: number;
+  cleanTimeSum: number;
+  cleanTimeCount: number;
+  correctCount: number;
+  totalQuestionCount: number;
+}> {
   // Get all component names from the current study
   const componentNames = Object.keys(studyConfig.components);
-  const componentData: ComponentData[] = componentNames.map((name) => {
+  const componentData: Array<ComponentData & {
+    timeSum: number;
+    timeCount: number;
+    cleanTimeSum: number;
+    cleanTimeCount: number;
+    correctCount: number;
+    totalQuestionCount: number;
+  }> = componentNames.map((name) => {
     const timeStats = calculateTimeStats(visibleParticipants, name);
+    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
 
     return {
       component: name,
       participants: calculateParticipantCounts(visibleParticipants, name).total,
       avgTime: timeStats.avgTime,
       avgCleanTime: timeStats.avgCleanTime,
-      correctness: calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs),
+      correctness: correctnessStats.correctness,
+      timeSum: timeStats.totalTimeSum,
+      timeCount: timeStats.totalTimeCount,
+      cleanTimeSum: timeStats.totalCleanTimeSum,
+      cleanTimeCount: timeStats.totalCleanTimeCount,
+      correctCount: correctnessStats.correctCount,
+      totalQuestionCount: correctnessStats.totalQuestionCount,
     };
   });
 
@@ -280,7 +324,15 @@ export function getComponentStatsForConfigs(
     }));
   });
 
-  const mergedRows: Array<ComponentData & { studyConfig: StudyConfig }> = [];
+  const mergedRows: Array<ComponentData & {
+    timeSum: number;
+    timeCount: number;
+    cleanTimeSum: number;
+    cleanTimeCount: number;
+    correctCount: number;
+    totalQuestionCount: number;
+    studyConfig: StudyConfig;
+  }> = [];
 
   rows.forEach((row) => {
     const existingRow = mergedRows.find((candidate) => candidate.component === row.component);
@@ -290,23 +342,31 @@ export function getComponentStatsForConfigs(
     }
 
     const totalParticipants = existingRow.participants + row.participants;
-    const correctness = totalParticipants > 0
-      ? (((Number.isNaN(existingRow.correctness) ? 0 : existingRow.correctness) * existingRow.participants)
-        + ((Number.isNaN(row.correctness) ? 0 : row.correctness) * row.participants)) / totalParticipants
-      : NaN;
+    const totalTimeSum = (existingRow.timeSum ?? 0) + (row.timeSum ?? 0);
+    const totalTimeCount = (existingRow.timeCount ?? 0) + (row.timeCount ?? 0);
+    const totalCleanTimeSum = (existingRow.cleanTimeSum ?? 0) + (row.cleanTimeSum ?? 0);
+    const totalCleanTimeCount = (existingRow.cleanTimeCount ?? 0) + (row.cleanTimeCount ?? 0);
+    const totalCorrectCount = (existingRow.correctCount ?? 0) + (row.correctCount ?? 0);
+    const totalQuestionCount = (existingRow.totalQuestionCount ?? 0) + (row.totalQuestionCount ?? 0);
 
     Object.assign(existingRow, {
       ...existingRow,
       participants: totalParticipants,
-      avgTime: totalParticipants > 0
-        ? ((Number.isNaN(existingRow.avgTime) ? 0 : existingRow.avgTime) * existingRow.participants
-          + (Number.isNaN(row.avgTime) ? 0 : row.avgTime) * row.participants) / totalParticipants
+      avgTime: totalTimeCount > 0
+        ? totalTimeSum / totalTimeCount
         : NaN,
-      avgCleanTime: totalParticipants > 0
-        ? ((Number.isNaN(existingRow.avgCleanTime) ? 0 : existingRow.avgCleanTime) * existingRow.participants
-          + (Number.isNaN(row.avgCleanTime) ? 0 : row.avgCleanTime) * row.participants) / totalParticipants
+      avgCleanTime: totalCleanTimeCount > 0
+        ? totalCleanTimeSum / totalCleanTimeCount
         : NaN,
-      correctness,
+      correctness: totalQuestionCount > 0
+        ? (totalCorrectCount / totalQuestionCount) * 100
+        : NaN,
+      timeSum: totalTimeSum,
+      timeCount: totalTimeCount,
+      cleanTimeSum: totalCleanTimeSum,
+      cleanTimeCount: totalCleanTimeCount,
+      correctCount: totalCorrectCount,
+      totalQuestionCount,
       configs: row.configs?.[0] === undefined
         ? existingRow.configs
         : mergeConfigLabels(existingRow.configs, row.configs[0]),
@@ -320,13 +380,21 @@ export function getResponseStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
   allConfigs: Record<string, StudyConfig> = {},
-): ResponseData[] {
+): Array<ResponseData & {
+  responseId?: string;
+  correctCount: number;
+  totalQuestionCount: number;
+}> {
   // Get all responses for each component
-  const responseData: ResponseData[] = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
+  const responseData: Array<ResponseData & {
+    responseId?: string;
+    correctCount: number;
+    totalQuestionCount: number;
+  }> = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
     const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
     const responses = component.response ?? [];
     if (responses.length === 0) return [];
-    const correctness = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
+    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
 
     return responses.map((response) => ({
       responseId: response.id,
@@ -334,7 +402,9 @@ export function getResponseStats(
       type: response.type,
       question: response.prompt ?? 'N/A',
       options: getResponseOptions(response),
-      correctness,
+      correctness: correctnessStats.correctness,
+      correctCount: correctnessStats.correctCount,
+      totalQuestionCount: correctnessStats.totalQuestionCount,
     }));
   });
 
@@ -352,7 +422,7 @@ export function getResponseStatsForConfigs(
       const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
       const responses = component.response ?? [];
       if (responses.length === 0) return [];
-      const correctness = calculateCorrectnessStats(configParticipants, name, studyConfig, allConfigs);
+      const correctnessStats = calculateCorrectnessStats(configParticipants, name, studyConfig, allConfigs);
 
       return responses.map((response) => ({
         responseId: response.id,
@@ -360,7 +430,9 @@ export function getResponseStatsForConfigs(
         type: response.type,
         question: response.prompt ?? 'N/A',
         options: getResponseOptions(response),
-        correctness,
+        correctness: correctnessStats.correctness,
+        correctCount: correctnessStats.correctCount,
+        totalQuestionCount: correctnessStats.totalQuestionCount,
         configs: [configLabel],
       }));
     });
@@ -368,7 +440,11 @@ export function getResponseStatsForConfigs(
     return responseEntries;
   });
 
-  const mergedRows: ResponseData[] = [];
+  const mergedRows: Array<ResponseData & {
+    responseId?: string;
+    correctCount: number;
+    totalQuestionCount: number;
+  }> = [];
 
   rows.forEach((row) => {
     const existingRow = mergedRows.find((candidate) => (
@@ -385,9 +461,18 @@ export function getResponseStatsForConfigs(
       configs: !row.configs || row.configs.length === 0
         ? existingRow.configs
         : mergeConfigLabels(existingRow.configs, row.configs[0]),
-      correctness: Number.isNaN(existingRow.correctness) ? row.correctness : existingRow.correctness,
+      correctCount: (existingRow.correctCount ?? 0) + (row.correctCount ?? 0),
+      totalQuestionCount: (existingRow.totalQuestionCount ?? 0) + (row.totalQuestionCount ?? 0),
     });
+    existingRow.correctness = (existingRow.totalQuestionCount ?? 0) > 0
+      ? ((existingRow.correctCount ?? 0) / (existingRow.totalQuestionCount ?? 0)) * 100
+      : NaN;
   });
 
-  return mergedRows;
+  return mergedRows.map(({
+    responseId: _responseId,
+    correctCount: _correctCount,
+    totalQuestionCount: _totalQuestionCount,
+    ...row
+  }) => row);
 }

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -8,6 +8,16 @@ import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { getMatrixAnswerOptions } from '../../../utils/responseOptions';
 
+type ConfigScopedStudyConfig = {
+  configHash: string;
+  configLabel: string;
+  studyConfig: StudyConfig;
+};
+
+function mergeConfigLabels(existing: string[] | undefined, next: string) {
+  return [...new Set([...(existing ?? []), next])];
+}
+
 function getParticipantStudyConfig(
   participantConfigHash: string,
   studyConfig?: StudyConfig,
@@ -256,6 +266,56 @@ export function getComponentStats(
   return componentData;
 }
 
+export function getComponentStatsForConfigs(
+  visibleParticipants: ParticipantDataWithStatus[],
+  configs: ConfigScopedStudyConfig[],
+  allConfigs: Record<string, StudyConfig> = {},
+): ComponentData[] {
+  const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
+    const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
+    return getComponentStats(configParticipants, studyConfig, allConfigs).map((row) => ({
+      ...row,
+      configs: [configLabel],
+      studyConfig,
+    }));
+  });
+
+  const mergedRows: Array<ComponentData & { studyConfig: StudyConfig }> = [];
+
+  rows.forEach((row) => {
+    const existingRow = mergedRows.find((candidate) => candidate.component === row.component);
+    if (!existingRow) {
+      mergedRows.push(row);
+      return;
+    }
+
+    const totalParticipants = existingRow.participants + row.participants;
+    const correctness = totalParticipants > 0
+      ? (((Number.isNaN(existingRow.correctness) ? 0 : existingRow.correctness) * existingRow.participants)
+        + ((Number.isNaN(row.correctness) ? 0 : row.correctness) * row.participants)) / totalParticipants
+      : NaN;
+
+    Object.assign(existingRow, {
+      ...existingRow,
+      participants: totalParticipants,
+      avgTime: totalParticipants > 0
+        ? ((Number.isNaN(existingRow.avgTime) ? 0 : existingRow.avgTime) * existingRow.participants
+          + (Number.isNaN(row.avgTime) ? 0 : row.avgTime) * row.participants) / totalParticipants
+        : NaN,
+      avgCleanTime: totalParticipants > 0
+        ? ((Number.isNaN(existingRow.avgCleanTime) ? 0 : existingRow.avgCleanTime) * existingRow.participants
+          + (Number.isNaN(row.avgCleanTime) ? 0 : row.avgCleanTime) * row.participants) / totalParticipants
+        : NaN,
+      correctness,
+      configs: row.configs?.[0] === undefined
+        ? existingRow.configs
+        : mergeConfigLabels(existingRow.configs, row.configs[0]),
+    });
+  });
+
+  return mergedRows.map(({ studyConfig: _studyConfig, ...row }) => row);
+}
+
 export function getResponseStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
@@ -269,6 +329,7 @@ export function getResponseStats(
     const correctness = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
 
     return responses.map((response) => ({
+      responseId: response.id,
       component: name,
       type: response.type,
       question: response.prompt ?? 'N/A',
@@ -278,4 +339,55 @@ export function getResponseStats(
   });
 
   return responseData;
+}
+
+export function getResponseStatsForConfigs(
+  visibleParticipants: ParticipantDataWithStatus[],
+  configs: ConfigScopedStudyConfig[],
+  allConfigs: Record<string, StudyConfig> = {},
+): ResponseData[] {
+  const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
+    const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
+    const responseEntries = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
+      const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
+      const responses = component.response ?? [];
+      if (responses.length === 0) return [];
+      const correctness = calculateCorrectnessStats(configParticipants, name, studyConfig, allConfigs);
+
+      return responses.map((response) => ({
+        responseId: response.id,
+        component: name,
+        type: response.type,
+        question: response.prompt ?? 'N/A',
+        options: getResponseOptions(response),
+        correctness,
+        configs: [configLabel],
+      }));
+    });
+
+    return responseEntries;
+  });
+
+  const mergedRows: ResponseData[] = [];
+
+  rows.forEach((row) => {
+    const existingRow = mergedRows.find((candidate) => (
+      candidate.component === row.component
+      && candidate.responseId === row.responseId
+    ));
+    if (!existingRow) {
+      mergedRows.push(row);
+      return;
+    }
+
+    Object.assign(existingRow, {
+      ...existingRow,
+      configs: !row.configs || row.configs.length === 0
+        ? existingRow.configs
+        : mergeConfigLabels(existingRow.configs, row.configs[0]),
+      correctness: Number.isNaN(existingRow.correctness) ? row.correctness : existingRow.correctness,
+    });
+  });
+
+  return mergedRows;
 }

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -16,14 +16,11 @@ function getParticipantStudyConfig(
   if (!participantConfigHash) {
     return studyConfig;
   }
-
   const participantStudyConfig = allConfigs[participantConfigHash];
-
   if (!participantStudyConfig) {
     console.warn(`Missing study config for participant config hash "${participantConfigHash}". Correctness stats should not be computed against the current study config.`);
     return undefined;
   }
-
   return participantStudyConfig;
 }
 
@@ -78,7 +75,7 @@ function calculateDateStats(visibleParticipants: ParticipantDataWithStatus[], co
 }
 
 function calculateTimeStats(visibleParticipants: ParticipantDataWithStatus[], componentName?: string): { avgTime: number; avgCleanTime: number; participantsWithInvalidCleanTimeCount: number } {
-  // Filter out rejected participants and filter by component if provided
+  // Time stats use any non-rejected participant who has finished the relevant answer(s).
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
 
   let participantsWithInvalidCleanTimeCount = 0;
@@ -99,20 +96,30 @@ function calculateTimeStats(visibleParticipants: ParticipantDataWithStatus[], co
     if (timeStats.length > 0) {
       const totalTime = timeStats.reduce((sum, t) => sum + t.totalTime, 0);
       const cleanTime = timeStats.reduce((sum, t) => sum + t.cleanTime, 0);
+      const countIncrement = componentName ? timeStats.length : 1;
 
-      acc.count += componentName ? timeStats.length : 1;
+      // Overview (no componentName) averages total study duration per participant; component view averages per answer.
+      acc.count += countIncrement;
       acc.totalTimeSum += totalTime;
-      acc.cleanTimeSum += cleanTime;
+      if (!hasInvalidCleanTime) {
+        acc.cleanCount += countIncrement;
+        acc.cleanTimeSum += cleanTime;
+      }
       if (hasInvalidCleanTime) {
         participantsWithInvalidCleanTimeCount += 1;
       }
     }
     return acc;
-  }, { count: 0, totalTimeSum: 0, cleanTimeSum: 0 });
+  }, {
+    count: 0,
+    cleanCount: 0,
+    totalTimeSum: 0,
+    cleanTimeSum: 0,
+  });
 
   return {
     avgTime: time.count > 0 ? time.totalTimeSum / time.count : NaN,
-    avgCleanTime: time.count > 0 ? time.cleanTimeSum / time.count : NaN,
+    avgCleanTime: time.cleanCount > 0 ? time.cleanTimeSum / time.cleanCount : NaN,
     participantsWithInvalidCleanTimeCount,
   };
 }
@@ -259,13 +266,14 @@ export function getResponseStats(
     const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
     const responses = component.response ?? [];
     if (responses.length === 0) return [];
+    const correctness = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
 
     return responses.map((response) => ({
       component: name,
       type: response.type,
       question: response.prompt ?? 'N/A',
       options: getResponseOptions(response),
-      correctness: calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs),
+      correctness,
     }));
   });
 

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -158,7 +158,7 @@ function calculateCorrectnessStats(
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
   const participantAnswers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
-    .filter((answer) => (!componentName || answer.componentName === componentName))
+    .filter((answer) => (!componentName || answer.componentName === componentName) && answer.endTime !== -1)
     .map((answer) => ({ answer, participant })));
 
   const hasCorrectAnswer = participantAnswers.some(({ answer }) => answer.correctAnswer && answer.correctAnswer.length > 0);

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -4,7 +4,7 @@ import {
   ComponentData, OverviewData, ParticipantCounts, ResponseData,
 } from '../../types';
 import { MatrixResponse, Response, StudyConfig } from '../../../parser/types';
-import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
+import { responseAnswerIsCorrect, shouldIgnoreArrayOrder } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { getMatrixAnswerOptions } from '../../../utils/responseOptions';
 
@@ -16,6 +16,22 @@ type ConfigScopedStudyConfig = {
 
 function mergeConfigLabels(existing: string[] | undefined, next: string) {
   return [...new Set([...(existing ?? []), next])];
+}
+
+function getParticipantStudyConfig(
+  participantConfigHash: string,
+  studyConfig?: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
+) {
+  if (!participantConfigHash) {
+    return studyConfig;
+  }
+  const participantStudyConfig = allConfigs[participantConfigHash];
+  if (!participantStudyConfig) {
+    console.warn(`Missing study config for participant config hash "${participantConfigHash}". Correctness stats should not be computed against the current study config.`);
+    return undefined;
+  }
+  return participantStudyConfig;
 }
 
 function filterParticipants(
@@ -136,18 +152,30 @@ function calculateTimeStats(
 function calculateCorrectnessStats(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
+  studyConfig?: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
   responseId?: string,
 ): { correctness: number; correctCount: number; totalQuestionCount: number } {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
-  const answers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
-    .filter((answer) => (!componentName || answer.componentName === componentName) && answer.endTime !== -1));
+  const participantAnswers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
+    .filter((answer) => (!componentName || answer.componentName === componentName) && answer.endTime !== -1)
+    .map((answer) => ({ answer, participant })));
 
   let totalQuestions = 0;
   let correctSum = 0;
 
-  answers.forEach((answer) => {
+  participantAnswers.forEach(({ answer, participant }) => {
     if (!answer.correctAnswer || answer.correctAnswer.length === 0) return;
+
+    const participantStudyConfig = getParticipantStudyConfig(participant.participantConfigHash, studyConfig, allConfigs);
+    const component = participantStudyConfig?.components[answer.componentName]
+      ? studyComponentToIndividualComponent(
+        participantStudyConfig.components[answer.componentName],
+        participantStudyConfig,
+      )
+      : undefined;
+    const responsesById = new Map((component?.response ?? []).map((r) => [r.id, r]));
 
     answer.correctAnswer.forEach((correctEntry) => {
       if (responseId !== undefined && correctEntry.id !== responseId) return;
@@ -157,11 +185,13 @@ function calculateCorrectnessStats(
       const userAnswer = answer.answer[correctEntry.id];
       if (userAnswer === undefined) return;
 
+      const response = responsesById.get(correctEntry.id);
       const isCorrect = responseAnswerIsCorrect(
         userAnswer,
         correctEntry.answer,
         correctEntry.acceptableLow,
         correctEntry.acceptableHigh,
+        { ignoreArrayOrder: shouldIgnoreArrayOrder(response) },
       );
 
       if (isCorrect) {
@@ -226,6 +256,8 @@ export function convertNumberToString(number: number | Date | null, type: 'date'
 export function getOverviewStats(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
+  studyConfig?: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
 ): OverviewData {
   const timeStats = calculateTimeStats(visibleParticipants, componentName);
   const dateStats = calculateDateStats(visibleParticipants, componentName);
@@ -238,7 +270,7 @@ export function getOverviewStats(
     avgTime: timeStats.avgTime,
     avgCleanTime: timeStats.avgCleanTime,
     participantsWithInvalidCleanTimeCount: timeStats.participantsWithInvalidCleanTimeCount,
-    correctness: calculateCorrectnessStats(visibleParticipants, componentName).correctness,
+    correctness: calculateCorrectnessStats(visibleParticipants, componentName, studyConfig, allConfigs).correctness,
   };
 
   return overviewData;
@@ -247,6 +279,7 @@ export function getOverviewStats(
 export function getComponentStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
 ): Array<ComponentData & {
   timeSum: number;
   timeCount: number;
@@ -266,7 +299,7 @@ export function getComponentStats(
     totalQuestionCount: number;
   }> = componentNames.map((name) => {
     const timeStats = calculateTimeStats(visibleParticipants, name);
-    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name);
+    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
 
     return {
       component: name,
@@ -289,10 +322,11 @@ export function getComponentStats(
 export function getComponentStatsForConfigs(
   visibleParticipants: ParticipantDataWithStatus[],
   configs: ConfigScopedStudyConfig[],
+  allConfigs: Record<string, StudyConfig> = {},
 ): ComponentData[] {
   const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
     const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
-    return getComponentStats(configParticipants, studyConfig).map((row) => ({
+    return getComponentStats(configParticipants, studyConfig, allConfigs).map((row) => ({
       ...row,
       configs: [configLabel],
       studyConfig,
@@ -354,6 +388,7 @@ export function getComponentStatsForConfigs(
 export function getResponseStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
 ): Array<ResponseData & {
   responseId?: string;
   correctCount: number;
@@ -370,7 +405,7 @@ export function getResponseStats(
     if (responses.length === 0) return [];
 
     return responses.map((response) => {
-      const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, response.id);
+      const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs, response.id);
       return {
         responseId: response.id,
         component: name,
@@ -390,6 +425,7 @@ export function getResponseStats(
 export function getResponseStatsForConfigs(
   visibleParticipants: ParticipantDataWithStatus[],
   configs: ConfigScopedStudyConfig[],
+  allConfigs: Record<string, StudyConfig> = {},
 ): ResponseData[] {
   const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
     const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
@@ -399,7 +435,7 @@ export function getResponseStatsForConfigs(
       if (responses.length === 0) return [];
 
       return responses.map((response) => {
-        const correctnessStats = calculateCorrectnessStats(configParticipants, name, response.id);
+        const correctnessStats = calculateCorrectnessStats(configParticipants, name, studyConfig, allConfigs, response.id);
         return {
           responseId: response.id,
           component: name,

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -8,6 +8,14 @@ import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { getMatrixAnswerOptions } from '../../../utils/responseOptions';
 
+function getParticipantStudyConfig(
+  participantConfigHash: string,
+  studyConfig?: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
+) {
+  return allConfigs[participantConfigHash] ?? studyConfig;
+}
+
 function filterParticipants(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
@@ -78,9 +86,12 @@ function calculateTimeStats(visibleParticipants: ParticipantDataWithStatus[], co
         };
       });
     if (timeStats.length > 0) {
-      acc.count += timeStats.length;
-      acc.totalTimeSum += timeStats.reduce((sum, t) => sum + t.totalTime, 0);
-      acc.cleanTimeSum += timeStats.reduce((sum, t) => sum + t.cleanTime, 0);
+      const totalTime = timeStats.reduce((sum, t) => sum + t.totalTime, 0);
+      const cleanTime = timeStats.reduce((sum, t) => sum + t.cleanTime, 0);
+
+      acc.count += componentName ? timeStats.length : 1;
+      acc.totalTimeSum += totalTime;
+      acc.cleanTimeSum += cleanTime;
       if (hasInvalidCleanTime) {
         participantsWithInvalidCleanTimeCount += 1;
       }
@@ -99,14 +110,15 @@ function calculateCorrectnessStats(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
   studyConfig?: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
 ): number {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
-  const answers = filteredParticipants
-    .flatMap((participant) => Object.values(participant.answers))
-    .filter((answer) => (!componentName || answer.componentName === componentName));
+  const participantAnswers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
+    .filter((answer) => (!componentName || answer.componentName === componentName))
+    .map((answer) => ({ answer, participant })));
 
-  const hasCorrectAnswer = answers.some((answer) => answer.correctAnswer && answer.correctAnswer.length > 0);
+  const hasCorrectAnswer = participantAnswers.some(({ answer }) => answer.correctAnswer && answer.correctAnswer.length > 0);
   if (!hasCorrectAnswer) {
     return NaN;
   }
@@ -114,11 +126,15 @@ function calculateCorrectnessStats(
   let totalQuestions = 0;
   let correctSum = 0;
 
-  answers.forEach((answer) => {
+  participantAnswers.forEach(({ answer, participant }) => {
     const correctCount = answer.correctAnswer.length;
     if (!correctCount) return;
-    const component = studyConfig?.components[answer.componentName]
-      ? studyComponentToIndividualComponent(studyConfig.components[answer.componentName], studyConfig)
+    const participantStudyConfig = getParticipantStudyConfig(participant.participantConfigHash, studyConfig, allConfigs);
+    const component = participantStudyConfig?.components[answer.componentName]
+      ? studyComponentToIndividualComponent(
+        participantStudyConfig.components[answer.componentName],
+        participantStudyConfig,
+      )
       : undefined;
 
     totalQuestions += correctCount;
@@ -181,6 +197,7 @@ export function getOverviewStats(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
   studyConfig?: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
 ): OverviewData {
   const timeStats = calculateTimeStats(visibleParticipants, componentName);
   const dateStats = calculateDateStats(visibleParticipants, componentName);
@@ -193,13 +210,17 @@ export function getOverviewStats(
     avgTime: timeStats.avgTime,
     avgCleanTime: timeStats.avgCleanTime,
     participantsWithInvalidCleanTimeCount: timeStats.participantsWithInvalidCleanTimeCount,
-    correctness: calculateCorrectnessStats(visibleParticipants, componentName, studyConfig),
+    correctness: calculateCorrectnessStats(visibleParticipants, componentName, studyConfig, allConfigs),
   };
 
   return overviewData;
 }
 
-export function getComponentStats(visibleParticipants: ParticipantDataWithStatus[], studyConfig: StudyConfig): ComponentData[] {
+export function getComponentStats(
+  visibleParticipants: ParticipantDataWithStatus[],
+  studyConfig: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
+): ComponentData[] {
   // Get all component names from the current study
   const componentNames = Object.keys(studyConfig.components);
   const componentData: ComponentData[] = componentNames.map((name) => {
@@ -210,14 +231,18 @@ export function getComponentStats(visibleParticipants: ParticipantDataWithStatus
       participants: calculateParticipantCounts(visibleParticipants, name).total,
       avgTime: timeStats.avgTime,
       avgCleanTime: timeStats.avgCleanTime,
-      correctness: calculateCorrectnessStats(visibleParticipants, name, studyConfig),
+      correctness: calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs),
     };
   });
 
   return componentData;
 }
 
-export function getResponseStats(visibleParticipants: ParticipantDataWithStatus[], studyConfig: StudyConfig): ResponseData[] {
+export function getResponseStats(
+  visibleParticipants: ParticipantDataWithStatus[],
+  studyConfig: StudyConfig,
+  allConfigs: Record<string, StudyConfig> = {},
+): ResponseData[] {
   // Get all responses for each component
   const responseData: ResponseData[] = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
     const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
@@ -229,7 +254,7 @@ export function getResponseStats(visibleParticipants: ParticipantDataWithStatus[
       type: response.type,
       question: response.prompt ?? 'N/A',
       options: getResponseOptions(response),
-      correctness: calculateCorrectnessStats(visibleParticipants, name, studyConfig),
+      correctness: calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs),
     }));
   });
 

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -4,7 +4,7 @@ import {
   ComponentData, OverviewData, ParticipantCounts, ResponseData,
 } from '../../types';
 import { MatrixResponse, Response, StudyConfig } from '../../../parser/types';
-import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
+import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { getMatrixAnswerOptions } from '../../../utils/responseOptions';
 
@@ -16,22 +16,6 @@ type ConfigScopedStudyConfig = {
 
 function mergeConfigLabels(existing: string[] | undefined, next: string) {
   return [...new Set([...(existing ?? []), next])];
-}
-
-function getParticipantStudyConfig(
-  participantConfigHash: string,
-  studyConfig?: StudyConfig,
-  allConfigs: Record<string, StudyConfig> = {},
-) {
-  if (!participantConfigHash) {
-    return studyConfig;
-  }
-  const participantStudyConfig = allConfigs[participantConfigHash];
-  if (!participantStudyConfig) {
-    console.warn(`Missing study config for participant config hash "${participantConfigHash}". Correctness stats should not be computed against the current study config.`);
-    return undefined;
-  }
-  return participantStudyConfig;
 }
 
 function filterParticipants(
@@ -152,43 +136,38 @@ function calculateTimeStats(
 function calculateCorrectnessStats(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
-  studyConfig?: StudyConfig,
-  allConfigs: Record<string, StudyConfig> = {},
+  responseId?: string,
 ): { correctness: number; correctCount: number; totalQuestionCount: number } {
   // Filter out rejected participants and filter by component if provided
   const filteredParticipants = filterParticipants(visibleParticipants, componentName, true);
-  const participantAnswers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
-    .filter((answer) => (!componentName || answer.componentName === componentName) && answer.endTime !== -1)
-    .map((answer) => ({ answer, participant })));
-
-  const hasCorrectAnswer = participantAnswers.some(({ answer }) => answer.correctAnswer && answer.correctAnswer.length > 0);
-  if (!hasCorrectAnswer) {
-    return {
-      correctness: NaN,
-      correctCount: 0,
-      totalQuestionCount: 0,
-    };
-  }
+  const answers = filteredParticipants.flatMap((participant) => Object.values(participant.answers)
+    .filter((answer) => (!componentName || answer.componentName === componentName) && answer.endTime !== -1));
 
   let totalQuestions = 0;
   let correctSum = 0;
 
-  participantAnswers.forEach(({ answer, participant }) => {
-    const correctCount = answer.correctAnswer.length;
-    if (!correctCount) return;
-    const participantStudyConfig = getParticipantStudyConfig(participant.participantConfigHash, studyConfig, allConfigs);
-    const component = participantStudyConfig?.components[answer.componentName]
-      ? studyComponentToIndividualComponent(
-        participantStudyConfig.components[answer.componentName],
-        participantStudyConfig,
-      )
-      : undefined;
+  answers.forEach((answer) => {
+    if (!answer.correctAnswer || answer.correctAnswer.length === 0) return;
 
-    totalQuestions += correctCount;
-    const isCorrect = componentAnswersAreCorrect(answer.answer, answer.correctAnswer, component?.response);
-    if (isCorrect) {
-      correctSum += correctCount;
-    }
+    answer.correctAnswer.forEach((correctEntry) => {
+      if (responseId !== undefined && correctEntry.id !== responseId) return;
+
+      totalQuestions += 1;
+
+      const userAnswer = answer.answer[correctEntry.id];
+      if (userAnswer === undefined) return;
+
+      const isCorrect = responseAnswerIsCorrect(
+        userAnswer,
+        correctEntry.answer,
+        correctEntry.acceptableLow,
+        correctEntry.acceptableHigh,
+      );
+
+      if (isCorrect) {
+        correctSum += 1;
+      }
+    });
   });
 
   return {
@@ -247,8 +226,6 @@ export function convertNumberToString(number: number | Date | null, type: 'date'
 export function getOverviewStats(
   visibleParticipants: ParticipantDataWithStatus[],
   componentName?: string,
-  studyConfig?: StudyConfig,
-  allConfigs: Record<string, StudyConfig> = {},
 ): OverviewData {
   const timeStats = calculateTimeStats(visibleParticipants, componentName);
   const dateStats = calculateDateStats(visibleParticipants, componentName);
@@ -261,7 +238,7 @@ export function getOverviewStats(
     avgTime: timeStats.avgTime,
     avgCleanTime: timeStats.avgCleanTime,
     participantsWithInvalidCleanTimeCount: timeStats.participantsWithInvalidCleanTimeCount,
-    correctness: calculateCorrectnessStats(visibleParticipants, componentName, studyConfig, allConfigs).correctness,
+    correctness: calculateCorrectnessStats(visibleParticipants, componentName).correctness,
   };
 
   return overviewData;
@@ -270,7 +247,6 @@ export function getOverviewStats(
 export function getComponentStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
-  allConfigs: Record<string, StudyConfig> = {},
 ): Array<ComponentData & {
   timeSum: number;
   timeCount: number;
@@ -290,7 +266,7 @@ export function getComponentStats(
     totalQuestionCount: number;
   }> = componentNames.map((name) => {
     const timeStats = calculateTimeStats(visibleParticipants, name);
-    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
+    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name);
 
     return {
       component: name,
@@ -313,11 +289,10 @@ export function getComponentStats(
 export function getComponentStatsForConfigs(
   visibleParticipants: ParticipantDataWithStatus[],
   configs: ConfigScopedStudyConfig[],
-  allConfigs: Record<string, StudyConfig> = {},
 ): ComponentData[] {
   const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
     const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
-    return getComponentStats(configParticipants, studyConfig, allConfigs).map((row) => ({
+    return getComponentStats(configParticipants, studyConfig).map((row) => ({
       ...row,
       configs: [configLabel],
       studyConfig,
@@ -379,7 +354,6 @@ export function getComponentStatsForConfigs(
 export function getResponseStats(
   visibleParticipants: ParticipantDataWithStatus[],
   studyConfig: StudyConfig,
-  allConfigs: Record<string, StudyConfig> = {},
 ): Array<ResponseData & {
   responseId?: string;
   correctCount: number;
@@ -394,37 +368,10 @@ export function getResponseStats(
     const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
     const responses = component.response ?? [];
     if (responses.length === 0) return [];
-    const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, studyConfig, allConfigs);
 
-    return responses.map((response) => ({
-      responseId: response.id,
-      component: name,
-      type: response.type,
-      question: response.prompt ?? 'N/A',
-      options: getResponseOptions(response),
-      correctness: correctnessStats.correctness,
-      correctCount: correctnessStats.correctCount,
-      totalQuestionCount: correctnessStats.totalQuestionCount,
-    }));
-  });
-
-  return responseData;
-}
-
-export function getResponseStatsForConfigs(
-  visibleParticipants: ParticipantDataWithStatus[],
-  configs: ConfigScopedStudyConfig[],
-  allConfigs: Record<string, StudyConfig> = {},
-): ResponseData[] {
-  const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
-    const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
-    const responseEntries = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
-      const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
-      const responses = component.response ?? [];
-      if (responses.length === 0) return [];
-      const correctnessStats = calculateCorrectnessStats(configParticipants, name, studyConfig, allConfigs);
-
-      return responses.map((response) => ({
+    return responses.map((response) => {
+      const correctnessStats = calculateCorrectnessStats(visibleParticipants, name, response.id);
+      return {
         responseId: response.id,
         component: name,
         type: response.type,
@@ -433,8 +380,38 @@ export function getResponseStatsForConfigs(
         correctness: correctnessStats.correctness,
         correctCount: correctnessStats.correctCount,
         totalQuestionCount: correctnessStats.totalQuestionCount,
-        configs: [configLabel],
-      }));
+      };
+    });
+  });
+
+  return responseData;
+}
+
+export function getResponseStatsForConfigs(
+  visibleParticipants: ParticipantDataWithStatus[],
+  configs: ConfigScopedStudyConfig[],
+): ResponseData[] {
+  const rows = configs.flatMap(({ configHash, configLabel, studyConfig }) => {
+    const configParticipants = visibleParticipants.filter((participant) => participant.participantConfigHash === configHash);
+    const responseEntries = Object.entries(studyConfig.components).flatMap(([name, componentConfig]) => {
+      const component = studyComponentToIndividualComponent(componentConfig, studyConfig);
+      const responses = component.response ?? [];
+      if (responses.length === 0) return [];
+
+      return responses.map((response) => {
+        const correctnessStats = calculateCorrectnessStats(configParticipants, name, response.id);
+        return {
+          responseId: response.id,
+          component: name,
+          type: response.type,
+          question: response.prompt ?? 'N/A',
+          options: getResponseOptions(response),
+          correctness: correctnessStats.correctness,
+          correctCount: correctnessStats.correctCount,
+          totalQuestionCount: correctnessStats.totalQuestionCount,
+          configs: [configLabel],
+        };
+      });
     });
 
     return responseEntries;

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -13,7 +13,18 @@ function getParticipantStudyConfig(
   studyConfig?: StudyConfig,
   allConfigs: Record<string, StudyConfig> = {},
 ) {
-  return allConfigs[participantConfigHash] ?? studyConfig;
+  if (!participantConfigHash) {
+    return studyConfig;
+  }
+
+  const participantStudyConfig = allConfigs[participantConfigHash];
+
+  if (!participantStudyConfig) {
+    console.warn(`Missing study config for participant config hash "${participantConfigHash}". Correctness stats should not be computed against the current study config.`);
+    return undefined;
+  }
+
+  return participantStudyConfig;
 }
 
 function filterParticipants(

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -26,7 +26,6 @@ export interface ComponentData {
 
 export interface ResponseData {
   configs?: string[];
-  responseId?: string;
   component: string;
   type: string;
   question: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -16,6 +16,7 @@ export interface OverviewData {
 }
 
 export interface ComponentData {
+  configs?: string[];
   component: string;
   participants: number;
   avgTime: number;
@@ -24,6 +25,8 @@ export interface ComponentData {
 }
 
 export interface ResponseData {
+  configs?: string[];
+  responseId?: string;
   component: string;
   type: string;
   question: string;

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -154,8 +154,8 @@ export abstract class StorageEngine {
   protected participantDataWriteDelayMs = 3000;
 
   private pendingParticipantDataWrite:
-  | { participantId: string; snapshot: ParticipantData; cache: boolean }
-  | undefined;
+    | { participantId: string; snapshot: ParticipantData; cache: boolean }
+    | undefined;
 
   private pendingParticipantDataWriteTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -692,6 +692,11 @@ export abstract class StorageEngine {
     const allConfigs = tempHashes.map(async (singleHash) => [singleHash, await this._getFromStorage(`configs/${singleHash}`, 'config', studyId)]);
     const configs = (await Promise.all(allConfigs)) as [string, StudyConfig][];
     return Object.fromEntries(configs);
+  }
+
+  async getCurrentConfigHash(studyId: string) {
+    await this.initializeStudyDb(studyId);
+    return this._getCurrentConfigHash();
   }
 
   // Gets the current participant ID from the URL, local persistence, or generates a new one if none exists.

--- a/src/storage/tests/analysis-live-monitor.spec.ts
+++ b/src/storage/tests/analysis-live-monitor.spec.ts
@@ -55,7 +55,7 @@ function getParticipantViewIds(
   selectedStages: string[],
 ): string[] {
   const completed = includedParticipants.includes('completed') ? participants.filter((participant) => !participant.rejected && participant.completed) : [];
-  const inProgress = includedParticipants.includes('inprogress') ? participants.filter((participant) => !participant.rejected && !participant.completed) : [];
+  const inProgress = includedParticipants.includes('inProgress') ? participants.filter((participant) => !participant.rejected && !participant.completed) : [];
   const rejected = includedParticipants.includes('rejected') ? participants.filter((participant) => participant.rejected) : [];
 
   const statusFiltered = [...completed, ...inProgress, ...rejected];
@@ -80,7 +80,7 @@ describe('analysis live monitor', () => {
       }),
     ];
 
-    const filtered = getFilteredParticipantProgress(assignments, ['completed', 'inprogress', 'rejected'], ['ALL']);
+    const filtered = getFilteredParticipantProgress(assignments, ['completed', 'inProgress', 'rejected'], ['ALL']);
     const grouped = groupParticipantProgress(filtered);
 
     expect(filtered).toHaveLength(3);
@@ -124,7 +124,7 @@ describe('analysis live monitor', () => {
       }),
     ];
 
-    const includedParticipants = ['completed', 'inprogress'];
+    const includedParticipants = ['completed', 'inProgress'];
     const selectedStages = ['S1'];
 
     const liveMonitorIds = getFilteredParticipantProgress(assignments, includedParticipants, selectedStages)

--- a/src/utils/correctAnswer.ts
+++ b/src/utils/correctAnswer.ts
@@ -3,7 +3,7 @@ import {
   Answer, IndividualComponent, Response, StoredAnswer,
 } from '../parser/types';
 
-function shouldIgnoreArrayOrder(response?: Response) {
+export function shouldIgnoreArrayOrder(response?: Response) {
   return response?.type === 'checkbox' || response?.type === 'dropdown';
 }
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1172 
Closes #1185 

### Give a longer description of what this PR addresses and why it's needed
- Fixes the study overview so Average Time shows total study time per participant instead of average component time
- Add 'current' badge to the configs and add 'outdated' badge to the outdated configs
- Fix bug with live monitor participant count (it was including rejected participants to completed participants)

### Provide pictures/videos of the behavior before and after these changes (optional)

<img width="1725" height="829" alt="Screenshot 2026-04-27 at 5 09 37 PM" src="https://github.com/user-attachments/assets/5705e1c4-e6d6-43b2-a793-63f98173a7c0" />


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation (mention we use `component.id` to compare if they are the same component)
- [ ] ...

### Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/216

- [x] Done
- [ ] N/A