### PR TITLE
Add UEQ and UEQ-S libraries

### DIFF
--- a/public/global.json
+++ b/public/global.json
@@ -41,6 +41,8 @@
     "library-screen-recording",
     "library-smeq",
     "library-sus",
+    "library-ueq",
+    "library-ueq-s",
     "library-umux",
     "library-umux-lite",
     "library-virtual-chinrest",
@@ -187,6 +189,14 @@
     },
     "library-sus": {
       "path": "library-sus/config.json",
+      "test": true
+    },
+    "library-ueq": {
+      "path": "library-ueq/config.json",
+      "test": true
+    },
+    "library-ueq-s": {
+      "path": "library-ueq-s/config.json",
       "test": true
     },
     "library-vlat": {

--- a/public/libraries/ueq-s/config.json
+++ b/public/libraries/ueq-s/config.json
@@ -2,90 +2,61 @@
   "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/LibraryConfigSchema.json",
   "description": "The Short Version of the User Experience Questionnaire (UEQ-S) is a short version of the User Experience Questionnaire (UEQ), which is a widely used tool to measure user experience. This library contains one component with 8 questions. The component is the full UEQ-S questionnaire with 8 questions.",
   "reference": "M. Schrepp, A. Hinderks, and J. Thomaschewski, Design and Evaluation of a Short Version of the User Experience Questionnaire (UEQ-S), International Journal of Interactive Multimedia and Artificial Intelligence, vol. 4, no. 6, pp. 103–108, Sep. 2017.",
-  "doi":"10.9781/ijimai.2017.09.001",  
+  "doi": "10.9781/ijimai.2017.09.001",
   "components": {
     "ueq-s": {
       "type": "questionnaire",
       "response": [
         {
-          "id": "obstructive-supportive",
-          "prompt": "",
+          "id": "ueq-s-response",
+          "prompt": "For each word pair, select a value from 1 (left word) to 7 (right word).",
+          "secondaryText": "1 = left word, 7 = right word",
           "required": true,
           "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Obstructive",
-          "rightLabel": "Supportive"
-        },
-        {
-          "id": "complicated-easy",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Complicated",
-          "rightLabel": "Easy"
-        },
-        {
-          "id": "inefficient-efficient",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Inefficient",
-          "rightLabel": "Efficient"
-        },
-        {
-          "id": "clear-confusing",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Clear",
-          "rightLabel": "Confusing"
-        },
-        {
-          "id": "boring-exciting",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Boring",
-          "rightLabel": "Exciting"
-        },
-        {
-          "id": "not-interesting-interesting",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Not interesting",
-          "rightLabel": "Interesting"
-        },
-        {
-          "id": "conventional-inventive",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Conventional",
-          "rightLabel": "Inventive"
-        },
-        {
-          "id": "usual-leading-edge",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Usual",
-          "rightLabel": "Leading edge"
+          "type": "matrix-radio",
+          "answerOptions": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7"
+          ],
+          "questionOptions": [
+            {
+              "label": "Obstructive - Supportive",
+              "value": "obstructive-supportive"
+            },
+            {
+              "label": "Complicated - Easy",
+              "value": "complicated-easy"
+            },
+            {
+              "label": "Inefficient - Efficient",
+              "value": "inefficient-efficient"
+            },
+            {
+              "label": "Clear - Confusing",
+              "value": "clear-confusing"
+            },
+            {
+              "label": "Boring - Exciting",
+              "value": "boring-exciting"
+            },
+            {
+              "label": "Not interesting - Interesting",
+              "value": "not-interesting-interesting"
+            },
+            {
+              "label": "Conventional - Inventive",
+              "value": "conventional-inventive"
+            },
+            {
+              "label": "Usual - Leading edge",
+              "value": "usual-leading-edge"
+            }
+          ]
         }
       ]
     }

--- a/public/libraries/ueq-s/config.json
+++ b/public/libraries/ueq-s/config.json
@@ -2,8 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/LibraryConfigSchema.json",
   "description": "The Short Version of the User Experience Questionnaire (UEQ-S) is a short version of the User Experience Questionnaire (UEQ), which is a widely used tool to measure user experience. This library contains one component with 8 questions. The component is the full UEQ-S questionnaire with 8 questions.",
   "reference": "M. Schrepp, A. Hinderks, and J. Thomaschewski, Design and Evaluation of a Short Version of the User Experience Questionnaire (UEQ-S), International Journal of Interactive Multimedia and Artificial Intelligence, vol. 4, no. 6, pp. 103–108, Sep. 2017.",
-  "doi":"10.9781/ijimai.2017.09.001",
-  "externalLink": "https://www.ueq-online.org/",
+  "doi":"10.9781/ijimai.2017.09.001",  
   "components": {
     "ueq-s": {
       "type": "questionnaire",

--- a/public/libraries/ueq-s/config.json
+++ b/public/libraries/ueq-s/config.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/LibraryConfigSchema.json",
+  "description": "The Short Version of the User Experience Questionnaire (UEQ-S) is a short version of the User Experience Questionnaire (UEQ), which is a widely used tool to measure user experience. This library contains one component with 8 questions. The component is the full UEQ-S questionnaire with 8 questions.",
+  "reference": "M. Schrepp, A. Hinderks, and J. Thomaschewski, Design and Evaluation of a Short Version of the User Experience Questionnaire (UEQ-S), International Journal of Interactive Multimedia and Artificial Intelligence, vol. 4, no. 6, pp. 103–108, Sep. 2017.",
+  "doi":"10.9781/ijimai.2017.09.001",
+  "externalLink": "https://www.ueq-online.org/",
+  "components": {
+    "ueq-s": {
+      "type": "questionnaire",
+      "response": [
+        {
+          "id": "obstructive-supportive",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Obstructive",
+          "rightLabel": "Supportive"
+        },
+        {
+          "id": "complicated-easy",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Complicated",
+          "rightLabel": "Easy"
+        },
+        {
+          "id": "inefficient-efficient",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Inefficient",
+          "rightLabel": "Efficient"
+        },
+        {
+          "id": "clear-confusing",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Clear",
+          "rightLabel": "Confusing"
+        },
+        {
+          "id": "boring-exciting",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Boring",
+          "rightLabel": "Exciting"
+        },
+        {
+          "id": "not-interesting-interesting",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Not interesting",
+          "rightLabel": "Interesting"
+        },
+        {
+          "id": "conventional-inventive",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Conventional",
+          "rightLabel": "Inventive"
+        },
+        {
+          "id": "usual-leading-edge",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Usual",
+          "rightLabel": "Leading edge"
+        }
+      ]
+    }
+  },
+  "sequences": {}
+}

--- a/public/libraries/ueq/config.json
+++ b/public/libraries/ueq/config.json
@@ -2,272 +2,135 @@
   "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/LibraryConfigSchema.json",
   "description": "User Experience Questionnaire (UEQ) is a fast and reliable questionnaire to measure the User Experience of interactive products. This library contains one component with 26 questions. The component is the full UEQ questionnaire with 26 questions.",
   "reference": "B. Laugwitz, M. Schrepp, and T. Held, Construction and Evaluation of a User Experience Questionnaire, USAB 2008, LNCS 5298, pp. 63–76, 2008.",
-  "doi":"10.1007/978-3-540-89350-9_6",
+  "doi": "10.1007/978-3-540-89350-9_6",
   "externalLink": "https://www.ueq-online.org/",
   "components": {
     "ueq": {
       "type": "questionnaire",
-      "responseOrder": "random",
       "response": [
         {
-          "id": "annoying-enjoyable",
-          "prompt": "",
+          "id": "ueq-response",
+          "prompt": "For each word pair, select a value from 1 (left word) to 7 (right word).",
+          "secondaryText": "1 = left word, 7 = right word",
           "required": true,
           "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Annoying",
-          "rightLabel": "Enjoyable"
-        },
-        {
-          "id": "not-understandable-understandable",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Not understandable",
-          "rightLabel": "Understandable"
-        },
-        {
-          "id": "creative-dull",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Creative",
-          "rightLabel": "Dull"
-        },
-        {
-          "id": "easy-to-learn-difficult-to-learn",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Easy to learn",
-          "rightLabel": "Difficult to learn"
-        },
-        {
-          "id": "valuable-inferior",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Valuable",
-          "rightLabel": "Inferior"
-        },
-        {
-          "id": "boring-exciting",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Boring",
-          "rightLabel": "Exciting"
-        },
-        {
-          "id": "not-interesting-interesting",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Not interesting",
-          "rightLabel": "Interesting"
-        },
-        {
-          "id": "unpredictable-predictable",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Unpredictable",
-          "rightLabel": "Predictable"
-        },
-        {
-          "id": "fast-slow",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Fast",
-          "rightLabel": "Slow"
-        },
-        {
-          "id": "inventive-conventional",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Inventive",
-          "rightLabel": "Conventional"
-        },
-        {
-          "id": "obstructive-supportive",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Obstructive",
-          "rightLabel": "Supportive"
-        },
-        {
-          "id": "good-bad",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Good",
-          "rightLabel": "Bad"
-        },
-        {
-          "id": "complicated-easy",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Complicated",
-          "rightLabel": "Easy"
-        },
-        {
-          "id": "unlikable-pleasing",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Unlikable",
-          "rightLabel": "Pleasing"
-        },
-        {
-          "id": "usual-leading-edge",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Usual",
-          "rightLabel": "Leading edge"
-        },
-        {
-          "id": "unpleasant-pleasant",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Unpleasant",
-          "rightLabel": "Pleasant"
-        },
-        {
-          "id": "secure-not-secure",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Secure",
-          "rightLabel": "Not secure"
-        },
-        {
-          "id": "motivating-demotivating",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Motivating",
-          "rightLabel": "Demotivating"
-        },
-        {
-          "id": "meets-expectations-does-not-meet-expectations",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Meets expectations",
-          "rightLabel": "Does not meet expectations"
-        },
-        {
-          "id": "inefficient-efficient",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Inefficient",
-          "rightLabel": "Efficient"
-        },
-        {
-          "id": "clear-confusing",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Clear",
-          "rightLabel": "Confusing"
-        },
-        {
-          "id": "impractical-practical",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Impractical",
-          "rightLabel": "Practical"
-        },
-        {
-          "id": "organized-cluttered",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Organized",
-          "rightLabel": "Cluttered"
-        },
-        {
-          "id": "attractive-unattractive",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Attractive",
-          "rightLabel": "Unattractive"
-        },
-        {
-          "id": "friendly-unfriendly",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Friendly",
-          "rightLabel": "Unfriendly"
-        },
-        {
-          "id": "conservative-innovative",
-          "prompt": "",
-          "required": true,
-          "location": "aboveStimulus",
-          "type": "likert",
-          "numItems": 7,
-          "leftLabel": "Conservative",
-          "rightLabel": "Innovative"
+          "type": "matrix-radio",
+          "answerOptions": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7"
+          ],
+          "questionOptions": [
+            {
+              "label": "Annoying - Enjoyable",
+              "value": "annoying-enjoyable"
+            },
+            {
+              "label": "Not understandable - Understandable",
+              "value": "not-understandable-understandable"
+            },
+            {
+              "label": "Creative - Dull",
+              "value": "creative-dull"
+            },
+            {
+              "label": "Easy to learn - Difficult to learn",
+              "value": "easy-to-learn-difficult-to-learn"
+            },
+            {
+              "label": "Valuable - Inferior",
+              "value": "valuable-inferior"
+            },
+            {
+              "label": "Boring - Exciting",
+              "value": "boring-exciting"
+            },
+            {
+              "label": "Not interesting - Interesting",
+              "value": "not-interesting-interesting"
+            },
+            {
+              "label": "Unpredictable - Predictable",
+              "value": "unpredictable-predictable"
+            },
+            {
+              "label": "Fast - Slow",
+              "value": "fast-slow"
+            },
+            {
+              "label": "Inventive - Conventional",
+              "value": "inventive-conventional"
+            },
+            {
+              "label": "Obstructive - Supportive",
+              "value": "obstructive-supportive"
+            },
+            {
+              "label": "Good - Bad",
+              "value": "good-bad"
+            },
+            {
+              "label": "Complicated - Easy",
+              "value": "complicated-easy"
+            },
+            {
+              "label": "Unlikable - Pleasing",
+              "value": "unlikable-pleasing"
+            },
+            {
+              "label": "Usual - Leading edge",
+              "value": "usual-leading-edge"
+            },
+            {
+              "label": "Unpleasant - Pleasant",
+              "value": "unpleasant-pleasant"
+            },
+            {
+              "label": "Secure - Not secure",
+              "value": "secure-not-secure"
+            },
+            {
+              "label": "Motivating - Demotivating",
+              "value": "motivating-demotivating"
+            },
+            {
+              "label": "Meets expectations - Does not meet expectations",
+              "value": "meets-expectations-does-not-meet-expectations"
+            },
+            {
+              "label": "Inefficient - Efficient",
+              "value": "inefficient-efficient"
+            },
+            {
+              "label": "Clear - Confusing",
+              "value": "clear-confusing"
+            },
+            {
+              "label": "Impractical - Practical",
+              "value": "impractical-practical"
+            },
+            {
+              "label": "Organized - Cluttered",
+              "value": "organized-cluttered"
+            },
+            {
+              "label": "Attractive - Unattractive",
+              "value": "attractive-unattractive"
+            },
+            {
+              "label": "Friendly - Unfriendly",
+              "value": "friendly-unfriendly"
+            },
+            {
+              "label": "Conservative - Innovative",
+              "value": "conservative-innovative"
+            }
+          ],
+          "questionOrder": "random"
         }
       ]
     }

--- a/public/libraries/ueq/config.json
+++ b/public/libraries/ueq/config.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/LibraryConfigSchema.json",
+  "description": "User Experience Questionnaire (UEQ) is a fast and reliable questionnaire to measure the User Experience of interactive products. This library contains one component with 26 questions. The component is the full UEQ questionnaire with 26 questions.",
+  "reference": "B. Laugwitz, M. Schrepp, and T. Held, Construction and Evaluation of a User Experience Questionnaire, USAB 2008, LNCS 5298, pp. 63–76, 2008.",
+  "doi":"10.1007/978-3-540-89350-9_6",
+  "externalLink": "https://www.ueq-online.org/",
+  "components": {
+    "ueq": {
+      "type": "questionnaire",
+      "responseOrder": "random",
+      "response": [
+        {
+          "id": "annoying-enjoyable",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Annoying",
+          "rightLabel": "Enjoyable"
+        },
+        {
+          "id": "not-understandable-understandable",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Not understandable",
+          "rightLabel": "Understandable"
+        },
+        {
+          "id": "creative-dull",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Creative",
+          "rightLabel": "Dull"
+        },
+        {
+          "id": "easy-to-learn-difficult-to-learn",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Easy to learn",
+          "rightLabel": "Difficult to learn"
+        },
+        {
+          "id": "valuable-inferior",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Valuable",
+          "rightLabel": "Inferior"
+        },
+        {
+          "id": "boring-exciting",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Boring",
+          "rightLabel": "Exciting"
+        },
+        {
+          "id": "not-interesting-interesting",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Not interesting",
+          "rightLabel": "Interesting"
+        },
+        {
+          "id": "unpredictable-predictable",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Unpredictable",
+          "rightLabel": "Predictable"
+        },
+        {
+          "id": "fast-slow",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Fast",
+          "rightLabel": "Slow"
+        },
+        {
+          "id": "inventive-conventional",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Inventive",
+          "rightLabel": "Conventional"
+        },
+        {
+          "id": "obstructive-supportive",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Obstructive",
+          "rightLabel": "Supportive"
+        },
+        {
+          "id": "good-bad",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Good",
+          "rightLabel": "Bad"
+        },
+        {
+          "id": "complicated-easy",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Complicated",
+          "rightLabel": "Easy"
+        },
+        {
+          "id": "unlikable-pleasing",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Unlikable",
+          "rightLabel": "Pleasing"
+        },
+        {
+          "id": "usual-leading-edge",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Usual",
+          "rightLabel": "Leading edge"
+        },
+        {
+          "id": "unpleasant-pleasant",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Unpleasant",
+          "rightLabel": "Pleasant"
+        },
+        {
+          "id": "secure-not-secure",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Secure",
+          "rightLabel": "Not secure"
+        },
+        {
+          "id": "motivating-demotivating",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Motivating",
+          "rightLabel": "Demotivating"
+        },
+        {
+          "id": "meets-expectations-does-not-meet-expectations",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Meets expectations",
+          "rightLabel": "Does not meet expectations"
+        },
+        {
+          "id": "inefficient-efficient",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Inefficient",
+          "rightLabel": "Efficient"
+        },
+        {
+          "id": "clear-confusing",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Clear",
+          "rightLabel": "Confusing"
+        },
+        {
+          "id": "impractical-practical",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Impractical",
+          "rightLabel": "Practical"
+        },
+        {
+          "id": "organized-cluttered",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Organized",
+          "rightLabel": "Cluttered"
+        },
+        {
+          "id": "attractive-unattractive",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Attractive",
+          "rightLabel": "Unattractive"
+        },
+        {
+          "id": "friendly-unfriendly",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Friendly",
+          "rightLabel": "Unfriendly"
+        },
+        {
+          "id": "conservative-innovative",
+          "prompt": "",
+          "required": true,
+          "location": "aboveStimulus",
+          "type": "likert",
+          "numItems": 7,
+          "leftLabel": "Conservative",
+          "rightLabel": "Innovative"
+        }
+      ]
+    }
+  },
+  "sequences": {}
+}

--- a/public/library-ueq-s/assets/ueq-s.md
+++ b/public/library-ueq-s/assets/ueq-s.md
@@ -1,0 +1,24 @@
+
+# ueq-s
+
+This is an example study of the library `ueq-s`.
+
+The Short Version of the User Experience Questionnaire (UEQ-S) is a short version of the User Experience Questionnaire (UEQ), which is a widely used tool to measure user experience. This library contains one component with 8 questions. The component is the full UEQ-S questionnaire with 8 questions.
+
+## Reference
+
+M. Schrepp, A. Hinderks, and J. Thomaschewski, Design and Evaluation of a Short Version of the User Experience Questionnaire (UEQ-S), International Journal of Interactive Multimedia and Artificial Intelligence, vol. 4, no. 6, pp. 103–108, Sep. 2017.
+
+DOI: [10.9781/ijimai.2017.09.001](https://dx.doi.org/10.9781/ijimai.2017.09.001) d
+
+## Available Components
+
+- ueq-s
+
+## Available Sequences
+
+None
+
+
+
+

--- a/public/library-ueq-s/config.json
+++ b/public/library-ueq-s/config.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/dev/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "The Short Version of the User Experience Questionnaire (UEQ-S)",
+    "version": "1.0.0",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2026-06-04",
+    "description": "Example study using the ueq-s library.",
+    "organizations": [
+      "University of Utah",
+      "WPI"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "withSidebar": true
+  },
+  "importedLibraries": [
+    "ueq-s"
+  ],
+  "components": {
+    "introduction": {
+      "type": "markdown",
+      "path": "library-ueq-s/assets/ueq-s.md",
+      "response": []
+    }
+  },
+  "sequence": {
+    "order": "fixed",
+    "components": [
+      "introduction",
+      "$ueq-s.components.ueq-s"
+    ]
+  }
+}

--- a/public/library-ueq/assets/ueq.md
+++ b/public/library-ueq/assets/ueq.md
@@ -1,0 +1,26 @@
+
+# ueq
+
+This is an example study of the library `ueq`.
+
+User Experience Questionnaire (UEQ) is a fast and reliable questionnaire to measure the User Experience of interactive products. This library contains one component with 26 questions. The component is the full UEQ questionnaire with 26 questions.
+
+## Reference
+
+B. Laugwitz, M. Schrepp, and T. Held, Construction and Evaluation of a User Experience Questionnaire, USAB 2008, LNCS 5298, pp. 63–76, 2008.
+
+DOI: [10.1007/978-3-540-89350-9_6](https://dx.doi.org/10.1007/978-3-540-89350-9_6)
+
+Link: [https://www.ueq-online.org/](https://www.ueq-online.org/)
+
+## Available Components
+
+- ueq
+
+## Available Sequences
+
+None
+
+
+
+

--- a/public/library-ueq/config.json
+++ b/public/library-ueq/config.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/dev/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "User Experience Questionnaire (UEQ)",
+    "version": "1.0.0",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2026-06-04",
+    "description": "Example study using the ueq library.",
+    "organizations": [
+      "University of Utah",
+      "WPI"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "withSidebar": true
+  },
+  "importedLibraries": [
+    "ueq"
+  ],
+  "components": {
+    "introduction": {
+      "type": "markdown",
+      "path": "library-ueq/assets/ueq.md",
+      "response": []
+    }
+  },
+  "sequence": {
+    "order": "fixed",
+    "components": [
+      "introduction",
+      "$ueq.components.ueq"
+    ]
+  }
+}


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1224


### Give a longer description of what this PR addresses and why it's needed

Added the UEQ and UEQ-S questionnaires, and related example studies/doc

### Provide pictures/videos of the behavior before and after these changes (optional)

<img width="2254" height="522" alt="image" src="https://github.com/user-attachments/assets/d361cce6-204a-491b-816a-3b5b6bc0b5bc" />
<img width="2552" height="1507" alt="image" src="https://github.com/user-attachments/assets/f20a67ae-272f-43cd-a601-59c1be868202" />
<img width="2550" height="803" alt="image" src="https://github.com/user-attachments/assets/9a8b7c5e-34c4-439f-b404-f84d657b0e6c" />
<img width="2553" height="816" alt="image" src="https://github.com/user-attachments/assets/0dc2060b-3128-4618-bdad-9d925516d259" />


### Are there any additional TODOs before this PR is ready to go?
TODOs: 
- [ ] It would be better to align the radio buttons in columns, as shown in the images from the paper below, but I couldn't figure out how to do that.
<img width="611" height="728" alt="image" src="https://github.com/user-attachments/assets/ccf9f8ec-d338-4468-80aa-23df50bfc574" />
<img width="594" height="253" alt="image" src="https://github.com/user-attachments/assets/1546e2a9-c285-4bc2-bda6-cec5ee16963c" />


### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [x] Done
- [ ] N/A