### PR TITLE
Speed up study first load by deferring non-critical storage reads

### DIFF
--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -28,37 +28,69 @@ async function fetchGlobalConfigArray() {
   return parseGlobalConfig(configs);
 }
 
+function isHomeRoute() {
+  const pathname = window.location.pathname.replace(/\/+$/, '') || '/';
+  const basePath = PREFIX.replace(/\/+$/, '') || '/';
+
+  return pathname === basePath || pathname === `${basePath}/`;
+}
+
 export function GlobalConfigParser() {
   const [globalConfig, setGlobalConfig] = useState<Nullable<GlobalConfig>>(null);
   const [studyConfigs, setStudyConfigs] = useState<Record<string, ParsedConfig<StudyConfig> | null>>({});
 
   useEffect(() => {
-    async function fetchData() {
-      if (globalConfig) {
-        setStudyConfigs(await fetchStudyConfigs(globalConfig));
+    if (!globalConfig) {
+      return undefined;
+    }
+
+    if (!isHomeRoute()) {
+      setStudyConfigs({});
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function fetchData(currentGlobalConfig: GlobalConfig) {
+      const configs = await fetchStudyConfigs(currentGlobalConfig);
+      if (!cancelled) {
+        setStudyConfigs(configs);
       }
     }
-    fetchData();
+
+    fetchData(globalConfig);
+
+    return () => {
+      cancelled = true;
+    };
   }, [globalConfig]);
 
   useEffect(() => {
-    if (globalConfig) return;
+    if (globalConfig) {
+      return undefined;
+    }
 
     fetchGlobalConfigArray().then((gc) => {
       setGlobalConfig(gc);
     });
+
+    return undefined;
   }, [globalConfig]);
 
   // Initialize storage engine
   const { storageEngine, setStorageEngine } = useStorageEngine();
   useEffect(() => {
-    if (storageEngine !== undefined) return;
+    if (storageEngine !== undefined) {
+      return undefined;
+    }
 
     async function fn() {
       const _storageEngine = await initializeStorageEngine();
       setStorageEngine(_storageEngine);
     }
     fn();
+
+    return undefined;
   }, [setStorageEngine, storageEngine]);
 
   const analysisProtectedCallback = async (studyId: string) => {

--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -28,27 +28,10 @@ async function fetchGlobalConfigArray() {
   return parseGlobalConfig(configs);
 }
 
-function isHomeRoute() {
-  const pathname = window.location.pathname.replace(/\/+$/, '') || '/';
-  const basePath = PREFIX.replace(/\/+$/, '') || '/';
-
-  return pathname === basePath || pathname === `${basePath}/`;
-}
-
-export function GlobalConfigParser() {
-  const [globalConfig, setGlobalConfig] = useState<Nullable<GlobalConfig>>(null);
+function HomeRoute({ globalConfig }: { globalConfig: GlobalConfig }) {
   const [studyConfigs, setStudyConfigs] = useState<Record<string, ParsedConfig<StudyConfig> | null>>({});
 
   useEffect(() => {
-    if (!globalConfig) {
-      return undefined;
-    }
-
-    if (!isHomeRoute()) {
-      setStudyConfigs({});
-      return undefined;
-    }
-
     let cancelled = false;
 
     async function fetchData(currentGlobalConfig: GlobalConfig) {
@@ -64,6 +47,26 @@ export function GlobalConfigParser() {
       cancelled = true;
     };
   }, [globalConfig]);
+
+  return (
+    <>
+      <PageTitle title="ReVISit | Home" />
+      <AppShell
+        padding="md"
+        header={{ height: 70 }}
+      >
+        <AppHeader studyIds={globalConfig.configsList} />
+        <ConfigSwitcher
+          globalConfig={globalConfig}
+          studyConfigs={studyConfigs}
+        />
+      </AppShell>
+    </>
+  );
+}
+
+export function GlobalConfigParser() {
+  const [globalConfig, setGlobalConfig] = useState<Nullable<GlobalConfig>>(null);
 
   useEffect(() => {
     if (globalConfig) {
@@ -108,21 +111,7 @@ export function GlobalConfigParser() {
           <Routes>
             <Route
               path="/"
-              element={(
-                <>
-                  <PageTitle title="ReVISit | Home" />
-                  <AppShell
-                    padding="md"
-                    header={{ height: 70 }}
-                  >
-                    <AppHeader studyIds={globalConfig.configsList} />
-                    <ConfigSwitcher
-                      globalConfig={globalConfig}
-                      studyConfigs={studyConfigs}
-                    />
-                  </AppShell>
-                </>
-              )}
+              element={<HomeRoute globalConfig={globalConfig} />}
             />
             <Route
               path="/:studyId/*"

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -38,6 +38,40 @@ import {
   resolveParticipantConditions,
 } from '../utils/handleConditionLogic';
 
+function createParticipantMetadata(ip: string = ''): ParticipantMetadata {
+  return {
+    language: navigator.language,
+    userAgent: navigator.userAgent,
+    resolution: {
+      width: window.screen.width,
+      height: window.screen.height,
+      availHeight: window.screen.availHeight,
+      availWidth: window.screen.availWidth,
+      colorDepth: window.screen.colorDepth,
+      orientation: window.screen.orientation.type,
+      pixelDepth: window.screen.pixelDepth,
+    },
+    ip,
+  };
+}
+
+function createEmptyParticipantMetadata(): ParticipantMetadata {
+  return {
+    language: '',
+    userAgent: '',
+    resolution: {
+      width: 0,
+      height: 0,
+      availHeight: 0,
+      availWidth: 0,
+      colorDepth: 0,
+      orientation: '',
+      pixelDepth: 0,
+    },
+    ip: '',
+  };
+}
+
 export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   // Pull study config
   const routeStudyId = useStudyId();
@@ -53,19 +87,27 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   useEffect(() => {
     if (routeStudyId !== '__revisit-widget') {
-      getStudyConfig(routeStudyId, globalConfig).then((config) => {
+      const loadStudyConfig = async () => {
+        const config = await getStudyConfig(routeStudyId, globalConfig);
         setActiveConfig(config);
-      });
-      return () => { };
+      };
+
+      loadStudyConfig();
+      return undefined;
     }
+
     if (globalConfig && routeStudyId) {
       const messageListener = (event: MessageEvent) => {
         if (event.data.type === 'revisitWidget/CONFIG') {
-          parseStudyConfig(event.data.payload).then(async (config) => {
+          const loadWidgetConfig = async () => {
+            const config = await parseStudyConfig(event.data.payload);
             setActiveConfig(config);
+
             const sequenceArray = await generateSequenceArray(config);
             window.parent.postMessage({ type: 'revisitWidget/SEQUENCE_ARRAY', payload: sequenceArray }, '*');
-          });
+          };
+
+          loadWidgetConfig();
         }
       };
 
@@ -77,7 +119,8 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         window.removeEventListener('message', messageListener);
       };
     }
-    return () => { };
+
+    return undefined;
   }, [globalConfig, routeStudyId]);
 
   const [routes, setRoutes] = useState<RouteObject[]>([]);
@@ -89,6 +132,23 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   const studyCondition = useMemo(() => parseConditionParam(searchParams.get('condition')), [searchParams]);
 
   useEffect(() => {
+    let isCancelled = false;
+
+    async function fetchParticipantIp() {
+      const ipTimeoutController = new AbortController();
+      const ipTimeoutId = window.setTimeout(() => ipTimeoutController.abort(), 1200);
+
+      try {
+        const ipRes = await fetch('https://api.ipify.org?format=json', {
+          signal: ipTimeoutController.signal,
+        }).catch(() => '');
+
+        return ipRes instanceof Response ? await ipRes.json() as { ip: string } : { ip: '' };
+      } finally {
+        window.clearTimeout(ipTimeoutId);
+      }
+    }
+
     async function initializeUserStoreRouting() {
       // Check that we have a storage engine and active config (studyId is set for config, but typescript complains)
       if (!storageEngine || !activeConfig || !canonicalStudyId) return;
@@ -96,16 +156,19 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       try {
         // Make sure that we have a study database and that the study database has a sequence array
         await storageEngine.initializeStudyDb(canonicalStudyId);
+
+        const modesPromise = storageEngine.getModes(canonicalStudyId);
+        const activeHashPromise = hash(JSON.stringify(activeConfig));
+
         await storageEngine.saveConfig(activeConfig);
 
         const sequenceArray = await storageEngine.getSequenceArray();
-        if (!sequenceArray) {
-          await storageEngine.setSequenceArray(
-            await generateSequenceArray(activeConfig),
-          );
-        }
 
-        const modes = await storageEngine.getModes(canonicalStudyId);
+        if (!sequenceArray) {
+          const generatedSequenceArray = await generateSequenceArray(activeConfig);
+
+          await storageEngine.setSequenceArray(generatedSequenceArray);
+        }
 
         // Get or generate participant session
         const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam
@@ -114,33 +177,17 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           : undefined;
         const searchParamsObject = Object.fromEntries(searchParams.entries());
 
-        const ipTimeoutController = new AbortController();
-        const ipTimeoutId = window.setTimeout(() => ipTimeoutController.abort(), 1200);
-        const ipRes = await fetch('https://api.ipify.org?format=json', {
-          signal: ipTimeoutController.signal,
-        }).catch(() => '');
-        window.clearTimeout(ipTimeoutId);
-        const ip: { ip: string } = ipRes instanceof Response ? await ipRes.json() : { ip: '' };
+        const [modes, activeHash] = await Promise.all([
+          modesPromise,
+          activeHashPromise,
+        ]);
 
-        const metadata: ParticipantMetadata = {
-          language: navigator.language,
-          userAgent: navigator.userAgent,
-          resolution: {
-            width: window.screen.width,
-            height: window.screen.height,
-            availHeight: window.screen.availHeight,
-            availWidth: window.screen.availWidth,
-            colorDepth: window.screen.colorDepth,
-            orientation: window.screen.orientation.type,
-            pixelDepth: window.screen.pixelDepth,
-          },
-          ip: ip.ip,
-        };
+        const initialMetadata = createParticipantMetadata();
 
         let participantSession = await storageEngine.initializeParticipantSession(
           searchParamsObject,
           activeConfig,
-          metadata,
+          initialMetadata,
           participantId || urlParticipantId,
         );
 
@@ -157,7 +204,6 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
             conditions: studyCondition,
           };
         }
-        const activeHash = await hash(JSON.stringify(activeConfig));
 
         let participantConfig = activeConfig;
 
@@ -165,34 +211,68 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           participantConfig = (await storageEngine.getAllConfigsFromHash([participantSession.participantConfigHash], canonicalStudyId))[participantSession.participantConfigHash] as ParsedConfig<StudyConfig>;
         }
 
-        const effectiveStudyCondition = resolveParticipantConditions({
+        const resolvedCondition = resolveParticipantConditions({
           urlCondition: studyCondition,
           participantConditions: participantSession.conditions,
           participantSearchParamCondition: participantSession.searchParams?.condition,
           allowUrlOverride: modes.developmentModeEnabled,
         });
-        const filteredParticipantSequence = filterSequenceByCondition(participantSession.sequence, effectiveStudyCondition);
-        const participantCompleted = await storageEngine.getParticipantCompletionStatus(participantSession.participantId);
+        const filteredParticipantSequence = await filterSequenceByCondition(participantSession.sequence, resolvedCondition);
+
         // Initialize the redux stores
         const newStore = await studyStoreCreator(
           canonicalStudyId,
           participantConfig,
           filteredParticipantSequence,
-          metadata,
+          participantSession.metadata,
           participantSession.answers,
           modes,
           participantSession.participantId,
-          participantCompleted,
+          false,
           false,
           participantSession.participantConfigHash !== activeHash,
         );
+
+        if (isCancelled) {
+          return;
+        }
+
         setStore(newStore);
+
+        fetchParticipantIp().then(async (ip) => {
+          if (isCancelled || !ip.ip || participantSession.metadata.ip === ip.ip) {
+            return;
+          }
+
+          const metadataWithIp = createParticipantMetadata(ip.ip);
+          participantSession = {
+            ...participantSession,
+            metadata: metadataWithIp,
+          };
+
+          await storageEngine.updateParticipantMetadata(metadataWithIp);
+
+          if (!isCancelled) {
+            newStore.store.dispatch(newStore.actions.setMetadata(metadataWithIp));
+          }
+        }).catch((error) => {
+          console.error('Error fetching participant IP:', error);
+        });
+
+        storageEngine.getParticipantCompletionStatus(participantSession.participantId).then((participantCompleted) => {
+          if (!isCancelled) {
+            newStore.store.dispatch(newStore.actions.setParticipantCompleted(participantCompleted));
+          }
+        }).catch((error) => {
+          console.error('Error fetching participant completion status:', error);
+        });
       } catch (error) {
         console.error('Error initializing user store routing:', error);
         // Fallback: initialize the store with empty data
-        const generatedSequences = generateSequenceArray(activeConfig);
+        const generatedSequences = await generateSequenceArray(activeConfig);
+
         const matchingSequence = generatedSequences[0];
-        const fallbackSequence = filterSequenceByCondition(
+        const fallbackSequence = await filterSequenceByCondition(
           matchingSequence,
           studyCondition,
         );
@@ -201,27 +281,23 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           canonicalStudyId,
           activeConfig,
           fallbackSequence,
-          {
-            language: '',
-            userAgent: '',
-            resolution: {
-              width: 0,
-              height: 0,
-              availHeight: 0,
-              availWidth: 0,
-              colorDepth: 0,
-              orientation: '',
-              pixelDepth: 0,
-            },
-            ip: '',
-          },
+          createEmptyParticipantMetadata(),
           {},
           { developmentModeEnabled: true, dataSharingEnabled: true, dataCollectionEnabled: false },
           '',
           false,
           true,
         );
+
+        if (isCancelled) {
+          return;
+        }
+
         setStore(emptyStore);
+      }
+
+      if (isCancelled) {
+        return;
       }
 
       // Initialize the routing
@@ -255,6 +331,9 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       ]);
     }
     initializeUserStoreRouting();
+    return () => {
+      isCancelled = true;
+    };
   }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
 
   const routing = useRoutes(routes);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -239,25 +239,27 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         setStore(newStore);
 
-        fetchParticipantIp().then(async (ip) => {
-          if (isCancelled || !ip.ip || participantSession.metadata.ip === ip.ip) {
-            return;
-          }
+        if (modes.dataCollectionEnabled) {
+          fetchParticipantIp().then(async (ip) => {
+            if (isCancelled || !ip.ip || participantSession.metadata.ip === ip.ip) {
+              return;
+            }
 
-          const metadataWithIp = createParticipantMetadata(ip.ip);
-          participantSession = {
-            ...participantSession,
-            metadata: metadataWithIp,
-          };
+            const metadataWithIp = createParticipantMetadata(ip.ip);
+            participantSession = {
+              ...participantSession,
+              metadata: metadataWithIp,
+            };
 
-          await storageEngine.updateParticipantMetadata(metadataWithIp);
+            await storageEngine.updateParticipantMetadata(metadataWithIp);
 
-          if (!isCancelled) {
-            newStore.store.dispatch(newStore.actions.setMetadata(metadataWithIp));
-          }
-        }).catch((error) => {
-          console.error('Error fetching participant IP:', error);
-        });
+            if (!isCancelled) {
+              newStore.store.dispatch(newStore.actions.setMetadata(metadataWithIp));
+            }
+          }).catch((error) => {
+            console.error('Error fetching participant IP:', error);
+          });
+        }
 
         storageEngine.getParticipantCompletionStatus(participantSession.participantId).then((participantCompleted) => {
           if (!isCancelled) {

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -6,7 +6,9 @@ import {
 } from 'react';
 import { Provider } from 'react-redux';
 import { RouteObject, useRoutes, useSearchParams } from 'react-router';
-import { Box, LoadingOverlay, Title } from '@mantine/core';
+import {
+  Box, Button, LoadingOverlay, Stack, Text, Title,
+} from '@mantine/core';
 import {
   GlobalConfig,
   Nullable,
@@ -126,6 +128,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   const [routes, setRoutes] = useState<RouteObject[]>([]);
   const [store, setStore] = useState<Nullable<StudyStore>>(null);
   const [isCompletionCheckResolved, setIsCompletionCheckResolved] = useState(false);
+  const [completionCheckError, setCompletionCheckError] = useState<string | null>(null);
   const { storageEngine } = useStorageEngine();
   const [searchParams] = useSearchParams();
 
@@ -154,6 +157,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       // Check that we have a storage engine and active config (studyId is set for config, but typescript complains)
       if (!storageEngine || !activeConfig || !canonicalStudyId) return;
       setIsCompletionCheckResolved(false);
+      setCompletionCheckError(null);
 
       try {
         // Make sure that we have a study database and that the study database has a sequence array
@@ -274,7 +278,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           }).catch((error) => {
             console.error('Error fetching participant completion status:', error);
             if (!isCancelled) {
-              setIsCompletionCheckResolved(true);
+              setCompletionCheckError('We could not verify whether this study session was already completed. Please reload this page and try again.');
             }
           });
         }
@@ -369,6 +373,26 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           overlayProps={{ blur: 1 }}
           loaderProps={{ size: 'sm' }}
         />
+        {isInteractionLocked && completionCheckError && (
+          <Stack
+            align="center"
+            gap="sm"
+            style={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              zIndex: 1001,
+              maxWidth: 420,
+              textAlign: 'center',
+            }}
+          >
+            <Text>{completionCheckError}</Text>
+            <Button onClick={() => window.location.reload()}>
+              Reload
+            </Button>
+          </Stack>
+        )}
         <Box style={{ pointerEvents: isInteractionLocked ? 'none' : undefined }}>
           <StudyStoreContext.Provider value={store}>
             <Provider store={store.store}>{routing}</Provider>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -279,6 +279,8 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
             console.error('Error fetching participant completion status:', error);
             if (!isCancelled) {
               setCompletionCheckError('We could not verify whether this study session was already completed. Please reload this page and try again.');
+              // A transient completion-status lookup failure should not block study entry.
+              setIsCompletionCheckResolved(true);
             }
           });
         }

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react';
 import { Provider } from 'react-redux';
 import { RouteObject, useRoutes, useSearchParams } from 'react-router';
-import { LoadingOverlay, Title } from '@mantine/core';
+import { Box, LoadingOverlay, Title } from '@mantine/core';
 import {
   GlobalConfig,
   Nullable,
@@ -125,6 +125,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   const [routes, setRoutes] = useState<RouteObject[]>([]);
   const [store, setStore] = useState<Nullable<StudyStore>>(null);
+  const [isCompletionCheckResolved, setIsCompletionCheckResolved] = useState(false);
   const { storageEngine } = useStorageEngine();
   const [searchParams] = useSearchParams();
 
@@ -152,6 +153,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     async function initializeUserStoreRouting() {
       // Check that we have a storage engine and active config (studyId is set for config, but typescript complains)
       if (!storageEngine || !activeConfig || !canonicalStudyId) return;
+      setIsCompletionCheckResolved(false);
 
       try {
         // Make sure that we have a study database and that the study database has a sequence array
@@ -261,13 +263,21 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           });
         }
 
-        storageEngine.getParticipantCompletionStatus(participantSession.participantId).then((participantCompleted) => {
-          if (!isCancelled) {
-            newStore.store.dispatch(newStore.actions.setParticipantCompleted(participantCompleted));
-          }
-        }).catch((error) => {
-          console.error('Error fetching participant completion status:', error);
-        });
+        if (!modes.dataCollectionEnabled) {
+          setIsCompletionCheckResolved(true);
+        } else {
+          storageEngine.getParticipantCompletionStatus(participantSession.participantId).then((participantCompleted) => {
+            if (!isCancelled) {
+              newStore.store.dispatch(newStore.actions.setParticipantCompleted(participantCompleted));
+              setIsCompletionCheckResolved(true);
+            }
+          }).catch((error) => {
+            console.error('Error fetching participant completion status:', error);
+            if (!isCancelled) {
+              setIsCompletionCheckResolved(true);
+            }
+          });
+        }
       } catch (error) {
         console.error('Error initializing user store routing:', error);
         // Fallback: initialize the store with empty data
@@ -296,6 +306,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         }
 
         setStore(emptyStore);
+        setIsCompletionCheckResolved(true);
       }
 
       if (isCancelled) {
@@ -339,6 +350,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
 
   const routing = useRoutes(routes);
+  const isInteractionLocked = routes.length > 0 && store !== null && !isCompletionCheckResolved;
 
   let toRender: ReactNode = null;
 
@@ -350,9 +362,19 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   } else {
     // If routing is null, we didn't match any routes
     toRender = routing && store ? (
-      <StudyStoreContext.Provider value={store}>
-        <Provider store={store.store}>{routing}</Provider>
-      </StudyStoreContext.Provider>
+      <Box pos="relative" style={{ minHeight: '100vh' }}>
+        <LoadingOverlay
+          visible={isInteractionLocked}
+          zIndex={1000}
+          overlayProps={{ blur: 1 }}
+          loaderProps={{ size: 'sm' }}
+        />
+        <Box style={{ pointerEvents: isInteractionLocked ? 'none' : undefined }}>
+          <StudyStoreContext.Provider value={store}>
+            <Provider store={store.store}>{routing}</Provider>
+          </StudyStoreContext.Provider>
+        </Box>
+      </Box>
     ) : (
       <ResourceNotFound />
     );

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -7,7 +7,7 @@ import {
 import { Provider } from 'react-redux';
 import { RouteObject, useRoutes, useSearchParams } from 'react-router';
 import {
-  Box, Button, LoadingOverlay, Stack, Text, Title,
+  Button, LoadingOverlay, Stack, Text, Title,
 } from '@mantine/core';
 import {
   GlobalConfig,
@@ -223,7 +223,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           participantSearchParamCondition: participantSession.searchParams?.condition,
           allowUrlOverride: modes.developmentModeEnabled,
         });
-        const filteredParticipantSequence = await filterSequenceByCondition(participantSession.sequence, resolvedCondition);
+        const filteredParticipantSequence = filterSequenceByCondition(participantSession.sequence, resolvedCondition);
 
         // Initialize the redux stores
         const newStore = await studyStoreCreator(
@@ -354,54 +354,46 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
 
   const routing = useRoutes(routes);
-  const isInteractionLocked = routes.length > 0 && store !== null && !isCompletionCheckResolved;
+  const isLoading = isValidStudyId && (routes.length === 0 || store === null || !isCompletionCheckResolved);
 
-  let toRender: ReactNode = null;
+  let content: ReactNode = null;
 
-  // Definitely a 404
   if (!isValidStudyId) {
-    toRender = <ResourceNotFound />;
-  } else if (routes.length === 0) {
-    toRender = <LoadingOverlay visible />;
-  } else {
-    // If routing is null, we didn't match any routes
-    toRender = routing && store ? (
-      <Box pos="relative" style={{ minHeight: '100vh' }}>
-        <LoadingOverlay
-          visible={isInteractionLocked}
-          zIndex={1000}
-          overlayProps={{ blur: 1 }}
-          loaderProps={{ size: 'sm' }}
-        />
-        {isInteractionLocked && completionCheckError && (
-          <Stack
-            align="center"
-            gap="sm"
-            style={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              zIndex: 1001,
-              maxWidth: 420,
-              textAlign: 'center',
-            }}
-          >
-            <Text>{completionCheckError}</Text>
-            <Button onClick={() => window.location.reload()}>
-              Reload
-            </Button>
-          </Stack>
-        )}
-        <Box style={{ pointerEvents: isInteractionLocked ? 'none' : undefined }}>
-          <StudyStoreContext.Provider value={store}>
-            <Provider store={store.store}>{routing}</Provider>
-          </StudyStoreContext.Provider>
-        </Box>
-      </Box>
-    ) : (
-      <ResourceNotFound />
+    content = <ResourceNotFound />;
+  } else if (routing && store) {
+    content = (
+      <StudyStoreContext.Provider value={store}>
+        <Provider store={store.store}>{routing}</Provider>
+      </StudyStoreContext.Provider>
     );
+  } else if (!isLoading) {
+    content = <ResourceNotFound />;
   }
-  return toRender;
+
+  return (
+    <>
+      <LoadingOverlay visible={isLoading} />
+      {isLoading && completionCheckError && (
+        <Stack
+          align="center"
+          gap="sm"
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 1001,
+            maxWidth: 420,
+            textAlign: 'center',
+          }}
+        >
+          <Text>{completionCheckError}</Text>
+          <Button onClick={() => window.location.reload()}>
+            Reload
+          </Button>
+        </Stack>
+      )}
+      {content}
+    </>
+  );
 }

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -288,7 +288,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         const generatedSequences = await generateSequenceArray(activeConfig);
 
         const matchingSequence = generatedSequences[0];
-        const fallbackSequence = await filterSequenceByCondition(
+        const fallbackSequence = filterSequenceByCondition(
           matchingSequence,
           studyCondition,
         );

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -3,6 +3,7 @@ import localforage from 'localforage';
 import { initializeApp } from 'firebase/app';
 import {
   deleteObject,
+  getBlob,
   getDownloadURL,
   getStorage,
   ref,
@@ -94,9 +95,8 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
 
     let storageObj: StorageObject<T> = {} as StorageObject<T>;
     try {
-      const url = await getDownloadURL(storageRef);
-      const response = await fetch(url);
-      const fullProvStr = await response.text();
+      const blob = await getBlob(storageRef);
+      const fullProvStr = await blob.text();
       storageObj = JSON.parse(fullProvStr);
     } catch {
       console.warn(

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -66,6 +66,11 @@ interface StageData {
   allStages: StageInfo[];
 }
 
+type ModesAndStageData = {
+  modes: Record<REVISIT_MODE, boolean>;
+  stageData: StageData;
+};
+
 export interface ConditionData {
   allConditions: string[];
   conditionCounts: Record<string, number>;
@@ -186,6 +191,10 @@ export abstract class StorageEngine {
 
   isCloudEngine() {
     return this.cloudEngine;
+  }
+
+  protected shouldDeferInitialParticipantDataPersistence() {
+    return false;
   }
 
   /*
@@ -369,6 +378,33 @@ export abstract class StorageEngine {
       console.warn('Failed to read cached participant data:', error);
       return null;
     }
+  }
+
+  private async getModesAndStageData(studyId: string): Promise<ModesAndStageData> {
+    const modesDoc = await this.getModes(studyId);
+    const { stage, ...modeValues } = modesDoc;
+
+    if (stage) {
+      return {
+        modes: modeValues as Record<REVISIT_MODE, boolean>,
+        stageData: stage,
+      };
+    }
+
+    const defaultStageData: StageData = {
+      currentStage: { stageName: 'DEFAULT', color: defaultStageColor },
+      allStages: [{ stageName: 'DEFAULT', color: defaultStageColor }],
+    };
+
+    await this._setModesDocument(studyId, {
+      ...(modeValues as Record<REVISIT_MODE, boolean>),
+      stage: defaultStageData,
+    });
+
+    return {
+      modes: modeValues as Record<REVISIT_MODE, boolean>,
+      stageData: defaultStageData,
+    };
   }
 
   private clearPendingParticipantDataWriteTimer() {
@@ -566,19 +602,8 @@ export abstract class StorageEngine {
   }
 
   async getStageData(studyId: string): Promise<StageData> {
-    const modesDoc = await this.getModes(studyId);
-
-    if (modesDoc && modesDoc.stage) {
-      return modesDoc.stage as StageData;
-    }
-
-    // Set default stage data if it doesn't exist
-    const defaultStageData: StageData = {
-      currentStage: { stageName: 'DEFAULT', color: defaultStageColor },
-      allStages: [{ stageName: 'DEFAULT', color: defaultStageColor }],
-    };
-    await this.setCurrentStage(studyId, 'DEFAULT', defaultStageColor);
-    return defaultStageData;
+    const { stageData } = await this.getModesAndStageData(studyId);
+    return stageData;
   }
 
   async getConditionData(studyId: string): Promise<ConditionData> {
@@ -665,6 +690,10 @@ export abstract class StorageEngine {
     // Hash the provided config
     const configHash = await hash(JSON.stringify(config));
 
+    if (currentConfigHash === configHash) {
+      return;
+    }
+
     // Push the config to storage and cache it, since it won't change
     await this._pushToStorage(
       `configs/${configHash}`,
@@ -741,7 +770,7 @@ export abstract class StorageEngine {
   // This function is one of the most critical functions in the storage engine.
   // It uses the notion of sequence intents and assignments to determine the current sequence for the participant.
   // It handles rejected participants and allows for reusing a rejected participant's sequence.
-  protected async _getSequence(conditions?: string[]) {
+  protected async _getSequence(conditions?: string[], bootstrapData?: ModesAndStageData) {
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
@@ -750,8 +779,7 @@ export abstract class StorageEngine {
     }
     let sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
 
-    const modes = await this.getModes(this.studyId);
-    const stageData = await this.getStageData(this.studyId);
+    const { modes, stageData } = bootstrapData ?? await this.getModesAndStageData(this.studyId);
     const currentStage = stageData.currentStage.stageName;
 
     // Find all rejected documents
@@ -849,29 +877,24 @@ export abstract class StorageEngine {
       throw new Error('Participant not initialized');
     }
 
+    const cachedParticipant = await this.getCachedParticipantDataSnapshot(this.currentParticipantId);
+    if (cachedParticipant) {
+      this.participantData = cachedParticipant;
+      return cachedParticipant;
+    }
+
     // Check if the participant has already been initialized
     const participant = await this._getFromStorage(
       `participants/${this.currentParticipantId}`,
       'participantData',
     );
-    const cachedParticipant = await this.getCachedParticipantDataSnapshot(this.currentParticipantId);
 
     if (this.studyId === undefined) {
       throw new Error('Study ID is not set');
     }
 
-    // Get modes
-    const modes = await this.getModes(this.studyId);
-    const stageData = await this.getStageData(this.studyId);
+    const { modes, stageData } = await this.getModesAndStageData(this.studyId);
     const currentStage = stageData.currentStage.stageName;
-
-    if (
-      cachedParticipant
-      && (!isParticipantData(participant) || shouldPreferCachedParticipantData(cachedParticipant, participant))
-    ) {
-      this.participantData = cachedParticipant;
-      return cachedParticipant;
-    }
 
     if (isParticipantData(participant)) {
       // Participant already initialized
@@ -883,7 +906,7 @@ export abstract class StorageEngine {
     const participantConfigHash = await hash(JSON.stringify(config));
     const parsedConditions = parseConditionParam(searchParams.condition);
     const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
-    const { currentRow, creationIndex } = await this._getSequence(conditions);
+    const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData });
     this.participantData = {
       participantId: this.currentParticipantId,
       participantConfigHash,
@@ -900,7 +923,7 @@ export abstract class StorageEngine {
     };
 
     if (modes.dataCollectionEnabled) {
-      await this.persistCurrentParticipantData({ immediate: true });
+      await this.persistCurrentParticipantData({ immediate: !this.shouldDeferInitialParticipantDataPersistence() });
     } else {
       await this.cacheParticipantDataSnapshot(this.participantData, this.currentParticipantId);
     }
@@ -1035,6 +1058,18 @@ export abstract class StorageEngine {
     this.participantData.searchParams = searchParams;
 
     await this.persistCurrentParticipantData({ immediate: true });
+  }
+
+  async updateParticipantMetadata(metadata: ParticipantMetadata) {
+    await this.verifyStudyDatabase();
+
+    if (!this.participantData) {
+      throw new Error('Participant data not initialized');
+    }
+
+    this.participantData.metadata = metadata;
+
+    await this.persistCurrentParticipantData({ immediate: false });
   }
 
   async updateStudyCondition(condition: string | string[]) {
@@ -1695,6 +1730,10 @@ export abstract class CloudStorageEngine extends StorageEngine {
   protected cloudEngine = true;
 
   protected userManagementData: UserManagementData = {};
+
+  protected shouldDeferInitialParticipantDataPersistence() {
+    return true;
+  }
 
   /*
   * PRIMITIVE METHODS

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -1069,6 +1069,16 @@ export abstract class StorageEngine {
 
     this.participantData.metadata = metadata;
 
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+
+    const modes = await this.getModes(this.studyId);
+    if (!modes.dataCollectionEnabled) {
+      await this.cacheParticipantDataSnapshot(this.participantData, this.currentParticipantId);
+      return;
+    }
+
     await this.persistCurrentParticipantData({ immediate: false });
   }
 

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -923,7 +923,11 @@ export abstract class StorageEngine {
     };
 
     if (modes.dataCollectionEnabled) {
-      await this.persistCurrentParticipantData({ immediate: !this.shouldDeferInitialParticipantDataPersistence() });
+      if (this.shouldDeferInitialParticipantDataPersistence()) {
+        this.persistCurrentParticipantData({ immediate: true }).catch(() => undefined);
+      } else {
+        await this.persistCurrentParticipantData({ immediate: true });
+      }
     } else {
       await this.cacheParticipantDataSnapshot(this.participantData, this.currentParticipantId);
     }

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -278,6 +278,35 @@ describe.each([
     expect(storedHashes[configComplexHash]).toEqual(configSimple2);
   });
 
+  test('saveConfig skips storage writes when the config hash is unchanged', async () => {
+    await storageEngine.saveConfig(configSimple);
+
+    const pushSpy = vi.spyOn(
+      storageEngine as unknown as {
+        _pushToStorage: StorageEngine['_pushToStorage'];
+      },
+      '_pushToStorage',
+    );
+    const deleteSpy = vi.spyOn(
+      storageEngine as unknown as {
+        _deleteFromStorage: StorageEngine['_deleteFromStorage'];
+      },
+      '_deleteFromStorage',
+    );
+    const setHashSpy = vi.spyOn(
+      storageEngine as unknown as {
+        _setCurrentConfigHash: StorageEngine['_setCurrentConfigHash'];
+      },
+      '_setCurrentConfigHash',
+    );
+
+    await storageEngine.saveConfig(configSimple);
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(setHashSpy).not.toHaveBeenCalled();
+  });
+
   test('getCurrentParticipantId returns the current participant ID', async () => {
     const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
     const { participantId } = participantSession;
@@ -316,6 +345,14 @@ describe.each([
     expect(participantData!.metadata).toEqual(participantMetadata);
     expect(participantData!.rejected).toBe(false);
     expect(participantData!.participantTags).toEqual([]);
+  });
+
+  test('initializeParticipantSession reads modes only once for a new participant', async () => {
+    const getModesSpy = vi.spyOn(storageEngine, 'getModes');
+
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    expect(getModesSpy).toHaveBeenCalledTimes(1);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {
@@ -443,6 +480,24 @@ describe.each([
     expect(sequenceAssignment).toBeDefined();
     expect(sequenceAssignment!.conditions).toBeUndefined();
     expect(Object.hasOwn(sequenceAssignment!, 'conditions')).toBe(false);
+  });
+
+  test('updateParticipantMetadata updates participant metadata', async () => {
+    const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const updatedMetadata = {
+      ...participantMetadata,
+      ip: '8.8.8.8',
+    };
+
+    await storageEngine.updateParticipantMetadata(updatedMetadata);
+
+    expect(storageEngine.getCurrentParticipantDataSnapshot()!.metadata).toEqual(updatedMetadata);
+
+    await storageEngine.flushPendingParticipantData();
+
+    const participantData = await storageEngine.getParticipantData(participantSession.participantId);
+    expect(participantData).toBeDefined();
+    expect(participantData!.metadata).toEqual(updatedMetadata);
   });
 
   test('getConditionData includes default when participants have no explicit condition', async () => {

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -501,6 +501,7 @@ describe.each([
   });
 
   test('updateParticipantMetadata stays local when data collection is disabled', async () => {
+    await storageEngine.getModes(studyId);
     await storageEngine.setMode(studyId, 'dataCollectionEnabled', false);
 
     const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -500,6 +500,32 @@ describe.each([
     expect(participantData!.metadata).toEqual(updatedMetadata);
   });
 
+  test('updateParticipantMetadata stays local when data collection is disabled', async () => {
+    await storageEngine.setMode(studyId, 'dataCollectionEnabled', false);
+
+    const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const updatedMetadata = {
+      ...participantMetadata,
+      ip: '8.8.8.8',
+    };
+
+    const pushSpy = vi.spyOn(
+      storageEngine as unknown as {
+        _pushToStorage: StorageEngine['_pushToStorage'];
+      },
+      '_pushToStorage',
+    );
+
+    await storageEngine.updateParticipantMetadata(updatedMetadata);
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(storageEngine.getCurrentParticipantDataSnapshot()!.metadata).toEqual(updatedMetadata);
+
+    const participantData = await storageEngine.getParticipantData(participantSession.participantId);
+    expect(participantData).toBeDefined();
+    expect(participantData!.metadata).toEqual(updatedMetadata);
+  });
+
   test('getConditionData includes default when participants have no explicit condition', async () => {
     await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
     await storageEngine.clearCurrentParticipantId();

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -234,6 +234,12 @@ class DelayedLocalStorageEngine extends LocalStorageEngine {
   }
 }
 
+class DeferredInitialWriteLocalStorageEngine extends DelayedLocalStorageEngine {
+  protected override shouldDeferInitialParticipantDataPersistence() {
+    return true;
+  }
+}
+
 describe.each([
   { TestEngine: LocalStorageEngine },
   // { TestEngine: SupabaseStorageEngine }, // Uncomment to test with Supabase
@@ -353,6 +359,38 @@ describe.each([
     await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
 
     expect(getModesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('initializeParticipantSession starts deferred initial participant writes immediately in the background', async () => {
+    const deferredStorageEngine = new DeferredInitialWriteLocalStorageEngine(true);
+    await deferredStorageEngine.connect();
+    await deferredStorageEngine.initializeStudyDb(studyId);
+    await deferredStorageEngine.setSequenceArray(sequenceArray);
+    deferredStorageEngine.holdNextParticipantDataWrite();
+
+    const participantSessionPromise = deferredStorageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+    await deferredStorageEngine.waitForHeldParticipantDataWrite();
+
+    const participantSession = await participantSessionPromise;
+
+    const observerEngine = new LocalStorageEngine(true);
+    await observerEngine.connect();
+    await observerEngine.initializeStudyDb(studyId);
+
+    expect(await observerEngine.getParticipantData(participantSession.participantId)).toBeNull();
+
+    deferredStorageEngine.releaseHeldParticipantDataWrite();
+    await deferredStorageEngine.flushPendingParticipantData();
+
+    const persistedParticipantData = await observerEngine.getParticipantData(participantSession.participantId);
+    expect(persistedParticipantData).toBeDefined();
+    expect(persistedParticipantData?.participantId).toBe(participantSession.participantId);
+
+    // @ts-expect-error using protected method for testing
+    await deferredStorageEngine._testingReset(studyId);
+    // @ts-expect-error using protected method for testing
+    await observerEngine._testingReset(studyId);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {

--- a/src/store/hooks/useAuth.tsx
+++ b/src/store/hooks/useAuth.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
 } from 'react';
 import { LoadingOverlay } from '@mantine/core';
+import { useLocation, useMatch } from 'react-router';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { StoredUser, UserWrapped } from '../../storage/engines/types';
 import { isCloudStorageEngine } from '../../storage/engines/utils/storageEngineHelpers';
@@ -65,6 +66,8 @@ export function AuthProvider({ children } : { children: ReactNode }) {
   const [user, setUser] = useState(loadingNullUser);
   const [enableAuthTrigger, setEnableAuthTrigger] = useState(false);
   const { storageEngine } = useStorageEngine();
+  const location = useLocation();
+  const studyRouteMatch = useMatch('/:studyId/*');
 
   // Logs the user out by removing the user and navigating to '/login'
   const logout = async () => {
@@ -166,9 +169,11 @@ export function AuthProvider({ children } : { children: ReactNode }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [user]);
 
+  const allowChildrenWhileDeterminingStatus = Boolean(studyRouteMatch) && !location.pathname.startsWith('/analysis');
+
   return (
     <AuthContext.Provider value={value}>
-      {user.determiningStatus ? <LoadingOverlay visible /> : children }
+      {user.determiningStatus && !allowChildrenWhileDeterminingStatus ? <LoadingOverlay visible /> : children }
     </AuthContext.Provider>
   );
 }

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -146,6 +146,9 @@ export async function studyStoreCreator(
       setConfig(state, { payload }: PayloadAction<StudyConfig>) {
         state.config = payload;
       },
+      setMetadata(state, { payload }: PayloadAction<ParticipantMetadata>) {
+        state.metadata = payload;
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pushToFuncSequence(state, { payload }: PayloadAction<{ component: string, funcName: string, index: number, funcIndex: number, parameters: Record<string, any> | undefined, correctAnswer: Answer[] | undefined }>) {
         if (!state.funcSequence[payload.funcName]) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1221

### Give a longer description of what this PR addresses and why it's needed
Defers participant IP lookup and completion status reads until after the study store is initialized.
Avoids redundant config writes when the active config hash is unchanged.
Reduces storage round trips during participant initialization by sharing modes/stage bootstrap data.
Uses Firebase Storage getBlob directly for storage object reads.
Limits eager study config fetching to the home route and adds coverage for the storage optimizations.

### Provide pictures/videos of the behavior before and after these changes (optional)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [ ] Done
- [x] N/A