### PR TITLE
Fix check answer message handling on keyboard input

### DIFF
--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -5,6 +5,7 @@ import {
 import { IconInfoCircle, IconAlertTriangle } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
 import { useNextStep } from '../store/hooks/useNextStep';
+import { shouldIgnoreEnter } from './keyboardUtils';
 import type { IndividualComponent, ResponseBlockLocation } from '../parser/types';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
 import { useCurrentIdentifier } from '../routes/utils';
@@ -99,7 +100,7 @@ export function NextButton({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' && !disabled && !isNextDisabled && buttonTimerSatisfied) {
+      if (event.key === 'Enter' && !shouldIgnoreEnter(event.target) && !disabled && !isNextDisabled && buttonTimerSatisfied) {
         onNext();
       }
     };

--- a/src/components/keyboardUtils.ts
+++ b/src/components/keyboardUtils.ts
@@ -1,0 +1,18 @@
+// Skip our global Enter handler when the focused element already handles Enter itself — multiline text entry (typing) and plain buttons/links (their own click)
+function isTextEntry(el: HTMLElement): boolean {
+  return el.tagName === 'TEXTAREA'
+    || el.isContentEditable
+    || el.closest('[contenteditable=""], [contenteditable="true"]') !== null;
+}
+
+export function shouldIgnoreEnter(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (isTextEntry(target)) {
+    return true;
+  }
+  // except Radio.Card (<button role="radio">): its click only re-selects
+  const clickable = target.closest('button, a, [role="button"]');
+  return clickable !== null && clickable.getAttribute('role') !== 'radio';
+}

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../store/store';
 
 import { NextButton } from '../NextButton';
+import { shouldIgnoreEnter } from '../keyboardUtils';
 import {
   generateInitFields, mergeReactiveAnswers, useAnswerField,
 } from './utils';
@@ -354,7 +355,13 @@ export function ResponseBlock({
         }
       }
     });
-    (topmostElement as HTMLElement | null)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const target = topmostElement as HTMLElement | null;
+    target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Focus the first focusable element within the target element
+    const focusable = target?.querySelector<HTMLElement>(
+      'button:not(:disabled), input:not([type="hidden"]):not(:disabled), select:not(:disabled), textarea:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])',
+    );
+    focusable?.focus({ preventScroll: true });
   }, [unresolvedResponseIds]);
   const stickyVisibleRef = useRef(false);
   const stickyVisible = showBtnsInLocation && errors && !!summaryMessage;
@@ -577,9 +584,9 @@ export function ResponseBlock({
   const nextOnEnter = config?.nextOnEnter ?? studyConfig.uiConfig.nextOnEnter;
 
   useEffect(() => {
-    if (nextOnEnter) {
+    if (nextOnEnter && showBtnsInLocation && hasCorrectAnswerFeedback && !disabledAttempts) {
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && !shouldIgnoreEnter(event.target)) {
           checkAnswerProvideFeedback();
         }
       };
@@ -589,8 +596,8 @@ export function ResponseBlock({
         window.removeEventListener('keydown', handleKeyDown);
       };
     }
-    return () => { };
-  }, [checkAnswerProvideFeedback, nextOnEnter]);
+    return undefined;
+  }, [checkAnswerProvideFeedback, nextOnEnter, showBtnsInLocation, hasCorrectAnswerFeedback, disabledAttempts]);
 
   const nextButtonText = useMemo(() => config?.nextButtonText ?? studyConfig.uiConfig.nextButtonText ?? 'Next', [config, studyConfig]);
 

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -302,8 +302,7 @@ describe('ResponseBlock', () => {
 // ── focus recovery on validation errors ──────────────────────────────────────
 
 describe('ResponseBlock focus recovery', () => {
-  // jsdom implements neither CSS.escape (used by scrollToFirstUnresolvedQuestion)
-  // nor scrollIntoView, so stub both and restore after each test to avoid leaking
+  // Stub browser APIs missing in jsdom that are used by the focus/scroll logic
   const scrollSpy = vi.fn();
   let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
   beforeEach(() => {
@@ -351,7 +350,7 @@ describe('ResponseBlock focus recovery', () => {
   });
 });
 
-// ── keyboard Check Answer (issue #1237) ──────────────────────────────────────
+// ── Check Answer via keyboard ─────────────────────────────────────────────────
 
 describe('ResponseBlock keyboard Check Answer', () => {
   const feedbackEnterConfig = {
@@ -419,8 +418,7 @@ describe('ResponseBlock keyboard Check Answer', () => {
     const checkBtn = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent === 'Check Answer',
     )!;
-    // the browser synthesizes a click for Enter on a focused button, so the
-    // global handler must skip the keydown
+    // Avoid double-running when Enter on a focused button also triggers click
     await act(async () => { fireEvent.keyDown(checkBtn, { key: 'Enter' }); });
     expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
     await act(async () => { fireEvent.click(checkBtn); });

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -1,14 +1,24 @@
 import { ReactNode } from 'react';
-import { render, act, fireEvent } from '@testing-library/react';
+import {
+  render, act, fireEvent, cleanup,
+} from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
-  describe, expect, test, vi,
+  afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import type { IndividualComponent } from '../../../parser/types';
 import { ResponseBlock } from '../ResponseBlock';
 import { makeStoredAnswer } from '../../../tests/utils';
+import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
 
 // ── mocks ────────────────────────────────────────────────────────────────────
+
+const { saveIncorrectAnswerSpy, mockStoreState } = vi.hoisted(() => ({
+  saveIncorrectAnswerSpy: vi.fn((v: unknown) => v),
+  mockStoreState: {
+    responseSubmitAttempted: { trial1_0: false } as Record<string, boolean>,
+  },
+}));
 
 vi.mock('@mantine/core', () => ({
   Box: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -43,7 +53,7 @@ vi.mock('../../../store/store', () => ({
   useStoreDispatch: vi.fn(() => vi.fn()),
   useStoreActions: vi.fn(() => ({
     updateResponseBlockValidation: vi.fn((v: unknown) => v),
-    saveIncorrectAnswer: vi.fn((v: unknown) => v),
+    saveIncorrectAnswer: saveIncorrectAnswerSpy,
     setResponseSubmitAttempt: vi.fn((v: unknown) => v),
     setStimulusSubmitAttempt: vi.fn((v: unknown) => v),
   })),
@@ -55,7 +65,7 @@ vi.mock('../../../store/store', () => ({
     reactiveAnswers: {},
     matrixAnswers: {},
     rankingAnswers: {},
-    responseSubmitAttempted: { trial1_0: false },
+    responseSubmitAttempted: mockStoreState.responseSubmitAttempted,
     sequence: {
       order: 'fixed', orderPath: '', components: [], skip: [],
     },
@@ -120,13 +130,18 @@ vi.mock('../customResponseModules', () => ({
 }));
 
 vi.mock('../ResponseSwitcher', () => ({
-  ResponseSwitcher: ({ response }: { response: { type: string } }) => (
-    <div data-testid={`switcher-${response.type}`}>{response.type}</div>
+  ResponseSwitcher: ({ response }: { response: { id: string; type: string } }) => (
+    <div data-testid={`switcher-${response.type}`}>
+      {response.type}
+      <input data-testid={`control-${response.id}`} />
+    </div>
   ),
 }));
 
 vi.mock('../FeedbackAlert', () => ({
-  FeedbackAlert: () => null,
+  FeedbackAlert: ({ response, alertConfig }: { response: { id: string }; alertConfig: Record<string, { visible: boolean }> }) => (
+    alertConfig[response.id]?.visible ? <div data-testid={`feedback-alert-${response.id}`} /> : null
+  ),
 }));
 
 vi.mock('../../NextButton', () => ({
@@ -150,6 +165,15 @@ const baseConfig: IndividualComponent = {
 };
 
 // ── ResponseBlock ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  saveIncorrectAnswerSpy.mockClear();
+  vi.mocked(responseAnswerIsCorrect).mockReturnValue(true);
+  mockStoreState.responseSubmitAttempted = { trial1_0: false };
+});
+
+// Unmount between tests so window keydown listeners from prior renders don't leak
+afterEach(() => cleanup());
 
 describe('ResponseBlock', () => {
   test('renders without error', () => {
@@ -272,5 +296,148 @@ describe('ResponseBlock', () => {
     render(<ResponseBlock config={configWithEnter} location="belowStimulus" />);
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     // Verifies the listener registered without throwing
+  });
+});
+
+// ── focus recovery on validation errors ──────────────────────────────────────
+
+describe('ResponseBlock focus recovery', () => {
+  // jsdom implements neither CSS.escape (used by scrollToFirstUnresolvedQuestion)
+  // nor scrollIntoView, so stub both and restore after each test to avoid leaking
+  const scrollSpy = vi.fn();
+  let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+  beforeEach(() => {
+    vi.stubGlobal('CSS', { escape: (s: string) => s });
+    scrollSpy.mockClear();
+    originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+    window.HTMLElement.prototype.scrollIntoView = scrollSpy;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  test('revealing unanswered errors scrolls to and focuses the first unresolved question', () => {
+    mockStoreState.responseSubmitAttempted = { trial1_0: true };
+    const requiredConfig = {
+      type: 'questionnaire',
+      response: [
+        {
+          type: 'shortText', id: 'q1', prompt: 'Q1', required: true,
+        },
+      ],
+    } as IndividualComponent;
+    const { container } = render(
+      <ResponseBlock config={requiredConfig} location="belowStimulus" />,
+    );
+    expect(scrollSpy).toHaveBeenCalled();
+    const control = container.querySelector('[data-question-id="q1"] input');
+    expect(control).toBeTruthy();
+    expect(document.activeElement).toBe(control);
+  });
+
+  test('does not move focus while there are no validation errors', () => {
+    const requiredConfig = {
+      type: 'questionnaire',
+      response: [
+        {
+          type: 'shortText', id: 'q1', prompt: 'Q1', required: true,
+        },
+      ],
+    } as IndividualComponent;
+    render(<ResponseBlock config={requiredConfig} location="belowStimulus" />);
+    expect(scrollSpy).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(document.body);
+  });
+});
+
+// ── keyboard Check Answer (issue #1237) ──────────────────────────────────────
+
+describe('ResponseBlock keyboard Check Answer', () => {
+  const feedbackEnterConfig = {
+    ...baseConfig,
+    nextOnEnter: true,
+    provideFeedback: true,
+    correctAnswer: [{ id: 'q1', answer: 'correct' }],
+  } as IndividualComponent;
+
+  test('one Enter press shows one feedback alert and saves one incorrect answer across all mounted locations', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const { container } = render(
+      <>
+        <ResponseBlock config={feedbackEnterConfig} location="aboveStimulus" />
+        <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />
+        <ResponseBlock config={feedbackEnterConfig} location="sidebar" />
+      </>,
+    );
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
+    expect(saveIncorrectAnswerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-owner response block ignores Enter', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const { container } = render(
+      <ResponseBlock config={feedbackEnterConfig} location="sidebar" />,
+    );
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(0);
+    expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+  });
+
+  test('Enter pressed inside a textarea does not trigger Check Answer', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const { container } = render(
+      <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
+    );
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    try {
+      await act(async () => { fireEvent.keyDown(textarea, { key: 'Enter' }); });
+      expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(0);
+      expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  });
+
+  test('Enter stops counting attempts once training attempts are exhausted', async () => {
+    // uiConfig mock sets trainingAttempts: 2
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    render(<ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />);
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(saveIncorrectAnswerSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('Enter on the focused Check Answer button defers to its synthesized click (no double handling)', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const { container } = render(
+      <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
+    );
+    const checkBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Check Answer',
+    )!;
+    // the browser synthesizes a click for Enter on a focused button, so the
+    // global handler must skip the keydown
+    await act(async () => { fireEvent.keyDown(checkBtn, { key: 'Enter' }); });
+    expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+    await act(async () => { fireEvent.click(checkBtn); });
+    expect(saveIncorrectAnswerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('Enter after a correct answer does not re-run feedback', async () => {
+    const { container } = render(
+      <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
+    );
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    const checkBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Check Answer',
+    );
+    expect(checkBtn).toHaveProperty('disabled', true);
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
+    expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/tests/NextButton.spec.tsx
+++ b/src/components/tests/NextButton.spec.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import {
-  render, act, cleanup, screen,
+  render, act, cleanup, screen, fireEvent,
 } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
@@ -244,6 +244,34 @@ describe('NextButton', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
     });
     expect(onNext).toHaveBeenCalled();
+  });
+
+  test('nextOnEnter: Enter inside a textarea does not call onNext', async () => {
+    const onNext = vi.fn();
+    mockStudyConfig = { uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true } };
+    await act(async () => {
+      render(<NextButton checkAnswer={null} onNext={onNext} />);
+    });
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    try {
+      await act(async () => { fireEvent.keyDown(textarea, { key: 'Enter' }); });
+      expect(onNext).not.toHaveBeenCalled();
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  });
+
+  test('nextOnEnter: Enter on a focused button is left to its synthesized click', async () => {
+    const onNext = vi.fn();
+    mockStudyConfig = { uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true } };
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<NextButton checkAnswer={null} onNext={onNext} />));
+    });
+    const button = container.querySelector('button')!;
+    await act(async () => { fireEvent.keyDown(button, { key: 'Enter' }); });
+    expect(onNext).not.toHaveBeenCalled();
   });
 
   test('resets auto-advance state when the current identifier changes', async () => {

--- a/src/components/tests/keyboardUtils.spec.ts
+++ b/src/components/tests/keyboardUtils.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+import { shouldIgnoreEnter } from '../keyboardUtils';
+
+function elementFromHtml(html: string, selector: string): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html;
+  return wrapper.querySelector(selector)!;
+}
+
+describe('shouldIgnoreEnter', () => {
+  test('ignores Enter inside a textarea', () => {
+    expect(shouldIgnoreEnter(document.createElement('textarea'))).toBe(true);
+  });
+
+  test('ignores Enter inside a contenteditable element', () => {
+    const div = elementFromHtml('<div contenteditable="true"></div>', 'div');
+    expect(shouldIgnoreEnter(div)).toBe(true);
+  });
+
+  test('ignores Enter on a focused button (synthesized click handles it)', () => {
+    expect(shouldIgnoreEnter(document.createElement('button'))).toBe(true);
+  });
+
+  test('ignores Enter on an element nested inside a button', () => {
+    const span = elementFromHtml('<button><span>label</span></button>', 'span');
+    expect(shouldIgnoreEnter(span)).toBe(true);
+  });
+
+  test('ignores Enter on a link', () => {
+    expect(shouldIgnoreEnter(document.createElement('a'))).toBe(true);
+  });
+
+  test('does not ignore Enter on a button-styled radio card', () => {
+    const card = elementFromHtml('<button role="radio">option</button>', 'button');
+    expect(shouldIgnoreEnter(card)).toBe(false);
+  });
+
+  test('does not ignore Enter on an element nested inside a button-styled radio card', () => {
+    const label = elementFromHtml('<button role="radio"><span>option</span></button>', 'span');
+    expect(shouldIgnoreEnter(label)).toBe(false);
+  });
+
+  test('does not ignore Enter on a native radio input', () => {
+    const radio = elementFromHtml('<input type="radio" />', 'input');
+    expect(shouldIgnoreEnter(radio)).toBe(false);
+  });
+
+  test('does not ignore Enter on a single-line text input (Enter should still submit)', () => {
+    const input = elementFromHtml('<input type="text" />', 'input');
+    expect(shouldIgnoreEnter(input)).toBe(false);
+  });
+
+  test('does not ignore Enter on the document body', () => {
+    expect(shouldIgnoreEnter(document.body)).toBe(false);
+  });
+
+  test('does not ignore Enter on a non-element target', () => {
+    expect(shouldIgnoreEnter(null)).toBe(false);
+    expect(shouldIgnoreEnter(window)).toBe(false);
+  });
+});

--- a/tests/demo-dynamic.spec.ts
+++ b/tests/demo-dynamic.spec.ts
@@ -62,3 +62,29 @@ test('Test dynamic block', async ({ page }) => {
   }
   await waitForStudyEndMessage(page);
 });
+
+test('nextOnEnter shows Check Answer feedback once in the correct response location', async ({ page }) => {
+  await resetClientStudyState(page);
+  await openStudyFromLanding(page, 'Demo Studies', 'Dynamic Blocks');
+
+  const introText = page.getByText(/sample study.*dynamic blocks/i);
+  await expect(introText).toBeVisible({});
+  await nextClick(page);
+
+  const dynamicBlocks = await page.getByRole('heading', { name: 'Dynamic Blocks' });
+  await expect(dynamicBlocks).toBeVisible({ timeout: 15000 });
+
+  await page.waitForSelector('text=Left square saturation:', { timeout: 3000 });
+  const leftText = await page.locator('text=Left square saturation:').last().textContent() || '';
+  const rightText = await page.locator('text=Right square saturation:').last().textContent() || '';
+  const leftValue = parseInt(leftText.match(/\d+/)![0], 10);
+  const rightValue = parseInt(rightText.match(/\d+/)![0], 10);
+  const choice = (leftValue === rightValue) ? 'Same' : (leftValue > rightValue ? 'Left' : 'Right');
+
+  await page.getByRole('radio', { name: choice }).click();
+  await page.keyboard.press('Enter');
+
+  const feedback = page.getByText('You have answered the question correctly.');
+  await expect(feedback).toHaveCount(1);
+  await expect(page.locator('.responseBlock-belowStimulus').getByText('You have answered the question correctly.')).toHaveCount(1);
+});


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1237 

### Give a longer description of what this PR addresses and why it's needed
Fix check answer message handling Enter

Bug: With nextOnEnter, every mounted ResponseBlock (above/below/sidebar) registered its own Enter handler, so one Enter press showed Check Answer feedback multiple times

### Provide pictures/videos of the behavior before and after these changes (optional)
Before
<img width="2557" height="668" alt="image" src="https://github.com/user-attachments/assets/9b7d5fb9-696e-44f4-8f66-d042967a81bd" />

After
<img width="1542" height="675" alt="Screenshot 2026-07-07 at 9 21 08 PM" src="https://github.com/user-attachments/assets/be43c40e-939f-434f-8163-f231282d53fe" />

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [x] Merge #1294

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [ ] Done
- [x] N/A