### PR TITLE
Fix UI bugs (screen recording download, reject/undo reject participant buttons)

### DIFF
--- a/src/analysis/individualStudy/ParticipantRejectModal.tsx
+++ b/src/analysis/individualStudy/ParticipantRejectModal.tsx
@@ -150,9 +150,12 @@ export function ParticipantRejectModal({
               {' '}
               {rejectedParticipantsCount === 1 ? 'has' : 'have'}
               {' '}
-              already been rejected. Clicking reject participants will now reject the other
+              already been rejected. Clicking reject participant
+              {nonRejectedParticipantsCount === 1 ? '' : 's'}
               {' '}
-              {nonRejectedParticipantsCount}
+              will now reject
+              {' '}
+              {nonRejectedParticipantsCount === 1 ? 'this participant' : 'these participants'}
               .
               <br />
               <br />

--- a/src/analysis/individualStudy/ParticipantRejectModal.tsx
+++ b/src/analysis/individualStudy/ParticipantRejectModal.tsx
@@ -52,6 +52,8 @@ export function ParticipantRejectModal({
   const currentAndSelectedParticipants = useMemo(() => [...selectedParticipants, currentParticipantData].filter((p) => p !== null) as ParticipantData[], [selectedParticipants, currentParticipantData]);
   const rejectedParticipantsCount = useMemo(() => currentAndSelectedParticipants.filter((p) => p.rejected).length, [currentAndSelectedParticipants]);
   const nonRejectedParticipantsCount = useMemo(() => currentAndSelectedParticipants.filter((p) => !p.rejected).length, [currentAndSelectedParticipants]);
+  const rejectParticipantLabel = `Reject Participant${nonRejectedParticipantsCount === 1 ? '' : 's'}`;
+  const undoRejectParticipantLabel = `Undo Reject Participant${rejectedParticipantsCount === 1 ? '' : 's'}`;
 
   const rejectParticipant = useCallback(async (rejectParticipantId: string, reason: string) => {
     if (storageEngine && studyId) {
@@ -111,16 +113,14 @@ export function ParticipantRejectModal({
           {rejectedParticipantsCount > 0 && (
             <Tooltip label="Only admins can undo rejection" disabled={user.isAdmin}>
               <Button disabled={!user.isAdmin} onClick={() => setModalUndoRejectOpened(true)} color="blue">
-                Undo Reject
-                {!footer ? ` Participant${rejectedParticipantsCount === 1 ? '' : 's'} (${rejectedParticipantsCount})` : ''}
+                {footer ? 'Undo Reject' : `${undoRejectParticipantLabel} (${rejectedParticipantsCount})`}
               </Button>
             </Tooltip>
           )}
           {nonRejectedParticipantsCount > 0 && (
             <Tooltip label="Only admins can reject participants" disabled={user.isAdmin}>
               <Button disabled={!user.isAdmin} onClick={() => setModalRejectOpened(true)} color="red">
-                Reject
-                {!footer ? ` Participant${nonRejectedParticipantsCount === 1 ? '' : 's'} (${nonRejectedParticipantsCount})` : ''}
+                {footer ? 'Reject' : `${rejectParticipantLabel} (${nonRejectedParticipantsCount})`}
               </Button>
             </Tooltip>
           )}
@@ -129,7 +129,9 @@ export function ParticipantRejectModal({
       <Modal
         opened={modalRejectOpened}
         onClose={() => setModalRejectOpened(false)}
-        title={`Reject Participant${nonRejectedParticipantsCount === 1 ? '' : 's'} (${nonRejectedParticipantsCount})`}
+        title={footer
+          ? rejectParticipantLabel
+          : `${rejectParticipantLabel} (${nonRejectedParticipantsCount})`}
       >
         <Alert
           icon={<IconAlertTriangle size={16} />}
@@ -172,7 +174,7 @@ export function ParticipantRejectModal({
             Cancel
           </Button>
           <Button color="red" onClick={handleRejectParticipant}>
-            {`Reject Participant${nonRejectedParticipantsCount === 1 ? '' : 's'}`}
+            {rejectParticipantLabel}
           </Button>
         </Flex>
       </Modal>
@@ -180,11 +182,9 @@ export function ParticipantRejectModal({
       <Modal
         opened={modalUndoRejectOpened}
         onClose={() => setModalUndoRejectOpened(false)}
-        title={(
-          <Text>
-            {`Undo Reject Participant${rejectedParticipantsCount === 1 ? '' : 's'} (${rejectedParticipantsCount})`}
-          </Text>
-        )}
+        title={footer
+          ? undoRejectParticipantLabel
+          : `${undoRejectParticipantLabel} (${rejectedParticipantsCount})`}
       >
         <Alert
           icon={<IconAlertTriangle size={16} />}
@@ -218,7 +218,7 @@ export function ParticipantRejectModal({
             Cancel
           </Button>
           <Button color="blue" onClick={handleUndoRejectParticipant}>
-            {`Undo Reject Participant${rejectedParticipantsCount === 1 ? '' : 's'}`}
+            {undoRejectParticipantLabel}
           </Button>
         </Flex>
       </Modal>

--- a/src/analysis/individualStudy/ParticipantRejectModal.tsx
+++ b/src/analysis/individualStudy/ParticipantRejectModal.tsx
@@ -1,5 +1,5 @@
 import {
-  Modal, Text, TextInput, Flex, Button, Alert, Tooltip,
+  Modal, Text, TextInput, Flex, Button, Alert, Tooltip, Group,
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import {
@@ -106,26 +106,30 @@ export function ParticipantRejectModal({
 
   return (
     <>
-      {rejectedParticipantsCount > 0 && (
-      <Tooltip label="Only admins can undo rejection" disabled={user.isAdmin}>
-        <Button disabled={!user.isAdmin} onClick={() => setModalUndoRejectOpened(true)} color="blue">
-          Undo Reject
-          {!footer ? ` Participants (${rejectedParticipantsCount})` : ''}
-        </Button>
-      </Tooltip>
-      )}
-      {nonRejectedParticipantsCount > 0 && (
-      <Tooltip label="Only admins can reject participants" disabled={user.isAdmin}>
-        <Button disabled={!user.isAdmin} onClick={() => setModalRejectOpened(true)} color="red">
-          Reject
-          {!footer ? ` Participants (${nonRejectedParticipantsCount})` : ''}
-        </Button>
-      </Tooltip>
+      {(rejectedParticipantsCount > 0 || nonRejectedParticipantsCount > 0) && (
+        <Group gap="xs">
+          {rejectedParticipantsCount > 0 && (
+            <Tooltip label="Only admins can undo rejection" disabled={user.isAdmin}>
+              <Button disabled={!user.isAdmin} onClick={() => setModalUndoRejectOpened(true)} color="blue">
+                Undo Reject
+                {!footer ? ` Participant${rejectedParticipantsCount === 1 ? '' : 's'} (${rejectedParticipantsCount})` : ''}
+              </Button>
+            </Tooltip>
+          )}
+          {nonRejectedParticipantsCount > 0 && (
+            <Tooltip label="Only admins can reject participants" disabled={user.isAdmin}>
+              <Button disabled={!user.isAdmin} onClick={() => setModalRejectOpened(true)} color="red">
+                Reject
+                {!footer ? ` Participant${nonRejectedParticipantsCount === 1 ? '' : 's'} (${nonRejectedParticipantsCount})` : ''}
+              </Button>
+            </Tooltip>
+          )}
+        </Group>
       )}
       <Modal
         opened={modalRejectOpened}
         onClose={() => setModalRejectOpened(false)}
-        title={nonRejectedParticipantsCount > 0 ? `Reject Participants (${nonRejectedParticipantsCount})` : 'Reject Participant'}
+        title={`Reject Participant${nonRejectedParticipantsCount === 1 ? '' : 's'} (${nonRejectedParticipantsCount})`}
       >
         <Alert
           icon={<IconAlertTriangle size={16} />}
@@ -134,25 +138,25 @@ export function ParticipantRejectModal({
           mb="md"
         >
           {currentAndSelectedParticipants.length > 0 && rejectedParticipantsCount > 0 && (
-          <>
-            {rejectedParticipantsCount}
-            {' '}
-            of your
-            {' '}
-            {currentAndSelectedParticipants.length}
-            {' '}
-            selected participant
-            {currentAndSelectedParticipants.length === 1 ? '' : 's'}
-            {' '}
-            {rejectedParticipantsCount === 1 ? 'has' : 'have'}
-            {' '}
-            already been rejected. Clicking reject participants will now reject the other
-            {' '}
-            {nonRejectedParticipantsCount}
-            .
-            <br />
-            <br />
-          </>
+            <>
+              {rejectedParticipantsCount}
+              {' '}
+              of your
+              {' '}
+              {currentAndSelectedParticipants.length}
+              {' '}
+              selected participant
+              {currentAndSelectedParticipants.length === 1 ? '' : 's'}
+              {' '}
+              {rejectedParticipantsCount === 1 ? 'has' : 'have'}
+              {' '}
+              already been rejected. Clicking reject participants will now reject the other
+              {' '}
+              {nonRejectedParticipantsCount}
+              .
+              <br />
+              <br />
+            </>
           )}
           When participants are rejected, their sequences will be reassigned to other participants.
         </Alert>
@@ -165,7 +169,7 @@ export function ParticipantRejectModal({
             Cancel
           </Button>
           <Button color="red" onClick={handleRejectParticipant}>
-            {currentAndSelectedParticipants.length > 0 ? 'Reject Participants' : 'Reject Participant'}
+            {`Reject Participant${nonRejectedParticipantsCount === 1 ? '' : 's'}`}
           </Button>
         </Flex>
       </Modal>
@@ -175,9 +179,9 @@ export function ParticipantRejectModal({
         onClose={() => setModalUndoRejectOpened(false)}
         title={(
           <Text>
-            {`Undo Reject Participants (${currentAndSelectedParticipants.length})`}
+            {`Undo Reject Participant${rejectedParticipantsCount === 1 ? '' : 's'} (${rejectedParticipantsCount})`}
           </Text>
-          )}
+        )}
       >
         <Alert
           icon={<IconAlertTriangle size={16} />}
@@ -188,7 +192,12 @@ export function ParticipantRejectModal({
           When you undo participant rejections, you may end up with unbalanced latin squares. This is because the rejected sequence may have been reassigned.
         </Alert>
         {currentAndSelectedParticipants.length > 0 ? (
-          <Text>Are you sure you want to undo the rejection of these participants?</Text>
+          <Text>
+            Are you sure you want to undo the rejection of
+            {' '}
+            {rejectedParticipantsCount === 1 ? 'this participant' : 'these participants'}
+            ?
+          </Text>
         ) : (
           <>
             <Text>
@@ -206,7 +215,7 @@ export function ParticipantRejectModal({
             Cancel
           </Button>
           <Button color="blue" onClick={handleUndoRejectParticipant}>
-            {currentAndSelectedParticipants.length > 0 ? 'Undo Reject Participants' : 'Undo Reject Participant'}
+            {`Undo Reject Participant${rejectedParticipantsCount === 1 ? '' : 's'}`}
           </Button>
         </Flex>
       </Modal>

--- a/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
+++ b/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
@@ -125,6 +125,7 @@ export function ThinkAloudFooter({
     async function fetchAssetsUrl() {
       if (!storageEngine || !participantId || !currentTrial) {
         setAudioUrl(null);
+        setScreenRecordingUrl(null);
         return;
       }
 
@@ -599,7 +600,7 @@ export function ThinkAloudFooter({
             )}
             {screenRecordingUrl && (
               <Tooltip label="Download screen recording">
-                <ActionIcon variant="filled" size={30} onClick={handleDownloadScreenRecording}>
+                <ActionIcon variant="light" size={30} onClick={handleDownloadScreenRecording}>
                   <IconDeviceDesktopDown />
                 </ActionIcon>
               </Tooltip>


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1233
Closes #1234

### Give a longer description of what this PR addresses and why it's needed

Fix small UI bugs
- Fix the screen recording download button use the same light blue style as the audio download button.
- Add spacing between the Undo Reject Participant and Reject Participant buttons.
- Update reject button/modal labels to use singular/plural text correctly. (participant/participants)

### Provide pictures/videos of the behavior before and after these changes (optional)

After

<img width="1895" height="912" alt="Screenshot 2026-05-27 at 10 00 55 PM" src="https://github.com/user-attachments/assets/ed60ac89-c808-4b2b-9db4-4b124ded20cd" />

<img width="1895" height="912" alt="Screenshot 2026-05-27 at 10 01 33 PM" src="https://github.com/user-attachments/assets/150667d5-354e-49fb-8824-05c671bad017" />

Before

<img width="3412" height="1912" alt="image" src="https://github.com/user-attachments/assets/071d1f33-ba66-4b0c-a50e-6b8f286a6414" />

<img width="3434" height="1918" alt="image" src="https://github.com/user-attachments/assets/09a01824-745d-4234-af9b-a9ae283ae58b" />


### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [ ] Done
- [x] N/A