### PR TITLE
Re-save missing active config and handle missing configs in Tidy export

### DIFF
--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -251,6 +251,10 @@ function participantDataToRows(
     }).flat()], Array.from(newHeaders)];
 }
 
+function hasStoredStudyConfig(config: StudyConfig | null | undefined): config is StudyConfig {
+  return config ? Object.keys(config).length > 0 : false;
+}
+
 export async function getTableData(
   selectedProperties: Property[],
   data: ParticipantDataWithStatus[],
@@ -266,7 +270,7 @@ export async function getTableData(
 
   const allConfigHashes = [...new Set(data.map((part) => part.participantConfigHash))];
   const allConfigs = await storageEngine.getAllConfigsFromHash(allConfigHashes, studyId);
-  const participantsMissingConfig = data.filter((participant) => !allConfigs[participant.participantConfigHash]);
+  const participantsMissingConfig = data.filter((participant) => !hasStoredStudyConfig(allConfigs[participant.participantConfigHash]));
 
   const transcripts: Record<string, string | null> = {};
   const transcriptAvailable = storageEngine.getEngine() === 'firebase' && !!hasAudio;
@@ -298,7 +302,13 @@ export async function getTableData(
     .filter((p) => p !== 'condition' || hasCondition)
     .filter((p) => p !== 'metaData');
   const allData = await Promise.all(data.map(async (participant) => {
-    const partDataToRows = await participantDataToRows(participant, combinedProperties, allConfigs[participant.participantConfigHash], transcripts);
+    const participantConfig = allConfigs[participant.participantConfigHash];
+    const partDataToRows = await participantDataToRows(
+      participant,
+      combinedProperties,
+      hasStoredStudyConfig(participantConfig) ? participantConfig : undefined,
+      transcripts,
+    );
 
     return partDataToRows;
   }));

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -103,7 +103,7 @@ export function download(graph: string, filename: string) {
 function participantDataToRows(
   participant: ParticipantDataWithStatus,
   properties: Property[],
-  studyConfig: StudyConfig,
+  studyConfig?: StudyConfig,
   transcripts?: Record<string, string | null>,
 ): [TidyRow[], string[]] {
   const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (Object.entries(participant.answers).length)) * 100).toFixed(2);
@@ -135,8 +135,8 @@ function participantDataToRows(
       // Get the whole component, including the base component if there is inheritance
       const trialId = trialAnswer.componentName;
       const { trialOrder } = trialAnswer;
-      const trialConfig = studyConfig.components[trialId];
-      const completeComponent = studyComponentToIndividualComponent(trialConfig, studyConfig);
+      const trialConfig = studyConfig?.components[trialId];
+      const completeComponent = trialConfig && studyConfig ? studyComponentToIndividualComponent(trialConfig, studyConfig) : undefined;
 
       const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
       const cleanedDuration = getCleanedDuration(trialAnswer);
@@ -155,7 +155,7 @@ function participantDataToRows(
           newHeaders.add(`parameters_${_key}`);
         });
 
-        const response = completeComponent.response.find((resp) => resp.id === key);
+        const response = completeComponent?.response.find((resp) => resp.id === key);
         if (properties.includes('condition')) {
           tidyRow.condition = conditionValue;
         }
@@ -178,10 +178,10 @@ function participantDataToRows(
           tidyRow.percentComplete = percentComplete;
         }
         if (properties.includes('description')) {
-          tidyRow.description = completeComponent.description;
+          tidyRow.description = completeComponent?.description;
         }
         if (properties.includes('instruction')) {
-          tidyRow.instruction = completeComponent.instruction;
+          tidyRow.instruction = completeComponent?.instruction;
         }
         if (properties.includes('responsePrompt')) {
           tidyRow.responsePrompt = response?.prompt;
@@ -194,7 +194,7 @@ function participantDataToRows(
           tidyRow.transcript = transcripts?.[`${participant.participantId}_${identifier}`] ?? undefined;
         }
         if (properties.includes('correctAnswer')) {
-          const configCorrectAnswer = completeComponent.correctAnswer?.find((ans) => ans.id === key)?.answer;
+          const configCorrectAnswer = completeComponent?.correctAnswer?.find((ans) => ans.id === key)?.answer;
           const answerCorrectAnswer = trialAnswer.correctAnswer.find((ans) => ans.id === key)?.answer;
           const correctAnswer = answerCorrectAnswer || configCorrectAnswer;
           tidyRow.correctAnswer = typeof correctAnswer === 'object' ? JSON.stringify(correctAnswer) : correctAnswer;
@@ -212,7 +212,7 @@ function participantDataToRows(
           tidyRow.cleanedDuration = cleanedDuration;
         }
         if (properties.includes('meta')) {
-          tidyRow.meta = JSON.stringify(completeComponent.meta, null, 2);
+          tidyRow.meta = completeComponent?.meta ? JSON.stringify(completeComponent.meta, null, 2) : undefined;
         }
         if (properties.includes('responseMin')) {
           tidyRow.responseMin = response?.type === 'numerical' ? response.min : undefined;
@@ -251,7 +251,7 @@ function participantDataToRows(
     }).flat()], Array.from(newHeaders)];
 }
 
-async function getTableData(
+export async function getTableData(
   selectedProperties: Property[],
   data: ParticipantDataWithStatus[],
   storageEngine: StorageEngine | undefined,
@@ -259,13 +259,14 @@ async function getTableData(
   hasAudio?: boolean,
 ) {
   if (!storageEngine) {
-    return { header: [], rows: [] };
+    return { header: [], rows: [], missingConfigCount: 0 };
   }
 
   const combinedProperties = [...REQUIRED_PROPS, ...selectedProperties];
 
   const allConfigHashes = [...new Set(data.map((part) => part.participantConfigHash))];
   const allConfigs = await storageEngine.getAllConfigsFromHash(allConfigHashes, studyId);
+  const participantsMissingConfig = data.filter((participant) => !allConfigs[participant.participantConfigHash]);
 
   const transcripts: Record<string, string | null> = {};
   const transcriptAvailable = storageEngine.getEngine() === 'firebase' && !!hasAudio;
@@ -307,7 +308,11 @@ async function getTableData(
 
   const flatRows = rows.flat().sort((a, b) => (a !== b ? a.participantId.localeCompare(b.participantId) : a.trialOrder - b.trialOrder));
 
-  return { header: [...header, ...newHeaders], rows: flatRows };
+  return {
+    header: [...header, ...newHeaders],
+    rows: flatRows,
+    missingConfigCount: participantsMissingConfig.length,
+  };
 }
 
 export function DownloadTidy({
@@ -351,6 +356,7 @@ export function DownloadTidy({
   const transcriptAvailable = isFirebase && !!hasAudio;
   const selectedParticipantCount = data.length;
   const warnLargeTranscriptDownload = selectedProperties.includes('transcript') && selectedParticipantCount > 50;
+  const missingConfigCount = tableData?.missingConfigCount ?? 0;
 
   const downloadTidy = useCallback(async (skipWarning = false) => {
     if (!tableData) {
@@ -451,6 +457,34 @@ export function DownloadTidy({
           {selectedParticipantCount}
           {' '}
           selected participants, so it may take a while.
+        </Alert>
+      )}
+      {missingConfigCount > 0 && (
+        <Alert
+          color="orange"
+          icon={<IconAlertTriangle />}
+          mb="sm"
+          styles={{
+            icon: {
+              alignSelf: 'center',
+            },
+          }}
+        >
+          <Flex direction="column">
+            <Text size="sm">
+              Stored study configs could not be loaded for
+              {' '}
+              {missingConfigCount}
+              {' '}
+              selected
+              {' '}
+              {missingConfigCount === 1 ? 'participant' : 'participants'}
+              . Config-derived columns, such as description and instruction, may be blank for those rows.
+            </Text>
+            <Text size="sm">
+              To restore the current config, reload the study page. However, historical configs that differ from the current config must be restored from a storage snapshot or backup.
+            </Text>
+          </Flex>
         </Alert>
       )}
       {isDownloading && (

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -135,7 +135,7 @@ function participantDataToRows(
       // Get the whole component, including the base component if there is inheritance
       const trialId = trialAnswer.componentName;
       const { trialOrder } = trialAnswer;
-      const trialConfig = studyConfig?.components[trialId];
+      const trialConfig = studyConfig?.components?.[trialId];
       const completeComponent = trialConfig && studyConfig ? studyComponentToIndividualComponent(trialConfig, studyConfig) : undefined;
 
       const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -306,7 +306,15 @@ export async function getTableData(
   const rows = allData.map((partData) => partData[0]);
   const newHeaders = new Set(allData.map((partData) => partData[1]).flat());
 
-  const flatRows = rows.flat().sort((a, b) => (a !== b ? a.participantId.localeCompare(b.participantId) : a.trialOrder - b.trialOrder));
+  // Sort rows by participantId and trialOrder
+  const flatRows = rows.flat().sort((a, b) => {
+    const participantIdCompare = a.participantId.localeCompare(b.participantId);
+    if (participantIdCompare) {
+      return participantIdCompare;
+    }
+
+    return Number(a.trialOrder ?? -1) - Number(b.trialOrder ?? -1);
+  });
 
   return {
     header: [...header, ...newHeaders],
@@ -479,7 +487,8 @@ export function DownloadTidy({
               selected
               {' '}
               {missingConfigCount === 1 ? 'participant' : 'participants'}
-              . Config-derived columns, such as description and instruction, may be blank for those rows.
+              {'. '}
+              Config-derived columns, such as description and instruction, may be blank for those rows.
             </Text>
             <Text size="sm">
               To restore the current config, reload the study page. However, historical configs that differ from the current config must be restored from a storage snapshot or backup.

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -159,6 +159,7 @@ describe('getTableData', () => {
     });
     const storageEngine = makeStorageEngine({
       'hash-1': configSimple,
+      'missing-hash': {} as StudyConfig,
     });
     const selectedProperties = [
       'answer',

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -1,0 +1,496 @@
+import {
+  cleanup, render, waitFor,
+} from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import {
+  afterEach, describe, expect, test, vi,
+} from 'vitest';
+import { DownloadTidy, getTableData } from '../DownloadTidy';
+import type { StudyConfig } from '../../../parser/types';
+import type { StorageEngine } from '../../../storage/engines/types';
+import type { ParticipantDataWithStatus } from '../../../storage/types';
+import testConfigSimple from '../../../storage/tests/testConfigSimple.json';
+
+const storageEngineHookMock = vi.hoisted(() => ({
+  storageEngine: undefined as StorageEngine | undefined,
+}));
+
+vi.mock('../../../storage/storageEngineHooks', () => ({
+  useStorageEngine: () => ({ storageEngine: storageEngineHookMock.storageEngine }),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const configSimple = testConfigSimple as StudyConfig;
+const configWithComponentMetadata = {
+  ...configSimple,
+  components: {
+    testComponent: {
+      ...configSimple.components.testComponent,
+      description: 'Config description',
+      instruction: 'Config instruction',
+      response: [{
+        id: 'response',
+        prompt: 'Config prompt',
+        type: 'numerical',
+        min: 0,
+        max: 10,
+      }],
+      meta: { source: 'config' },
+    },
+  },
+} as StudyConfig;
+
+function makeParticipant(overrides: Partial<ParticipantDataWithStatus> = {}): ParticipantDataWithStatus {
+  return {
+    participantId: 'p1',
+    participantConfigHash: 'hash-1',
+    participantIndex: 0,
+    sequence: {
+      orderPath: 'root',
+      order: 'fixed',
+      components: ['testComponent'],
+      skip: [],
+    },
+    answers: {
+      testComponent_0: {
+        answer: { response: 'participant answer' },
+        identifier: 'testComponent_0',
+        componentName: 'testComponent',
+        trialOrder: '0',
+        incorrectAnswers: {},
+        startTime: 100,
+        endTime: 200,
+        windowEvents: [],
+        timedOut: false,
+        helpButtonClickedCount: 0,
+        parameters: { speed: 'fast' },
+        correctAnswer: [{ id: 'response', answer: 'answer from participant data' }],
+        optionOrders: {},
+        questionOrders: {},
+      },
+    },
+    searchParams: {},
+    metadata: {
+      userAgent: '',
+      resolution: { width: 0, height: 0 },
+      language: '',
+      ip: '',
+    },
+    completed: false,
+    rejected: false,
+    participantTags: [],
+    stage: 'DEFAULT',
+    ...overrides,
+  };
+}
+
+function makeStorageEngine(
+  configs: Record<string, StudyConfig>,
+  getTranscription = vi.fn(),
+  engine = 'firebase',
+): StorageEngine {
+  return {
+    getAllConfigsFromHash: vi.fn().mockResolvedValue(configs),
+    getEngine: vi.fn(() => engine),
+    getTranscription,
+  } as unknown as StorageEngine;
+}
+
+describe('getTableData', () => {
+  afterEach(() => {
+    cleanup();
+    storageEngineHookMock.storageEngine = undefined;
+    vi.clearAllMocks();
+  });
+
+  test('builds tidy rows with participant and config-derived fields', async () => {
+    const storageEngine = makeStorageEngine({
+      'hash-1': configWithComponentMetadata,
+    });
+
+    const tableData = await getTableData(
+      ['answer', 'description', 'instruction', 'responsePrompt', 'correctAnswer', 'duration', 'meta', 'responseMin', 'responseMax'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+    );
+
+    const answerRow = tableData.rows.find((row) => row.participantId === 'p1' && row.responseId === 'response');
+    expect(tableData.missingConfigCount).toBe(0);
+    expect(tableData.header).toEqual(expect.arrayContaining(['participantId', 'trialId', 'responseId', 'answer', 'parameters_speed']));
+    expect(answerRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'testComponent',
+      responseId: 'response',
+      answer: 'participant answer',
+      description: 'Config description',
+      instruction: 'Config instruction',
+      responsePrompt: 'Config prompt',
+      correctAnswer: 'answer from participant data',
+      duration: 100,
+      meta: JSON.stringify({ source: 'config' }, null, 2),
+      responseMin: 0,
+      responseMax: 10,
+      parameters_speed: 'fast',
+    }));
+  });
+
+  test('keeps participant-derived rows when configs are missing', async () => {
+    const participantWithConfig = makeParticipant({
+      participantId: 'p1',
+      participantConfigHash: 'hash-1',
+    });
+    const participantMissingConfig = makeParticipant({
+      participantId: 'p2',
+      participantConfigHash: 'missing-hash',
+    });
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+    const selectedProperties = [
+      'answer',
+      'configHash',
+      'description',
+      'instruction',
+      'responsePrompt',
+      'correctAnswer',
+      'duration',
+      'startTime',
+      'endTime',
+      'meta',
+      'responseMin',
+      'responseMax',
+    ] as const;
+
+    const tableData = await getTableData(
+      [...selectedProperties],
+      [participantWithConfig, participantMissingConfig],
+      storageEngine,
+      'test-study',
+    );
+
+    expect(tableData.missingConfigCount).toBe(1);
+    expect(tableData.header).toEqual(expect.arrayContaining(['answer', 'configHash']));
+    const missingConfigRow = tableData.rows.find((row) => row.participantId === 'p2' && row.responseId === 'response');
+    expect(tableData.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        participantId: 'p1',
+        trialId: 'testComponent',
+      }),
+    ]));
+    expect(missingConfigRow).toEqual(expect.objectContaining({
+      participantId: 'p2',
+      trialId: 'testComponent',
+      trialOrder: '0',
+      responseId: 'response',
+      answer: 'participant answer',
+      configHash: 'missing-hash',
+      duration: 100,
+      startTime: new Date(100).toISOString(),
+      endTime: new Date(200).toISOString(),
+      correctAnswer: 'answer from participant data',
+      parameters_speed: 'fast',
+    }));
+    expect(missingConfigRow?.description).toBeUndefined();
+    expect(missingConfigRow?.instruction).toBeUndefined();
+    expect(missingConfigRow?.responsePrompt).toBeUndefined();
+    expect(missingConfigRow?.meta).toBeUndefined();
+    expect(missingConfigRow?.responseMin).toBeUndefined();
+    expect(missingConfigRow?.responseMax).toBeUndefined();
+  });
+
+  test('returns participant-derived rows when all selected participant configs are missing', async () => {
+    const storageEngine = makeStorageEngine({});
+
+    const tableData = await getTableData(
+      ['answer'],
+      [makeParticipant({ participantId: 'p1', participantConfigHash: 'missing-a' })],
+      storageEngine,
+      'test-study',
+    );
+
+    expect(tableData.header).toEqual(expect.arrayContaining(['participantId', 'trialId', 'responseId', 'answer']));
+    expect(tableData.missingConfigCount).toBe(1);
+    expect(tableData.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        participantId: 'p1',
+        trialId: 'testComponent',
+      }),
+    ]));
+  });
+
+  test('fetches transcripts for participants whose config is missing', async () => {
+    const getTranscription = vi.fn().mockResolvedValue({
+      results: [{ alternatives: [{ transcript: 'spoken answer' }] }],
+    });
+    const participantWithConfig = makeParticipant({
+      participantId: 'p1',
+      participantConfigHash: 'hash-1',
+    });
+    const participantMissingConfig = makeParticipant({
+      participantId: 'p2',
+      participantConfigHash: 'missing-hash',
+    });
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    }, getTranscription);
+
+    await getTableData(
+      ['transcript'],
+      [participantWithConfig, participantMissingConfig],
+      storageEngine,
+      'test-study',
+      true,
+    );
+
+    expect(getTranscription).toHaveBeenCalledTimes(2);
+    expect(getTranscription).toHaveBeenCalledWith('testComponent_0', 'p1');
+    expect(getTranscription).toHaveBeenCalledWith('testComponent_0', 'p2');
+  });
+
+  test('includes participant status, condition, tags, and metadata rows', async () => {
+    const rejectedAt = 300;
+    const participant = makeParticipant({
+      completed: true,
+      rejected: {
+        reason: 'low quality',
+        timestamp: rejectedAt,
+      },
+      conditions: ['alpha', 'beta'],
+      metadata: {
+        userAgent: 'test-agent',
+        resolution: { width: 1920, height: 1080 },
+        language: 'en-US',
+        ip: '127.0.0.1',
+      },
+      participantTags: ['pilot', 'review'],
+      stage: 'COMPLETE',
+    });
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+
+    const tableData = await getTableData(
+      ['condition', 'stage', 'status', 'rejectReason', 'rejectTime', 'percentComplete', 'metaData'],
+      [participant],
+      storageEngine,
+      'test-study',
+    );
+
+    const participantTagsRow = tableData.rows.find((row) => row.responseId === 'participantTags');
+    const metaDataRow = tableData.rows.find((row) => row.responseId === 'metaData');
+    const answerRow = tableData.rows.find((row) => row.responseId === 'response');
+
+    expect(tableData.header).toEqual(expect.arrayContaining(['condition', 'stage', 'status', 'rejectReason', 'rejectTime', 'percentComplete']));
+    expect(tableData.header).not.toContain('metaData');
+    expect(participantTagsRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'participantTags',
+      responseId: 'participantTags',
+      answer: JSON.stringify(['pilot', 'review']),
+      condition: 'alpha,beta',
+      stage: 'COMPLETE',
+    }));
+    expect(metaDataRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'metaData',
+      responseId: 'metaData',
+      answer: JSON.stringify(participant.metadata),
+      condition: 'alpha,beta',
+      stage: 'COMPLETE',
+    }));
+    expect(answerRow).toEqual(expect.objectContaining({
+      status: 'rejected',
+      rejectReason: 'low quality',
+      rejectTime: new Date(rejectedAt).toISOString(),
+      percentComplete: '100.00',
+    }));
+  });
+
+  test('exports empty answer rows and window event counts', async () => {
+    const participant = makeParticipant({
+      answers: {
+        testComponent_0: {
+          ...makeParticipant().answers.testComponent_0,
+          answer: {},
+          windowEvents: [
+            [100, 'focus', 'visible'],
+            [101, 'focus', 'hidden'],
+            [102, 'input', 'typed'],
+            [103, 'keydown', 'Enter'],
+            [104, 'keyup', 'Enter'],
+            [105, 'mousemove', [1, 2]],
+            [106, 'mousedown', [1, 2]],
+            [107, 'mouseup', [1, 2]],
+            [108, 'resize', [800, 600]],
+            [109, 'scroll', [0, 100]],
+            [110, 'visibility', 'visible'],
+          ],
+        },
+      },
+    });
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+
+    const tableData = await getTableData(
+      ['answer'],
+      [participant],
+      storageEngine,
+      'test-study',
+    );
+
+    const emptyAnswerRow = tableData.rows.find((row) => row.responseId === '');
+    const windowEventsRow = tableData.rows.find((row) => row.responseId === 'windowEvents');
+
+    expect(emptyAnswerRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'testComponent',
+      responseId: '',
+    }));
+    expect(emptyAnswerRow?.answer).toBeUndefined();
+    expect(windowEventsRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'testComponent',
+      responseId: 'windowEvents',
+      answer: JSON.stringify({
+        focus: 2,
+        input: 1,
+        keydown: 1,
+        keyup: 1,
+        mousemove: 1,
+        mousedown: 1,
+        mouseup: 1,
+        resize: 1,
+        scroll: 1,
+        visibility: 1,
+      }),
+    }));
+  });
+
+  test('keeps participant-derived rows when an answer references a missing component in an available config', async () => {
+    const participant = makeParticipant({
+      answers: {
+        missingComponent_0: {
+          ...makeParticipant().answers.testComponent_0,
+          componentName: 'missingComponent',
+          identifier: 'missingComponent_0',
+        },
+      },
+    });
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+
+    const tableData = await getTableData(
+      ['answer', 'description', 'instruction', 'responsePrompt', 'responseMin', 'responseMax'],
+      [participant],
+      storageEngine,
+      'test-study',
+    );
+
+    const answerRow = tableData.rows.find((row) => row.responseId === 'response');
+    expect(tableData.missingConfigCount).toBe(0);
+    expect(answerRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'missingComponent',
+      responseId: 'response',
+      answer: 'participant answer',
+    }));
+    expect(answerRow?.description).toBeUndefined();
+    expect(answerRow?.instruction).toBeUndefined();
+    expect(answerRow?.responsePrompt).toBeUndefined();
+    expect(answerRow?.responseMin).toBeUndefined();
+    expect(answerRow?.responseMax).toBeUndefined();
+  });
+
+  test('does not fetch transcripts when audio is unavailable or storage is not firebase', async () => {
+    const getTranscription = vi.fn();
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    }, getTranscription, 'localStorage');
+
+    await getTableData(
+      ['transcript'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+      true,
+    );
+
+    expect(getTranscription).not.toHaveBeenCalled();
+  });
+
+  test('keeps config lookup rejection as an export-blocking storage error', async () => {
+    const storageEngine = {
+      getAllConfigsFromHash: vi.fn().mockRejectedValue(new Error('storage unavailable')),
+      getEngine: vi.fn(() => 'firebase'),
+    } as unknown as StorageEngine;
+
+    await expect(getTableData(
+      ['answer'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+    )).rejects.toThrow('storage unavailable');
+  });
+
+  test('returns empty table data when storage engine is unavailable', async () => {
+    const tableData = await getTableData(
+      ['answer'],
+      [makeParticipant()],
+      undefined,
+      'test-study',
+    );
+
+    expect(tableData).toEqual({
+      header: [],
+      rows: [],
+      missingConfigCount: 0,
+    });
+  });
+});
+
+describe('DownloadTidy', () => {
+  afterEach(() => {
+    cleanup();
+    storageEngineHookMock.storageEngine = undefined;
+    vi.clearAllMocks();
+  });
+
+  test('shows an informational warning when selected participants reference missing configs', async () => {
+    storageEngineHookMock.storageEngine = makeStorageEngine({});
+
+    render(
+      <MantineProvider>
+        <DownloadTidy
+          opened
+          close={vi.fn()}
+          filename="test-study_tidy.csv"
+          data={[makeParticipant({ participantConfigHash: 'missing-hash' })]}
+          studyId="test-study"
+        />
+      </MantineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Stored study configs could not be loaded for 1 selected participant.');
+    });
+    expect(document.body.textContent).toContain('Config-derived columns, such as description and instruction, may be blank for those rows.');
+    expect(document.body.textContent).toContain('To restore the current config, reload the study page.');
+    expect(document.body.textContent).toContain('historical configs that differ from the current config must be restored from a storage snapshot or backup.');
+  });
+});

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -418,6 +418,33 @@ describe('getTableData', () => {
     expect(answerRow?.responseMax).toBeUndefined();
   });
 
+  test('keeps participant-derived rows when a stored config is missing components', async () => {
+    const storageEngine = makeStorageEngine({
+      'hash-1': {
+        studyMetadata: configSimple.studyMetadata,
+      } as StudyConfig,
+    });
+
+    const tableData = await getTableData(
+      ['answer', 'description', 'instruction', 'responsePrompt'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+    );
+
+    const answerRow = tableData.rows.find((row) => row.responseId === 'response');
+    expect(tableData.missingConfigCount).toBe(0);
+    expect(answerRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'testComponent',
+      responseId: 'response',
+      answer: 'participant answer',
+    }));
+    expect(answerRow?.description).toBeUndefined();
+    expect(answerRow?.instruction).toBeUndefined();
+    expect(answerRow?.responsePrompt).toBeUndefined();
+  });
+
   test('does not fetch transcripts when audio is unavailable or storage is not firebase', async () => {
     const getTranscription = vi.fn();
     const storageEngine = makeStorageEngine({

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -713,8 +713,12 @@ export abstract class StorageEngine {
     // Hash the provided config
     const configHash = await hash(JSON.stringify(config));
 
+    // Skip saving config if the active config is already saved in storage
     if (currentConfigHash === configHash) {
-      return;
+      const storedConfig = await this._getFromStorage(`configs/${configHash}`, 'config');
+      if (storedConfig && Object.keys(storedConfig).length > 0) {
+        return;
+      }
     }
 
     // Push the config to storage and cache it, since it won't change
@@ -736,7 +740,9 @@ export abstract class StorageEngine {
       }
     }
 
-    await this._setCurrentConfigHash(configHash);
+    if (currentConfigHash !== configHash) {
+      await this._setCurrentConfigHash(configHash);
+    }
   }
 
   // Gets all configs from the storage engine based on the provided temporary hashes and studyId.

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -304,6 +304,25 @@ describe.each([
     expect(setHashSpy).not.toHaveBeenCalled();
   });
 
+  test('saveConfig restores missing config storage when the hash pointer is unchanged', async () => {
+    const configHash = await hash(JSON.stringify(configSimple));
+    await storageEngine.saveConfig(configSimple);
+
+    await (
+      storageEngine as unknown as {
+        _deleteFromStorage: StorageEngine['_deleteFromStorage'];
+      }
+    )._deleteFromStorage(`configs/${configHash}`, 'config');
+
+    let storedHashes = await storageEngine.getAllConfigsFromHash([configHash], studyId);
+    expect(storedHashes[configHash]).toBeNull();
+
+    await storageEngine.saveConfig(configSimple);
+
+    storedHashes = await storageEngine.getAllConfigsFromHash([configHash], studyId);
+    expect(storedHashes[configHash]).toEqual(configSimple);
+  });
+
   test('getCurrentParticipantId returns the current participant ID', async () => {
     const participantSession = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
     const { participantId } = participantSession;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1273

### Give a longer description of what this PR addresses and why it's needed
- Re-save the active config if the stored config file is missing
- Make Tidy CSV handle missing configs gracefully (which should not happen anymore but this is a defensive fallback)

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [ ] Done
- [x] N/A