### PR TITLE
Add matrix side labels for UEQ libraries

### DIFF
--- a/public/libraries/ueq-s/config.json
+++ b/public/libraries/ueq-s/config.json
@@ -26,35 +26,51 @@
           "questionOptions": [
             {
               "label": "Obstructive - Supportive",
-              "value": "obstructive-supportive"
+              "value": "obstructive-supportive",
+              "leftLabel": "Obstructive",
+              "rightLabel": "Supportive"
             },
             {
               "label": "Complicated - Easy",
-              "value": "complicated-easy"
+              "value": "complicated-easy",
+              "leftLabel": "Complicated",
+              "rightLabel": "Easy"
             },
             {
               "label": "Inefficient - Efficient",
-              "value": "inefficient-efficient"
+              "value": "inefficient-efficient",
+              "leftLabel": "Inefficient",
+              "rightLabel": "Efficient"
             },
             {
               "label": "Clear - Confusing",
-              "value": "clear-confusing"
+              "value": "clear-confusing",
+              "leftLabel": "Clear",
+              "rightLabel": "Confusing"
             },
             {
               "label": "Boring - Exciting",
-              "value": "boring-exciting"
+              "value": "boring-exciting",
+              "leftLabel": "Boring",
+              "rightLabel": "Exciting"
             },
             {
               "label": "Not interesting - Interesting",
-              "value": "not-interesting-interesting"
+              "value": "not-interesting-interesting",
+              "leftLabel": "Not interesting",
+              "rightLabel": "Interesting"
             },
             {
               "label": "Conventional - Inventive",
-              "value": "conventional-inventive"
+              "value": "conventional-inventive",
+              "leftLabel": "Conventional",
+              "rightLabel": "Inventive"
             },
             {
               "label": "Usual - Leading edge",
-              "value": "usual-leading-edge"
+              "value": "usual-leading-edge",
+              "leftLabel": "Usual",
+              "rightLabel": "Leading edge"
             }
           ]
         }

--- a/public/libraries/ueq/config.json
+++ b/public/libraries/ueq/config.json
@@ -27,107 +27,159 @@
           "questionOptions": [
             {
               "label": "Annoying - Enjoyable",
-              "value": "annoying-enjoyable"
+              "value": "annoying-enjoyable",
+              "leftLabel": "Annoying",
+              "rightLabel": "Enjoyable"
             },
             {
               "label": "Not understandable - Understandable",
-              "value": "not-understandable-understandable"
+              "value": "not-understandable-understandable",
+              "leftLabel": "Not understandable",
+              "rightLabel": "Understandable"
             },
             {
               "label": "Creative - Dull",
-              "value": "creative-dull"
+              "value": "creative-dull",
+              "leftLabel": "Creative",
+              "rightLabel": "Dull"
             },
             {
               "label": "Easy to learn - Difficult to learn",
-              "value": "easy-to-learn-difficult-to-learn"
+              "value": "easy-to-learn-difficult-to-learn",
+              "leftLabel": "Easy to learn",
+              "rightLabel": "Difficult to learn"
             },
             {
               "label": "Valuable - Inferior",
-              "value": "valuable-inferior"
+              "value": "valuable-inferior",
+              "leftLabel": "Valuable",
+              "rightLabel": "Inferior"
             },
             {
               "label": "Boring - Exciting",
-              "value": "boring-exciting"
+              "value": "boring-exciting",
+              "leftLabel": "Boring",
+              "rightLabel": "Exciting"
             },
             {
               "label": "Not interesting - Interesting",
-              "value": "not-interesting-interesting"
+              "value": "not-interesting-interesting",
+              "leftLabel": "Not interesting",
+              "rightLabel": "Interesting"
             },
             {
               "label": "Unpredictable - Predictable",
-              "value": "unpredictable-predictable"
+              "value": "unpredictable-predictable",
+              "leftLabel": "Unpredictable",
+              "rightLabel": "Predictable"
             },
             {
               "label": "Fast - Slow",
-              "value": "fast-slow"
+              "value": "fast-slow",
+              "leftLabel": "Fast",
+              "rightLabel": "Slow"
             },
             {
               "label": "Inventive - Conventional",
-              "value": "inventive-conventional"
+              "value": "inventive-conventional",
+              "leftLabel": "Inventive",
+              "rightLabel": "Conventional"
             },
             {
               "label": "Obstructive - Supportive",
-              "value": "obstructive-supportive"
+              "value": "obstructive-supportive",
+              "leftLabel": "Obstructive",
+              "rightLabel": "Supportive"
             },
             {
               "label": "Good - Bad",
-              "value": "good-bad"
+              "value": "good-bad",
+              "leftLabel": "Good",
+              "rightLabel": "Bad"
             },
             {
               "label": "Complicated - Easy",
-              "value": "complicated-easy"
+              "value": "complicated-easy",
+              "leftLabel": "Complicated",
+              "rightLabel": "Easy"
             },
             {
               "label": "Unlikable - Pleasing",
-              "value": "unlikable-pleasing"
+              "value": "unlikable-pleasing",
+              "leftLabel": "Unlikable",
+              "rightLabel": "Pleasing"
             },
             {
               "label": "Usual - Leading edge",
-              "value": "usual-leading-edge"
+              "value": "usual-leading-edge",
+              "leftLabel": "Usual",
+              "rightLabel": "Leading edge"
             },
             {
               "label": "Unpleasant - Pleasant",
-              "value": "unpleasant-pleasant"
+              "value": "unpleasant-pleasant",
+              "leftLabel": "Unpleasant",
+              "rightLabel": "Pleasant"
             },
             {
               "label": "Secure - Not secure",
-              "value": "secure-not-secure"
+              "value": "secure-not-secure",
+              "leftLabel": "Secure",
+              "rightLabel": "Not secure"
             },
             {
               "label": "Motivating - Demotivating",
-              "value": "motivating-demotivating"
+              "value": "motivating-demotivating",
+              "leftLabel": "Motivating",
+              "rightLabel": "Demotivating"
             },
             {
               "label": "Meets expectations - Does not meet expectations",
-              "value": "meets-expectations-does-not-meet-expectations"
+              "value": "meets-expectations-does-not-meet-expectations",
+              "leftLabel": "Meets expectations",
+              "rightLabel": "Does not meet expectations"
             },
             {
               "label": "Inefficient - Efficient",
-              "value": "inefficient-efficient"
+              "value": "inefficient-efficient",
+              "leftLabel": "Inefficient",
+              "rightLabel": "Efficient"
             },
             {
               "label": "Clear - Confusing",
-              "value": "clear-confusing"
+              "value": "clear-confusing",
+              "leftLabel": "Clear",
+              "rightLabel": "Confusing"
             },
             {
               "label": "Impractical - Practical",
-              "value": "impractical-practical"
+              "value": "impractical-practical",
+              "leftLabel": "Impractical",
+              "rightLabel": "Practical"
             },
             {
               "label": "Organized - Cluttered",
-              "value": "organized-cluttered"
+              "value": "organized-cluttered",
+              "leftLabel": "Organized",
+              "rightLabel": "Cluttered"
             },
             {
               "label": "Attractive - Unattractive",
-              "value": "attractive-unattractive"
+              "value": "attractive-unattractive",
+              "leftLabel": "Attractive",
+              "rightLabel": "Unattractive"
             },
             {
               "label": "Friendly - Unfriendly",
-              "value": "friendly-unfriendly"
+              "value": "friendly-unfriendly",
+              "leftLabel": "Friendly",
+              "rightLabel": "Unfriendly"
             },
             {
               "label": "Conservative - Innovative",
-              "value": "conservative-innovative"
+              "value": "conservative-innovative",
+              "leftLabel": "Conservative",
+              "rightLabel": "Innovative"
             }
           ],
           "questionOrder": "random"

--- a/src/components/response/MatrixInput.spec.tsx
+++ b/src/components/response/MatrixInput.spec.tsx
@@ -1,0 +1,83 @@
+import { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  describe, expect, it, vi,
+} from 'vitest';
+import type { MatrixResponse } from '../../parser/types';
+import { MatrixInput } from './MatrixInput';
+
+vi.mock('@mantine/core', () => {
+  const Radio = Object.assign(
+    ({ value }: { value: string }) => <input readOnly type="radio" value={value} />,
+    {
+      Group: ({ children, value }: { children: ReactNode; value?: string }) => (
+        <div data-radio-value={value || ''}>{children}</div>
+      ),
+    },
+  );
+
+  return {
+    Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Checkbox: ({ checked, value }: { checked?: boolean; value: string }) => (
+      <input readOnly type="checkbox" checked={checked} value={value} />
+    ),
+    Radio,
+    Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  };
+});
+
+vi.mock('../../store/store', () => ({
+  useStoreActions: () => ({
+    setMatrixAnswersCheckbox: vi.fn((payload) => payload),
+    setMatrixAnswersRadio: vi.fn((payload) => payload),
+  }),
+  useStoreDispatch: () => vi.fn(),
+}));
+
+vi.mock('../../store/hooks/useStoredAnswer', () => ({
+  useStoredAnswer: () => ({
+    questionOrders: {},
+  }),
+}));
+
+vi.mock('./InputLabel', () => ({
+  InputLabel: ({ prompt }: { prompt: string }) => <label>{prompt}</label>,
+}));
+
+vi.mock('./OptionLabel', () => ({
+  OptionLabel: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+describe('MatrixInput', () => {
+  it('renders matrix rows when the form value has not initialized yet', () => {
+    const response: MatrixResponse = {
+      id: 'ueq-response',
+      prompt: 'For each word pair, select a value from 1 to 7.',
+      type: 'matrix-radio',
+      required: true,
+      answerOptions: ['1', '2', '3', '4', '5', '6', '7'],
+      questionOptions: [
+        {
+          label: 'Unpleasant - Pleasant',
+          value: 'unpleasant-pleasant',
+          leftLabel: 'Unpleasant',
+          rightLabel: 'Pleasant',
+        },
+      ],
+    };
+
+    const markup = renderToStaticMarkup(
+      <MatrixInput
+        response={response}
+        answer={{ value: undefined }}
+        index={0}
+        disabled={false}
+        enumerateQuestions={false}
+      />,
+    );
+
+    expect(markup).toContain('Unpleasant');
+    expect(markup).toContain('Pleasant');
+    expect(markup).toContain('data-radio-value=""');
+  });
+});

--- a/src/components/response/MatrixInput.tsx
+++ b/src/components/response/MatrixInput.tsx
@@ -4,7 +4,7 @@ import {
 import {
   ChangeEvent, useMemo,
 } from 'react';
-import { MatrixResponse, ParsedStringOption } from '../../parser/types';
+import { MatrixResponse, ParsedMatrixQuestionOption, ParsedStringOption } from '../../parser/types';
 import { useStoreDispatch, useStoreActions } from '../../store/store';
 import checkboxClasses from './css/Checkbox.module.css';
 import radioClasses from './css/Radio.module.css';
@@ -28,7 +28,7 @@ function CheckboxComponent({
   _n: number,
   idx: number,
   question: string,
-  answer: { value: Record<string, string> },
+  answer: { value?: Record<string, string> },
   onChange: (event: ChangeEvent<HTMLInputElement>, questionKey: string, option: ParsedStringOption) => void
   disabled: boolean
 }) {
@@ -45,7 +45,7 @@ function CheckboxComponent({
         <Checkbox
           disabled={disabled}
           key={`${checkbox.label}-${idx}`}
-          checked={(answer.value[question] || '').split('|').includes(checkbox.value)}
+          checked={(answer.value?.[question] || '').split('|').includes(checkbox.value)}
           onChange={(event) => onChange(event, question, checkbox)}
           value={checkbox.value}
           classNames={{ input: checkboxClasses.fixDisabled, icon: checkboxClasses.fixDisabledIcon }}
@@ -69,7 +69,7 @@ function RadioGroupComponent({
   idx: number,
   question: string,
   response: MatrixResponse,
-  answer: { value: Record<string, string> },
+  answer: { value?: Record<string, string> },
   onChange: (val: string, questionKey: string) => void,
   disabled: boolean
 }) {
@@ -82,7 +82,7 @@ function RadioGroupComponent({
         flex: 1,
       }}
       onChange={(val) => onChange(val, question)}
-      value={answer.value[question]}
+      value={answer.value?.[question] || ''}
     >
       <div
         style={{
@@ -113,7 +113,7 @@ export function MatrixInput({
   enumerateQuestions,
 }: {
   response: MatrixResponse;
-  answer: { value: Record<string, string> };
+  answer: { value?: Record<string, string> };
   index: number;
   disabled: boolean;
   enumerateQuestions: boolean;
@@ -133,8 +133,8 @@ export function MatrixInput({
     [response],
   );
 
-  const questions = useMemo(
-    () => parseStringOptions(response.questionOptions),
+  const questions = useMemo<ParsedMatrixQuestionOption[]>(
+    () => parseStringOptions(response.questionOptions) as ParsedMatrixQuestionOption[],
     [response.questionOptions],
   );
   const questionsByValue = useMemo(
@@ -144,6 +144,14 @@ export function MatrixInput({
 
   const { questionOrders } = useStoredAnswer();
   const orderedQuestions = useMemo(() => questionOrders[response.id] || questions.map((question) => question.value), [questionOrders, questions, response.id]);
+  const answerValue = useMemo(
+    () => (answer.value && typeof answer.value === 'object' && !Array.isArray(answer.value) ? answer.value : {}),
+    [answer.value],
+  );
+  const normalizedAnswer = useMemo(
+    () => ({ ...answer, value: answerValue }),
+    [answer, answerValue],
+  );
 
   // Re-define on change functions. Dispatch answers to store.
   const onChangeRadio = (val: string, questionKey: string) => {
@@ -158,7 +166,7 @@ export function MatrixInput({
 
   const onChangeCheckbox = (event: ChangeEvent<HTMLInputElement>, questionKey: string, option: ParsedStringOption) => {
     const isChecked = event.target.checked;
-    const currentValues = (answer.value[questionKey] || '').split('|').filter((entry) => entry !== '');
+    const currentValues = (answerValue[questionKey] || '').split('|').filter((entry) => entry !== '');
     const dispatchCheckboxUpdate = (value: string, checked: boolean) => storeDispatch(setMatrixAnswersCheckbox({
       questionKey,
       responseId: response.id,
@@ -179,10 +187,11 @@ export function MatrixInput({
     dispatchCheckboxUpdate(option.value, isChecked);
   };
 
-  const error = generateErrorMessage(response, answer);
+  const error = generateErrorMessage(response, normalizedAnswer);
 
   const _n = _choices.length;
   const _m = orderedQuestions.length;
+  const hasRightQuestionLabels = questions.some((question) => question.rightLabel);
   const dontKnowIndex = _choices.findIndex(
     (choice) => isMatrixDontKnowValue(choice.value) || isMatrixDontKnowValue(choice.label),
   );
@@ -194,7 +203,7 @@ export function MatrixInput({
       <Box
         style={{
           display: 'grid',
-          gridTemplateColumns: 'auto 1fr',
+          gridTemplateColumns: hasRightQuestionLabels ? 'auto 1fr auto' : 'auto 1fr',
           gridTemplateRows: 'auto 1fr',
         }}
         m="md"
@@ -261,6 +270,14 @@ export function MatrixInput({
             </Box>
           ))}
         </div>
+        {hasRightQuestionLabels && (
+          <div
+            style={{
+              borderBottom: '1px solid var(--mantine-color-dark-0)',
+              borderLeft: '1px solid var(--mantine-color-dark-0)',
+            }}
+          />
+        )}
         {/* Row Headers */}
         <div
           style={{
@@ -287,7 +304,10 @@ export function MatrixInput({
               miw={140}
               maw={400}
             >
-              <OptionLabel label={(questionsByValue[questionKey]?.label || questionKey)} infoText={questionsByValue[questionKey]?.infoText} />
+              <OptionLabel
+                label={(questionsByValue[questionKey]?.leftLabel || questionsByValue[questionKey]?.label || questionKey)}
+                infoText={questionsByValue[questionKey]?.infoText}
+              />
             </Box>
           ))}
         </div>
@@ -330,7 +350,7 @@ export function MatrixInput({
                     disabled={disabled}
                     idx={idx}
                     question={questionKey}
-                    answer={answer}
+                    answer={normalizedAnswer}
                     _choices={_choices}
                     _n={_n}
                     onChange={onChangeRadio}
@@ -342,7 +362,7 @@ export function MatrixInput({
                     disabled={disabled}
                     idx={idx}
                     question={questionKey}
-                    answer={answer}
+                    answer={normalizedAnswer}
                     _choices={_choices}
                     _n={_n}
                     onChange={onChangeCheckbox}
@@ -351,6 +371,42 @@ export function MatrixInput({
             </div>
           ))}
         </div>
+        {hasRightQuestionLabels && (
+          <div
+            style={{
+              height: '100%',
+              display: 'grid',
+              gridTemplateRows: `repeat(${_m}, 1fr)`,
+            }}
+          >
+            {orderedQuestions.map((questionKey, idx) => (
+              <Box
+                key={`question-${idx}-right-label`}
+                style={{
+                  height: '80px',
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'safe center',
+                  justifyContent: 'start',
+                  borderLeft: '1px solid var(--mantine-color-dark-0)',
+                  backgroundColor: `${(idx + 1) % 2 === 0 ? 'var(--mantine-color-gray-2)' : 'white'}`,
+                  overflowY: 'auto',
+                }}
+                ta="left"
+                p="sm"
+                miw={140}
+                maw={400}
+              >
+                {questionsByValue[questionKey]?.rightLabel && (
+                  <OptionLabel
+                    label={questionsByValue[questionKey].rightLabel}
+                    infoText={questionsByValue[questionKey]?.infoText}
+                  />
+                )}
+              </Box>
+            ))}
+          </div>
+        )}
       </Box>
       {error && (
         <Text c={required ? 'red' : 'orange'} size="sm" mt="xs">

--- a/src/components/response/utils.spec.ts
+++ b/src/components/response/utils.spec.ts
@@ -50,6 +50,12 @@ describe('generateInitFields', () => {
       questionOptions: [
         { label: 'Question without value' },
         { label: 'Question with value', value: 'question-2' },
+        {
+          label: 'Obstructive - Supportive',
+          value: 'obstructive-supportive',
+          leftLabel: 'Obstructive',
+          rightLabel: 'Supportive',
+        },
       ],
     };
 
@@ -59,6 +65,7 @@ describe('generateInitFields', () => {
       'matrix-question-fallback': {
         'Question without value': '',
         'question-2': '',
+        'obstructive-supportive': '',
       },
     });
   });
@@ -470,7 +477,15 @@ describe('generateErrorMessage matrix', () => {
     type: 'matrix-radio',
     required: true,
     answerOptions: ['0', '1'],
-    questionOptions: ['q1', 'q2'],
+    questionOptions: [
+      {
+        label: 'Obstructive - Supportive',
+        value: 'q1',
+        leftLabel: 'Obstructive',
+        rightLabel: 'Supportive',
+      },
+      'q2',
+    ],
   };
 
   it('does not show matrix incomplete message when untouched', () => {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -80,10 +80,6 @@
             "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "object"
           },
-          "nextButtonDisableTime": {
-            "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-            "type": "number"
-          },
           "nextButtonAutoAdvanceTime": {
             "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
             "type": "number"
@@ -94,6 +90,10 @@
           },
           "nextButtonAutoAdvanceWarningTime": {
             "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+            "type": "number"
+          },
+          "nextButtonDisableTime": {
+            "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
             "type": "number"
           },
           "nextButtonEnableTime": {
@@ -956,10 +956,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -970,6 +966,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -1231,10 +1231,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1245,6 +1241,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -1761,10 +1761,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1775,6 +1771,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -1961,11 +1961,11 @@
           "type": "string"
         },
         "questionOptions": {
-          "description": "The question options (rows) are the prompts for each response you'd like to record.",
+          "description": "The question options (rows) are the prompts for each response you'd like to record. Use `leftLabel` and `rightLabel` on object options to display bipolar row labels such as `\"Obstructive - Supportive\"` on either side of the matrix.",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/StringOption"
+                "$ref": "#/definitions/MatrixQuestionOption"
               },
               {
                 "type": "string"
@@ -2027,9 +2027,39 @@
       ],
       "type": "object"
     },
+    "MatrixQuestionOption": {
+      "additionalProperties": false,
+      "description": "The MatrixQuestionOption interface is used to define the question options for matrix responses. The label is the fallback text displayed to participants, and the value is the key stored in the participant's data. The optional left and right labels allow bipolar rows to label each side of the matrix without changing stored values. When `leftLabel` is specified, it takes precedence over `label` for the left-side row text.",
+      "properties": {
+        "infoText": {
+          "description": "The description that is displayed when the participant hovers over the option. This does not accept markdown.",
+          "type": "string"
+        },
+        "label": {
+          "description": "The label displayed to participants. Markdown is supported.",
+          "type": "string"
+        },
+        "leftLabel": {
+          "description": "The label displayed on the left side of the matrix row. Takes precedence over label when specified. Defaults to label.",
+          "type": "string"
+        },
+        "rightLabel": {
+          "description": "The label displayed on the right side of the matrix row.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value stored in the participant's data. Defaults to label.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "type": "object"
+    },
     "MatrixRadioResponse": {
       "additionalProperties": false,
-      "description": "The MatrixRadioResponse interface defines a matrix where each row accepts exactly one selected option. `questionOptions` are rendered as rows, and `answerOptions` are rendered as columns. `answerOptions` can be custom labels/values or one of the built-in shortcuts: `satisfaction5`, `satisfaction7`, `likely5`, `likely7`.\n\nExample: ```json {   \"id\": \"multi-satisfaction\",   \"prompt\": \"Rate your satisfaction from 1 (not enjoyable) to 5 (very enjoyable) for the following items.\",   \"location\": \"aboveStimulus\",   \"type\": \"matrix-radio\",   \"answerOptions\": \"satisfaction5\",   \"questionOptions\": [     \"The tool we created\",     \"The technique we developed\",     \"The authors of the tools\"   ],   \"default\": {     \"The tool we created\": \"Highly Satisfied\",     \"The technique we developed\": \"Satisfied\",     \"The authors of the tools\": \"Neutral\"   },   \"questionOrder\": \"random\" } ```",
+      "description": "The MatrixRadioResponse interface defines a matrix where each row accepts exactly one selected option. `questionOptions` are rendered as rows, and `answerOptions` are rendered as columns. `answerOptions` can be custom labels/values or one of the built-in shortcuts: `satisfaction5`, `satisfaction7`, `likely5`, `likely7`.\n\nExample: ```json {   \"id\": \"multi-satisfaction\",   \"prompt\": \"Rate your satisfaction from 1 (not enjoyable) to 5 (very enjoyable) for the following items.\",   \"location\": \"aboveStimulus\",   \"type\": \"matrix-radio\",   \"answerOptions\": \"satisfaction5\",   \"questionOptions\": [     \"The tool we created\",     {       \"label\": \"Obstructive - Supportive\",       \"value\": \"obstructive-supportive\",       \"leftLabel\": \"Obstructive\",       \"rightLabel\": \"Supportive\"     },     \"The authors of the tools\"   ],   \"default\": {     \"The tool we created\": \"Highly Satisfied\",     \"obstructive-supportive\": \"Satisfied\",     \"The authors of the tools\": \"Neutral\"   },   \"questionOrder\": \"random\" } ```",
       "properties": {
         "answerOptions": {
           "anyOf": [
@@ -2101,11 +2131,11 @@
           "type": "string"
         },
         "questionOptions": {
-          "description": "The question options (rows) are the prompts for each response you'd like to record.",
+          "description": "The question options (rows) are the prompts for each response you'd like to record. Use `leftLabel` and `rightLabel` on object options to display bipolar row labels such as `\"Obstructive - Supportive\"` on either side of the matrix.",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/StringOption"
+                "$ref": "#/definitions/MatrixQuestionOption"
               },
               {
                 "type": "string"
@@ -2331,10 +2361,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -2345,6 +2371,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -2753,10 +2783,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -2767,6 +2793,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -3571,10 +3601,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -3585,6 +3611,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -3738,10 +3768,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -3752,6 +3778,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -3913,10 +3943,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -3927,6 +3953,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -4084,10 +4114,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4098,6 +4124,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -80,10 +80,6 @@
             "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "object"
           },
-          "nextButtonDisableTime": {
-            "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-            "type": "number"
-          },
           "nextButtonAutoAdvanceTime": {
             "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
             "type": "number"
@@ -94,6 +90,10 @@
           },
           "nextButtonAutoAdvanceWarningTime": {
             "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+            "type": "number"
+          },
+          "nextButtonDisableTime": {
+            "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
             "type": "number"
           },
           "nextButtonEnableTime": {
@@ -1029,10 +1029,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1043,6 +1039,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -1304,10 +1304,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1318,6 +1314,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -1785,10 +1785,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1799,6 +1795,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -1985,11 +1985,11 @@
           "type": "string"
         },
         "questionOptions": {
-          "description": "The question options (rows) are the prompts for each response you'd like to record.",
+          "description": "The question options (rows) are the prompts for each response you'd like to record. Use `leftLabel` and `rightLabel` on object options to display bipolar row labels such as `\"Obstructive - Supportive\"` on either side of the matrix.",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/StringOption"
+                "$ref": "#/definitions/MatrixQuestionOption"
               },
               {
                 "type": "string"
@@ -2051,9 +2051,39 @@
       ],
       "type": "object"
     },
+    "MatrixQuestionOption": {
+      "additionalProperties": false,
+      "description": "The MatrixQuestionOption interface is used to define the question options for matrix responses. The label is the fallback text displayed to participants, and the value is the key stored in the participant's data. The optional left and right labels allow bipolar rows to label each side of the matrix without changing stored values. When `leftLabel` is specified, it takes precedence over `label` for the left-side row text.",
+      "properties": {
+        "infoText": {
+          "description": "The description that is displayed when the participant hovers over the option. This does not accept markdown.",
+          "type": "string"
+        },
+        "label": {
+          "description": "The label displayed to participants. Markdown is supported.",
+          "type": "string"
+        },
+        "leftLabel": {
+          "description": "The label displayed on the left side of the matrix row. Takes precedence over label when specified. Defaults to label.",
+          "type": "string"
+        },
+        "rightLabel": {
+          "description": "The label displayed on the right side of the matrix row.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value stored in the participant's data. Defaults to label.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "type": "object"
+    },
     "MatrixRadioResponse": {
       "additionalProperties": false,
-      "description": "The MatrixRadioResponse interface defines a matrix where each row accepts exactly one selected option. `questionOptions` are rendered as rows, and `answerOptions` are rendered as columns. `answerOptions` can be custom labels/values or one of the built-in shortcuts: `satisfaction5`, `satisfaction7`, `likely5`, `likely7`.\n\nExample: ```json {   \"id\": \"multi-satisfaction\",   \"prompt\": \"Rate your satisfaction from 1 (not enjoyable) to 5 (very enjoyable) for the following items.\",   \"location\": \"aboveStimulus\",   \"type\": \"matrix-radio\",   \"answerOptions\": \"satisfaction5\",   \"questionOptions\": [     \"The tool we created\",     \"The technique we developed\",     \"The authors of the tools\"   ],   \"default\": {     \"The tool we created\": \"Highly Satisfied\",     \"The technique we developed\": \"Satisfied\",     \"The authors of the tools\": \"Neutral\"   },   \"questionOrder\": \"random\" } ```",
+      "description": "The MatrixRadioResponse interface defines a matrix where each row accepts exactly one selected option. `questionOptions` are rendered as rows, and `answerOptions` are rendered as columns. `answerOptions` can be custom labels/values or one of the built-in shortcuts: `satisfaction5`, `satisfaction7`, `likely5`, `likely7`.\n\nExample: ```json {   \"id\": \"multi-satisfaction\",   \"prompt\": \"Rate your satisfaction from 1 (not enjoyable) to 5 (very enjoyable) for the following items.\",   \"location\": \"aboveStimulus\",   \"type\": \"matrix-radio\",   \"answerOptions\": \"satisfaction5\",   \"questionOptions\": [     \"The tool we created\",     {       \"label\": \"Obstructive - Supportive\",       \"value\": \"obstructive-supportive\",       \"leftLabel\": \"Obstructive\",       \"rightLabel\": \"Supportive\"     },     \"The authors of the tools\"   ],   \"default\": {     \"The tool we created\": \"Highly Satisfied\",     \"obstructive-supportive\": \"Satisfied\",     \"The authors of the tools\": \"Neutral\"   },   \"questionOrder\": \"random\" } ```",
       "properties": {
         "answerOptions": {
           "anyOf": [
@@ -2125,11 +2155,11 @@
           "type": "string"
         },
         "questionOptions": {
-          "description": "The question options (rows) are the prompts for each response you'd like to record.",
+          "description": "The question options (rows) are the prompts for each response you'd like to record. Use `leftLabel` and `rightLabel` on object options to display bipolar row labels such as `\"Obstructive - Supportive\"` on either side of the matrix.",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/StringOption"
+                "$ref": "#/definitions/MatrixQuestionOption"
               },
               {
                 "type": "string"
@@ -2355,10 +2385,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -2369,6 +2395,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -2777,10 +2807,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -2791,6 +2817,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -3915,10 +3945,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -3929,6 +3955,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -4082,10 +4112,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4096,6 +4122,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -4257,10 +4287,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4271,6 +4297,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {
@@ -4428,10 +4458,6 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
-        "nextButtonDisableTime": {
-          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
-          "type": "number"
-        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4442,6 +4468,10 @@
         },
         "nextButtonAutoAdvanceWarningTime": {
           "description": "The time in milliseconds before auto-advance when the warning message is shown. Defaults to 30000.",
+          "type": "number"
+        },
+        "nextButtonDisableTime": {
+          "description": "The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig.",
           "type": "number"
         },
         "nextButtonEnableTime": {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -347,8 +347,26 @@ export interface StringOption {
   infoText?: string;
 }
 
+/**
+ * The MatrixQuestionOption interface is used to define the question options for matrix responses.
+ * The label is the fallback text displayed to participants, and the value is the key stored in the participant's data.
+ * The optional left and right labels allow bipolar rows to label each side of the matrix without changing stored values.
+ * When `leftLabel` is specified, it takes precedence over `label` for the left-side row text.
+ */
+export interface MatrixQuestionOption extends StringOption {
+  /** The label displayed on the left side of the matrix row. Takes precedence over label when specified. Defaults to label. */
+  leftLabel?: string;
+  /** The label displayed on the right side of the matrix row. */
+  rightLabel?: string;
+}
+
 /** StringOption normalized to always include a value. */
 export interface ParsedStringOption extends Omit<StringOption, 'value'> {
+  value: string;
+}
+
+/** MatrixQuestionOption normalized to always include a value. */
+export interface ParsedMatrixQuestionOption extends Omit<MatrixQuestionOption, 'value'> {
   value: string;
 }
 
@@ -508,8 +526,8 @@ export interface LikertResponse extends BaseResponse {
 interface BaseMatrixResponse extends BaseResponse {
   /** The answer options (columns). We provide some shortcuts for a likelihood scale (ranging from highly unlikely to highly likely) and a satisfaction scale (ranging from highly unsatisfied to highly satisfied) with either 5 or 7 options to choose from. */
   answerOptions: (StringOption | string)[] | `likely${5 | 7}` | `satisfaction${5 | 7}`;
-  /** The question options (rows) are the prompts for each response you'd like to record. */
-  questionOptions: (StringOption | string)[];
+  /** The question options (rows) are the prompts for each response you'd like to record. Use `leftLabel` and `rightLabel` on object options to display bipolar row labels such as `"Obstructive - Supportive"` on either side of the matrix. */
+  questionOptions: (MatrixQuestionOption | string)[];
   /** The order in which the questions are displayed. Defaults to fixed. */
   questionOrder?: 'fixed' | 'random';
 }
@@ -529,12 +547,17 @@ interface BaseMatrixResponse extends BaseResponse {
  *   "answerOptions": "satisfaction5",
  *   "questionOptions": [
  *     "The tool we created",
- *     "The technique we developed",
+ *     {
+ *       "label": "Obstructive - Supportive",
+ *       "value": "obstructive-supportive",
+ *       "leftLabel": "Obstructive",
+ *       "rightLabel": "Supportive"
+ *     },
  *     "The authors of the tools"
  *   ],
  *   "default": {
  *     "The tool we created": "Highly Satisfied",
- *     "The technique we developed": "Satisfied",
+ *     "obstructive-supportive": "Satisfied",
  *     "The authors of the tools": "Neutral"
  *   },
  *   "questionOrder": "random"

--- a/src/utils/handleResponseRandomization.spec.ts
+++ b/src/utils/handleResponseRandomization.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { IndividualComponent } from '../parser/types';
+import { randomizeQuestionOrder } from './handleResponseRandomization';
+
+describe('randomizeQuestionOrder', () => {
+  it('stores matrix question order by value when rows have side labels', () => {
+    const componentConfig = {
+      type: 'questionnaire',
+      response: [
+        {
+          id: 'matrix-side-labels',
+          prompt: 'Matrix prompt',
+          type: 'matrix-radio',
+          answerOptions: ['1', '2', '3'],
+          questionOptions: [
+            {
+              label: 'Obstructive - Supportive',
+              value: 'obstructive-supportive',
+              leftLabel: 'Obstructive',
+              rightLabel: 'Supportive',
+            },
+            {
+              label: 'Annoying - Enjoyable',
+              value: 'annoying-enjoyable',
+              leftLabel: 'Annoying',
+              rightLabel: 'Enjoyable',
+            },
+          ],
+        },
+      ],
+    } as IndividualComponent;
+
+    expect(randomizeQuestionOrder(componentConfig)).toEqual({
+      'matrix-side-labels': ['obstructive-supportive', 'annoying-enjoyable'],
+    });
+  });
+});

--- a/src/utils/stringOptions.spec.ts
+++ b/src/utils/stringOptions.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { MatrixQuestionOption } from '../parser/types';
 import { parseStringOption, parseStringOptionValue, parseStringOptions } from './stringOptions';
 
 describe('stringOptions', () => {
@@ -44,6 +45,33 @@ describe('stringOptions', () => {
     ])).toEqual([
       { label: 'A', value: 'A', infoText: 'Info A' },
       { label: 'B', value: 'b-value', infoText: 'Info B' },
+    ]);
+  });
+
+  it('preserves matrix side labels while normalizing option values', () => {
+    const matrixOptions: MatrixQuestionOption[] = [
+      {
+        label: 'Obstructive - Supportive',
+        value: 'obstructive-supportive',
+        leftLabel: 'Obstructive',
+        rightLabel: 'Supportive',
+      },
+      {
+        label: 'Plain fallback label',
+      },
+    ];
+
+    expect(parseStringOptions(matrixOptions)).toEqual([
+      {
+        label: 'Obstructive - Supportive',
+        value: 'obstructive-supportive',
+        leftLabel: 'Obstructive',
+        rightLabel: 'Supportive',
+      },
+      {
+        label: 'Plain fallback label',
+        value: 'Plain fallback label',
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- add matrix-specific leftLabel / rightLabel row metadata while preserving stored row values
- render optional right-side row labels in matrix inputs and tolerate uninitialized matrix form values on direct loads
- update UEQ and UEQ-S library rows to split bipolar labels across the matrix

## Verification
- yarn generate-schemas
- yarn unittest (491 tests)
- yarn typecheck
- yarn lint
- browser check: http://localhost:8080/library-ueq/T1hJdnBYMWx2NWxMNEJLc2pkSmVldz09 rendered without console errors

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [x] Done
- [ ] N/A