### PR TITLE
Add uniform participant timeline mode

### DIFF
--- a/PARTICIPANT_FEEDBACK_VALIDATION_DESIGN.md
+++ b/PARTICIPANT_FEEDBACK_VALIDATION_DESIGN.md
@@ -1,0 +1,170 @@
+# Participant Feedback, Validation, and Progression Design
+
+This document combines the design questions from:
+
+- [Improve Provide Feedback Options for Training](https://github.com/revisit-studies/study/issues/526)
+- [Add response validation for all response types](https://github.com/revisit-studies/study/issues/486)
+- [Built in validations](https://github.com/revisit-studies/study/issues/751)
+- [Extending feedback types and options](https://github.com/revisit-studies/study/issues/637)
+
+The goal is to define a flexible study config interface that lets a Study Designer validate participant responses, evaluate correctness, show participant-facing feedback, and control training progression.
+
+## Proposed Conceptual Model
+
+The default design separates four related concerns:
+
+- `validation`: Determines whether a response is acceptable input. Examples: required answer, valid email, number within range, text matches regex.
+- `evaluation`: Determines whether an acceptable response is correct, partially correct, or incorrect. Examples: equals expected answer, selected option is correct, numeric estimate is within tolerance.
+- `feedback`: Determines what participant-facing message or hint is shown after validation or evaluation.
+- `progression`: Determines whether the Participant can continue, retry, pass a trial, pass a training block, or see a summary.
+
+This separation keeps form validity distinct from training correctness. For example, a numeric answer can be valid because it is inside the allowed input range, but still incorrect because it is outside the target answer tolerance.
+
+## Core Defaults
+
+| Question | Default |
+| --- | --- |
+| What does validation mean? | `validation` means input acceptability, not correctness. |
+| Should correctness be separate? | Yes. Use separate concepts: `validation`, `evaluation`, `feedback`, and `progression`. |
+| Does invalid input block submission? | Yes. Invalid input blocks submission. Incorrect but valid input may submit unless `progression` blocks it. |
+| Can feedback attach to both invalid and incorrect answers? | Yes. Feedback can be attached to validation failures and evaluation outcomes. |
+
+## Built-In Rule Defaults
+
+| Question | Default |
+| --- | --- |
+| Which built-ins should v1 support? | `required`, `equals`, `notEquals`, `oneOf`, `notOneOf`, `min`, `max`, `range`, `length`, `regex`, `includes`. |
+| Should numeric tolerance be supported? | Support absolute tolerance in v1. Defer percent tolerance unless it is easy to include. |
+| Are numeric bounds inclusive? | Yes. Bounds are inclusive by default. |
+| What does checkbox `equals` mean? | Exact set equality. Also add explicit `containsAll` and `containsAny` rules. |
+| How should object-shaped answers be validated? | Validate the normalized stored answer value by default. Allow an optional `path` for object answers. |
+
+## Rule Combination Defaults
+
+| Question | Default |
+| --- | --- |
+| How are multiple rules combined? | Multiple rules default to `AND`. |
+| Are `OR` groups required in v1? | No. Defer `OR` groups until there is a clear use case. |
+| Should rules have names? | Yes. Every rule may have an optional `id`; the system can generate one if omitted. |
+| Can one response have multiple targets? | Yes. One response can have multiple validation or evaluation targets. |
+
+## Feedback Defaults
+
+| Question | Default |
+| --- | --- |
+| Where can feedback be configured? | Per rule and per option. Trial-level fallback feedback applies only when no more specific message exists. |
+| Which feedback states are built in? | `valid`, `invalid`, `correct`, `incorrect`, and `partial`. |
+| Should feedback support templates? | Yes. Templates should support participant answer, expected answer, option label, attempt number, score, and tolerance. |
+| Should feedback reveal the correct answer? | Only when explicitly configured. |
+| When does feedback appear? | Validation feedback appears after submit or blur. Correctness feedback appears after submit. |
+| Should directional numeric feedback be built in? | Yes. Numeric evaluation should support `tooLow`, `tooHigh`, and `withinTolerance`. |
+
+## Progression Defaults
+
+| Question | Default |
+| --- | --- |
+| Which trial-level progression modes should exist? | `allowContinue`, `blockUntilValid`, `retryUntilCorrect`, and `retryUntilMaxAttempts`. |
+| Where is max attempts configured? | Per trial by default, with optional response-level override. |
+| What happens after max attempts? | Allow continue, but mark the trial failed unless configured otherwise. |
+| How does a training section pass by default? | Percent correct. Default threshold is `100%` unless specified. |
+| Is a built-in summary page required for v1? | No. Expose enough state for summaries in v1; a built-in summary page can be a follow-up. |
+| Can progression rules apply outside training? | Yes, but documentation should present them as training-focused. |
+
+## Custom Function Defaults
+
+| Question | Default |
+| --- | --- |
+| How are custom functions provided? | Referenced from approved study or library code, not inline JavaScript strings. |
+| Are async functions supported in v1? | No. Custom functions are sync only in v1. |
+| What inputs does a function receive? | Answer, response config, trial config, attempt number, prior attempts, and current participant answers. |
+| What does a function return? | A structured result such as `{ valid, score, feedback, metadata }` or `{ evaluation, score, feedback, metadata }`. |
+| Are custom functions allowed in deployed studies? | Yes, but only through the existing trusted config/library mechanism. Arbitrary inline deployment code is not allowed. |
+
+## Data and Analysis Defaults
+
+| Question | Default |
+| --- | --- |
+| What answer data is stored? | Final submitted answers plus attempt history when validation, evaluation, feedback, or progression is configured. |
+| What result data is stored? | Validation result, evaluation result, feedback id or message shown, rule ids, score, and attempt number. |
+| Should blocked invalid attempts be distinguishable? | Yes. Analysts should be able to distinguish blocked invalid attempts from submitted incorrect answers. |
+| Should feedback and progression enter provenance? | Yes. Feedback and progression events should be included in provenance tracking. |
+
+## Config Shape Defaults
+
+| Question | Default |
+| --- | --- |
+| Where does response-level config live? | Under response-level `validation`, `evaluation`, `feedback`, and `progression` fields. |
+| Is block-level progression needed? | Yes. Add sequence or block-level `progression` for aggregate training pass/fail behavior. |
+| Where does option-level feedback live? | Embedded directly on options by default, with rule references allowed for advanced cases. |
+| How is existing right/wrong behavior handled? | Preserve existing behavior by translating it into `evaluation`. |
+| Should unsupported rules be rejected by schema? | Yes for clearly unsupported built-ins. Custom functions can target arbitrary values. |
+
+## Participant UX Defaults
+
+| Question | Default |
+| --- | --- |
+| Where do validation messages appear? | Inline near the response. |
+| Where does correctness feedback appear? | In the existing feedback area. |
+| Should blocked progression explain itself? | Yes. The UI should explain why Next is unavailable. |
+| Should numeric inputs silently clamp? | No. Preserve typed invalid values where feasible and show a warning. |
+| Which feedback severities are built in? | `error`, `warning`, `info`, `success`, and `hint`. |
+
+## Draft Config Sketch
+
+This sketch is illustrative. Field names and exact types should be refined during implementation.
+
+```json
+{
+  "response": [
+    {
+      "id": "estimate",
+      "type": "numerical",
+      "prompt": "Estimate the correlation.",
+      "validation": [
+        {
+          "id": "required-estimate",
+          "type": "required",
+          "message": "Enter an estimate before continuing."
+        },
+        {
+          "id": "estimate-range",
+          "type": "range",
+          "min": -1,
+          "max": 1,
+          "message": "Enter a value between -1 and 1."
+        }
+      ],
+      "evaluation": [
+        {
+          "id": "target-correlation",
+          "type": "equals",
+          "value": 0.62,
+          "tolerance": 0.05,
+          "feedback": {
+            "correct": "Correct.",
+            "incorrect": "That estimate is outside the acceptable range.",
+            "tooLow": "Try a higher value.",
+            "tooHigh": "Try a lower value."
+          }
+        }
+      ],
+      "progression": {
+        "mode": "retryUntilMaxAttempts",
+        "maxAttempts": 3
+      }
+    }
+  ]
+}
+```
+
+## Open Design Decisions
+
+The defaults above still leave these higher-level choices to confirm:
+
+- Whether `evaluation` is the right name, or whether the config should use `grading`, `scoring`, or another term.
+- Whether percent tolerance belongs in v1.
+- Whether `OR` rule groups are needed immediately.
+- Whether a built-in training summary page should be part of the first implementation.
+- Whether custom functions should use the same mechanism as existing dynamic functions.
+- Which exact values custom functions can access without exposing too much participant or study state.
+- How much existing right/wrong training config exists and how it should migrate.

--- a/RESPONSE_ONE_FORM_ARCHITECTURE_PLAN.md
+++ b/RESPONSE_ONE_FORM_ARCHITECTURE_PLAN.md
@@ -1,0 +1,200 @@
+# Trial-Level Response Form Architecture Plan
+
+## Goal
+
+Evaluate and plan a larger refactor from one Mantine form per `ResponseBlock` location to one Mantine form per trial/component. This is a potential later change after `codex/response-validation-cleanup` and the smaller trial-validation answer helper follow-up.
+
+The intended benefit is to make the trial answer object a direct product of one form instead of reconstructing it from per-location snapshots.
+
+## Current Shape
+
+Today, each rendered response location owns its own Mantine form:
+
+- `ResponseBlock` for `aboveStimulus`
+- `ResponseBlock` for `belowStimulus`
+- `ResponseBlock` for `sidebar`
+
+Each block writes a plain snapshot into `trialValidation[identifier][location]`:
+
+```ts
+{
+  valid: boolean,
+  values: object,
+  provenanceGraph?: TrrackedProvenance,
+}
+```
+
+Other code then merges those snapshots for:
+
+- response issue summaries
+- feedback and correct-answer checks
+- participant answer persistence
+
+## Proposed End State
+
+Create one trial-level response form that owns all response values for the current component. Individual `ResponseBlock` instances render filtered views of that shared form.
+
+Conceptually:
+
+```txt
+TrialResponseFormProvider
+  useAnswerField(allResponsesForTrial)
+  values for all response locations
+  validation for all response fields
+
+  ResponseBlock aboveStimulus
+    renders fields from shared form
+
+  ResponseBlock belowStimulus
+    renders fields from shared form
+
+  ResponseBlock sidebar
+    renders fields from shared form
+```
+
+The saved answer path could then read from one canonical form snapshot instead of merging three response-block snapshots.
+
+## Potential Benefits
+
+- One canonical `values` object for all responses in a trial.
+- One validation call can evaluate all response fields.
+- Less answer copying when saving.
+- Less duplication between feedback checks, summaries, and persistence.
+- Easier reasoning about cross-location response dependencies.
+- A clearer future path for field-level validation summaries and submit behavior.
+
+## Tradeoffs
+
+This is a larger ownership change than the immediate follow-up plan.
+
+The current per-location forms map naturally to the rendered UI structure and to per-location provenance. A trial-level form would need a new owner above all response blocks, likely in the component or trial controller layer.
+
+Open questions:
+
+- Where should the trial-level form provider live?
+- How should per-location provenance graphs be preserved?
+- Should `trialValidation` keep per-location validity, or become a trial-level response validation snapshot?
+- How should stimulus validation continue to compose with response validation?
+- How should analysis mode read saved provenance and historical values?
+- How should hidden responses, reactive responses, matrix answers, ranking answers, and custom responses synchronize with one shared form?
+- What happens if a response location is not mounted because of layout or sidebar state?
+
+## Recommended Migration Strategy
+
+Do not replace all per-location forms in one PR. Use staged changes.
+
+### Stage 1: Stabilize Plain Snapshots
+
+Complete the immediate follow-up plan:
+
+- Add one shared helper for constructing the saved trial answer from `trialValidation`.
+- Keep per-location forms.
+- Keep behavior identical.
+
+This creates a baseline for comparing old and new answer snapshots.
+
+### Stage 2: Extract a Response Form Boundary
+
+Introduce a hook or provider that can own the shared response form without changing rendering behavior yet.
+
+Possible API:
+
+```ts
+function useTrialResponseForm({
+  responses,
+  currentStep,
+  storedAnswer,
+  customResponseValidators,
+  customResponseLoadErrors,
+}: UseTrialResponseFormOptions): UseTrialResponseFormResult;
+```
+
+It should own:
+
+- `useAnswerField`
+- initial values
+- custom response validators
+- custom response load errors
+- reactive answer merging
+- matrix answer merging
+- ranking answer merging
+
+At this stage, `ResponseBlock` can still receive the form through props or context and render only its location.
+
+### Stage 3: Move Validation Publishing
+
+Move the Mantine-to-`trialValidation` synchronization out of each `ResponseBlock`.
+
+The publisher should write either:
+
+- one trial-level response validation snapshot, or
+- per-location snapshots derived from the same shared form
+
+Prefer preserving the existing `trialValidation` shape at first to reduce migration risk.
+
+### Stage 4: Replace Answer Save Source
+
+Once one trial-level form snapshot exists, update the save path so `useNextStep` reads the canonical trial response answer rather than merging per-location snapshots.
+
+This should happen only after tests prove the form snapshot and current merged answer are identical for representative studies.
+
+### Stage 5: Simplify ResponseBlock
+
+After the shared form and publishing boundary are stable, simplify `ResponseBlock` so it mostly handles rendering:
+
+- filter responses by location
+- render `ResponseSwitcher`
+- render feedback alerts
+- render local layout
+
+Avoid mixing persistence, full-trial answer aggregation, and form ownership back into the component.
+
+## Test Plan
+
+Unit tests:
+
+- Shared form initializes values for all response locations.
+- Location-specific `ResponseBlock` renders only its assigned responses.
+- Form values update correctly from each location.
+- Hidden responses do not create visible errors but preserve expected answer behavior.
+- Matrix, ranking, reactive, custom response, `withOther`, and `withDontKnow` cases keep current validation behavior.
+- Trial-level answer snapshot matches the current `trialValidation` merged answer.
+
+Integration tests:
+
+- Participant can complete a study with responses above stimulus, below stimulus, and in sidebar.
+- Correct-answer feedback reads answers from all locations.
+- Next button blocks on unresolved required responses across all locations.
+- Saved participant answer matches the pre-refactor shape.
+- Analysis mode can replay/read saved answers.
+
+Browser scenarios to request before merge:
+
+- required short text
+- checkbox and dropdown min/max
+- matrix partial completion
+- ranking response
+- `Other`
+- `I don't know`
+- custom response validation
+- feedback/check-answer training flow
+- responses split across above, below, and sidebar
+
+## Risk Assessment
+
+This is a high-risk refactor because it changes the owner of response form state. It should be treated as an architectural migration, not a cleanup patch.
+
+Highest-risk areas:
+
+- provenance graph preservation
+- answer persistence shape
+- analysis/replay behavior
+- side-channel state for matrix, ranking, and reactive responses
+- correct-answer feedback and failed-training progression
+- unmounted or hidden response locations
+
+## Recommendation
+
+Use the immediate follow-up PR to remove duplicated answer aggregation first. Then revisit the one-form architecture with current behavior pinned by tests.
+
+The one-form architecture is probably the cleaner end state, but it should only proceed once the project has enough coverage to prove that saved answers, validation gating, feedback, and analysis mode remain unchanged.

--- a/RESPONSE_VALIDATION_FOLLOWUP_PLAN.md
+++ b/RESPONSE_VALIDATION_FOLLOWUP_PLAN.md
@@ -1,0 +1,114 @@
+# Response Validation Follow-Up Plan
+
+## Goal
+
+Reduce the remaining duplication around response answer snapshots without changing the current per-location Mantine form architecture. This follow-up PR should target `codex/response-validation-cleanup`, not `dev`.
+
+The immediate problem is that multiple code paths rebuild the same trial answer object from `trialValidation[identifier]`:
+
+- Response issue summaries in `ResponseBlock.tsx`
+- Correct-answer feedback checks in `ResponseBlock.tsx`
+- Final answer persistence in `useNextStep.ts`
+
+Those paths should agree on exactly which response values are considered the current answer for a trial.
+
+## Non-Goals
+
+- Do not replace per-location Mantine forms.
+- Do not change validation semantics.
+- Do not move stimulus validation into response validation.
+- Do not change saved answer shape.
+- Do not introduce new dependencies.
+
+## Current Shape
+
+Each `ResponseBlock` owns a Mantine form for one response location:
+
+- `aboveStimulus`
+- `belowStimulus`
+- `sidebar`
+
+Each block publishes a plain validation snapshot into `trialValidation[identifier][location]`. Later, other code merges those snapshots to get the answer object for the whole trial.
+
+That snapshot boundary is the right place for a small cleanup. Mantine remains local UI state, and `trialValidation` remains global coordination and persistence state.
+
+## Proposed Change
+
+Add one shared helper for constructing the trial response answer from a trial validation entry.
+
+Suggested location:
+
+```txt
+src/components/response/trialValidationAnswers.ts
+```
+
+Suggested API:
+
+```ts
+export function collectResponseValuesFromTrialValidation(
+  validationForStep?: Partial<Record<ResponseBlockLocation | 'stimulus', ValidationStatus>>,
+): StoredAnswer['answer'];
+```
+
+Behavior:
+
+- Return `{}` when no validation exists.
+- Merge only entries that have a `values` property.
+- Preserve the current overwrite behavior when multiple locations contain the same response id.
+- Ignore non-validation fields such as `provenanceGraph`.
+- Keep `stimulus.values` behavior consistent with the current reducer, even if it is usually `{}`.
+
+## Call Sites
+
+Replace the local helper in `ResponseBlock.tsx` for:
+
+- `combinedLiveValues`
+- `checkAnswerProvideFeedback`
+
+Replace the duplicate reducer in `useNextStep.ts` for:
+
+- `answer` construction before saving participant data
+
+Do not alter the analysis-mode collection from `analysisProvState` unless a separate duplicate path is found and covered.
+
+## Tests
+
+Add sibling unit tests near the helper:
+
+```txt
+src/components/response/tests/trialValidationAnswers.spec.ts
+```
+
+Cover:
+
+- Missing validation returns an empty object.
+- Above, below, and sidebar values merge into one answer object.
+- Entries without `values` are ignored.
+- Existing overwrite behavior is preserved when the same key appears in multiple locations.
+- A `stimulus` validation entry with empty values does not affect response answers.
+
+Update existing tests only where imports move:
+
+- `src/components/response/tests/ResponseBlock.spec.tsx`
+- `src/store/hooks/tests/useNextStep.spec.ts`
+
+## Verification
+
+Run:
+
+```bash
+yarn unittest --run src/components/response/tests src/store/hooks/tests/useNextStep.spec.ts
+yarn typecheck
+yarn lint
+yarn build
+```
+
+Do not run `yarn test` directly. If browser confidence is needed, describe the Playwright scenarios for a human to run.
+
+## Review Checklist
+
+- The saved answer object is unchanged for existing tests.
+- Feedback checks read the same answer object as persistence.
+- Required, optional, custom, matrix, ranking, `withOther`, and `withDontKnow` validation behavior is unchanged.
+- No Mantine form object is stored in Redux or `trialValidation`.
+- The PR diff stays focused on one helper, call-site replacement, and tests.

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -226,25 +226,24 @@ export function AllTasksTimeline({
     });
   }, [xScale, maxHeight, participantData.answers, timelineMode]);
 
-  const hoveredTask = tasks.find((task) => task.identifier === hoveredTaskIdentifier);
-  const nonHoveredTasks = tasks.filter((task) => task.identifier !== hoveredTaskIdentifier);
-
   return (
-    <Center>
-      <Stack gap={15} style={{ width: '100%' }}>
-        <Box style={{ width: '100%', overflowX: timelineMode === 'uniform' ? 'auto' : 'visible', overflowY: 'visible' }}>
+    <Center style={{ width: '100%', minWidth: 0 }}>
+      <Stack gap={15} style={{ width: '100%', minWidth: 0 }}>
+        <Box style={{
+          width: '100%', maxWidth: '100%', minWidth: 0, overflowX: timelineMode === 'uniform' ? 'auto' : 'visible', overflowY: 'visible',
+        }}
+        >
           <svg
             onMouseLeave={() => setHoveredTaskIdentifier(null)}
             style={{
               width: timelineWidth,
-              minWidth: timelineWidth,
               height: maxHeight,
+              display: 'block',
               overflow: 'visible',
             }}
           >
             {tasks.map((t) => t.line)}
-            {nonHoveredTasks.map((t) => t.label)}
-            {hoveredTask?.label}
+            {tasks.map((t) => t.label)}
             {browsedAway}
           </svg>
         </Box>

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -3,7 +3,7 @@ import {
 } from 'react';
 import * as d3 from 'd3';
 import {
-  Center, Stack, Tooltip, Text,
+  Box, Center, Stack, Tooltip, Text,
 } from '@mantine/core';
 import { ParticipantData } from '../../../storage/types';
 import { SingleTaskLabelLines } from './SingleTaskLabelLines';
@@ -16,6 +16,11 @@ import {
   compareReplayAnswerEntries,
   orderedReplayAnswerEntries,
 } from './taskOrdering';
+import {
+  getUniformTimelineMetrics,
+  orderedUniformReplayAnswerEntries,
+  TimelineMode,
+} from './timelineLayout';
 
 const LABEL_GAP = 25;
 const CHARACTER_SIZE = 8;
@@ -25,8 +30,8 @@ const margin = {
 };
 
 export function AllTasksTimeline({
-  participantData, width, studyId, studyConfig, maxLength,
-}: { participantData: ParticipantData, width: number, studyId: string, studyConfig: StudyConfig | undefined, maxLength: number | undefined }) {
+  participantData, width, studyId, studyConfig, maxLength, timelineMode = 'time',
+}: { participantData: ParticipantData, width: number, studyId: string, studyConfig: StudyConfig | undefined, maxLength: number | undefined, timelineMode?: TimelineMode }) {
   const [hoveredTaskIdentifier, setHoveredTaskIdentifier] = useState<string | null>(null);
 
   const percentComplete = useMemo(() => {
@@ -35,26 +40,45 @@ export function AllTasksTimeline({
     return (Object.entries(participantData.answers).length - incompleteEntries.length) / (Object.entries(participantData.answers).length);
   }, [participantData.answers]);
 
+  const timelineWidth = useMemo(() => {
+    if (timelineMode === 'time') {
+      return width;
+    }
+
+    return getUniformTimelineMetrics({
+      availableWidth: width,
+      taskCount: Object.entries(participantData.answers || {}).length,
+      margin,
+    }).timelineWidth;
+  }, [participantData.answers, timelineMode, width]);
+
   const xScale = useMemo(() => {
+    if (timelineMode === 'uniform') {
+      return d3.scaleLinear([margin.left, timelineWidth - margin.right]).domain([0, Math.max(Object.entries(participantData.answers || {}).length, 1)]).clamp(true);
+    }
+
     const allStartTimes = Object.values(participantData.answers || {}).filter((answer) => answer.startTime).map((answer) => [answer.startTime, answer.endTime]).flat();
 
     const extent = d3.extent(allStartTimes) as [number, number];
 
-    const scale = d3.scaleLinear([margin.left, (width * percentComplete - (percentComplete !== 1 ? 0 : margin.right))]).domain([extent[0], maxLength ? extent[0] + maxLength : extent[1]]).clamp(true);
+    const scale = d3.scaleLinear([margin.left, (timelineWidth * percentComplete - (percentComplete !== 1 ? 0 : margin.right))]).domain([extent[0], maxLength ? extent[0] + maxLength : extent[1]]).clamp(true);
 
     return scale;
-  }, [maxLength, participantData.answers, percentComplete, width]);
+  }, [maxLength, participantData.answers, percentComplete, timelineMode, timelineWidth]);
 
   const incompleteXScale = useMemo(() => {
-    const scale = d3.scaleLinear([width * percentComplete, width - margin.right]).domain([0, Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).length]).clamp(true);
+    const scale = d3.scaleLinear([timelineWidth * percentComplete, timelineWidth - margin.right]).domain([0, Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).length]).clamp(true);
 
     return scale;
-  }, [participantData.answers, percentComplete, width]);
+  }, [participantData.answers, percentComplete, timelineWidth]);
 
   const maxHeight = useMemo(() => {
     const incompleteEntries = Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).sort(compareReplayAnswerEntries);
     const incompleteEntryIndexes = new Map(incompleteEntries.map(([identifier], index) => [identifier, index]));
-    const sortedEntries = orderedReplayAnswerEntries(participantData.answers);
+    const sortedEntries = timelineMode === 'uniform'
+      ? orderedUniformReplayAnswerEntries(participantData.answers)
+      : orderedReplayAnswerEntries(participantData.answers);
+    const entryIndexes = new Map(sortedEntries.map(([identifier], index) => [identifier, index]));
 
     let currentHeight = 0;
     let _maxHeight = 0;
@@ -64,10 +88,10 @@ export function AllTasksTimeline({
 
       // Check if the previous entry overlaps with the current entry
       const prev = i > 0 ? sortedEntries[i - currentHeight - 1] : null;
-      const prevScale = prev && prev[1].startTime ? xScale : incompleteXScale;
-      const prevStart = prev ? prev[1].startTime ? prev[1].startTime : incompleteEntryIndexes.get(prev[0]) ?? 0 : 0;
-      const scale = answer.startTime === 0 ? incompleteXScale : xScale;
-      const scaleStart = answer.startTime ? answer.startTime : incompleteEntryIndexes.get(identifier) ?? 0;
+      const prevScale = timelineMode === 'uniform' || (prev && prev[1].startTime) ? xScale : incompleteXScale;
+      const prevStart = prev ? timelineMode === 'uniform' ? entryIndexes.get(prev[0]) ?? 0 : prev[1].startTime ? prev[1].startTime : incompleteEntryIndexes.get(prev[0]) ?? 0 : 0;
+      const scale = timelineMode === 'uniform' || answer.startTime !== 0 ? xScale : incompleteXScale;
+      const scaleStart = timelineMode === 'uniform' ? entryIndexes.get(identifier) ?? 0 : answer.startTime ? answer.startTime : incompleteEntryIndexes.get(identifier) ?? 0;
 
       // If the previous entry overlaps with the current entry , increase the height
       if (prev && prev[0].length * (CHARACTER_SIZE + 1) + prevScale(prevStart) > scale(scaleStart)) {
@@ -82,7 +106,7 @@ export function AllTasksTimeline({
     });
 
     return (_maxHeight + 1) * LABEL_GAP + margin.top + margin.bottom;
-  }, [incompleteXScale, participantData.answers, xScale]);
+  }, [incompleteXScale, participantData.answers, timelineMode, xScale]);
 
   const conditionParam = useMemo(() => {
     const parsedConditions = parseConditionParam(participantData.conditions ?? participantData.searchParams?.condition);
@@ -95,20 +119,24 @@ export function AllTasksTimeline({
 
     const incompleteEntries = Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).sort(compareReplayAnswerEntries);
     const incompleteEntryIndexes = new Map(incompleteEntries.map(([identifier], index) => [identifier, index]));
-    const combined = orderedReplayAnswerEntries(participantData.answers);
+    const combined = timelineMode === 'uniform'
+      ? orderedUniformReplayAnswerEntries(participantData.answers)
+      : orderedReplayAnswerEntries(participantData.answers);
+    const entryIndexes = new Map(combined.map(([identifier], index) => [identifier, index]));
 
     const allElements = combined.map((entry, i) => {
-      const scale = entry[1].startTime === 0 ? incompleteXScale : xScale;
+      const scale = timelineMode === 'uniform' || entry[1].startTime !== 0 ? xScale : incompleteXScale;
 
       const [identifier, answer] = entry;
 
       const prev = i > 0 ? combined[i - currentHeight - 1] : null;
 
-      const prevScale = prev && prev[1].startTime ? xScale : incompleteXScale;
-      const prevStart = prev ? prev[1].startTime ? prev[1].startTime : incompleteEntryIndexes.get(prev[0]) ?? 0 : 0;
+      const prevScale = timelineMode === 'uniform' || (prev && prev[1].startTime) ? xScale : incompleteXScale;
+      const prevStart = prev ? timelineMode === 'uniform' ? entryIndexes.get(prev[0]) ?? 0 : prev[1].startTime ? prev[1].startTime : incompleteEntryIndexes.get(prev[0]) ?? 0 : 0;
       const incompleteEntryIndex = incompleteEntryIndexes.get(identifier) ?? 0;
-      const scaleStart = answer.startTime ? answer.startTime : incompleteEntryIndex;
-      const scaleEnd = answer.endTime > 0 ? answer.endTime : incompleteEntryIndex + 1;
+      const uniformEntryIndex = entryIndexes.get(identifier) ?? 0;
+      const scaleStart = timelineMode === 'uniform' ? uniformEntryIndex : answer.startTime ? answer.startTime : incompleteEntryIndex;
+      const scaleEnd = timelineMode === 'uniform' ? uniformEntryIndex + 1 : answer.endTime > 0 ? answer.endTime : incompleteEntryIndex + 1;
 
       if (prev && prev[0].length * (CHARACTER_SIZE + 1) + prevScale(prevStart) > scale(scaleStart)) {
         currentHeight += 1;
@@ -160,10 +188,14 @@ export function AllTasksTimeline({
     });
 
     return allElements;
-  }, [participantData.answers, participantData.participantId, incompleteXScale, xScale, studyConfig, maxHeight, studyId, conditionParam, hoveredTaskIdentifier]);
+  }, [participantData.answers, participantData.participantId, incompleteXScale, xScale, studyConfig, maxHeight, studyId, conditionParam, hoveredTaskIdentifier, timelineMode]);
 
   // Find entries of someone browsing away. Show them
   const browsedAway = useMemo(() => {
+    if (timelineMode === 'uniform') {
+      return [];
+    }
+
     const sortedEntries = Object.entries(participantData.answers || {}).sort((a, b) => a[1].startTime - b[1].startTime);
 
     return sortedEntries.map((entry) => {
@@ -192,7 +224,7 @@ export function AllTasksTimeline({
         browsedAwayList.map((browse, i) => <Tooltip withinPortal key={i} label="Browsed away"><rect x={xScale(browse[0])} width={Math.max(0, xScale(browse[1]) - xScale(browse[0]))} y={maxHeight - 5} height={10} /></Tooltip>)
       );
     });
-  }, [xScale, maxHeight, participantData.answers]);
+  }, [xScale, maxHeight, participantData.answers, timelineMode]);
 
   const hoveredTask = tasks.find((task) => task.identifier === hoveredTaskIdentifier);
   const nonHoveredTasks = tasks.filter((task) => task.identifier !== hoveredTaskIdentifier);
@@ -200,12 +232,22 @@ export function AllTasksTimeline({
   return (
     <Center>
       <Stack gap={15} style={{ width: '100%' }}>
-        <svg onMouseLeave={() => setHoveredTaskIdentifier(null)} style={{ width, height: maxHeight, overflow: 'visible' }}>
-          {tasks.map((t) => t.line)}
-          {nonHoveredTasks.map((t) => t.label)}
-          {hoveredTask?.label}
-          {browsedAway}
-        </svg>
+        <Box style={{ width: '100%', overflowX: timelineMode === 'uniform' ? 'auto' : 'visible', overflowY: 'visible' }}>
+          <svg
+            onMouseLeave={() => setHoveredTaskIdentifier(null)}
+            style={{
+              width: timelineWidth,
+              minWidth: timelineWidth,
+              height: maxHeight,
+              overflow: 'visible',
+            }}
+          >
+            {tasks.map((t) => t.line)}
+            {nonHoveredTasks.map((t) => t.label)}
+            {hoveredTask?.label}
+            {browsedAway}
+          </svg>
+        </Box>
       </Stack>
     </Center>
 

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -3,8 +3,9 @@ import {
 } from 'react';
 import * as d3 from 'd3';
 import {
-  Box, Center, Stack, Tooltip, Text,
+  Box, Stack, Tooltip, Text,
 } from '@mantine/core';
+import { useResizeObserver } from '@mantine/hooks';
 import { ParticipantData } from '../../../storage/types';
 import { SingleTaskLabelLines } from './SingleTaskLabelLines';
 import { SingleTask } from './SingleTask';
@@ -33,6 +34,8 @@ export function AllTasksTimeline({
   participantData, width, studyId, studyConfig, maxLength, timelineMode = 'time',
 }: { participantData: ParticipantData, width: number, studyId: string, studyConfig: StudyConfig | undefined, maxLength: number | undefined, timelineMode?: TimelineMode }) {
   const [hoveredTaskIdentifier, setHoveredTaskIdentifier] = useState<string | null>(null);
+  const [timelineContainerRef, { width: containerWidth }] = useResizeObserver();
+  const availableWidth = Math.max(containerWidth || width, 0);
 
   const percentComplete = useMemo(() => {
     const incompleteEntries = Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0);
@@ -42,15 +45,15 @@ export function AllTasksTimeline({
 
   const timelineWidth = useMemo(() => {
     if (timelineMode === 'time') {
-      return width;
+      return availableWidth;
     }
 
     return getUniformTimelineMetrics({
-      availableWidth: width,
+      availableWidth,
       taskCount: Object.entries(participantData.answers || {}).length,
       margin,
     }).timelineWidth;
-  }, [participantData.answers, timelineMode, width]);
+  }, [availableWidth, participantData.answers, timelineMode]);
 
   const xScale = useMemo(() => {
     if (timelineMode === 'uniform') {
@@ -227,28 +230,30 @@ export function AllTasksTimeline({
   }, [xScale, maxHeight, participantData.answers, timelineMode]);
 
   return (
-    <Center style={{ width: '100%', minWidth: 0 }}>
-      <Stack gap={15} style={{ width: '100%', minWidth: 0 }}>
-        <Box style={{
-          width: '100%', maxWidth: '100%', minWidth: 0, overflowX: timelineMode === 'uniform' ? 'auto' : 'visible', overflowY: 'visible',
+    <Box
+      ref={timelineContainerRef}
+      style={{
+        width: '100%',
+        maxWidth: '100%',
+        minWidth: 0,
+        overflowX: timelineMode === 'uniform' ? 'auto' : 'visible',
+        overflowY: 'visible',
+      }}
+    >
+      <svg
+        onMouseLeave={() => setHoveredTaskIdentifier(null)}
+        style={{
+          width: timelineWidth,
+          height: maxHeight,
+          display: 'block',
+          overflow: 'visible',
         }}
-        >
-          <svg
-            onMouseLeave={() => setHoveredTaskIdentifier(null)}
-            style={{
-              width: timelineWidth,
-              height: maxHeight,
-              display: 'block',
-              overflow: 'visible',
-            }}
-          >
-            {tasks.map((t) => t.line)}
-            {tasks.map((t) => t.label)}
-            {browsedAway}
-          </svg>
-        </Box>
-      </Stack>
-    </Center>
+      >
+        {tasks.map((t) => t.line)}
+        {tasks.map((t) => t.label)}
+        {browsedAway}
+      </svg>
+    </Box>
 
   );
 }

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -229,6 +229,8 @@ export function AllTasksTimeline({
     });
   }, [xScale, maxHeight, participantData.answers, timelineMode]);
 
+  const hoveredTask = tasks.find((task) => task.identifier === hoveredTaskIdentifier);
+
   return (
     <Box
       ref={timelineContainerRef}
@@ -242,6 +244,8 @@ export function AllTasksTimeline({
     >
       <svg
         onMouseLeave={() => setHoveredTaskIdentifier(null)}
+        onPointerLeave={() => setHoveredTaskIdentifier(null)}
+        onPointerCancel={() => setHoveredTaskIdentifier(null)}
         style={{
           width: timelineWidth,
           height: maxHeight,
@@ -250,8 +254,9 @@ export function AllTasksTimeline({
         }}
       >
         {tasks.map((t) => t.line)}
-        {tasks.map((t) => t.label)}
+        {tasks.filter((t) => t.identifier !== hoveredTaskIdentifier).map((t) => t.label)}
         {browsedAway}
+        {hoveredTask?.label}
       </svg>
     </Box>
 

--- a/src/analysis/individualStudy/replay/SingleTask.tsx
+++ b/src/analysis/individualStudy/replay/SingleTask.tsx
@@ -16,6 +16,26 @@ const LABEL_MAX_WIDTH = 160;
 const ICON_SIZE = 14;
 const ICON_GAP = 2;
 
+function taskFill({
+  incomplete,
+  hasCorrect,
+  isCorrect,
+}: {
+  incomplete: boolean,
+  hasCorrect: boolean,
+  isCorrect: boolean,
+}) {
+  if (incomplete) {
+    return '#ffe8cc';
+  }
+
+  if (!hasCorrect) {
+    return '#dee2e6';
+  }
+
+  return isCorrect ? '#40c057' : '#fa5252';
+}
+
 export function SingleTask({
   xScale,
   identifier,
@@ -72,8 +92,10 @@ export function SingleTask({
       style={{ cursor: 'pointer' }}
     >
       <rect
-        opacity={1}
-        fill={isHovered ? 'cornflowerblue' : incomplete ? '#e9ecef' : 'lightgray'}
+        opacity={isDimmed ? 0.45 : 1}
+        fill={taskFill({ incomplete, hasCorrect, isCorrect })}
+        stroke={isHovered ? 'cornflowerblue' : undefined}
+        strokeWidth={isHovered ? 3 : 0}
         x={xScale(scaleStart) + TASK_GAP}
         width={Math.max(0, xScale(scaleEnd) - xScale(scaleStart) - TASK_GAP * 2)}
         y={height - TIMELINE_HEIGHT}

--- a/src/analysis/individualStudy/replay/SingleTask.tsx
+++ b/src/analysis/individualStudy/replay/SingleTask.tsx
@@ -26,14 +26,14 @@ function taskFill({
   isCorrect: boolean,
 }) {
   if (incomplete) {
-    return '#ffe8cc';
+    return '#e9ecef';
   }
 
   if (!hasCorrect) {
-    return '#dee2e6';
+    return 'lightgray';
   }
 
-  return isCorrect ? '#40c057' : '#fa5252';
+  return isCorrect ? '#bfe8c6' : '#f3c1c1';
 }
 
 export function SingleTask({
@@ -87,8 +87,9 @@ export function SingleTask({
   return (
     <g
       onClick={() => navigateToTrial(trialOrder, participantId, studyId, condition)}
-      onMouseEnter={onHover}
-      onMouseLeave={onHoverEnd}
+      onPointerEnter={onHover}
+      onPointerLeave={onHoverEnd}
+      onPointerCancel={onHoverEnd}
       style={{ cursor: 'pointer' }}
     >
       <rect

--- a/src/analysis/individualStudy/replay/timelineLayout.spec.ts
+++ b/src/analysis/individualStudy/replay/timelineLayout.spec.ts
@@ -1,0 +1,66 @@
+import {
+  describe,
+  expect,
+  test,
+} from 'vitest';
+import { StoredAnswer } from '../../../parser/types';
+import {
+  getUniformTimelineMetrics,
+  orderedUniformReplayAnswerEntries,
+} from './timelineLayout';
+
+function answer(identifier: string, trialOrder: string, startTime: number, endTime = startTime + 10): StoredAnswer {
+  return {
+    answer: {},
+    identifier,
+    componentName: identifier,
+    trialOrder,
+    incorrectAnswers: {},
+    startTime,
+    endTime,
+    windowEvents: [],
+    timedOut: false,
+    helpButtonClickedCount: 0,
+    parameters: {},
+    correctAnswer: [],
+    optionOrders: {},
+    questionOrders: {},
+  };
+}
+
+describe('getUniformTimelineMetrics', () => {
+  test('fills available width when tasks can be wider than the minimum', () => {
+    const metrics = getUniformTimelineMetrics({
+      availableWidth: 640,
+      taskCount: 5,
+      margin: { left: 20, right: 20 },
+    });
+
+    expect(metrics.timelineWidth).toBe(640);
+    expect(metrics.taskWidth).toBe(120);
+  });
+
+  test('uses the minimum task width and expands the timeline when needed', () => {
+    const metrics = getUniformTimelineMetrics({
+      availableWidth: 200,
+      taskCount: 6,
+      margin: { left: 20, right: 20 },
+    });
+
+    expect(metrics.timelineWidth).toBe(328);
+    expect(metrics.taskWidth).toBe(48);
+  });
+});
+
+describe('orderedUniformReplayAnswerEntries', () => {
+  test('orders completed tasks first, then incomplete tasks by trial order', () => {
+    const entries = orderedUniformReplayAnswerEntries({
+      task_3: answer('task_3', '3', 3000),
+      task_1: answer('task_1', '1', 0, 0),
+      task_2: answer('task_2', '2', 2000),
+      task_0: answer('task_0', '0', 1000),
+    });
+
+    expect(entries.map(([identifier]) => identifier)).toEqual(['task_0', 'task_2', 'task_3', 'task_1']);
+  });
+});

--- a/src/analysis/individualStudy/replay/timelineLayout.ts
+++ b/src/analysis/individualStudy/replay/timelineLayout.ts
@@ -1,0 +1,40 @@
+import { StoredAnswer } from '../../../parser/types';
+import { compareReplayAnswerEntries, ReplayAnswerEntry } from './taskOrdering';
+
+export type TimelineMode = 'time' | 'uniform';
+
+export const UNIFORM_TASK_MIN_WIDTH = 48;
+
+type TimelineMargin = {
+  left: number;
+  right: number;
+};
+
+export function getUniformTimelineMetrics({
+  availableWidth,
+  taskCount,
+  margin,
+  minTaskWidth = UNIFORM_TASK_MIN_WIDTH,
+}: {
+  availableWidth: number;
+  taskCount: number;
+  margin: TimelineMargin;
+  minTaskWidth?: number;
+}) {
+  const safeTaskCount = Math.max(taskCount, 1);
+  const availableInnerWidth = Math.max(0, availableWidth - margin.left - margin.right);
+  const timelineInnerWidth = Math.max(availableInnerWidth, safeTaskCount * minTaskWidth);
+
+  return {
+    taskWidth: timelineInnerWidth / safeTaskCount,
+    timelineWidth: timelineInnerWidth + margin.left + margin.right,
+  };
+}
+
+export function orderedUniformReplayAnswerEntries(answers: Record<string, StoredAnswer> = {}) {
+  const entries = Object.entries(answers) as ReplayAnswerEntry[];
+  const completed = entries.filter((entry) => entry[1].startTime !== 0).sort(compareReplayAnswerEntries);
+  const incomplete = entries.filter((entry) => entry[1].startTime === 0).sort(compareReplayAnswerEntries);
+
+  return [...completed, ...incomplete];
+}

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 import {
-  Text, Flex, Group, Space, Tooltip, Badge, RingProgress, Stack, ActionIcon,
+  Text, Flex, Group, Space, Tooltip, Badge, RingProgress, Stack, ActionIcon, SegmentedControl,
 } from '@mantine/core';
 import {
   JSX, useCallback, useEffect, useMemo, useState,
@@ -19,6 +19,7 @@ import { StoredAnswer } from '../../../store/types';
 import { ParticipantRejectModal } from '../ParticipantRejectModal';
 import { participantName } from '../../../utils/participantName';
 import { AllTasksTimeline } from '../replay/AllTasksTimeline';
+import { TimelineMode } from '../replay/timelineLayout';
 import { youtubeReadableDuration } from '../../../utils/humanReadableDuration';
 import { getSequenceFlatMap } from '../../../utils/getSequenceFlatMap';
 import { MetaCell } from './MetaCell';
@@ -54,6 +55,7 @@ export function TableView({
 }) {
   const { studyId } = useParams();
   const [checked, setChecked] = useState<MrtRowSelectionState>({});
+  const [timelineMode, setTimelineMode] = useState<TimelineMode>('time');
 
   useEffect(() => {
     const newSelectedParticipants = Object.keys(checked).filter((v) => checked[v])
@@ -275,7 +277,7 @@ export function TableView({
       }
 
       return (
-        <AllTasksTimeline maxLength={undefined} studyConfig={allConfigs[r.participantConfigHash] ?? studyConfig} studyId={studyId || ''} participantData={r} width={width - 60} />
+        <AllTasksTimeline maxLength={undefined} studyConfig={allConfigs[r.participantConfigHash] ?? studyConfig} studyId={studyId || ''} participantData={r} width={width - 60} timelineMode={timelineMode} />
       );
     },
     defaultColumn: {
@@ -286,8 +288,17 @@ export function TableView({
     enableDensityToggle: false,
     positionToolbarAlertBanner: 'none',
     renderTopToolbarCustomActions: () => (
-      <Flex mb={8} p={8}>
+      <Flex mb={8} p={8} gap="md" align="center">
         <ParticipantRejectModal selectedParticipants={selectedParticipants} refresh={handleRefresh} />
+        <SegmentedControl
+          size="xs"
+          value={timelineMode}
+          onChange={(value) => setTimelineMode(value as TimelineMode)}
+          data={[
+            { value: 'time', label: 'Time' },
+            { value: 'uniform', label: 'Uniform' },
+          ]}
+        />
       </Flex>
     ),
   });

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -289,9 +289,8 @@ export function TableView({
     positionToolbarAlertBanner: 'none',
     renderTopToolbarCustomActions: () => (
       <Flex mb={8} p={8} gap="md" align="center">
-        <ParticipantRejectModal selectedParticipants={selectedParticipants} refresh={handleRefresh} />
         <SegmentedControl
-          size="xs"
+          size="sm"
           value={timelineMode}
           onChange={(value) => setTimelineMode(value as TimelineMode)}
           data={[
@@ -299,6 +298,7 @@ export function TableView({
             { value: 'uniform', label: 'Uniform' },
           ]}
         />
+        <ParticipantRejectModal selectedParticipants={selectedParticipants} refresh={handleRefresh} />
       </Flex>
     ),
   });

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -268,6 +268,14 @@ export function TableView({
     enablePagination: false,
     enableRowVirtualization: true,
     mantinePaperProps: { style: { maxHeight: '100%', display: 'flex', flexDirection: 'column' } },
+    mantineDetailPanelProps: {
+      style: {
+        flex: '1 1 100%',
+        maxWidth: '100%',
+        minWidth: 0,
+        width: '100%',
+      },
+    },
     layoutMode: 'grid',
     renderDetailPanel: ({ row }) => {
       const r = row.original;


### PR DESCRIPTION
<img width="1403" height="122" alt="image" src="https://github.com/user-attachments/assets/04404663-755d-4840-aacc-826f587c4419" />

<img width="1700" height="408" alt="Screenshot 2026-06-22 at 3 04 01 PM" src="https://github.com/user-attachments/assets/84298138-5ee4-4416-9a04-3bd38274107a" />

## Summary
- add a Participant View timeline mode control for Time vs Uniform layouts
- render uniform task bars with a 48px minimum width and horizontal overflow when needed
- color timeline task bars by correctness/incomplete/no-correct-answer state and hide duration-only browsed-away markers in uniform mode
- add focused tests for uniform timeline sizing and ordering

## Verification
- `yarn unittest src/analysis/individualStudy/replay/timelineLayout.spec.ts src/analysis/individualStudy/replay/taskOrdering.spec.ts --run`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- Browser smoke loaded `http://localhost:8080/analysis/stats/demo-choropleth-map/table` with no console errors; local data had no participant rows, so the table toolbar was not mounted for visual interaction.

Fixes #1239

### Documentation
Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [x] Done
- [ ] N/A