### PR TITLE
Fix go to study button link

### DIFF
--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -377,7 +377,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
 
   return (
     <>
-      <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyHref={routeStudyId ? `/${routeStudyId}` : undefined} studyConfigs={studyConfig && displayStudyId ? { [displayStudyId]: studyConfig } : undefined} />
+      <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyConfigs={studyConfig && displayStudyId ? { [displayStudyId]: studyConfig } : undefined} />
       <AppShell.Main style={{ height: '100dvh' }}>
         <Stack ref={ref} style={{ height: '100%', maxHeight: '100dvh', overflow: 'hidden' }} justify="space-between">
           <Flex direction="row" align="center" justify="space-between" p="sm" gap="md">


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1271

### Give a longer description of what this PR addresses and why it's needed
Before this change, clicking on "Go to Study" from 
https://revisit.dev/study/analysis/stats/demo-condition/summary
 directed to 
https://revisit.dev/demo-condition
, which missed the`/study/` base path.

### Are there any additional TODOs before this PR is ready to go?
TODOs:
No

### Documentation

- [ ] Done
- [x] N/A