### PR TITLE
Fix vega replay against missing signals

### DIFF
--- a/src/controllers/VegaController.tsx
+++ b/src/controllers/VegaController.tsx
@@ -131,6 +131,8 @@ export function VegaController({ currentConfig, provState }: { currentConfig: Ve
     }, {} as Listeners);
   }, [handleRevisitAnswer, handleSignalEvt, vegaConfig]);
 
+  const configuredSignalNames = useMemo(() => new Set(Object.keys(signalListeners)), [signalListeners]);
+
   useEffect(() => {
     async function fetchVega() {
       setLoading(true);
@@ -154,9 +156,11 @@ export function VegaController({ currentConfig, provState }: { currentConfig: Ve
 
   useEffect(() => {
     if (view && provState && provState.event && provState.event.key) {
-      view!.signal(provState.event.key, structuredClone(provState.event.value)).run();
+      if (configuredSignalNames.has(provState.event.key)) {
+        view.signal(provState.event.key, structuredClone(provState.event.value)).run();
+      }
     }
-  }, [view, provState]);
+  }, [configuredSignalNames, view, provState]);
 
   // If the vega spec can't be fetched (404) or parsed (invalid JSON), clear
   // stimulus validation so the participant isn't stuck on a trial that can

--- a/src/controllers/tests/ComponentController.spec.tsx
+++ b/src/controllers/tests/ComponentController.spec.tsx
@@ -710,4 +710,38 @@ describe('VegaController — signal and event coverage', () => {
 
     expect(mockDispatch).toHaveBeenCalled();
   });
+
+  test('ignores replayed provenance for signals missing from the active vega config', async () => {
+    type SignalHandler = (name: string, value: string | Record<string, string>) => void;
+    let capturedOnNewView: ((v: View) => void) | undefined;
+
+    vi.mocked(getJsonAssetByPath).mockResolvedValueOnce({
+      $schema: 'vega',
+      config: { signals: [{ name: 'revisitAnswer' }] },
+    });
+
+    mockVegaImpl = (props: {
+      signalListeners?: Record<string, SignalHandler>;
+      onNewView?: (v: View) => void;
+    }) => {
+      capturedOnNewView = props.onNewView;
+      return React.createElement('div', null, 'Vega');
+    };
+
+    render(
+      <VegaController
+        currentConfig={{ type: 'vega', path: '/chart.json', response: [] }}
+        provState={{ event: { key: 'tooltip', value: { category: 'A' } } }}
+      />,
+    );
+
+    await waitFor(() => expect(capturedOnNewView).toBeDefined());
+
+    const fakeView = { signal: vi.fn().mockReturnValue({ run: vi.fn() }) } as unknown as View;
+    await act(async () => {
+      capturedOnNewView?.(fakeView);
+    });
+
+    expect(fakeView.signal).not.toHaveBeenCalled();
+  });
 });

--- a/src/controllers/tests/ComponentController.spec.tsx
+++ b/src/controllers/tests/ComponentController.spec.tsx
@@ -695,7 +695,7 @@ describe('VegaController — signal and event coverage', () => {
     render(
       <VegaController
         currentConfig={{ type: 'vega', path: '/chart.json', response: [] }}
-        provState={{ event: { key: 'testKey', value: 'testVal' } }}
+        provState={{ event: { key: 'mySignal', value: 'testVal' } }}
       />,
     );
 
@@ -709,6 +709,7 @@ describe('VegaController — signal and event coverage', () => {
     });
 
     expect(mockDispatch).toHaveBeenCalled();
+    expect(fakeView.signal).toHaveBeenCalledWith('mySignal', 'testVal');
   });
 
   test('ignores replayed provenance for signals missing from the active vega config', async () => {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1268

### Give a longer description of what this PR addresses and why it's needed
This PR fixes an occasional `demo-vega` replay crash where Vega throws:
`Uncaught Error: Unrecognized signal name: "tooltip"`

During replay, a signal saved from one Vega chart can sometimes be applied after another Vega chart is shown. If the new chart does not have that signal, Vega throws an error.

This fix checks the signals for the current chart before applying a replayed signal. If the current chart does not have that signal, replay skips it instead of crashing.

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [ ] Done
- [x] N/A