### PR TITLE
Add qualitative coding download functionality for JSON and CSV

### DIFF
--- a/src/analysis/tests/thinkAloudUtils.spec.ts
+++ b/src/analysis/tests/thinkAloudUtils.spec.ts
@@ -43,6 +43,25 @@ describe.each([
     expect(initial).toEqual({ participantTags: [], taskTags: {} });
   });
 
+  test('participant/task tag reads only create storage records when requested', async () => {
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const storagePath = `audio/transcriptAndTags/${ownerKey}/${participant.participantId}`;
+
+    const readOnlyDefault = await storageEngine.getParticipantAndTaskTags(ownerKey, participant.participantId);
+    expect(readOnlyDefault).toEqual({ participantTags: [], taskTags: {} });
+
+    // @ts-expect-error using protected method for testing
+    const afterReadOnlyDefault = await storageEngine._getFromStorage(storagePath, 'participantTags');
+    expect(afterReadOnlyDefault).toBeNull();
+
+    const createIfMissingDefault = await storageEngine.getParticipantAndTaskTags(ownerKey, participant.participantId, true);
+    expect(createIfMissingDefault).toEqual({ participantTags: [], taskTags: {} });
+
+    // @ts-expect-error using protected method for testing
+    const afterCreateIfMissing = await storageEngine._getFromStorage(storagePath, 'participantTags');
+    expect(afterCreateIfMissing).toEqual({ participantTags: [], taskTags: {} });
+  });
+
   test('get participant/task tag defaults is stable across repeated reads', async () => {
     const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
 

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -11,12 +11,12 @@ import { ParticipantDataWithStatus } from '../../storage/types';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { downloadParticipantsAudioZip, downloadParticipantsProvenanceZip, downloadParticipantsScreenRecordingZip } from '../../utils/handleDownloadFiles';
 import { useAuth } from '../../store/hooks/useAuth';
-import type { ParticipantTags } from '../../analysis/individualStudy/thinkAloud/types';
 import type { StorageEngine } from '../../storage/engines/types';
 import { getParticipantQualitativeCodes } from './qualitativeCodes';
+import type { DownloadedQualitativeCodes } from './qualitativeCodes';
 
 type ParticipantDataFetcher = ParticipantDataWithStatus[] | (() => Promise<ParticipantDataWithStatus[]>);
-type ParticipantDataWithQualitativeCodes = ParticipantDataWithStatus & { qualitativeCodes: ParticipantTags };
+type ParticipantDataWithQualitativeCodes = ParticipantDataWithStatus & { qualitativeCodes: DownloadedQualitativeCodes };
 
 async function attachQualitativeCodesToParticipants(
   participants: ParticipantDataWithStatus[],

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -10,8 +10,27 @@ import { DownloadTidy, download } from './DownloadTidy';
 import { ParticipantDataWithStatus } from '../../storage/types';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { downloadParticipantsAudioZip, downloadParticipantsProvenanceZip, downloadParticipantsScreenRecordingZip } from '../../utils/handleDownloadFiles';
+import { useAuth } from '../../store/hooks/useAuth';
+import type { ParticipantTags } from '../../analysis/individualStudy/thinkAloud/types';
+import type { StorageEngine } from '../../storage/engines/types';
+import { getParticipantQualitativeCodes } from './qualitativeCodes';
 
 type ParticipantDataFetcher = ParticipantDataWithStatus[] | (() => Promise<ParticipantDataWithStatus[]>);
+type ParticipantDataWithQualitativeCodes = ParticipantDataWithStatus & { qualitativeCodes: ParticipantTags };
+
+async function attachQualitativeCodesToParticipants(
+  participants: ParticipantDataWithStatus[],
+  storageEngine: StorageEngine | undefined,
+  authEmail: string,
+): Promise<ParticipantDataWithQualitativeCodes[]> {
+  return Promise.all(participants.map(async (participant) => {
+    const qualitativeCodes = await getParticipantQualitativeCodes(storageEngine, authEmail, participant);
+    return {
+      ...participant,
+      qualitativeCodes,
+    };
+  }));
+}
 
 export function DownloadButtons({
   visibleParticipants, studyId, gap, fileName, hasAudio, hasScreenRecording,
@@ -22,6 +41,7 @@ export function DownloadButtons({
   const [loadingAudio, setLoadingAudio] = useState(false);
   const [loadingScreenRecording, setLoadingScreenRecording] = useState(false);
   const { storageEngine } = useStorageEngine();
+  const auth = useAuth();
 
   const fetchParticipants = async () => {
     const currParticipants = typeof visibleParticipants === 'function' ? await visibleParticipants() : visibleParticipants;
@@ -30,8 +50,13 @@ export function DownloadButtons({
 
   const handleDownloadJSON = async () => {
     const currParticipants = await fetchParticipants();
+    const participantsWithQualitativeCodes = await attachQualitativeCodesToParticipants(
+      currParticipants,
+      storageEngine,
+      auth.user.user?.email || 'temp',
+    );
     const currFileName = fileName ? `${fileName}.json` : `${studyId}_all.json`;
-    download(JSON.stringify(currParticipants, null, 2), currFileName);
+    download(JSON.stringify(participantsWithQualitativeCodes, null, 2), currFileName);
   };
 
   const handleOpenTidy = async () => {

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -23,10 +23,13 @@ import { StorageEngine } from '../../storage/engines/types';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 import { useAsync } from '../../store/hooks/useAsync';
+import { useAuth } from '../../store/hooks/useAuth';
 import { getCleanedDuration } from '../../utils/getCleanedDuration';
 import { showNotification } from '../../utils/notifications';
 import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
+import type { ParticipantTags } from '../../analysis/individualStudy/thinkAloud/types';
+import { getAnswerIdentifier, getParticipantQualitativeCodes } from './qualitativeCodes';
 
 const OPTIONAL_COMMON_PROPS = [
   'condition',
@@ -50,6 +53,7 @@ const OPTIONAL_COMMON_PROPS = [
   'responseMax',
   'configHash',
   'metaData',
+  'qualitativeCodes',
 ] as const;
 
 const REQUIRED_PROPS = [
@@ -105,6 +109,7 @@ function participantDataToRows(
   properties: Property[],
   studyConfig?: StudyConfig,
   transcripts?: Record<string, string | null>,
+  qualitativeCodes?: ParticipantTags,
 ): [TidyRow[], string[]] {
   const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (Object.entries(participant.answers).length)) * 100).toFixed(2);
   const newHeaders = new Set<string>();
@@ -137,6 +142,11 @@ function participantDataToRows(
       const { trialOrder } = trialAnswer;
       const trialConfig = studyConfig?.components?.[trialId];
       const completeComponent = trialConfig && studyConfig ? studyComponentToIndividualComponent(trialConfig, studyConfig) : undefined;
+      const identifier = getAnswerIdentifier(trialAnswer);
+      const trialQualitativeCodes = {
+        participantTags: qualitativeCodes?.participantTags ?? [],
+        taskTags: qualitativeCodes?.taskTags[identifier] ?? [],
+      };
 
       const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
       const cleanedDuration = getCleanedDuration(trialAnswer);
@@ -189,8 +199,10 @@ function participantDataToRows(
         if (properties.includes('answer')) {
           tidyRow.answer = typeof value === 'object' ? JSON.stringify(value) : value;
         }
+        if (properties.includes('qualitativeCodes')) {
+          tidyRow.qualitativeCodes = JSON.stringify(trialQualitativeCodes);
+        }
         if (properties.includes('transcript')) {
-          const identifier = trialAnswer.identifier || `${trialId}_${trialOrder}`;
           tidyRow.transcript = transcripts?.[`${participant.participantId}_${identifier}`] ?? undefined;
         }
         if (properties.includes('correctAnswer')) {
@@ -261,6 +273,7 @@ export async function getTableData(
   storageEngine: StorageEngine | undefined,
   studyId: string,
   hasAudio?: boolean,
+  authEmail = 'temp',
 ) {
   if (!storageEngine) {
     return { header: [], rows: [], missingConfigCount: 0 };
@@ -280,7 +293,7 @@ export async function getTableData(
       .filter((answer) => ((answer?.endTime ?? -1) > 0) || ((answer?.startTime ?? -1) > 0))
       .map((answer) => ({ answer, participantId: p.participantId })));
     const tasks = allAnswers.map(({ answer, participantId }) => async () => {
-      const identifier = answer.identifier || `${answer.componentName}_${answer.trialOrder}`;
+      const identifier = getAnswerIdentifier(answer);
       const key = `${participantId}_${identifier}`;
 
       try {
@@ -303,11 +316,15 @@ export async function getTableData(
     .filter((p) => p !== 'metaData');
   const allData = await Promise.all(data.map(async (participant) => {
     const participantConfig = allConfigs[participant.participantConfigHash];
+    const qualitativeCodes = selectedProperties.includes('qualitativeCodes')
+      ? await getParticipantQualitativeCodes(storageEngine, authEmail, participant)
+      : undefined;
     const partDataToRows = await participantDataToRows(
       participant,
       combinedProperties,
       hasStoredStudyConfig(participantConfig) ? participantConfig : undefined,
       transcripts,
+      qualitativeCodes,
     );
 
     return partDataToRows;
@@ -351,6 +368,7 @@ export function DownloadTidy({
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [showTranscriptWarning, setShowTranscriptWarning] = useState(false);
+  const auth = useAuth();
 
   const [selectedProperties, setSelectedProperties] = useState<Array<OptionalProperty>>([
     'condition',
@@ -369,7 +387,7 @@ export function DownloadTidy({
   ]);
 
   const { storageEngine } = useStorageEngine();
-  const { value: tableData, status: tableDataStatus, error: tableError } = useAsync(getTableData, [selectedProperties, data, storageEngine, studyId, hasAudio]);
+  const { value: tableData, status: tableDataStatus, error: tableError } = useAsync(getTableData, [selectedProperties, data, storageEngine, studyId, hasAudio, auth.user.user?.email || 'temp']);
   const isFirebase = storageEngine?.getEngine() === 'firebase';
   const transcriptAvailable = isFirebase && !!hasAudio;
   const selectedParticipantCount = data.length;

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -28,8 +28,8 @@ import { getCleanedDuration } from '../../utils/getCleanedDuration';
 import { showNotification } from '../../utils/notifications';
 import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
-import type { ParticipantTags } from '../../analysis/individualStudy/thinkAloud/types';
 import { getAnswerIdentifier, getParticipantQualitativeCodes } from './qualitativeCodes';
+import type { DownloadedQualitativeCodes } from './qualitativeCodes';
 
 const OPTIONAL_COMMON_PROPS = [
   'condition',
@@ -53,7 +53,8 @@ const OPTIONAL_COMMON_PROPS = [
   'responseMax',
   'configHash',
   'metaData',
-  'qualitativeCodes',
+  'participantTags',
+  'taskTags',
 ] as const;
 
 const REQUIRED_PROPS = [
@@ -109,24 +110,25 @@ function participantDataToRows(
   properties: Property[],
   studyConfig?: StudyConfig,
   transcripts?: Record<string, string | null>,
-  qualitativeCodes?: ParticipantTags,
+  qualitativeCodes?: DownloadedQualitativeCodes,
 ): [TidyRow[], string[]] {
   const percentComplete = ((Object.entries(participant.answers).filter(([_, entry]) => entry.endTime !== -1).length / (Object.entries(participant.answers).length)) * 100).toFixed(2);
   const newHeaders = new Set<string>();
   const participantConditions = parseConditionParam(participant.conditions ?? participant.searchParams?.condition);
   const conditionValue = participantConditions.length > 0 ? participantConditions.join(',') : 'default';
   const metaData = JSON.stringify(participant.metadata);
+  const participantQualitativeTags = JSON.stringify(qualitativeCodes?.participantTags ?? []);
 
   return [[
-    {
+    ...(properties.includes('participantTags') ? [{
       participantId: participant.participantId,
       trialId: 'participantTags',
       trialOrder: null,
       responseId: 'participantTags',
-      answer: JSON.stringify(participant.participantTags),
+      answer: participantQualitativeTags,
       ...(properties.includes('condition') ? { condition: conditionValue } : {}),
       ...(properties.includes('stage') ? { stage: participant.stage } : {}),
-    },
+    }] : []),
     ...(properties.includes('metaData') ? [{
       participantId: participant.participantId,
       trialId: 'metaData',
@@ -143,10 +145,7 @@ function participantDataToRows(
       const trialConfig = studyConfig?.components?.[trialId];
       const completeComponent = trialConfig && studyConfig ? studyComponentToIndividualComponent(trialConfig, studyConfig) : undefined;
       const identifier = getAnswerIdentifier(trialAnswer);
-      const trialQualitativeCodes = {
-        participantTags: qualitativeCodes?.participantTags ?? [],
-        taskTags: qualitativeCodes?.taskTags[identifier] ?? [],
-      };
+      const taskQualitativeTags = JSON.stringify(qualitativeCodes?.taskTags[identifier] ?? []);
 
       const duration = trialAnswer.endTime === -1 ? undefined : trialAnswer.endTime - trialAnswer.startTime;
       const cleanedDuration = getCleanedDuration(trialAnswer);
@@ -199,8 +198,8 @@ function participantDataToRows(
         if (properties.includes('answer')) {
           tidyRow.answer = typeof value === 'object' ? JSON.stringify(value) : value;
         }
-        if (properties.includes('qualitativeCodes')) {
-          tidyRow.qualitativeCodes = JSON.stringify(trialQualitativeCodes);
+        if (properties.includes('taskTags')) {
+          tidyRow.taskTags = taskQualitativeTags;
         }
         if (properties.includes('transcript')) {
           tidyRow.transcript = transcripts?.[`${participant.participantId}_${identifier}`] ?? undefined;
@@ -313,10 +312,11 @@ export async function getTableData(
   });
   const header = combinedProperties
     .filter((p) => p !== 'condition' || hasCondition)
-    .filter((p) => p !== 'metaData');
+    .filter((p) => p !== 'metaData')
+    .filter((p) => p !== 'participantTags');
   const allData = await Promise.all(data.map(async (participant) => {
     const participantConfig = allConfigs[participant.participantConfigHash];
-    const qualitativeCodes = selectedProperties.includes('qualitativeCodes')
+    const qualitativeCodes = selectedProperties.includes('participantTags') || selectedProperties.includes('taskTags')
       ? await getParticipantQualitativeCodes(storageEngine, authEmail, participant)
       : undefined;
     const partDataToRows = await participantDataToRows(

--- a/src/components/downloader/qualitativeCodes.ts
+++ b/src/components/downloader/qualitativeCodes.ts
@@ -1,0 +1,65 @@
+import type { ParticipantTags } from '../../analysis/individualStudy/thinkAloud/types';
+import type { StorageEngine } from '../../storage/engines/types';
+import type { ParticipantDataWithStatus } from '../../storage/types';
+import type { StoredAnswer } from '../../store/types';
+import { parseTrialOrder } from '../../utils/parseTrialOrder';
+
+export const createEmptyQualitativeCodes = (): ParticipantTags => ({
+  participantTags: [],
+  taskTags: {},
+});
+
+export function getAnswerIdentifier(answer: Pick<StoredAnswer, 'componentName' | 'identifier' | 'trialOrder'>) {
+  return answer.identifier || `${answer.componentName}_${answer.trialOrder}`;
+}
+
+export function normalizeQualitativeCodes(
+  qualitativeCodes: ParticipantTags | undefined,
+  participant: ParticipantDataWithStatus,
+): ParticipantTags {
+  const storedTaskTags = qualitativeCodes?.taskTags ?? {};
+  const taskTags: ParticipantTags['taskTags'] = {};
+
+  Object.values(participant.answers).sort((a, b) => {
+    const aOrder = parseTrialOrder(a.trialOrder);
+    const bOrder = parseTrialOrder(b.trialOrder);
+    const aStep = aOrder.step ?? Number.MAX_SAFE_INTEGER;
+    const bStep = bOrder.step ?? Number.MAX_SAFE_INTEGER;
+    const stepDiff = aStep - bStep;
+
+    if (stepDiff !== 0) {
+      return stepDiff;
+    }
+
+    return (aOrder.funcIndex ?? -1) - (bOrder.funcIndex ?? -1);
+  }).forEach((answer) => {
+    const identifier = getAnswerIdentifier(answer);
+    taskTags[identifier] = storedTaskTags[identifier] ?? [];
+  });
+
+  Object.entries(storedTaskTags).forEach(([identifier, tags]) => {
+    taskTags[identifier] ??= tags;
+  });
+
+  return {
+    participantTags: qualitativeCodes?.participantTags ?? [],
+    taskTags,
+  };
+}
+
+export async function getParticipantQualitativeCodes(
+  storageEngine: StorageEngine | undefined,
+  authEmail: string,
+  participant: ParticipantDataWithStatus,
+) {
+  if (!storageEngine) {
+    return normalizeQualitativeCodes(createEmptyQualitativeCodes(), participant);
+  }
+
+  try {
+    const qualitativeCodes = await storageEngine.getParticipantAndTaskTags(authEmail, participant.participantId, false);
+    return normalizeQualitativeCodes(qualitativeCodes, participant);
+  } catch {
+    return normalizeQualitativeCodes(createEmptyQualitativeCodes(), participant);
+  }
+}

--- a/src/components/downloader/qualitativeCodes.ts
+++ b/src/components/downloader/qualitativeCodes.ts
@@ -1,10 +1,19 @@
-import type { ParticipantTags } from '../../analysis/individualStudy/thinkAloud/types';
+import type { ParticipantTags, Tag } from '../../analysis/individualStudy/thinkAloud/types';
 import type { StorageEngine } from '../../storage/engines/types';
 import type { ParticipantDataWithStatus } from '../../storage/types';
 import type { StoredAnswer } from '../../store/types';
 import { parseTrialOrder } from '../../utils/parseTrialOrder';
 
-export const createEmptyQualitativeCodes = (): ParticipantTags => ({
+export type DownloadedTag = Pick<Tag, 'id' | 'name'>;
+
+export interface DownloadedQualitativeCodes {
+  participantTags: DownloadedTag[];
+  taskTags: Record<string, DownloadedTag[]>;
+}
+
+const removeTagColor = ({ id, name }: Tag): DownloadedTag => ({ id, name });
+
+export const createEmptyQualitativeCodes = (): DownloadedQualitativeCodes => ({
   participantTags: [],
   taskTags: {},
 });
@@ -16,9 +25,11 @@ export function getAnswerIdentifier(answer: Pick<StoredAnswer, 'componentName' |
 export function normalizeQualitativeCodes(
   qualitativeCodes: ParticipantTags | undefined,
   participant: ParticipantDataWithStatus,
-): ParticipantTags {
-  const storedTaskTags = qualitativeCodes?.taskTags ?? {};
-  const taskTags: ParticipantTags['taskTags'] = {};
+): DownloadedQualitativeCodes {
+  const storedTaskTags = Object.fromEntries(
+    Object.entries(qualitativeCodes?.taskTags ?? {}).map(([identifier, tags]) => [identifier, tags.map(removeTagColor)]),
+  );
+  const taskTags: DownloadedQualitativeCodes['taskTags'] = {};
 
   Object.values(participant.answers).sort((a, b) => {
     const aOrder = parseTrialOrder(a.trialOrder);
@@ -42,7 +53,7 @@ export function normalizeQualitativeCodes(
   });
 
   return {
-    participantTags: qualitativeCodes?.participantTags ?? [],
+    participantTags: qualitativeCodes?.participantTags.map(removeTagColor) ?? [],
     taskTags,
   };
 }
@@ -53,13 +64,13 @@ export async function getParticipantQualitativeCodes(
   participant: ParticipantDataWithStatus,
 ) {
   if (!storageEngine) {
-    return normalizeQualitativeCodes(createEmptyQualitativeCodes(), participant);
+    return normalizeQualitativeCodes(undefined, participant);
   }
 
   try {
     const qualitativeCodes = await storageEngine.getParticipantAndTaskTags(authEmail, participant.participantId, false);
     return normalizeQualitativeCodes(qualitativeCodes, participant);
   } catch {
-    return normalizeQualitativeCodes(createEmptyQualitativeCodes(), participant);
+    return normalizeQualitativeCodes(undefined, participant);
   }
 }

--- a/src/components/downloader/tests/DownloadButtons.spec.tsx
+++ b/src/components/downloader/tests/DownloadButtons.spec.tsx
@@ -218,9 +218,9 @@ describe('DownloadButtons click handlers', () => {
     expect(mockState.storageEngine.getParticipantAndTaskTags).toHaveBeenCalledWith('analyst@example.com', 'p1', false);
     const exportedJson = vi.mocked(download).mock.calls[0][0];
     expect(JSON.parse(exportedJson)[0].qualitativeCodes).toEqual({
-      participantTags: [participantTag],
+      participantTags: [{ id: participantTag.id, name: participantTag.name }],
       taskTags: {
-        trial_0: [taskTag],
+        trial_0: [{ id: taskTag.id, name: taskTag.name }],
         trial_1: [],
       },
     });

--- a/src/components/downloader/tests/DownloadButtons.spec.tsx
+++ b/src/components/downloader/tests/DownloadButtons.spec.tsx
@@ -10,11 +10,27 @@ import { DownloadButtons } from '../DownloadButtons';
 import { download } from '../DownloadTidy';
 import { downloadParticipantsAudioZip, downloadParticipantsScreenRecordingZip } from '../../../utils/handleDownloadFiles';
 import type { ParticipantDataWithStatus } from '../../../storage/types';
+import { makeStoredAnswer } from '../../../tests/utils';
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
 
+const mockState = vi.hoisted(() => ({
+  storageEngine: {
+    getEngine: vi.fn(() => 'firebase'),
+    getParticipantAndTaskTags: vi.fn(),
+  },
+}));
+
 vi.mock('../../../storage/storageEngineHooks', () => ({
-  useStorageEngine: () => ({ storageEngine: { getEngine: () => 'firebase' } }),
+  useStorageEngine: () => ({ storageEngine: mockState.storageEngine }),
+}));
+
+vi.mock('../../../store/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      user: { email: 'analyst@example.com' },
+    },
+  }),
 }));
 
 vi.mock('@mantine/hooks', () => ({
@@ -58,6 +74,11 @@ const baseProps = {
   studyId: 'test-study',
   visibleParticipants: [] as ParticipantDataWithStatus[],
 };
+
+beforeEach(() => {
+  mockState.storageEngine.getEngine.mockReturnValue('firebase');
+  mockState.storageEngine.getParticipantAndTaskTags.mockResolvedValue({ participantTags: [], taskTags: {} });
+});
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
@@ -167,6 +188,43 @@ describe('DownloadButtons click handlers', () => {
       expect.stringContaining('p1'),
       'test-study_all.json',
     );
+  });
+
+  test('JSON button includes TA participant and task qualitative codes', async () => {
+    const participantTag = { id: 'participant-code', name: 'Hesitation', color: '#ff0000' };
+    const taskTag = { id: 'task-code', name: 'Chart Reading', color: '#0000ff' };
+    const participantWithAnswers = {
+      ...participant,
+      answers: {
+        trial_1: makeStoredAnswer({ identifier: 'trial_1', trialOrder: '1' }),
+        trial_0: makeStoredAnswer({ identifier: 'trial_0', trialOrder: '0' }),
+      },
+    };
+    mockState.storageEngine.getParticipantAndTaskTags.mockResolvedValueOnce({
+      participantTags: [participantTag],
+      taskTags: {
+        trial_1: [],
+        trial_0: [taskTag],
+      },
+    });
+
+    await act(async () => {
+      render(<DownloadButtons studyId="test-study" visibleParticipants={[participantWithAnswers]} />);
+    });
+
+    const jsonBtn = screen.getByText('json-icon').closest('button')!;
+    await act(async () => { fireEvent.click(jsonBtn); });
+
+    expect(mockState.storageEngine.getParticipantAndTaskTags).toHaveBeenCalledWith('analyst@example.com', 'p1', false);
+    const exportedJson = vi.mocked(download).mock.calls[0][0];
+    expect(JSON.parse(exportedJson)[0].qualitativeCodes).toEqual({
+      participantTags: [participantTag],
+      taskTags: {
+        trial_0: [taskTag],
+        trial_1: [],
+      },
+    });
+    expect(Object.keys(JSON.parse(exportedJson)[0].qualitativeCodes.taskTags)).toEqual(['trial_0', 'trial_1']);
   });
 
   test('JSON button uses custom fileName when provided', async () => {

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -264,7 +264,7 @@ describe('getTableData', () => {
     expect(getTranscription).toHaveBeenCalledWith('testComponent_0', 'p2');
   });
 
-  test('adds TA qualitative codes to the corresponding task rows', async () => {
+  test('adds TA participant tags as participant-level row and task tags to task rows', async () => {
     const qualitativeCodes = {
       participantTags: [{ id: 'participant-code', name: 'Hesitation', color: '#ff0000' }],
       taskTags: {
@@ -277,7 +277,7 @@ describe('getTableData', () => {
     }, vi.fn(), 'firebase', getParticipantAndTaskTags);
 
     const tableData = await getTableData(
-      ['qualitativeCodes'],
+      ['participantTags', 'taskTags'],
       [makeParticipant()],
       storageEngine,
       'test-study',
@@ -286,24 +286,29 @@ describe('getTableData', () => {
     );
 
     const answerRow = tableData.rows.find((row) => row.responseId === 'response');
+    const participantTagsRows = tableData.rows.filter((row) => row.responseId === 'participantTags');
     expect(getParticipantAndTaskTags).toHaveBeenCalledWith('analyst@example.com', 'p1', false);
-    expect(tableData.header).toContain('qualitativeCodes');
-    expect(tableData.rows).not.toContainEqual(expect.objectContaining({
-      trialId: 'qualitativeCodes',
+    expect(tableData.header).toContain('taskTags');
+    expect(tableData.header).not.toContain('participantTags');
+    expect(participantTagsRows).toHaveLength(1);
+    expect(participantTagsRows[0]).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'participantTags',
+      trialOrder: null,
+      responseId: 'participantTags',
+      answer: JSON.stringify([{ id: 'participant-code', name: 'Hesitation' }]),
     }));
     expect(answerRow).toEqual(expect.objectContaining({
       participantId: 'p1',
       trialId: 'testComponent',
       trialOrder: '0',
       responseId: 'response',
-      qualitativeCodes: JSON.stringify({
-        participantTags: qualitativeCodes.participantTags,
-        taskTags: qualitativeCodes.taskTags.testComponent_0,
-      }),
+      taskTags: JSON.stringify([{ id: 'task-code', name: 'Chart Reading' }]),
     }));
+    expect(answerRow?.participantTags).toBeUndefined();
   });
 
-  test('includes participant status, condition, tags, and metadata rows', async () => {
+  test('includes participant status, condition, and metadata rows', async () => {
     const rejectedAt = 300;
     const participant = makeParticipant({
       completed: true,
@@ -332,20 +337,12 @@ describe('getTableData', () => {
       'test-study',
     );
 
-    const participantTagsRow = tableData.rows.find((row) => row.responseId === 'participantTags');
     const metaDataRow = tableData.rows.find((row) => row.responseId === 'metaData');
     const answerRow = tableData.rows.find((row) => row.responseId === 'response');
 
     expect(tableData.header).toEqual(expect.arrayContaining(['condition', 'stage', 'status', 'rejectReason', 'rejectTime', 'percentComplete']));
     expect(tableData.header).not.toContain('metaData');
-    expect(participantTagsRow).toEqual(expect.objectContaining({
-      participantId: 'p1',
-      trialId: 'participantTags',
-      responseId: 'participantTags',
-      answer: JSON.stringify(['pilot', 'review']),
-      condition: 'alpha,beta',
-      stage: 'COMPLETE',
-    }));
+    expect(tableData.rows.find((row) => row.responseId === 'participantTags')).toBeUndefined();
     expect(metaDataRow).toEqual(expect.objectContaining({
       participantId: 'p1',
       trialId: 'metaData',

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -101,11 +101,13 @@ function makeStorageEngine(
   configs: Record<string, StudyConfig>,
   getTranscription = vi.fn(),
   engine = 'firebase',
+  getParticipantAndTaskTags = vi.fn().mockResolvedValue({ participantTags: [], taskTags: {} }),
 ): StorageEngine {
   return {
     getAllConfigsFromHash: vi.fn().mockResolvedValue(configs),
     getEngine: vi.fn(() => engine),
     getTranscription,
+    getParticipantAndTaskTags,
   } as unknown as StorageEngine;
 }
 
@@ -260,6 +262,45 @@ describe('getTableData', () => {
     expect(getTranscription).toHaveBeenCalledTimes(2);
     expect(getTranscription).toHaveBeenCalledWith('testComponent_0', 'p1');
     expect(getTranscription).toHaveBeenCalledWith('testComponent_0', 'p2');
+  });
+
+  test('adds TA qualitative codes to the corresponding task rows', async () => {
+    const qualitativeCodes = {
+      participantTags: [{ id: 'participant-code', name: 'Hesitation', color: '#ff0000' }],
+      taskTags: {
+        testComponent_0: [{ id: 'task-code', name: 'Chart Reading', color: '#0000ff' }],
+      },
+    };
+    const getParticipantAndTaskTags = vi.fn().mockResolvedValue(qualitativeCodes);
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    }, vi.fn(), 'firebase', getParticipantAndTaskTags);
+
+    const tableData = await getTableData(
+      ['qualitativeCodes'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+      false,
+      'analyst@example.com',
+    );
+
+    const answerRow = tableData.rows.find((row) => row.responseId === 'response');
+    expect(getParticipantAndTaskTags).toHaveBeenCalledWith('analyst@example.com', 'p1', false);
+    expect(tableData.header).toContain('qualitativeCodes');
+    expect(tableData.rows).not.toContainEqual(expect.objectContaining({
+      trialId: 'qualitativeCodes',
+    }));
+    expect(answerRow).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'testComponent',
+      trialOrder: '0',
+      responseId: 'response',
+      qualitativeCodes: JSON.stringify({
+        participantTags: qualitativeCodes.participantTags,
+        taskTags: qualitativeCodes.taskTags.testComponent_0,
+      }),
+    }));
   });
 
   test('includes participant status, condition, tags, and metadata rows', async () => {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -994,16 +994,24 @@ export abstract class StorageEngine {
     return await this._getFromStorage(`audio/transcriptAndTags/${tagType}`, 'tags');
   }
 
-  async getAllParticipantAndTaskTags(authEmail: string, participantId: string) {
+  async getParticipantAndTaskTags(authEmail: string, participantId: string, createIfMissing = false) {
     const tags = await this._getFromStorage(`audio/transcriptAndTags/${authEmail}/${participantId}`, 'participantTags');
 
     if (tags?.participantTags) {
       return tags;
     }
 
-    this.saveAllParticipantAndTaskTags(authEmail, participantId, { participantTags: [], taskTags: {} });
+    const emptyTags: ParticipantTags = { participantTags: [], taskTags: {} };
 
-    return { participantTags: [], taskTags: {} };
+    if (createIfMissing) {
+      await this.saveAllParticipantAndTaskTags(authEmail, participantId, emptyTags);
+    }
+
+    return emptyTags;
+  }
+
+  async getAllParticipantAndTaskTags(authEmail: string, participantId: string) {
+    return this.getParticipantAndTaskTags(authEmail, participantId, true);
   }
 
   async saveAllParticipantAndTaskTags(authEmail: string, participantId: string, participantTags: ParticipantTags) {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #935

### Give a longer description of what this PR addresses and why it's needed
This PR adds qualitative coding data to study downloads so analysts can export participant-level and task-level TA/tagging codes alongside collected study data. JSON downloads now include qualitativeCodes per participant, and tidy CSV export adds an optional qualitativeCodes column on corresponding task rows, while using read-only tag fetching to avoid creating empty records during export.


### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="545" height="704" alt="图片" src="https://github.com/user-attachments/assets/bd8e7840-2033-4f5e-8ffa-9a4bbea43f7f" />
<img width="1158" height="677" alt="图片" src="https://github.com/user-attachments/assets/d27a8d15-f83b-433d-a2cd-9144dea3e632" />
<img width="1154" height="679" alt="图片" src="https://github.com/user-attachments/assets/2aba7a47-344a-4481-9123-256a290512ab" />




### Are there any additional TODOs before this PR is ready to go?
TODOs:


### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [x] Done
- [ ] N/A