### PR TITLE
Add verification pass for unresolved React components

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -19,6 +19,7 @@ import {
   shouldWarnForDefaultFirebaseConfig,
   shouldWarnForDefaultSupabaseConfig,
 } from '../utils/defaultStorageConfig';
+import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 
 const modules = import.meta.glob(
   [
@@ -119,6 +120,28 @@ function verifyStudySkip(
   // If this block has a skip, add the skip.to component to the skipTargets array
   if (sequence.skip && sequence.skip.length > 0) {
     skipTargets.push(...sequence.skip.map((skip) => skip.to).filter((target) => target !== 'end'));
+  }
+}
+
+function verifyReactComponent(
+  instancePath: string,
+  component: Partial<IndividualComponent>,
+  errors: ParserErrorWarning[],
+) {
+  if (
+    'path' in component
+      && component.path != null
+      && component.type === 'react-component'
+      && !(`../public/${component.path}` in modules)
+  ) {
+    errors.push({
+      message: 'Unresolved path',
+      instancePath,
+      params: {
+        action: 'Make sure the React component is in `src/public/`, not `public/`',
+      },
+      category: 'undefined-component',
+    });
   }
 }
 
@@ -320,25 +343,17 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
   });
 
   // Verify that paths to React components exist under the correct base directory
-  if (studyConfig.baseComponents != null) {
-    for (const key of ['baseComponents', 'components'] as const) {
-      for (const [name, component] of Object.entries(studyConfig[key] ?? {})) {
-        if (
-          'path' in component
-            && component.path != null
-            && component.type === 'react-component'
-            && !(`../public/${component.path}` in modules)
-        ) {
-          errors.push({
-            message: 'Unresolved path',
-            instancePath: `/${key}/${name}/path`,
-            params: {
-              action: 'Make sure the React component is in `src/public/`, not `public/`',
-            },
-            category: 'undefined-component',
-          });
-        }
-      }
+
+  for (const [name, component] of Object.entries(studyConfig.baseComponents ?? {})) {
+    verifyReactComponent(`/baseComponents/${name}/path`, component, errors);
+  }
+
+  for (const [name, component] of Object.entries(studyConfig.components ?? {})) {
+    if ('path' in component) {
+      const mergedComponent = studyComponentToIndividualComponent(component, studyConfig);
+      verifyReactComponent(`/components/${name}/path`, mergedComponent, errors);
+    } else {
+      // Path is inherited and will be verified on the base component
     }
   }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -20,6 +20,14 @@ import {
   shouldWarnForDefaultSupabaseConfig,
 } from '../utils/defaultStorageConfig';
 
+const modules = import.meta.glob(
+  [
+    '../public/**/*.{mjs,js,mts,ts,jsx,tsx}',
+    '!../public/**/*.spec.{mjs,js,mts,ts,jsx,tsx}',
+  ],
+  { eager: false }, // the parser only checks if the path exists
+);
+
 const ajv1 = new Ajv({ allowUnionTypes: true });
 ajv1.addSchema(globalSchema);
 const globalValidate = ajv1.getSchema<GlobalConfig>('#/definitions/GlobalConfig')!;
@@ -310,6 +318,29 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
       category: 'skip-validation',
     });
   });
+
+  // Verify that paths to React components exist under the correct base directory
+  if (studyConfig.baseComponents != null) {
+    for (const key of ['baseComponents', 'components'] as const) {
+      for (const [name, component] of Object.entries(studyConfig[key] ?? {})) {
+        if (
+          'path' in component
+            && component.path != null
+            && component.type === 'react-component'
+            && !(`../public/${component.path}` in modules)
+        ) {
+          errors.push({
+            message: 'Unresolved path',
+            instancePath: `/${key}/${name}/path`,
+            params: {
+              action: 'Make sure the React component is in `src/public/`, not `public/`',
+            },
+            category: 'undefined-component',
+          });
+        }
+      }
+    }
+  }
 
   return { errors, warnings };
 }


### PR DESCRIPTION
### Does this PR close any open issues?

I couldn't find a related issue, but this is a feature request from Lane (@codementum).

### Give a longer description of what this PR addresses and why it's needed

This PR adds a pass to `verifyStudyConfig` that checks whether imported React components exist in `src/public/`. It uses the same logic to fetch modules as ReactComponentController.tsx. If the module doesn't exist, it suggests to check that the component is in `src/public/` and not `public/`.

### Provide pictures/videos of the behavior before and after these changes (optional)

In demo-react-trrack/config.json, changing the component name to `Missing.tsx` produces this error:

<img width="803" height="269" alt="verify-unresolved-react-components" src="https://github.com/user-attachments/assets/4672041b-f099-4bae-af0e-3376eee3dd9a" />

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] Other component types?
