### PR TITLE
resolve #1213 and #1193

### DIFF
--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -55,7 +55,7 @@ function HomeRoute({ globalConfig }: { globalConfig: GlobalConfig }) {
         padding="md"
         header={{ height: 70 }}
       >
-        <AppHeader studyIds={globalConfig.configsList} />
+        <AppHeader studyIds={globalConfig.configsList} studyConfigs={studyConfigs} />
         <ConfigSwitcher
           globalConfig={globalConfig}
           studyConfigs={studyConfigs}

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -377,7 +377,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
 
   return (
     <>
-      <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyHref={routeStudyId ? `/${routeStudyId}` : undefined} />
+      <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyHref={routeStudyId ? `/${routeStudyId}` : undefined} studyConfigs={studyConfig && displayStudyId ? { [displayStudyId]: studyConfig } : undefined} />
       <AppShell.Main style={{ height: '100dvh' }}>
         <Stack ref={ref} style={{ height: '100%', maxHeight: '100dvh', overflow: 'hidden' }} justify="space-between">
           <Flex direction="row" align="center" justify="space-between" p="sm" gap="md">

--- a/src/analysis/interface/AppHeader.tsx
+++ b/src/analysis/interface/AppHeader.tsx
@@ -1,5 +1,5 @@
 import {
-  Flex, Image, Select, Title, Space, Grid, AppShell, Button,
+  Flex, Image, Select, Title, Space, Grid, AppShell, Button, Text,
 } from '@mantine/core';
 
 import { useLocation, useNavigate, useParams } from 'react-router';
@@ -7,20 +7,28 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { IconListCheck, IconSettings } from '@tabler/icons-react';
 import { PREFIX } from '../../utils/Prefix';
 
+const STUDY_SCHEMA_VERSION_REGEX = /\/study\/(v\d+\.\d+\.\d+)\//;
+
 export function AppHeader({
   studyIds,
   selectedStudyId,
   studyHref,
+  studyConfigs,
 }: {
   studyIds: string[];
   selectedStudyId?: string;
   studyHref?: string;
+  studyConfigs?: Record<string, { $schema: string } | null>;
 }) {
   const navigate = useNavigate();
   const { studyId } = useParams();
   const location = useLocation();
 
   const selectorData = studyIds.map((id) => ({ value: id, label: id })).sort((a, b) => a.label.localeCompare(b.label));
+  const revisitVersion = studyIds
+    .map((id) => studyConfigs?.[id]?.$schema.match(STUDY_SCHEMA_VERSION_REGEX)?.[1])
+    .filter((version): version is string => version !== undefined)
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0];
 
   const inAnalysis = location.pathname.includes('analysis');
 
@@ -39,6 +47,7 @@ export function AppHeader({
 
         <Grid.Col span={6}>
           <Flex
+            align="center"
             justify="flex-end"
             direction="row"
           >
@@ -58,7 +67,8 @@ export function AppHeader({
               </>
             )}
 
-            <IconSettings onClick={() => navigate('/settings')} style={{ cursor: 'pointer', marginTop: inAnalysis ? 6 : undefined }} />
+            {revisitVersion && <Text c="dimmed" size="sm" mr="sm">{`reVISit ${revisitVersion}`}</Text>}
+            <IconSettings onClick={() => navigate('/settings')} style={{ cursor: 'pointer' }} />
           </Flex>
         </Grid.Col>
       </Grid>

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -23,8 +23,6 @@ import { useStudyRecordings } from '../utils/useStudyRecordings';
 import { useDeviceRules } from '../utils/useDeviceRules';
 import { getUnmetDeviceRestrictionLines, getUnmetDeviceRestrictionTooltip } from './interface/DeviceRestrictionString';
 
-const STUDY_SCHEMA_VERSION_REGEX = /\/study\/(v\d+\.\d+\.\d+)\//;
-
 function StudyCard({
   configName,
   config,
@@ -384,10 +382,6 @@ export function ConfigSwitcher({
     () => configsList.some((configName) => !(configName in studyConfigs)),
     [configsList, studyConfigs],
   );
-  const revisitVersion = useMemo(() => configsList
-    .map((configName) => studyConfigs[configName]?.$schema.match(STUDY_SCHEMA_VERSION_REGEX)?.[1])
-    .filter((version): version is string => version !== undefined)
-    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0], [configsList, studyConfigs]);
   const isLoadingStudies = isLoadingVisibility || isLoadingStudyConfigs;
   const configsFiltered = useMemo(() => configsList.filter((configName) => studyVisibility[configName] || user.isAdmin), [configsList, studyVisibility, user]);
 
@@ -550,19 +544,6 @@ export function ConfigSwitcher({
               </Text>
             )}
           </>
-        )}
-        {revisitVersion && (
-          <Text
-            c="dimmed"
-            size="xs"
-            style={{
-              position: 'fixed',
-              right: 12,
-              bottom: 8,
-            }}
-          >
-            {`reVISit ${revisitVersion}`}
-          </Text>
         )}
       </Container>
     </AppShell.Main>

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -22,6 +22,9 @@ import { getSequenceConditions } from '../utils/handleConditionLogic';
 import { useStudyRecordings } from '../utils/useStudyRecordings';
 import { useDeviceRules } from '../utils/useDeviceRules';
 import { getUnmetDeviceRestrictionLines, getUnmetDeviceRestrictionTooltip } from './interface/DeviceRestrictionString';
+import packageJson from '../../package.json';
+
+const REVISIT_VERSION = packageJson.version;
 
 function StudyCard({
   configName,
@@ -545,6 +548,17 @@ export function ConfigSwitcher({
             )}
           </>
         )}
+        <Text
+          c="dimmed"
+          size="xs"
+          style={{
+            position: 'fixed',
+            right: 12,
+            bottom: 8,
+          }}
+        >
+          {`reVISit v${REVISIT_VERSION}`}
+        </Text>
       </Container>
     </AppShell.Main>
   );

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -22,9 +22,8 @@ import { getSequenceConditions } from '../utils/handleConditionLogic';
 import { useStudyRecordings } from '../utils/useStudyRecordings';
 import { useDeviceRules } from '../utils/useDeviceRules';
 import { getUnmetDeviceRestrictionLines, getUnmetDeviceRestrictionTooltip } from './interface/DeviceRestrictionString';
-import packageJson from '../../package.json';
 
-const REVISIT_VERSION = packageJson.version;
+const STUDY_SCHEMA_VERSION_REGEX = /\/study\/(v\d+\.\d+\.\d+)\//;
 
 function StudyCard({
   configName,
@@ -385,6 +384,10 @@ export function ConfigSwitcher({
     () => configsList.some((configName) => !(configName in studyConfigs)),
     [configsList, studyConfigs],
   );
+  const revisitVersion = useMemo(() => configsList
+    .map((configName) => studyConfigs[configName]?.$schema.match(STUDY_SCHEMA_VERSION_REGEX)?.[1])
+    .filter((version): version is string => version !== undefined)
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0], [configsList, studyConfigs]);
   const isLoadingStudies = isLoadingVisibility || isLoadingStudyConfigs;
   const configsFiltered = useMemo(() => configsList.filter((configName) => studyVisibility[configName] || user.isAdmin), [configsList, studyVisibility, user]);
 
@@ -548,17 +551,19 @@ export function ConfigSwitcher({
             )}
           </>
         )}
-        <Text
-          c="dimmed"
-          size="xs"
-          style={{
-            position: 'fixed',
-            right: 12,
-            bottom: 8,
-          }}
-        >
-          {`reVISit v${REVISIT_VERSION}`}
-        </Text>
+        {revisitVersion && (
+          <Text
+            c="dimmed"
+            size="xs"
+            style={{
+              position: 'fixed',
+              right: 12,
+              bottom: 8,
+            }}
+          >
+            {`reVISit ${revisitVersion}`}
+          </Text>
+        )}
       </Container>
     </AppShell.Main>
   );

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -121,8 +121,16 @@ function participantDataToRows(
       answer: JSON.stringify(participant.participantTags),
       ...(properties.includes('condition') ? { condition: conditionValue } : {}),
       ...(properties.includes('stage') ? { stage: participant.stage } : {}),
-      ...(properties.includes('metaData') ? { metaData } : {}),
     },
+    ...(properties.includes('metaData') ? [{
+      participantId: participant.participantId,
+      trialId: 'metaData',
+      trialOrder: null,
+      responseId: 'metaData',
+      answer: metaData,
+      ...(properties.includes('condition') ? { condition: conditionValue } : {}),
+      ...(properties.includes('stage') ? { stage: participant.stage } : {}),
+    }] : []),
     ...Object.values(participant.answers).map((trialAnswer) => {
       // Get the whole component, including the base component if there is inheritance
       const trialId = trialAnswer.componentName;
@@ -212,9 +220,6 @@ function participantDataToRows(
         if (properties.includes('responseMax')) {
           tidyRow.responseMax = response?.type === 'numerical' ? response.max : undefined;
         }
-        if (properties.includes('metaData')) {
-          tidyRow.metaData = metaData;
-        }
         return tidyRow;
       }).flat();
 
@@ -240,7 +245,6 @@ function participantDataToRows(
         answer: JSON.stringify(windowEventsCount),
         ...(properties.includes('condition') ? { condition: conditionValue } : {}),
         ...(properties.includes('stage') ? { stage: participant.stage } : {}),
-        ...(properties.includes('metaData') ? { metaData } : {}),
       } as TidyRow);
 
       return rows;
@@ -289,7 +293,9 @@ async function getTableData(
     const legacyStudyCondition = (p as { studyCondition?: string | string[] }).studyCondition;
     return parseConditionParam(p.conditions ?? legacyStudyCondition ?? p.searchParams?.condition).length > 0;
   });
-  const header = combinedProperties.filter((p) => p !== 'condition' || hasCondition);
+  const header = combinedProperties
+    .filter((p) => p !== 'condition' || hasCondition)
+    .filter((p) => p !== 'metaData');
   const allData = await Promise.all(data.map(async (participant) => {
     const partDataToRows = await participantDataToRows(participant, combinedProperties, allConfigs[participant.participantConfigHash], transcripts);
 

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -49,6 +49,7 @@ const OPTIONAL_COMMON_PROPS = [
   'responseMin',
   'responseMax',
   'configHash',
+  'metaData',
 ] as const;
 
 const REQUIRED_PROPS = [
@@ -109,6 +110,7 @@ function participantDataToRows(
   const newHeaders = new Set<string>();
   const participantConditions = parseConditionParam(participant.conditions ?? participant.searchParams?.condition);
   const conditionValue = participantConditions.length > 0 ? participantConditions.join(',') : 'default';
+  const metaData = JSON.stringify(participant.metadata);
 
   return [[
     {
@@ -119,6 +121,7 @@ function participantDataToRows(
       answer: JSON.stringify(participant.participantTags),
       ...(properties.includes('condition') ? { condition: conditionValue } : {}),
       ...(properties.includes('stage') ? { stage: participant.stage } : {}),
+      ...(properties.includes('metaData') ? { metaData } : {}),
     },
     ...Object.values(participant.answers).map((trialAnswer) => {
       // Get the whole component, including the base component if there is inheritance
@@ -209,6 +212,9 @@ function participantDataToRows(
         if (properties.includes('responseMax')) {
           tidyRow.responseMax = response?.type === 'numerical' ? response.max : undefined;
         }
+        if (properties.includes('metaData')) {
+          tidyRow.metaData = metaData;
+        }
         return tidyRow;
       }).flat();
 
@@ -234,6 +240,7 @@ function participantDataToRows(
         answer: JSON.stringify(windowEventsCount),
         ...(properties.includes('condition') ? { condition: conditionValue } : {}),
         ...(properties.includes('stage') ? { stage: participant.stage } : {}),
+        ...(properties.includes('metaData') ? { metaData } : {}),
       } as TidyRow);
 
       return rows;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1213
Closes #1193.

### Give a longer description of what this PR addresses and why it's needed
Resolve #1213 and #1193. 
- Add an optionalProperty for metadata tidy CSV download.
- Add a little footnote on the bottom right corner of the landing page showing ReVISiT version.


### Provide pictures/videos of the behavior before and after these changes (optional)
#1193 - add an optionalProperties that covers keys under metadata:
<img width="1161" height="649" alt="图片" src="https://github.com/user-attachments/assets/55c773d4-3372-4dac-ab35-f6c93172d6f0" />


#1213 - add a small version tag on the landing page:
<img width="1421" height="721" alt="图片" src="https://github.com/user-attachments/assets/fb830ff9-5a35-467b-b237-7d146a062b3b" />



### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [x] Done
- [ ] N/A