### PR TITLE
Refactor response validation

### DIFF
--- a/.github/workflows/lint_build.yaml
+++ b/.github/workflows/lint_build.yaml
@@ -21,7 +21,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install yarn packages (from cache if available)
-        run: yarn install --immutable
+        run: yarn install --frozen-lockfile
 
       - name: Run linter
         run: yarn lint

--- a/.github/workflows/lint_build.yaml
+++ b/.github/workflows/lint_build.yaml
@@ -11,4 +11,20 @@ on:
 
 jobs:
   lint:
-    uses: revisit-studies/.github/.github/workflows/lint.yaml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'yarn'
+
+      - name: Install yarn packages (from cache if available)
+        run: yarn install --immutable
+
+      - name: Run linter
+        run: yarn lint
+
+      - name: Build application
+        run: yarn build

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -63,6 +63,19 @@ function findMatchingStrings(arr1: string[], arr2: string[]): string[] {
   return matches;
 }
 
+function collectResponseValuesFromAnalysisState(
+  analysisProvState: Partial<Record<ResponseBlockLocation, FormElementProvenance>>,
+  status?: StoredAnswer,
+): StoredAnswer['answer'] {
+  return (['aboveStimulus', 'belowStimulus', 'sidebar'] as ResponseBlockLocation[]).reduce((acc, responseLocation) => {
+    const locationProv = analysisProvState[responseLocation];
+    return {
+      ...acc,
+      ...(locationProv?.form || {}),
+    };
+  }, { ...(status?.answer || {}) } as StoredAnswer['answer']);
+}
+
 export function ResponseBlock({
   config,
   location,
@@ -242,13 +255,10 @@ export function ResponseBlock({
   );
   const combinedLiveValues = useMemo(() => getAnswersFromAllLocations(trialValidation[identifier]), [identifier, trialValidation]);
   const combinedAnalysisValues = useMemo(
-    () => ['aboveStimulus', 'belowStimulus', 'sidebar'].reduce((acc, responseLocation) => {
-      const locationProv = analysisProvState[responseLocation as ResponseBlockLocation] as FormElementProvenance | undefined;
-      return {
-        ...acc,
-        ...(locationProv?.form || {}),
-      };
-    }, { ...(status?.answer || {}) } as StoredAnswer['answer']),
+    () => collectResponseValuesFromAnalysisState(
+      analysisProvState as Partial<Record<ResponseBlockLocation, FormElementProvenance>>,
+      status,
+    ),
     [analysisProvState, status],
   );
   const combinedValues = useMemo(

--- a/src/components/response/responseErrors.ts
+++ b/src/components/response/responseErrors.ts
@@ -1,111 +1,46 @@
-import isEqual from 'lodash.isequal';
 import {
-  CheckboxResponse, CustomResponse, DropdownResponse, MatrixResponse, NumberOption, NumericalResponse, Response, StringOption,
+  CustomResponse, NumberOption, Response, StringOption,
 } from '../../parser/types';
 import { CustomResponseValidate, StoredAnswer } from '../../store/types';
-import { parseStringOptionValue } from '../../utils/stringOptions';
+import {
+  checkCheckboxResponseForValidation,
+  checkDropdownResponse,
+  checkMatrixResponse,
+  checkNumericalResponse,
+  isEmptyCustomResponseValue,
+  isOtherSelectionIncomplete,
+  REQUIRED_ERROR_MESSAGE,
+  ResponseIssueSummary,
+  ResponseIssueType,
+  ResponseValidationResult,
+  shouldBypassValidationForStandaloneDontKnow,
+  usesStandaloneDontKnowField,
+  validateResponse,
+} from './responseValidation';
 
-export const REQUIRED_ERROR_MESSAGE = 'Please answer this question to continue.';
-export type ResponseIssueType = 'unanswered' | 'invalid';
-export type ResponseIssueSummary = { unansweredCount: number; invalidCount: number };
+export {
+  checkCheckboxResponseForValidation,
+  checkDropdownResponse,
+  checkMatrixResponse,
+  checkNumericalResponse,
+  isEmptyCustomResponseValue,
+  isOtherSelectionIncomplete,
+  REQUIRED_ERROR_MESSAGE,
+  shouldBypassValidationForStandaloneDontKnow,
+  usesStandaloneDontKnowField,
+};
+
+export type {
+  ResponseIssueSummary,
+  ResponseIssueType,
+  ResponseValidationResult,
+};
+
 export type ResponseValidationIssue = {
   type: 'none' | 'unanswered' | 'invalid';
   message?: string;
   reason?: 'requiredValueMismatch';
 };
-
-export function isEmptyCustomResponseValue(value: StoredAnswer['answer'][string] | undefined): boolean {
-  if (value === null || value === undefined || value === '') {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length === 0 || value.every((entry) => isEmptyCustomResponseValue(entry));
-  }
-
-  if (typeof value === 'object') {
-    const objectValues = Object.values(value);
-    return objectValues.length === 0 || objectValues.every((entry) => isEmptyCustomResponseValue(entry));
-  }
-
-  return false;
-}
-
-export function checkDropdownResponse(dropdownResponse: DropdownResponse, value: string[]) {
-  const minNotSelected = dropdownResponse.minSelections && value.length < dropdownResponse.minSelections;
-  const maxNotSelected = dropdownResponse.maxSelections && value.length > dropdownResponse.maxSelections;
-
-  if (minNotSelected) {
-    return `Please select at least ${dropdownResponse.minSelections} options`;
-  }
-  if (maxNotSelected) {
-    return `Please select at most ${dropdownResponse.maxSelections} options`;
-  }
-  return null;
-}
-
-function checkCheckboxResponse(response: CheckboxResponse, value: string[]) {
-  const minNotSelected = response.minSelections && value.length < response.minSelections;
-  const maxNotSelected = response.maxSelections && value.length > response.maxSelections;
-
-  if (minNotSelected && maxNotSelected) {
-    return `Please select between ${response.minSelections} and ${response.maxSelections} options`;
-  }
-  if (minNotSelected) {
-    return `Please select at least ${response.minSelections} options`;
-  }
-  if (maxNotSelected) {
-    return `Please select at most ${response.maxSelections} options`;
-  }
-  return null;
-}
-
-export function checkCheckboxResponseForValidation(
-  response: CheckboxResponse,
-  value: string[],
-  dontKnowChecked = false,
-) {
-  if (response.withDontKnow && dontKnowChecked) {
-    return null;
-  }
-
-  return checkCheckboxResponse(response, value);
-}
-
-export function checkNumericalResponse(response: NumericalResponse, value: number) {
-  const numValue = typeof value === 'string' ? parseFloat(value) : value;
-
-  const { min, max } = response;
-
-  if (min !== undefined && max !== undefined && (numValue < min || numValue > max)) {
-    return `Please enter a value between ${min} and ${max}`;
-  }
-  if (min !== undefined && numValue < min) {
-    return `Please enter a value of ${min} or greater`;
-  }
-  if (max !== undefined && numValue > max) {
-    return `Please enter a value of ${max} or less`;
-  }
-  return null;
-}
-
-export function checkMatrixResponse(response: MatrixResponse, value: Record<string, string>) {
-  const expectedQuestionKeys = response.questionOptions.map((entry) => parseStringOptionValue(entry));
-  const unanswered = expectedQuestionKeys.some((questionKey) => {
-    const rowValue = value[questionKey];
-    return rowValue === undefined || rowValue === '';
-  });
-
-  if (unanswered) {
-    return 'Please answer all questions in the matrix to continue.';
-  }
-
-  return null;
-}
-
-function hasOtherText(value: StoredAnswer['answer'][string] | undefined) {
-  return typeof value === 'string' && value.trim().length > 0;
-}
 
 function getRequiredValueMismatchMessage(
   response: Response,
@@ -124,35 +59,6 @@ function getRequiredValueMismatchMessage(
   return `Please ${options ? 'select' : 'enter'} ${requiredLabel || (options ? options.find((opt) => opt.value === requiredValue)?.label : requiredValue.toString())} to continue.`;
 }
 
-export function isOtherSelectionIncomplete(
-  response: Response,
-  value: StoredAnswer['answer'][string] | undefined,
-  values: StoredAnswer['answer'],
-) {
-  if (!('withOther' in response) || !response.withOther) {
-    return false;
-  }
-
-  const otherInputValue = values[`${response.id}-other`];
-  if (response.type === 'radio') {
-    return value === 'other' && !hasOtherText(otherInputValue);
-  }
-
-  if (response.type === 'checkbox') {
-    return Array.isArray(value) && value.includes('__other') && !hasOtherText(otherInputValue);
-  }
-
-  return false;
-}
-
-export const usesStandaloneDontKnowField = (response: Response) => !!response.withDontKnow
-  && response.type !== 'matrix-radio'
-  && response.type !== 'matrix-checkbox';
-
-export const shouldBypassValidationForStandaloneDontKnow = (response: Response, dontKnowChecked: boolean) => (
-  usesStandaloneDontKnowField(response) && dontKnowChecked
-);
-
 export function evaluateResponseIssue(
   response: Response,
   value: StoredAnswer['answer'][string] | undefined,
@@ -160,121 +66,12 @@ export function evaluateResponseIssue(
   customValidate?: CustomResponseValidate,
   loadError?: string,
 ): ResponseValidationIssue {
-  const dontKnowChecked = !!values[`${response.id}-dontKnow`];
-
-  if (response.type === 'textOnly' || response.type === 'divider' || response.type === 'reactive') {
-    return { type: 'none' };
-  }
-
-  if (response.type === 'custom') {
-    if (loadError) {
-      return { type: 'invalid', message: loadError };
-    }
-
-    if (shouldBypassValidationForStandaloneDontKnow(response, dontKnowChecked)) {
-      return { type: 'none' };
-    }
-
-    if (response.required === false && isEmptyCustomResponseValue(value)) {
-      return { type: 'none' };
-    }
-
-    if (isEmptyCustomResponseValue(value)) {
-      return response.required === false ? { type: 'none' } : { type: 'unanswered' };
-    }
-
-    const customValue = value as StoredAnswer['answer'][string];
-
-    if (response.requiredValue !== undefined && !isEqual(customValue, response.requiredValue)) {
-      return { type: 'invalid', message: 'Incorrect input' };
-    }
-
-    if (!customValidate) {
-      return { type: 'none' };
-    }
-
-    const customValidationMessage = customValidate(customValue, values, response);
-    return customValidationMessage
-      ? { type: 'invalid', message: customValidationMessage }
-      : { type: 'none' };
-  }
-
-  if (shouldBypassValidationForStandaloneDontKnow(response, dontKnowChecked)) {
-    return { type: 'none' };
-  }
-
-  // Selecting "Other" without filling its companion input is invalid
-  if (isOtherSelectionIncomplete(response, value, values)) {
-    return { type: 'invalid', message: 'Please fill in Other to continue.' };
-  }
-
-  if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
-    if (response.type === 'matrix-radio' || response.type === 'matrix-checkbox') {
-      const matrixValue = value as Record<string, string>;
-      const hasAnsweredAtLeastOne = Object.values(matrixValue).some((entry) => entry !== '');
-
-      if (!hasAnsweredAtLeastOne) {
-        return response.required ? { type: 'unanswered' } : { type: 'none' };
-      }
-
-      // A partially answered matrix is invalid
-      const matrixError = checkMatrixResponse(response, matrixValue);
-      return matrixError ? { type: 'invalid', message: matrixError } : { type: 'none' };
-    }
-
-    if (response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {
-      return Object.keys(value).length === 0 && response.required ? { type: 'unanswered' } : { type: 'none' };
-    }
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return response.required ? { type: 'unanswered' } : { type: 'none' };
-    }
-
-    if (Array.isArray(response.requiredValue)) {
-      const sortedRequired = [...response.requiredValue].sort();
-      const sortedValue = [...value].sort();
-      const matches = sortedRequired.length === sortedValue.length
-        && sortedRequired.every((entry, idx) => entry === sortedValue[idx]);
-
-      // Array inputs are invalid when they do not exactly match the configured requiredValue
-      if (!matches) {
-        return { type: 'invalid', reason: 'requiredValueMismatch' };
-      }
-    }
-
-    // Checkbox answers can be present but still invalid if they miss selection-count rule
-    if (response.type === 'checkbox') {
-      const checkboxError = checkCheckboxResponseForValidation(response, value as string[], dontKnowChecked);
-      return checkboxError ? { type: 'invalid', message: checkboxError } : { type: 'none' };
-    }
-
-    // Dropdown answers can be present but still invalid if they miss selection-count rules
-    if (response.type === 'dropdown') {
-      const dropdownError = checkDropdownResponse(response, value as string[]);
-      return dropdownError ? { type: 'invalid', message: dropdownError } : { type: 'none' };
-    }
-
-    return { type: 'none' };
-  }
-
-  if (value === null || value === undefined || value === '') {
-    return response.required ? { type: 'unanswered' } : { type: 'none' };
-  }
-
-  // Single-value inputs (e.g. shortText, longText, numerical, radio, buttons, likert and single-select dropdown) are invalid when they do not match the configured requiredValue.
-  if (response.requiredValue != null && value.toString() !== response.requiredValue.toString()) {
-    return { type: 'invalid', reason: 'requiredValueMismatch' };
-  }
-
-  // Numerical answers can be present but still invalid when they fall outside the allowed range
-  if (response.type === 'numerical') {
-    const numericalError = checkNumericalResponse(response, value as unknown as number);
-    return numericalError ? { type: 'invalid', message: numericalError } : { type: 'none' };
-  }
-
-  return { type: 'none' };
+  const result = validateResponse(response, value, values, { customValidate, loadError });
+  return {
+    type: result.issueType,
+    message: result.message,
+    reason: result.reason,
+  };
 }
 
 export function generateCustomResponseErrorMessage(
@@ -285,28 +82,25 @@ export function generateCustomResponseErrorMessage(
   loadError?: string,
   options?: { showRequiredErrors?: boolean },
 ) {
-  const issue = evaluateResponseIssue(
+  const result = validateResponse(
     response,
     value,
     {
       ...values,
       [response.id]: value,
     },
-    customValidate,
-    loadError,
+    { customValidate, loadError },
   );
 
-  if (issue.type === 'unanswered') {
+  if (result.issueType === 'unanswered') {
     return options?.showRequiredErrors ? REQUIRED_ERROR_MESSAGE : null;
   }
 
-  if (issue.type === 'invalid') {
-    // Keep validation styling quiet until the participant attempts to submit,
-    // so typing/selecting answers in order just shows the question text.
+  if (result.issueType === 'invalid') {
     if (!options?.showRequiredErrors) {
       return null;
     }
-    return issue.message ?? null;
+    return result.message ?? null;
   }
 
   return null;
@@ -334,52 +128,41 @@ export function generateErrorMessage(
       ...values,
       [response.id]: responseValue,
     };
-  const issue = evaluateResponseIssue(
-    response,
-    responseValue,
-    issueValues,
-  );
+  const result = validateResponse(response, responseValue, issueValues);
 
-  if (issue.type === 'unanswered') {
+  if (result.issueType === 'unanswered') {
     return errorOptions?.showRequiredErrors ? REQUIRED_ERROR_MESSAGE : null;
   }
 
-  if (issue.type === 'invalid') {
-    // Keep validation styling quiet until the participant attempts to submit,
-    // so typing/selecting answers in order just shows the question text.
+  if (result.issueType === 'invalid') {
     if (!errorOptions?.showRequiredErrors) {
       return null;
     }
 
-    if (issue.reason === 'requiredValueMismatch') {
+    if (result.reason === 'requiredValueMismatch') {
       return getRequiredValueMismatchMessage(response, options);
     }
 
-    return issue.message ?? null;
+    return result.message ?? null;
   }
 
   return null;
 }
 
-// Checks whether a response has an issue that should block progression, and if so, what type of issue it is (unanswered vs. invalid)
 export function getResponseIssueType(
   response: Response,
   values: StoredAnswer['answer'],
   customValidate?: CustomResponseValidate,
   loadError?: string,
 ): ResponseIssueType | null {
-  const issue = evaluateResponseIssue(
+  const result = validateResponse(
     response,
     values[response.id],
     values,
-    customValidate,
-    loadError,
+    { customValidate, loadError },
   );
 
-  if (issue.type === 'none') return null;
-  // Optional responses with invalid values still display an orange warning but they should not block progression — only required issues gate the Next button
-  if (issue.type === 'invalid' && response.required === false) return null;
-  return issue.type;
+  return result.blocksProgression ? result.issueType as ResponseIssueType : null;
 }
 
 export function summarizeResponseIssues(

--- a/src/components/response/responseErrors.ts
+++ b/src/components/response/responseErrors.ts
@@ -3,19 +3,14 @@ import {
 } from '../../parser/types';
 import { CustomResponseValidate, StoredAnswer } from '../../store/types';
 import {
-  checkCheckboxResponseForValidation,
-  checkDropdownResponse,
-  checkMatrixResponse,
-  checkNumericalResponse,
-  isEmptyCustomResponseValue,
   isOtherSelectionIncomplete,
   REQUIRED_ERROR_MESSAGE,
+  validateResponse,
+} from './responseValidation';
+import type {
   ResponseIssueSummary,
   ResponseIssueType,
-  ResponseValidationResult,
-  shouldBypassValidationForStandaloneDontKnow,
-  usesStandaloneDontKnowField,
-  validateResponse,
+  ResponseValidationOptions,
 } from './responseValidation';
 
 export {
@@ -28,13 +23,13 @@ export {
   REQUIRED_ERROR_MESSAGE,
   shouldBypassValidationForStandaloneDontKnow,
   usesStandaloneDontKnowField,
-};
+} from './responseValidation';
 
 export type {
   ResponseIssueSummary,
   ResponseIssueType,
   ResponseValidationResult,
-};
+} from './responseValidation';
 
 export type ResponseValidationIssue = {
   type: 'none' | 'unanswered' | 'invalid';
@@ -104,6 +99,33 @@ export function generateCustomResponseErrorMessage(
   }
 
   return null;
+}
+
+export function generateInvalidResponseErrorMessage(
+  response: Response,
+  value: StoredAnswer['answer'][string],
+  values: StoredAnswer['answer'],
+  options: ResponseValidationOptions = {},
+): string | null {
+  const result = validateResponse(response, value, values, options);
+
+  if (result.issueType === 'none') {
+    return null;
+  }
+
+  if (result.issueType === 'unanswered') {
+    return REQUIRED_ERROR_MESSAGE;
+  }
+
+  if (response.type === 'custom' && options.loadError) {
+    return result.message ?? null;
+  }
+
+  if (isOtherSelectionIncomplete(response, value, values)) {
+    return REQUIRED_ERROR_MESSAGE;
+  }
+
+  return result.blocksProgression ? result.message ?? 'Incorrect input' : null;
 }
 
 export function generateErrorMessage(

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -1,0 +1,293 @@
+import isEqual from 'lodash.isequal';
+import {
+  CheckboxResponse,
+  DropdownResponse,
+  MatrixResponse,
+  NumericalResponse,
+  Response,
+} from '../../parser/types';
+import { CustomResponseValidate, StoredAnswer } from '../../store/types';
+import { parseStringOptionValue } from '../../utils/stringOptions';
+
+export const REQUIRED_ERROR_MESSAGE = 'Please answer this question to continue.';
+
+export type ResponseIssueType = 'unanswered' | 'invalid';
+export type ResponseIssueSummary = { unansweredCount: number; invalidCount: number };
+export type ResponseValidationIssueType = 'none' | ResponseIssueType;
+export type ResponseValidationResult = {
+  valid: boolean;
+  issueType: ResponseValidationIssueType;
+  message?: string;
+  reason?: 'requiredValueMismatch';
+  blocksProgression: boolean;
+};
+
+export type ResponseValidationOptions = {
+  customValidate?: CustomResponseValidate;
+  loadError?: string;
+};
+
+export function isEmptyCustomResponseValue(value: StoredAnswer['answer'][string] | undefined): boolean {
+  if (value === null || value === undefined || value === '') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.every((entry) => isEmptyCustomResponseValue(entry));
+  }
+
+  if (typeof value === 'object') {
+    const objectValues = Object.values(value);
+    return objectValues.length === 0 || objectValues.every((entry) => isEmptyCustomResponseValue(entry));
+  }
+
+  return false;
+}
+
+export function checkDropdownResponse(dropdownResponse: DropdownResponse, value: string[]) {
+  const minNotSelected = dropdownResponse.minSelections && value.length < dropdownResponse.minSelections;
+  const maxNotSelected = dropdownResponse.maxSelections && value.length > dropdownResponse.maxSelections;
+
+  if (minNotSelected) {
+    return `Please select at least ${dropdownResponse.minSelections} options`;
+  }
+  if (maxNotSelected) {
+    return `Please select at most ${dropdownResponse.maxSelections} options`;
+  }
+  return null;
+}
+
+function checkCheckboxResponse(response: CheckboxResponse, value: string[]) {
+  const minNotSelected = response.minSelections && value.length < response.minSelections;
+  const maxNotSelected = response.maxSelections && value.length > response.maxSelections;
+
+  if (minNotSelected && maxNotSelected) {
+    return `Please select between ${response.minSelections} and ${response.maxSelections} options`;
+  }
+  if (minNotSelected) {
+    return `Please select at least ${response.minSelections} options`;
+  }
+  if (maxNotSelected) {
+    return `Please select at most ${response.maxSelections} options`;
+  }
+  return null;
+}
+
+export function checkCheckboxResponseForValidation(
+  response: CheckboxResponse,
+  value: string[],
+  dontKnowChecked = false,
+) {
+  if (response.withDontKnow && dontKnowChecked) {
+    return null;
+  }
+
+  return checkCheckboxResponse(response, value);
+}
+
+export function checkNumericalResponse(response: NumericalResponse, value: number) {
+  const numValue = typeof value === 'string' ? parseFloat(value) : value;
+
+  const { min, max } = response;
+
+  if (min !== undefined && max !== undefined && (numValue < min || numValue > max)) {
+    return `Please enter a value between ${min} and ${max}`;
+  }
+  if (min !== undefined && numValue < min) {
+    return `Please enter a value of ${min} or greater`;
+  }
+  if (max !== undefined && numValue > max) {
+    return `Please enter a value of ${max} or less`;
+  }
+  return null;
+}
+
+export function checkMatrixResponse(response: MatrixResponse, value: Record<string, string>) {
+  const expectedQuestionKeys = response.questionOptions.map((entry) => parseStringOptionValue(entry));
+  const unanswered = expectedQuestionKeys.some((questionKey) => {
+    const rowValue = value[questionKey];
+    return rowValue === undefined || rowValue === '';
+  });
+
+  if (unanswered) {
+    return 'Please answer all questions in the matrix to continue.';
+  }
+
+  return null;
+}
+
+function hasOtherText(value: StoredAnswer['answer'][string] | undefined) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function isOtherSelectionIncomplete(
+  response: Response,
+  value: StoredAnswer['answer'][string] | undefined,
+  values: StoredAnswer['answer'],
+) {
+  if (!('withOther' in response) || !response.withOther) {
+    return false;
+  }
+
+  const otherInputValue = values[`${response.id}-other`];
+  if (response.type === 'radio') {
+    return value === 'other' && !hasOtherText(otherInputValue);
+  }
+
+  if (response.type === 'checkbox') {
+    return Array.isArray(value) && value.includes('__other') && !hasOtherText(otherInputValue);
+  }
+
+  return false;
+}
+
+export const usesStandaloneDontKnowField = (response: Response) => !!response.withDontKnow
+  && response.type !== 'matrix-radio'
+  && response.type !== 'matrix-checkbox';
+
+export const shouldBypassValidationForStandaloneDontKnow = (response: Response, dontKnowChecked: boolean) => (
+  usesStandaloneDontKnowField(response) && dontKnowChecked
+);
+
+function createValidationResult(
+  response: Response,
+  issueType: ResponseValidationIssueType,
+  options: Pick<ResponseValidationResult, 'message' | 'reason'> = {},
+): ResponseValidationResult {
+  return {
+    valid: issueType === 'none',
+    issueType,
+    ...options,
+    blocksProgression: issueType !== 'none' && response.required !== false,
+  };
+}
+
+export function validateResponse(
+  response: Response,
+  value: StoredAnswer['answer'][string] | undefined,
+  values: StoredAnswer['answer'],
+  options: ResponseValidationOptions = {},
+): ResponseValidationResult {
+  const dontKnowChecked = !!values[`${response.id}-dontKnow`];
+
+  if (response.type === 'textOnly' || response.type === 'divider' || response.type === 'reactive') {
+    return createValidationResult(response, 'none');
+  }
+
+  if (response.type === 'custom') {
+    const { customValidate, loadError } = options;
+
+    if (loadError) {
+      return createValidationResult(response, 'invalid', { message: loadError });
+    }
+
+    if (shouldBypassValidationForStandaloneDontKnow(response, dontKnowChecked)) {
+      return createValidationResult(response, 'none');
+    }
+
+    if (response.required === false && isEmptyCustomResponseValue(value)) {
+      return createValidationResult(response, 'none');
+    }
+
+    if (isEmptyCustomResponseValue(value)) {
+      return createValidationResult(response, response.required === false ? 'none' : 'unanswered');
+    }
+
+    const customValue = value as StoredAnswer['answer'][string];
+
+    if (response.requiredValue !== undefined && !isEqual(customValue, response.requiredValue)) {
+      return createValidationResult(response, 'invalid', { message: 'Incorrect input' });
+    }
+
+    if (!customValidate) {
+      return createValidationResult(response, 'none');
+    }
+
+    const customValidationMessage = customValidate(customValue, values, response);
+    return customValidationMessage
+      ? createValidationResult(response, 'invalid', { message: customValidationMessage })
+      : createValidationResult(response, 'none');
+  }
+
+  if (shouldBypassValidationForStandaloneDontKnow(response, dontKnowChecked)) {
+    return createValidationResult(response, 'none');
+  }
+
+  if (isOtherSelectionIncomplete(response, value, values)) {
+    return createValidationResult(response, 'invalid', { message: 'Please fill in Other to continue.' });
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+    if (response.type === 'matrix-radio' || response.type === 'matrix-checkbox') {
+      const matrixValue = value as Record<string, string>;
+      const hasAnsweredAtLeastOne = Object.values(matrixValue).some((entry) => entry !== '');
+
+      if (!hasAnsweredAtLeastOne) {
+        return createValidationResult(response, response.required ? 'unanswered' : 'none');
+      }
+
+      const matrixError = checkMatrixResponse(response, matrixValue);
+      return matrixError
+        ? createValidationResult(response, 'invalid', { message: matrixError })
+        : createValidationResult(response, 'none');
+    }
+
+    if (response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {
+      return createValidationResult(response, Object.keys(value).length === 0 && response.required ? 'unanswered' : 'none');
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return createValidationResult(response, response.required ? 'unanswered' : 'none');
+    }
+
+    if (response.requiredValue != null && !Array.isArray(response.requiredValue)) {
+      return createValidationResult(response, 'invalid', { message: 'Incorrect required value. Contact study administrator.' });
+    }
+
+    if (Array.isArray(response.requiredValue)) {
+      const sortedRequired = [...response.requiredValue].sort();
+      const sortedValue = [...value].sort();
+      const matches = sortedRequired.length === sortedValue.length
+        && sortedRequired.every((entry, idx) => entry === sortedValue[idx]);
+
+      if (!matches) {
+        return createValidationResult(response, 'invalid', { reason: 'requiredValueMismatch' });
+      }
+    }
+
+    if (response.type === 'checkbox') {
+      const checkboxError = checkCheckboxResponseForValidation(response, value as string[], dontKnowChecked);
+      return checkboxError
+        ? createValidationResult(response, 'invalid', { message: checkboxError })
+        : createValidationResult(response, 'none');
+    }
+
+    if (response.type === 'dropdown') {
+      const dropdownError = checkDropdownResponse(response, value as string[]);
+      return dropdownError
+        ? createValidationResult(response, 'invalid', { message: dropdownError })
+        : createValidationResult(response, 'none');
+    }
+
+    return createValidationResult(response, 'none');
+  }
+
+  if (value === null || value === undefined || value === '') {
+    return createValidationResult(response, response.required ? 'unanswered' : 'none');
+  }
+
+  if (response.requiredValue != null && value.toString() !== response.requiredValue.toString()) {
+    return createValidationResult(response, 'invalid', { reason: 'requiredValueMismatch' });
+  }
+
+  if (response.type === 'numerical') {
+    const numericalError = checkNumericalResponse(response, value as unknown as number);
+    return numericalError
+      ? createValidationResult(response, 'invalid', { message: numericalError })
+      : createValidationResult(response, 'none');
+  }
+
+  return createValidationResult(response, 'none');
+}

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -18,6 +18,7 @@ import {
   checkCheckboxResponseForValidation,
   generateCustomResponseErrorMessage,
   generateErrorMessage,
+  getResponseIssueType,
   REQUIRED_ERROR_MESSAGE,
   shouldBypassValidationForStandaloneDontKnow,
   usesStandaloneDontKnowField,
@@ -337,6 +338,42 @@ describe('validateResponse', () => {
     });
   });
 
+  test('scalar requiredValue accepts only the configured value', () => {
+    const response: Response = {
+      ...requiredShortText,
+      requiredValue: 'expected',
+    };
+
+    expect(validateResponse(response, 'expected', { q1: 'expected' })).toMatchObject({
+      valid: true,
+      issueType: 'none',
+      blocksProgression: false,
+    });
+    expect(validateResponse(response, 'different', { q1: 'different' })).toMatchObject({
+      valid: false,
+      issueType: 'invalid',
+      reason: 'requiredValueMismatch',
+      blocksProgression: true,
+    });
+  });
+
+  test.each(['textOnly', 'divider', 'reactive'] as const)(
+    '%s responses do not participate in response validation',
+    (type) => {
+      const response = {
+        id: 'display-only',
+        prompt: 'Display only',
+        type,
+      } as Response;
+
+      expect(validateResponse(response, undefined, {})).toEqual({
+        valid: true,
+        issueType: 'none',
+        blocksProgression: false,
+      });
+    },
+  );
+
   test('numerical min, max, and range are inclusive', () => {
     const response: NumericalResponse = {
       id: 'q1', prompt: 'Question', type: 'numerical', required: true, min: 1, max: 10,
@@ -433,6 +470,30 @@ describe('validateResponse', () => {
     expect(validateResponse(response, {}, { ranking: {} })).toMatchObject({
       issueType: 'unanswered',
       blocksProgression: true,
+    });
+    expect(validateResponse(response, { A: '0' }, { ranking: { A: '0' } })).toEqual({
+      valid: true,
+      issueType: 'none',
+      blocksProgression: false,
+    });
+  });
+
+  test('Mantine and progression adapters agree for required response states', () => {
+    const response: Response = {
+      ...requiredShortText,
+      requiredValue: 'expected',
+    };
+    const validator = generateValidation([response])[response.id];
+    const cases = [
+      { value: '', expectedError: REQUIRED_ERROR_MESSAGE, expectedIssue: 'unanswered' },
+      { value: 'different', expectedError: 'Incorrect input', expectedIssue: 'invalid' },
+      { value: 'expected', expectedError: null, expectedIssue: null },
+    ] as const;
+
+    cases.forEach(({ value, expectedError, expectedIssue }) => {
+      const values = { [response.id]: value };
+      expect(validator(value, values)).toBe(expectedError);
+      expect(getResponseIssueType(response, values)).toBe(expectedIssue);
     });
   });
 

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -22,6 +22,7 @@ import {
   shouldBypassValidationForStandaloneDontKnow,
   usesStandaloneDontKnowField,
 } from '../responseErrors';
+import { validateResponse } from '../responseValidation';
 
 describe('generateInitFields', () => {
   const originalWindow = globalThis.window;
@@ -294,6 +295,192 @@ describe('generateValidation custom', () => {
     });
 
     expect(error).toBeNull();
+  });
+});
+
+describe('validateResponse', () => {
+  const requiredShortText: Response = {
+    id: 'q1', prompt: 'Question', type: 'shortText', required: true,
+  };
+
+  test('required empty scalar returns unanswered and blocks progression', () => {
+    expect(validateResponse(requiredShortText, '', { q1: '' })).toEqual({
+      valid: false,
+      issueType: 'unanswered',
+      blocksProgression: true,
+    });
+  });
+
+  test('optional empty scalar returns valid and non-blocking', () => {
+    const response: Response = {
+      ...requiredShortText,
+      required: false,
+    };
+
+    expect(validateResponse(response, '', { q1: '' })).toEqual({
+      valid: true,
+      issueType: 'none',
+      blocksProgression: false,
+    });
+  });
+
+  test('optional invalid numerical value is invalid but non-blocking', () => {
+    const response: NumericalResponse = {
+      id: 'q1', prompt: 'Question', type: 'numerical', required: false, min: 1,
+    };
+
+    expect(validateResponse(response, 0, { q1: 0 })).toMatchObject({
+      valid: false,
+      issueType: 'invalid',
+      message: 'Please enter a value of 1 or greater',
+      blocksProgression: false,
+    });
+  });
+
+  test('numerical min, max, and range are inclusive', () => {
+    const response: NumericalResponse = {
+      id: 'q1', prompt: 'Question', type: 'numerical', required: true, min: 1, max: 10,
+    };
+
+    expect(validateResponse(response, 1, { q1: 1 }).valid).toBe(true);
+    expect(validateResponse(response, 10, { q1: 10 }).valid).toBe(true);
+    expect(validateResponse(response, 0, { q1: 0 }).message).toBe('Please enter a value between 1 and 10');
+    expect(validateResponse(response, 11, { q1: 11 }).message).toBe('Please enter a value between 1 and 10');
+  });
+
+  test('checkbox and dropdown min/max produce current messages', () => {
+    const checkboxResponse: CheckboxResponse = {
+      id: 'checkbox', prompt: 'Question', type: 'checkbox', required: true, options: [], minSelections: 2, maxSelections: 3,
+    };
+    const dropdownResponse: DropdownResponse = {
+      id: 'dropdown', prompt: 'Question', type: 'dropdown', required: true, options: [], maxSelections: 1,
+    };
+
+    expect(validateResponse(checkboxResponse, ['A'], { checkbox: ['A'] }).message).toBe('Please select at least 2 options');
+    expect(validateResponse(checkboxResponse, ['A', 'B', 'C', 'D'], { checkbox: ['A', 'B', 'C', 'D'] }).message).toBe('Please select at most 3 options');
+    expect(validateResponse(dropdownResponse, ['A', 'B'], { dropdown: ['A', 'B'] }).message).toBe('Please select at most 1 options');
+  });
+
+  test('checkbox requiredValue exact set equality ignores order', () => {
+    const response: CheckboxResponse = {
+      id: 'q1', prompt: 'Question', type: 'checkbox', required: true, options: [], requiredValue: ['A', 'B'],
+    };
+
+    expect(validateResponse(response, ['B', 'A'], { q1: ['B', 'A'] }).valid).toBe(true);
+    expect(validateResponse(response, ['A'], { q1: ['A'] })).toMatchObject({
+      valid: false,
+      issueType: 'invalid',
+      reason: 'requiredValueMismatch',
+      blocksProgression: true,
+    });
+  });
+
+  test('matrix required states distinguish untouched, partial, and complete values', () => {
+    const response: MatrixResponse = {
+      id: 'matrix', prompt: 'Question', type: 'matrix-radio', required: true, answerOptions: ['0', '1'], questionOptions: ['q1', 'q2'],
+    };
+
+    expect(validateResponse(response, { q1: '', q2: '' }, { matrix: { q1: '', q2: '' } })).toMatchObject({
+      issueType: 'unanswered',
+      blocksProgression: true,
+    });
+    expect(validateResponse(response, { q1: '0', q2: '' }, { matrix: { q1: '0', q2: '' } })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please answer all questions in the matrix to continue.',
+    });
+    expect(validateResponse(response, { q1: '0', q2: '1' }, { matrix: { q1: '0', q2: '1' } }).valid).toBe(true);
+  });
+
+  test('standalone withDontKnow bypasses required, min/max, and requiredValue validation', () => {
+    const response: NumericalResponse = {
+      id: 'q1', prompt: 'Question', type: 'numerical', required: true, min: 10, requiredValue: 42, withDontKnow: true,
+    };
+
+    expect(validateResponse(response, '', { q1: '', 'q1-dontKnow': true })).toEqual({
+      valid: true,
+      issueType: 'none',
+      blocksProgression: false,
+    });
+  });
+
+  test('matrix withDontKnow does not use the standalone bypass', () => {
+    const response: MatrixResponse = {
+      id: 'matrix', prompt: 'Question', type: 'matrix-radio', required: true, withDontKnow: true, answerOptions: ['0', '1'], questionOptions: ['q1'],
+    };
+
+    expect(validateResponse(response, { q1: '' }, { matrix: { q1: '' }, 'matrix-dontKnow': true })).toMatchObject({
+      issueType: 'unanswered',
+      blocksProgression: true,
+    });
+  });
+
+  test('withOther selected without text is invalid', () => {
+    const response: Response = {
+      id: 'q1', prompt: 'Question', type: 'radio', required: true, options: [], withOther: true,
+    };
+
+    expect(validateResponse(response, 'other', { q1: 'other', 'q1-other': '' })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please fill in Other to continue.',
+    });
+  });
+
+  test('ranking required empty object is unanswered', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-categorical', required: true, options: [],
+    };
+
+    expect(validateResponse(response, {}, { ranking: {} })).toMatchObject({
+      issueType: 'unanswered',
+      blocksProgression: true,
+    });
+  });
+
+  test('custom response empty required value is unanswered', () => {
+    const response: CustomResponse = {
+      id: 'custom', prompt: 'Question', type: 'custom', required: true, path: 'custom-response/Example.tsx',
+    };
+
+    expect(validateResponse(response, null, { custom: null })).toMatchObject({
+      issueType: 'unanswered',
+      blocksProgression: true,
+    });
+  });
+
+  test('custom response custom validator message is invalid', () => {
+    const response: CustomResponse = {
+      id: 'custom', prompt: 'Question', type: 'custom', required: true, path: 'custom-response/Example.tsx',
+    };
+    const customValidate: CustomResponseValidate = () => 'Custom validation failed.';
+
+    expect(validateResponse(response, { value: true }, { custom: { value: true } }, { customValidate })).toMatchObject({
+      valid: false,
+      issueType: 'invalid',
+      message: 'Custom validation failed.',
+      blocksProgression: true,
+    });
+  });
+
+  test('custom response load error is invalid for both required and optional responses', () => {
+    const requiredResponse: CustomResponse = {
+      id: 'custom-required', prompt: 'Question', type: 'custom', required: true, path: 'custom-response/Example.tsx',
+    };
+    const optionalResponse: CustomResponse = {
+      ...requiredResponse,
+      id: 'custom-optional',
+      required: false,
+    };
+
+    expect(validateResponse(requiredResponse, null, {}, { loadError: 'Unable to load custom response module at custom-response/Example.tsx' })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Unable to load custom response module at custom-response/Example.tsx',
+      blocksProgression: true,
+    });
+    expect(validateResponse(optionalResponse, null, {}, { loadError: 'Unable to load custom response module at custom-response/Example.tsx' })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Unable to load custom response module at custom-response/Example.tsx',
+      blocksProgression: false,
+    });
   });
 });
 

--- a/src/components/response/utils.ts
+++ b/src/components/response/utils.ts
@@ -1,22 +1,16 @@
 import { useForm } from '@mantine/form';
 import { useEffect, useState } from 'react';
-import isEqual from 'lodash.isequal';
 import {
-  CheckboxResponse, CustomResponse, JsonValue, RadioResponse, Response,
+  CheckboxResponse, JsonValue, RadioResponse, Response,
 } from '../../parser/types';
 import { CustomResponseValidate, StoredAnswer } from '../../store/types';
 import { parseStringOptionValue } from '../../utils/stringOptions';
 import {
-  checkCheckboxResponseForValidation,
-  checkDropdownResponse,
-  checkMatrixResponse,
-  checkNumericalResponse,
-  isEmptyCustomResponseValue,
   isOtherSelectionIncomplete,
   REQUIRED_ERROR_MESSAGE,
-  shouldBypassValidationForStandaloneDontKnow,
   usesStandaloneDontKnowField,
-} from './responseErrors';
+  validateResponse,
+} from './responseValidation';
 
 type ResponseDefault = JsonValue;
 type ResponseWithDefault = Response & { default?: ResponseDefault };
@@ -157,40 +151,6 @@ export const mergeReactiveAnswers = (
   return mergedValues ?? currentValues;
 };
 
-function validateCustomResponse(
-  response: CustomResponse,
-  value: StoredAnswer['answer'][string],
-  values: StoredAnswer['answer'],
-  customValidate?: CustomResponseValidate,
-  loadError?: string,
-) {
-  if (loadError) {
-    return loadError;
-  }
-
-  if (shouldBypassValidationForStandaloneDontKnow(response, !!values[`${response.id}-dontKnow`])) {
-    return null;
-  }
-
-  if (response.required !== false && isEmptyCustomResponseValue(value)) {
-    return REQUIRED_ERROR_MESSAGE;
-  }
-
-  if (response.requiredValue !== undefined && !isEmptyCustomResponseValue(value) && !isEqual(value, response.requiredValue)) {
-    return 'Incorrect input';
-  }
-
-  if (!customValidate) {
-    return null;
-  }
-
-  if (response.required === false && isEmptyCustomResponseValue(value)) {
-    return null;
-  }
-
-  return customValidate(value, values, response);
-}
-
 export const generateValidation = (
   responses: Response[],
   customResponseValidators: Record<string, CustomResponseValidate | undefined> = {},
@@ -202,68 +162,28 @@ export const generateValidation = (
       validateObj = {
         ...validateObj,
         [response.id]: (value: StoredAnswer['answer'][string], values: StoredAnswer['answer']) => {
-          if (response.type === 'custom') {
-            return validateCustomResponse(
-              response,
-              value,
-              values,
-              customResponseValidators[response.id],
-              customResponseLoadErrors[response.id],
-            );
+          const result = validateResponse(response, value, values, {
+            customValidate: customResponseValidators[response.id],
+            loadError: customResponseLoadErrors[response.id],
+          });
+
+          if (result.issueType === 'none') {
+            return null;
           }
 
-          if (shouldBypassValidationForStandaloneDontKnow(response, !!values[`${response.id}-dontKnow`])) {
-            return null;
+          if (result.issueType === 'unanswered') {
+            return REQUIRED_ERROR_MESSAGE;
+          }
+
+          if (response.type === 'custom' && customResponseLoadErrors[response.id]) {
+            return result.message ?? null;
           }
 
           if (isOtherSelectionIncomplete(response, value, values)) {
             return REQUIRED_ERROR_MESSAGE;
           }
 
-          if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
-            if (response.type === 'matrix-checkbox' || response.type === 'matrix-radio') {
-              return checkMatrixResponse(response, value as Record<string, string>);
-            }
-            if (response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {
-              return Object.keys(value).length > 0 ? null : REQUIRED_ERROR_MESSAGE;
-            }
-            return Object.values(value).every((val) => val !== '') ? null : REQUIRED_ERROR_MESSAGE;
-          }
-          if (Array.isArray(value)) {
-            if (response.requiredValue != null && !Array.isArray(response.requiredValue)) {
-              return 'Incorrect required value. Contact study administrator.';
-            }
-            if (response.requiredValue != null && Array.isArray(response.requiredValue)) {
-              if (response.requiredValue.length !== value.length) {
-                return 'Incorrect input';
-              }
-              const sortedReq = [...response.requiredValue].sort();
-              const sortedVal = [...value].sort();
-
-              return sortedReq.every((val, index) => val === sortedVal[index]) ? null : 'Incorrect input';
-            }
-            if (response.type === 'checkbox') {
-              return checkCheckboxResponseForValidation(response, value as string[], !!values[`${response.id}-dontKnow`]);
-            }
-            if (response.type === 'dropdown') {
-              return checkDropdownResponse(response, value as string[]);
-            }
-            return value.length === 0 ? REQUIRED_ERROR_MESSAGE : null;
-          }
-
-          if (response.required && response.requiredValue != null && value != null) {
-            return value.toString() !== response.requiredValue.toString() ? 'Incorrect input' : null;
-          }
-          if (response.required) {
-            if ((value === null || value === undefined || value === '') && !values[`${response.id}-dontKnow`]) {
-              return REQUIRED_ERROR_MESSAGE;
-            }
-            if (response.type === 'numerical') {
-              return checkNumericalResponse(response, value as unknown as number);
-            }
-          }
-
-          return value === null ? REQUIRED_ERROR_MESSAGE : null;
+          return result.blocksProgression ? result.message ?? 'Incorrect input' : null;
         },
       };
     }

--- a/src/components/response/utils.ts
+++ b/src/components/response/utils.ts
@@ -6,11 +6,9 @@ import {
 import { CustomResponseValidate, StoredAnswer } from '../../store/types';
 import { parseStringOptionValue } from '../../utils/stringOptions';
 import {
-  isOtherSelectionIncomplete,
-  REQUIRED_ERROR_MESSAGE,
+  generateInvalidResponseErrorMessage,
   usesStandaloneDontKnowField,
-  validateResponse,
-} from './responseValidation';
+} from './responseErrors';
 
 type ResponseDefault = JsonValue;
 type ResponseWithDefault = Response & { default?: ResponseDefault };
@@ -161,30 +159,15 @@ export const generateValidation = (
     if (response.required || response.type === 'custom') {
       validateObj = {
         ...validateObj,
-        [response.id]: (value: StoredAnswer['answer'][string], values: StoredAnswer['answer']) => {
-          const result = validateResponse(response, value, values, {
+        [response.id]: (value: StoredAnswer['answer'][string], values: StoredAnswer['answer']) => generateInvalidResponseErrorMessage(
+          response,
+          value,
+          values,
+          {
             customValidate: customResponseValidators[response.id],
             loadError: customResponseLoadErrors[response.id],
-          });
-
-          if (result.issueType === 'none') {
-            return null;
-          }
-
-          if (result.issueType === 'unanswered') {
-            return REQUIRED_ERROR_MESSAGE;
-          }
-
-          if (response.type === 'custom' && customResponseLoadErrors[response.id]) {
-            return result.message ?? null;
-          }
-
-          if (isOtherSelectionIncomplete(response, value, values)) {
-            return REQUIRED_ERROR_MESSAGE;
-          }
-
-          return result.blocksProgression ? result.message ?? 'Incorrect input' : null;
-        },
+          },
+        ),
       };
     }
   });


### PR DESCRIPTION
## Summary
- add a pure validateResponse API as the single source of truth for response validity
- make Mantine form validation and response issue summaries delegate to the pure validator
- extract response-value aggregation helpers in ResponseBlock
- add focused unit coverage for current validation behavior and ResponseBlock feedback/error guards

## Verification
- yarn unittest --run src/components/response/tests/utils.spec.ts src/components/response/tests/ResponseBlock.spec.tsx
- yarn typecheck
- yarn lint
- git diff --check

### Documentation
Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [ ] Done
- [x] N/A