### PR TITLE
Save Check Answer progress and fix Enter handling

### DIFF
--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -22,6 +22,7 @@ type Props = {
   config?: IndividualComponent;
   location?: ResponseBlockLocation;
   checkAnswer: JSX.Element | null;
+  onCheckAnswer?: () => void;
   onNext: () => void;
 };
 
@@ -31,6 +32,7 @@ export function NextButton({
   config,
   location,
   checkAnswer,
+  onCheckAnswer,
   onNext,
 }: Props) {
   const { isNextDisabled, goToNextStep } = useNextStep();
@@ -100,7 +102,15 @@ export function NextButton({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' && !shouldIgnoreEnter(event.target) && !disabled && !isNextDisabled && buttonTimerSatisfied) {
+      if (event.key !== 'Enter' || shouldIgnoreEnter(event.target)) {
+        return;
+      }
+
+      if (onCheckAnswer) {
+        onCheckAnswer();
+        return;
+      }
+      if (!disabled && !isNextDisabled && buttonTimerSatisfied) {
         onNext();
       }
     };
@@ -111,7 +121,7 @@ export function NextButton({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [disabled, isNextDisabled, buttonTimerSatisfied, onNext, nextOnEnter]);
+  }, [disabled, isNextDisabled, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter]);
 
   const nextButtonDisabled = disabled || isNextDisabled || !buttonTimerSatisfied;
   const previousButtonText = config?.previousButtonText ?? studyConfig.uiConfig.previousButtonText ?? 'Previous';

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../store/store';
 
 import { NextButton } from '../NextButton';
-import { shouldIgnoreEnter } from '../keyboardUtils';
 import {
   generateInitFields, mergeReactiveAnswers, useAnswerField,
 } from './utils';
@@ -589,24 +588,6 @@ export function ResponseBlock({
     }));
   }, [allResponsesWithDefaults, allowFailedTraining, attemptsUsed, config, hasCorrectAnswerFeedback, hasResponseIssues, hasStimulusIssue, identifier, navigate, revealResponseErrors, revealStimulusErrors, saveIncorrectAnswer, setCheckAnswerResult, storeDispatch, trainingAttempts, trialValidation]);
 
-  const nextOnEnter = config?.nextOnEnter ?? studyConfig.uiConfig.nextOnEnter;
-
-  useEffect(() => {
-    if (nextOnEnter && showBtnsInLocation && hasCorrectAnswerFeedback && !disabledAttempts) {
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Enter' && !shouldIgnoreEnter(event.target)) {
-          checkAnswerProvideFeedback();
-        }
-      };
-
-      window.addEventListener('keydown', handleKeyDown);
-      return () => {
-        window.removeEventListener('keydown', handleKeyDown);
-      };
-    }
-    return undefined;
-  }, [checkAnswerProvideFeedback, nextOnEnter, showBtnsInLocation, hasCorrectAnswerFeedback, disabledAttempts]);
-
   const nextButtonText = useMemo(() => config?.nextButtonText ?? studyConfig.uiConfig.nextButtonText ?? 'Next', [config, studyConfig]);
 
   useEffect(() => {
@@ -750,6 +731,7 @@ export function ResponseBlock({
           config={config}
           location={location}
           onNext={handleNextClick}
+          onCheckAnswer={!isAnalysis && hasCorrectAnswerFeedback && !disabledAttempts ? checkAnswerProvideFeedback : undefined}
           checkAnswer={showBtnsInLocation && hasCorrectAnswerFeedback ? (
             <Button
               disabled={hasCorrectAnswer || (attemptsUsed >= trainingAttempts && trainingAttempts >= 0)}

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -3,7 +3,7 @@ import {
 } from '@mantine/core';
 
 import React, {
-  useEffect, useMemo, useState, useCallback, useRef,
+  useEffect, useMemo, useCallback, useRef,
 } from 'react';
 import isEqual from 'lodash.isequal';
 import { IconAlertTriangle } from '@tabler/icons-react';
@@ -69,7 +69,7 @@ export function ResponseBlock({
 }: Props) {
   const storeDispatch = useStoreDispatch();
   const {
-    updateResponseBlockValidation, saveIncorrectAnswer, setResponseSubmitAttempt, setStimulusSubmitAttempt,
+    updateResponseBlockValidation, saveIncorrectAnswer, setResponseSubmitAttempt, setStimulusSubmitAttempt, setCheckAnswerResult,
   } = useStoreActions();
 
   const currentStep = useCurrentStep();
@@ -155,15 +155,23 @@ export function ResponseBlock({
   const provideFeedback = useMemo(() => config?.provideFeedback ?? studyConfig.uiConfig.provideFeedback, [config, studyConfig]);
   const hasCorrectAnswerFeedback = !!provideFeedback && ((config?.correctAnswer?.length || 0) > 0);
   const allowFailedTraining = useMemo(() => config?.allowFailedTraining ?? studyConfig.uiConfig.allowFailedTraining ?? true, [config, studyConfig]);
-  const [attemptsUsed, setAttemptsUsed] = useState(0);
   const trainingAttempts = useMemo(() => config?.trainingAttempts ?? studyConfig.uiConfig.trainingAttempts ?? 2, [config, studyConfig]);
-  const [enableNextButton, setEnableNextButton] = useState(false);
-  const [hasCorrectAnswer, setHasCorrectAnswer] = useState(false);
   const identifier = useCurrentIdentifier();
   const savedSubmitAttempt = storedAnswerData?.responseSubmitAttempted ?? status?.responseSubmitAttempted ?? false;
   const currentSubmitAttempt = useStoreSelector((state) => state.responseSubmitAttempted[identifier]);
   const liveErrors = currentSubmitAttempt ?? savedSubmitAttempt;
+  const savedCheckAnswer = storedAnswerData?.checkAnswer ?? status?.checkAnswer;
+  const currentCheckAnswer = useStoreSelector((state) => state.checkAnswer[identifier]);
+  const storeAnswers = useStoreSelector((state) => state.answers);
+  const attemptsUsed = currentCheckAnswer?.attemptsUsed ?? 0;
+  const hasCorrectAnswer = currentCheckAnswer?.correct ?? false;
+  const checkAnswerResponses = currentCheckAnswer?.responses;
   const usedAllAttempts = attemptsUsed >= trainingAttempts && trainingAttempts >= 0;
+  // Enable next button if there is correct answer feedback, at least one attempt has been used, and either failed training is allowed and the participant has used all attempts, or the participant has answered correctly within the allowed attempts
+  const enableNextButton = hasCorrectAnswerFeedback && attemptsUsed > 0 && (
+    (allowFailedTraining && attemptsUsed >= trainingAttempts)
+    || (hasCorrectAnswer && attemptsUsed <= trainingAttempts)
+  );
   const bypassValidationForFailedTraining = hasCorrectAnswerFeedback && allowFailedTraining && usedAllAttempts;
   const disabledAttempts = usedAllAttempts || hasCorrectAnswer;
   const showBtnsInLocation = useMemo(() => location === (config?.nextButtonLocation ?? studyConfig.uiConfig.nextButtonLocation ?? 'belowStimulus'), [config, studyConfig, location]);
@@ -474,23 +482,49 @@ export function ResponseBlock({
       }),
     );
   }, [actions, answerValidator, bypassValidationForFailedTraining, identifier, isAnalysis, liveErrors, location, storeDispatch, trrack, updateResponseBlockValidation]);
-  const [alertConfig, setAlertConfig] = useState(Object.fromEntries(allResponsesWithDefaults.map((response) => ([response.id, {
-    visible: false,
-    title: 'Correct Answer',
-    message: 'The correct answer is: ',
-    color: 'green',
-  }]))));
-  const updateAlertConfig = (id: string, visible: boolean, title: string, message: string, color: string) => {
-    setAlertConfig((conf) => ({
-      ...conf,
-      [id]: {
-        visible,
-        title,
-        message,
-        color,
-      },
-    }));
-  };
+  const alertConfig = useMemo(() => Object.fromEntries(allResponsesWithDefaults.map((response) => {
+    const hiddenAlert = {
+      visible: false,
+      title: 'Correct Answer',
+      message: 'The correct answer is: ',
+      color: 'green',
+    };
+    if (!hasCorrectAnswerFeedback || !checkAnswerResponses || !Object.hasOwn(checkAnswerResponses, response.id) || response.type === 'textOnly' || response.type === 'divider') {
+      return [response.id, hiddenAlert];
+    }
+    if (checkAnswerResponses[response.id]) {
+      return [response.id, {
+        visible: true, title: 'Correct Answer', message: 'You have answered the question correctly.', color: 'green',
+      }];
+    }
+    let message = '';
+    // -1 gives unlimited attempts
+    if (trainingAttempts === -1) {
+      message = 'Please try again.';
+    } else if (attemptsUsed >= trainingAttempts) {
+      message = `You didn't answer this question correctly after ${trainingAttempts} attempts. ${allowFailedTraining ? 'You can continue to the next question.' : 'Unfortunately you have not met the criteria for continuing this study.'}`;
+    } else if (trainingAttempts - attemptsUsed === 1) {
+      message = 'Please try again. You have 1 attempt left.';
+    } else {
+      message = `Please try again. You have ${trainingAttempts - attemptsUsed} attempts left.`;
+    }
+    if (response.type === 'checkbox') {
+      const correct = config?.correctAnswer?.find((answer) => answer.id === response.id)?.answer;
+      const incorrectValues = storeAnswers[identifier]?.incorrectAnswers?.[response.id]?.value;
+      const lastIncorrect = incorrectValues?.[incorrectValues.length - 1];
+      if (Array.isArray(correct)) {
+        const suppliedAnswer = Array.isArray(lastIncorrect) ? lastIncorrect as string[] : [];
+        const matches = findMatchingStrings(suppliedAnswer, correct);
+
+        const tooManySelected = correct.length === matches.length && suppliedAnswer.length > correct.length ? 'However, you have selected too many boxes. ' : '';
+
+        message = `You have successfully checked ${matches.length}/${correct.length} correct boxes. ${tooManySelected}${message}`;
+      }
+    }
+    return [response.id, {
+      visible: true, title: 'Incorrect Answer', message, color: 'red',
+    }];
+  })), [allResponsesWithDefaults, allowFailedTraining, attemptsUsed, checkAnswerResponses, config, hasCorrectAnswerFeedback, identifier, storeAnswers, trainingAttempts]);
   const checkAnswerProvideFeedback = useCallback(() => {
     if (hasStimulusIssue) {
       revealStimulusErrors();
@@ -503,7 +537,6 @@ export function ResponseBlock({
     }
 
     const newAttemptsUsed = attemptsUsed + 1;
-    setAttemptsUsed(newAttemptsUsed);
 
     const trialValidationCopy = structuredClone(trialValidation[identifier]);
     const allAnswers = (trialValidationCopy ? Object.values(trialValidationCopy).reduce((acc, curr) => {
@@ -527,6 +560,7 @@ export function ResponseBlock({
         )];
       }),
     );
+    const allCorrect = Object.values(correctAnswers).every((isCorrect) => isCorrect);
 
     if (hasCorrectAnswerFeedback) {
       (config?.correctAnswer ?? []).forEach((configCorrectAnswer) => {
@@ -534,52 +568,26 @@ export function ResponseBlock({
         if (!response || response.type === 'textOnly' || response.type === 'divider') {
           return;
         }
-        if (correctAnswers[response.id] && !alertConfig[response.id]?.message.includes('You\'ve failed to answer this question correctly')) {
-          updateAlertConfig(response.id, true, 'Correct Answer', 'You have answered the question correctly.', 'green');
-        } else {
+        if (!correctAnswers[response.id]) {
           storeDispatch(saveIncorrectAnswer({ question: identifier, identifier: response.id, answer: allAnswers[response.id] }));
-          let message = '';
-          if (trainingAttempts === -1) {
-            message = 'Please try again.';
-          } else if (newAttemptsUsed >= trainingAttempts) {
-            message = `You didn't answer this question correctly after ${trainingAttempts} attempts. ${allowFailedTraining ? 'You can continue to the next question.' : 'Unfortunately you have not met the criteria for continuing this study.'}`;
-
-            // If the user has failed the training, wait 5 seconds and redirect to a fail page
-            if (!allowFailedTraining) {
-              setTimeout(() => {
-                navigate(`./../__trainingFailed${window.location.search}`);
-              }, 5000);
-            }
-          } else if (trainingAttempts - newAttemptsUsed === 1) {
-            message = 'Please try again. You have 1 attempt left.';
-          } else {
-            message = `Please try again. You have ${trainingAttempts - newAttemptsUsed} attempts left.`;
-          }
-          if (response.type === 'checkbox') {
-            const correct = config?.correctAnswer?.find((answer) => answer.id === response.id)?.answer;
-
-            const suppliedAnswer = allAnswers[response.id] as string[];
-            const matches = findMatchingStrings(suppliedAnswer, correct);
-
-            const tooManySelected = correct.length === matches.length && suppliedAnswer.length > correct.length ? 'However, you have selected too many boxes. ' : '';
-
-            message = `You have successfully checked ${matches.length}/${correct.length} correct boxes. ${tooManySelected}${message}`;
-          }
-          updateAlertConfig(response.id, true, 'Incorrect Answer', message, 'red');
         }
       });
 
-      setHasCorrectAnswer(Object.values(correctAnswers).every((isCorrect) => isCorrect));
-      setEnableNextButton(
-        (
-          allowFailedTraining && newAttemptsUsed >= trainingAttempts
-        ) || (
-          Object.values(correctAnswers).every((isCorrect) => isCorrect)
-          && newAttemptsUsed <= trainingAttempts
-        ),
-      );
+      // If the user has failed the training, wait 5 seconds and redirect to a fail page
+      if (!allCorrect && trainingAttempts >= 0 && newAttemptsUsed >= trainingAttempts && !allowFailedTraining) {
+        setTimeout(() => {
+          navigate(`./../__trainingFailed${window.location.search}`);
+        }, 5000);
+      }
     }
-  }, [alertConfig, allResponsesWithDefaults, allowFailedTraining, attemptsUsed, config, hasCorrectAnswerFeedback, hasResponseIssues, hasStimulusIssue, identifier, navigate, revealResponseErrors, revealStimulusErrors, saveIncorrectAnswer, storeDispatch, trainingAttempts, trialValidation]);
+
+    storeDispatch(setCheckAnswerResult({
+      identifier,
+      attemptsUsed: newAttemptsUsed,
+      correct: allCorrect,
+      responses: correctAnswers,
+    }));
+  }, [allResponsesWithDefaults, allowFailedTraining, attemptsUsed, config, hasCorrectAnswerFeedback, hasResponseIssues, hasStimulusIssue, identifier, navigate, revealResponseErrors, revealStimulusErrors, saveIncorrectAnswer, setCheckAnswerResult, storeDispatch, trainingAttempts, trialValidation]);
 
   const nextOnEnter = config?.nextOnEnter ?? studyConfig.uiConfig.nextOnEnter;
 
@@ -608,6 +616,15 @@ export function ResponseBlock({
 
     storeDispatch(setResponseSubmitAttempt({ identifier, attempted: savedSubmitAttempt }));
   }, [currentSubmitAttempt, identifier, isAnalysis, savedSubmitAttempt, setResponseSubmitAttempt, storeDispatch]);
+
+  useEffect(() => {
+    // If in analysis or does not have a saved check answer, do not set the check answer result
+    if (isAnalysis || currentCheckAnswer !== undefined || savedCheckAnswer === undefined) {
+      return;
+    }
+
+    storeDispatch(setCheckAnswerResult({ identifier, ...savedCheckAnswer }));
+  }, [currentCheckAnswer, identifier, isAnalysis, savedCheckAnswer, setCheckAnswerResult, storeDispatch]);
 
   const handleNextClick = useCallback(() => {
     if (hasStimulusIssue) {
@@ -695,16 +712,7 @@ export function ResponseBlock({
                     />
                   </div>
                 )
-              ) : (
-                <FeedbackAlert
-                  response={response}
-                  correctAnswer={correctAnswer}
-                  alertConfig={alertConfig}
-                  identifier={identifier}
-                  attemptsUsed={attemptsUsed}
-                  trainingAttempts={trainingAttempts}
-                />
-              )}
+              ) : null}
             </React.Fragment>
           );
         })}

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -33,7 +33,7 @@ import { shouldUseStimulusValidation } from './stimulusErrors';
 import { ResponseSwitcher } from './ResponseSwitcher';
 import { FeedbackAlert } from './FeedbackAlert';
 import {
-  CustomResponseField, FormElementProvenance, StoredAnswer, ValidationStatus,
+  CustomResponseField, FormElementProvenance, StoredAnswer,
 } from '../../store/types';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import { useStoredAnswer } from '../../store/hooks/useStoredAnswer';
@@ -42,6 +42,9 @@ import { useIsAnalysis } from '../../store/hooks/useIsAnalysis';
 import { responseAnswerIsCorrect } from '../../utils/correctAnswer';
 import { getCustomResponseModule, getCustomResponseModuleLoadError } from './customResponseModules';
 import { appendStimulusShowErrorsToGraph } from './stimulusProvenance';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
+import { showNotification } from '../../utils/notifications';
+import { getAnswersFromAllLocations } from '../../utils/getAnswersFromAllLocations';
 
 type Props = {
   status?: StoredAnswer;
@@ -68,7 +71,7 @@ export function ResponseBlock({
 }: Props) {
   const storeDispatch = useStoreDispatch();
   const {
-    updateResponseBlockValidation, saveIncorrectAnswer, setResponseSubmitAttempt, setStimulusSubmitAttempt, setCheckAnswerResult,
+    updateResponseBlockValidation, saveIncorrectAnswer, saveTrialAnswer, setResponseSubmitAttempt, setStimulusSubmitAttempt, setCheckAnswerResult,
   } = useStoreActions();
 
   const currentStep = useCurrentStep();
@@ -162,6 +165,8 @@ export function ResponseBlock({
   const savedCheckAnswer = storedAnswerData?.checkAnswer ?? status?.checkAnswer;
   const currentCheckAnswer = useStoreSelector((state) => state.checkAnswer[identifier]);
   const storeAnswers = useStoreSelector((state) => state.answers);
+  const dataCollectionEnabled = useStoreSelector((state) => state.modes.dataCollectionEnabled);
+  const { storageEngine } = useStorageEngine();
   const attemptsUsed = currentCheckAnswer?.attemptsUsed ?? 0;
   const hasCorrectAnswer = currentCheckAnswer?.correct ?? false;
   const checkAnswerResponses = currentCheckAnswer?.responses;
@@ -235,19 +240,7 @@ export function ResponseBlock({
     ),
     [customResponseModules],
   );
-  const combinedLiveValues = useMemo(() => {
-    const validationForStep = trialValidation[identifier];
-    if (!validationForStep) {
-      return {};
-    }
-
-    return Object.values(validationForStep).reduce((acc, curr) => {
-      if (Object.hasOwn(curr, 'values')) {
-        return { ...acc, ...(curr as ValidationStatus).values };
-      }
-      return acc;
-    }, {}) as StoredAnswer['answer'];
-  }, [identifier, trialValidation]);
+  const combinedLiveValues = useMemo(() => getAnswersFromAllLocations(trialValidation[identifier]), [identifier, trialValidation]);
   const combinedAnalysisValues = useMemo(
     () => ['aboveStimulus', 'belowStimulus', 'sidebar'].reduce((acc, responseLocation) => {
       const locationProv = analysisProvState[responseLocation as ResponseBlockLocation] as FormElementProvenance | undefined;
@@ -534,13 +527,7 @@ export function ResponseBlock({
 
     const newAttemptsUsed = attemptsUsed + 1;
 
-    const trialValidationCopy = structuredClone(trialValidation[identifier]);
-    const allAnswers = (trialValidationCopy ? Object.values(trialValidationCopy).reduce((acc, curr) => {
-      if (Object.hasOwn(curr, 'values')) {
-        return { ...acc, ...(curr as ValidationStatus).values };
-      }
-      return acc;
-    }, {}) : {}) as StoredAnswer['answer'];
+    const allAnswers = getAnswersFromAllLocations(trialValidation[identifier]);
 
     const correctAnswers = Object.fromEntries(
       (config?.correctAnswer ?? []).map((configCorrectAnswer) => {
@@ -568,13 +555,6 @@ export function ResponseBlock({
           storeDispatch(saveIncorrectAnswer({ question: identifier, identifier: response.id, answer: allAnswers[response.id] }));
         }
       });
-
-      // If the user has failed the training, wait 5 seconds and redirect to a fail page
-      if (!allCorrect && trainingAttempts >= 0 && newAttemptsUsed >= trainingAttempts && !allowFailedTraining) {
-        setTimeout(() => {
-          navigate(`./../__trainingFailed${window.location.search}`);
-        }, 5000);
-      }
     }
 
     storeDispatch(setCheckAnswerResult({
@@ -583,7 +563,7 @@ export function ResponseBlock({
       correct: allCorrect,
       responses: correctAnswers,
     }));
-  }, [allResponsesWithDefaults, allowFailedTraining, attemptsUsed, config, hasCorrectAnswerFeedback, hasResponseIssues, hasStimulusIssue, identifier, navigate, revealResponseErrors, revealStimulusErrors, saveIncorrectAnswer, setCheckAnswerResult, storeDispatch, trainingAttempts, trialValidation]);
+  }, [allResponsesWithDefaults, attemptsUsed, config, hasCorrectAnswerFeedback, hasResponseIssues, hasStimulusIssue, identifier, revealResponseErrors, revealStimulusErrors, saveIncorrectAnswer, setCheckAnswerResult, storeDispatch, trialValidation]);
 
   const nextButtonText = useMemo(() => config?.nextButtonText ?? studyConfig.uiConfig.nextButtonText ?? 'Next', [config, studyConfig]);
 
@@ -603,6 +583,49 @@ export function ResponseBlock({
 
     storeDispatch(setCheckAnswerResult({ identifier, ...savedCheckAnswer }));
   }, [currentCheckAnswer, identifier, isAnalysis, savedCheckAnswer, setCheckAnswerResult, storeDispatch]);
+
+  useEffect(() => {
+    // Do not save the check answer result if in analysis, if the buttons are not shown in this location, if there is no current check answer, or if the current check answer has the same number of attempts used as the stored answer
+    if (isAnalysis || !showBtnsInLocation || currentCheckAnswer === undefined || currentCheckAnswer.attemptsUsed === storeAnswers[identifier]?.checkAnswer?.attemptsUsed) {
+      return;
+    }
+
+    const draftAnswer = {
+      ...storeAnswers[identifier],
+      answer: getAnswersFromAllLocations(trialValidation[identifier]),
+      checkAnswer: currentCheckAnswer,
+    };
+
+    storeDispatch(saveTrialAnswer(draftAnswer));
+
+    if (dataCollectionEnabled && storageEngine) {
+      storageEngine.saveAnswers({
+        ...storeAnswers,
+        [identifier]: draftAnswer,
+      }).catch((error) => {
+        console.error('Failed to save Check Answer progress', error);
+        showNotification({
+          title: 'Failed to Save Response',
+          message: 'Your response could not be saved. Please check your connection and try again.',
+          color: 'red',
+        });
+      });
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentCheckAnswer, dataCollectionEnabled, identifier, isAnalysis, saveTrialAnswer, showBtnsInLocation, storageEngine, storeAnswers, storeDispatch]);
+
+  // If the user has failed the training, wait 5 seconds and redirect to a fail page
+  useEffect(() => {
+    if (isAnalysis || !showBtnsInLocation || currentCheckAnswer === undefined || hasCorrectAnswer || allowFailedTraining || !usedAllAttempts) {
+      return undefined;
+    }
+
+    const timer = setTimeout(() => {
+      navigate(`./../__trainingFailed${window.location.search}`);
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [allowFailedTraining, currentCheckAnswer, hasCorrectAnswer, isAnalysis, navigate, showBtnsInLocation, usedAllAttempts]);
 
   const handleNextClick = useCallback(() => {
     if (hasStimulusIssue) {
@@ -646,6 +669,7 @@ export function ResponseBlock({
                   <div data-question-id={response.id}>
                     <ResponseSwitcher
                       storedAnswer={storedAnswer}
+                      answerFinalized={!!status && status.endTime !== -1}
                       form={{
                         ...answerValidator.getInputProps(response.id),
                       }}

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -166,11 +166,8 @@ export function ResponseBlock({
   const hasCorrectAnswer = currentCheckAnswer?.correct ?? false;
   const checkAnswerResponses = currentCheckAnswer?.responses;
   const usedAllAttempts = attemptsUsed >= trainingAttempts && trainingAttempts >= 0;
-  // Enable next button if there is correct answer feedback, at least one attempt has been used, and either failed training is allowed and the participant has used all attempts, or the participant has answered correctly within the allowed attempts
-  const enableNextButton = hasCorrectAnswerFeedback && attemptsUsed > 0 && (
-    (allowFailedTraining && attemptsUsed >= trainingAttempts)
-    || (hasCorrectAnswer && attemptsUsed <= trainingAttempts)
-  );
+  // Unlock Next after a correct answer, or once attempts run out if failed training is allowed. usedAllAttempts excludes -1, so unlimited attempts require a correct answer
+  const enableNextButton = hasCorrectAnswerFeedback && attemptsUsed > 0 && (hasCorrectAnswer || (allowFailedTraining && usedAllAttempts));
   const bypassValidationForFailedTraining = hasCorrectAnswerFeedback && allowFailedTraining && usedAllAttempts;
   const disabledAttempts = usedAllAttempts || hasCorrectAnswer;
   const showBtnsInLocation = useMemo(() => location === (config?.nextButtonLocation ?? studyConfig.uiConfig.nextButtonLocation ?? 'belowStimulus'), [config, studyConfig, location]);
@@ -734,7 +731,7 @@ export function ResponseBlock({
           onCheckAnswer={!isAnalysis && hasCorrectAnswerFeedback && !disabledAttempts ? checkAnswerProvideFeedback : undefined}
           checkAnswer={showBtnsInLocation && hasCorrectAnswerFeedback ? (
             <Button
-              disabled={hasCorrectAnswer || (attemptsUsed >= trainingAttempts && trainingAttempts >= 0)}
+              disabled={disabledAttempts}
               onClick={() => checkAnswerProvideFeedback()}
               px={location === 'sidebar' ? 8 : undefined}
             >

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -41,6 +41,7 @@ export function ResponseSwitcher({
   response,
   form,
   storedAnswer,
+  answerFinalized,
   index,
   config,
   dontKnowCheckbox,
@@ -53,6 +54,7 @@ export function ResponseSwitcher({
   response: Response;
   form: GetInputPropsReturnType;
   storedAnswer?: StoredAnswer['answer'];
+  answerFinalized?: boolean;
   index: number;
   config: IndividualComponent;
   dontKnowCheckbox?: GetInputPropsReturnType;
@@ -74,14 +76,16 @@ export function ResponseSwitcher({
   const completed = useStoreSelector((state) => state.completed);
   const usesStandaloneDontKnow = usesStandaloneDontKnowField(response);
 
+  const finalStoredAnswer = isAnalysis || answerFinalized || completed ? storedAnswer : undefined;
+
   // Don't update if we're in analysis mode
-  const ans = useMemo(() => (isAnalysis || (Object.keys(storedAnswer || {}).length > 0 && !nextConfig?.previousButton) || completed ? { value: storedAnswer![response.id], readOnly: true } : form) || { value: undefined }, [isAnalysis, storedAnswer, response.id, form, nextConfig?.previousButton, completed]);
+  const ans = useMemo(() => (isAnalysis || (Object.keys(finalStoredAnswer || {}).length > 0 && !nextConfig?.previousButton) || completed ? { value: finalStoredAnswer![response.id], readOnly: true } : form) || { value: undefined }, [isAnalysis, finalStoredAnswer, response.id, form, nextConfig?.previousButton, completed]);
   const dontKnowValue = usesStandaloneDontKnow
-    ? ((Object.keys(storedAnswer || {}).length > 0 ? { checked: storedAnswer![`${response.id}-dontKnow`] } : dontKnowCheckbox) || { checked: undefined })
+    ? ((Object.keys(finalStoredAnswer || {}).length > 0 ? { checked: finalStoredAnswer![`${response.id}-dontKnow`] } : dontKnowCheckbox) || { checked: undefined })
     : { checked: undefined };
   const dontKnowChecked = !!dontKnowValue.checked;
-  const otherValue = (Object.keys(storedAnswer || {}).length > 0 ? { value: storedAnswer![`${response.id}-other`] } : otherInput) || { value: undefined };
-  const inputDisabled = !!(Object.keys(storedAnswer || {}).length > 0 || disabled || completed);
+  const otherValue = (Object.keys(finalStoredAnswer || {}).length > 0 ? { value: finalStoredAnswer![`${response.id}-other`] } : otherInput) || { value: undefined };
+  const inputDisabled = !!(Object.keys(finalStoredAnswer || {}).length > 0 || disabled || completed);
 
   const [searchParams] = useSearchParams();
 

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Provider } from 'react-redux';
 import {
   render, act, fireEvent, cleanup,
 } from '@testing-library/react';
@@ -6,22 +7,28 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
-import type { IndividualComponent } from '../../../parser/types';
+import type { IndividualComponent, StudyConfig } from '../../../parser/types';
+import type { CheckAnswerState, Sequence } from '../../../store/types';
+import type { REVISIT_MODE } from '../../../storage/engines/types';
+import { studyStoreCreator, StudyStoreContext } from '../../../store/store';
 import { ResponseBlock } from '../ResponseBlock';
 import { makeStoredAnswer } from '../../../tests/utils';
 import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
 
 // ── mocks ────────────────────────────────────────────────────────────────────
 
-const { saveIncorrectAnswerSpy, mockStoreState } = vi.hoisted(() => ({
-  saveIncorrectAnswerSpy: vi.fn((v: unknown) => v),
-  mockStoreState: {
-    responseSubmitAttempted: { trial1_0: false } as Record<string, boolean>,
+const { mockStoredAnswerData } = vi.hoisted(() => ({
+  mockStoredAnswerData: {
+    formOrder: { response: ['q1'] },
+    questionOrders: {},
+    optionOrders: {},
+    responseSubmitAttempted: undefined as boolean | undefined,
+    checkAnswer: undefined as { attemptsUsed: number; correct: boolean; responses: Record<string, boolean> } | undefined,
   },
 }));
 
 vi.mock('@mantine/core', () => ({
-  Box: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Box: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
   Button: ({ children, disabled, onClick }: { children?: ReactNode; disabled?: boolean; onClick?: () => void }) => (
     <button type="button" disabled={disabled} onClick={onClick}>{children}</button>
   ),
@@ -48,30 +55,14 @@ vi.mock('@trrack/core', () => ({
 
 vi.mock('lodash.isequal', () => ({ default: vi.fn(() => true) }));
 
-vi.mock('../../../store/store', () => ({
-  useFlatSequence: vi.fn(() => [{ id: 'trial1', component: 'trial1' }]),
-  useStoreDispatch: vi.fn(() => vi.fn()),
-  useStoreActions: vi.fn(() => ({
-    updateResponseBlockValidation: vi.fn((v: unknown) => v),
-    saveIncorrectAnswer: saveIncorrectAnswerSpy,
-    setResponseSubmitAttempt: vi.fn((v: unknown) => v),
-    setStimulusSubmitAttempt: vi.fn((v: unknown) => v),
-  })),
-  useStoreSelector: vi.fn((selector: (s: Record<string, unknown>) => unknown) => selector({
-    answers: {},
-    analysisProvState: {},
-    clickedPrevious: false,
-    modes: { dataCollectionEnabled: true },
-    reactiveAnswers: {},
-    matrixAnswers: {},
-    rankingAnswers: {},
-    responseSubmitAttempted: mockStoreState.responseSubmitAttempted,
-    sequence: {
-      order: 'fixed', orderPath: '', components: [], skip: [],
-    },
-    trialValidation: { trial1_0: {} },
-    completed: false,
-  })),
+vi.mock('../../../utils/handleComponentInheritance', () => ({
+  studyComponentToIndividualComponent: () => ({ response: [], correctAnswer: [] }),
+}));
+
+vi.mock('../../../utils/handleResponseRandomization', () => ({
+  randomizeOptions: vi.fn(() => ({})),
+  randomizeQuestionOrder: vi.fn(() => ({})),
+  randomizeForm: vi.fn(() => []),
 }));
 
 vi.mock('../../../store/hooks/useStudyConfig', () => ({
@@ -89,11 +80,7 @@ vi.mock('../../../store/hooks/useStudyConfig', () => ({
 }));
 
 vi.mock('../../../store/hooks/useStoredAnswer', () => ({
-  useStoredAnswer: vi.fn(() => ({
-    formOrder: { response: ['q1'] },
-    questionOrders: {},
-    optionOrders: {},
-  })),
+  useStoredAnswer: vi.fn(() => mockStoredAnswerData),
 }));
 
 vi.mock('../../../store/hooks/useWindowEvents', () => ({
@@ -106,19 +93,22 @@ vi.mock('../../../routes/utils', () => ({
   useStudyId: vi.fn(() => 'test-study'),
 }));
 
-vi.mock('../utils', () => ({
-  generateInitFields: vi.fn(() => ({})),
-  mergeReactiveAnswers: vi.fn((_: unknown, values: unknown) => values),
-  useAnswerField: vi.fn(() => ({
+vi.mock('../utils', () => {
+  const answerField = {
     values: {},
     isValid: vi.fn(() => true),
     setValues: vi.fn(),
     setInitialValues: vi.fn(),
     reset: vi.fn(),
     getInputProps: vi.fn(() => ({ value: '', onChange: vi.fn() })),
-  })),
-  usesStandaloneDontKnowField: vi.fn(() => false),
-}));
+  };
+  return {
+    generateInitFields: vi.fn(() => ({})),
+    mergeReactiveAnswers: vi.fn((_: unknown, values: unknown) => values),
+    useAnswerField: vi.fn(() => answerField),
+    usesStandaloneDontKnowField: vi.fn(() => false),
+  };
+});
 
 vi.mock('../../../utils/correctAnswer', () => ({
   responseAnswerIsCorrect: vi.fn(() => true),
@@ -139,8 +129,8 @@ vi.mock('../ResponseSwitcher', () => ({
 }));
 
 vi.mock('../FeedbackAlert', () => ({
-  FeedbackAlert: ({ response, alertConfig }: { response: { id: string }; alertConfig: Record<string, { visible: boolean }> }) => (
-    alertConfig[response.id]?.visible ? <div data-testid={`feedback-alert-${response.id}`} /> : null
+  FeedbackAlert: ({ response, alertConfig }: { response: { id: string }; alertConfig: Record<string, { visible: boolean; title: string }> }) => (
+    alertConfig[response.id]?.visible ? <div data-testid={`feedback-alert-${response.id}`} data-title={alertConfig[response.id].title} /> : null
   ),
 }));
 
@@ -153,7 +143,7 @@ vi.mock('../../NextButton', () => ({
   ),
 }));
 
-// ── fixture ───────────────────────────────────────────────────────────────────
+// ── fixtures ──────────────────────────────────────────────────────────────────
 
 const baseConfig: IndividualComponent = {
   type: 'questionnaire',
@@ -164,47 +154,120 @@ const baseConfig: IndividualComponent = {
   ],
 };
 
-// ── ResponseBlock ─────────────────────────────────────────────────────────────
+const storeConfig: StudyConfig = {
+  $schema: '',
+  studyMetadata: {
+    title: 'Test',
+    version: '1.0',
+    authors: [],
+    date: '2024-01-01',
+    description: '',
+    organizations: [],
+  },
+  uiConfig: {
+    contactEmail: 'test@test.com',
+    logoPath: '',
+    withProgressBar: false,
+    withSidebar: false,
+    sidebarWidth: 0,
+    studyEndMsg: '',
+    windowEventDebounceTime: 100,
+    showTitleBar: false,
+  },
+  components: {
+    trial1: { type: 'markdown', path: 'trial1.md', response: [] },
+  },
+  sequence: {
+    order: 'fixed',
+    components: ['trial1'],
+  },
+};
+
+const storeSequence: Sequence = {
+  id: 'root',
+  orderPath: 'root',
+  order: 'fixed',
+  components: ['trial1'],
+  skip: [],
+};
+
+const modes: Record<REVISIT_MODE, boolean> = {
+  dataCollectionEnabled: true,
+  developmentModeEnabled: false,
+  dataSharingEnabled: false,
+};
+
+const metadata = {
+  userAgent: 'test-agent',
+  resolution: { width: 1920, height: 1080 },
+  language: 'en',
+  ip: null,
+};
+
+type StudyStore = Awaited<ReturnType<typeof studyStoreCreator>>;
+
+async function makeStudyStore(): Promise<StudyStore> {
+  return studyStoreCreator('test-study', storeConfig, storeSequence, metadata, {}, modes, 'p1', false, false);
+}
+
+function withStore(studyStore: StudyStore, ui: ReactNode) {
+  return (
+    <Provider store={studyStore.store}>
+      <StudyStoreContext.Provider value={studyStore}>{ui}</StudyStoreContext.Provider>
+    </Provider>
+  );
+}
+
+async function renderWithStore(ui: ReactNode) {
+  const studyStore = await makeStudyStore();
+  const utils = render(withStore(studyStore, ui));
+  return { ...utils, studyStore, store: studyStore.store };
+}
+
+function incorrectCount(store: StudyStore['store']) {
+  return store.getState().answers.trial1_0?.incorrectAnswers?.q1?.value.length ?? 0;
+}
+
+// ── setup ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  saveIncorrectAnswerSpy.mockClear();
   vi.mocked(responseAnswerIsCorrect).mockReturnValue(true);
-  mockStoreState.responseSubmitAttempted = { trial1_0: false };
+  mockStoredAnswerData.formOrder = { response: ['q1'] };
+  mockStoredAnswerData.responseSubmitAttempted = undefined;
+  mockStoredAnswerData.checkAnswer = undefined;
 });
 
 // Unmount between tests so window keydown listeners from prior renders don't leak
 afterEach(() => cleanup());
 
+// ── ResponseBlock ─────────────────────────────────────────────────────────────
+
 describe('ResponseBlock', () => {
-  test('renders without error', () => {
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={baseConfig} location="belowStimulus" />,
-    );
+  test('renders without error', async () => {
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
     expect(html).toContain('<div');
   });
 
-  test('renders ResponseSwitcher for response at matching location', () => {
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={baseConfig} location="belowStimulus" />,
-    );
+  test('renders ResponseSwitcher for response at matching location', async () => {
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
     expect(html).toContain('switcher-shortText');
   });
 
-  test('shows NextButton when location matches nextButtonLocation', () => {
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={baseConfig} location="belowStimulus" />,
-    );
+  test('shows NextButton when location matches nextButtonLocation', async () => {
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
     expect(html).toContain('Next');
   });
 
-  test('omits NextButton when location does not match nextButtonLocation', () => {
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={baseConfig} location="sidebar" />,
-    );
+  test('omits NextButton when location does not match nextButtonLocation', async () => {
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="sidebar" />));
     expect(html).not.toContain('Next');
   });
 
-  test('skips ResponseSwitcher when response is hidden', () => {
+  test('skips ResponseSwitcher when response is hidden', async () => {
     const hiddenConfig = {
       ...baseConfig,
       response: [
@@ -213,57 +276,52 @@ describe('ResponseBlock', () => {
         },
       ],
     } as IndividualComponent;
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={hiddenConfig} location="belowStimulus" />,
-    );
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={hiddenConfig} location="belowStimulus" />));
     expect(html).not.toContain('switcher-shortText');
   });
 
-  test('renders with provided style prop without error', () => {
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={baseConfig} location="belowStimulus" style={{ color: 'red' }} />,
-    );
+  test('renders with provided style prop without error', async () => {
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" style={{ color: 'red' }} />));
     expect(html).toContain('switcher-shortText');
   });
 
-  test('uses custom nextButtonText from config', () => {
+  test('uses custom nextButtonText from config', async () => {
     const configWithText = {
       ...baseConfig,
       nextButtonText: 'Submit',
     } as IndividualComponent;
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={configWithText} location="belowStimulus" />,
-    );
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={configWithText} location="belowStimulus" />));
     expect(html).toContain('Submit');
   });
 
-  test('renders Check Answer button when provideFeedback and correctAnswer exist', () => {
+  test('renders Check Answer button when provideFeedback and correctAnswer exist', async () => {
     const configWithFeedback = {
       ...baseConfig,
       provideFeedback: true,
       correctAnswer: [{ id: 'q1', answer: 'correct' }],
     } as IndividualComponent;
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={configWithFeedback} location="belowStimulus" />,
-    );
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={configWithFeedback} location="belowStimulus" />));
     expect(html).toContain('Check Answer');
   });
 
-  test('does not add required=true for textOnly responses', () => {
+  test('does not add required=true for textOnly responses', async () => {
     const textOnlyConfig = {
       type: 'questionnaire',
       response: [{ type: 'textOnly', id: 'q1', prompt: 'Read this.' }],
     } as IndividualComponent;
-    const html = renderToStaticMarkup(
-      <ResponseBlock config={textOnlyConfig} location="belowStimulus" />,
-    );
+    const studyStore = await makeStudyStore();
+    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={textOnlyConfig} location="belowStimulus" />));
     expect(html).toContain('switcher-textOnly');
   });
 
-  test('initialises from status.answer when status prop is provided', () => {
+  test('initialises from status.answer when status prop is provided', async () => {
     const status = makeStoredAnswer({ answer: { q1: 'hello' } });
     // render (not SSR) so useEffect fires and reads status.answer
-    const { container } = render(
+    const { container } = await renderWithStore(
       <ResponseBlock config={baseConfig} location="belowStimulus" status={status} />,
     );
     expect(container.querySelector('div')).toBeTruthy();
@@ -275,7 +333,7 @@ describe('ResponseBlock', () => {
       provideFeedback: true,
       correctAnswer: [{ id: 'q1', answer: 'correct' }],
     } as IndividualComponent;
-    const { container } = render(
+    const { container } = await renderWithStore(
       <ResponseBlock config={configWithFeedback} location="belowStimulus" />,
     );
     const checkBtn = Array.from(container.querySelectorAll('button')).find(
@@ -293,7 +351,7 @@ describe('ResponseBlock', () => {
       provideFeedback: true,
       correctAnswer: [{ id: 'q1', answer: 'correct' }],
     } as IndividualComponent;
-    render(<ResponseBlock config={configWithEnter} location="belowStimulus" />);
+    await renderWithStore(<ResponseBlock config={configWithEnter} location="belowStimulus" />);
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     // Verifies the listener registered without throwing
   });
@@ -317,8 +375,8 @@ describe('ResponseBlock focus recovery', () => {
     window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   });
 
-  test('revealing unanswered errors scrolls to and focuses the first unresolved question', () => {
-    mockStoreState.responseSubmitAttempted = { trial1_0: true };
+  test('revealing unanswered errors scrolls to and focuses the first unresolved question', async () => {
+    mockStoredAnswerData.responseSubmitAttempted = true;
     const requiredConfig = {
       type: 'questionnaire',
       response: [
@@ -327,7 +385,7 @@ describe('ResponseBlock focus recovery', () => {
         },
       ],
     } as IndividualComponent;
-    const { container } = render(
+    const { container } = await renderWithStore(
       <ResponseBlock config={requiredConfig} location="belowStimulus" />,
     );
     expect(scrollSpy).toHaveBeenCalled();
@@ -336,7 +394,7 @@ describe('ResponseBlock focus recovery', () => {
     expect(document.activeElement).toBe(control);
   });
 
-  test('does not move focus while there are no validation errors', () => {
+  test('does not move focus while there are no validation errors', async () => {
     const requiredConfig = {
       type: 'questionnaire',
       response: [
@@ -345,7 +403,7 @@ describe('ResponseBlock focus recovery', () => {
         },
       ],
     } as IndividualComponent;
-    render(<ResponseBlock config={requiredConfig} location="belowStimulus" />);
+    await renderWithStore(<ResponseBlock config={requiredConfig} location="belowStimulus" />);
     expect(scrollSpy).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(document.body);
   });
@@ -363,7 +421,7 @@ describe('ResponseBlock keyboard Check Answer', () => {
 
   test('one Enter press shows one feedback alert and saves one incorrect answer across all mounted locations', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { container } = render(
+    const { container, store } = await renderWithStore(
       <>
         <ResponseBlock config={feedbackEnterConfig} location="aboveStimulus" />
         <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />
@@ -372,22 +430,23 @@ describe('ResponseBlock keyboard Check Answer', () => {
     );
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
-    expect(saveIncorrectAnswerSpy).toHaveBeenCalledTimes(1);
+    expect(incorrectCount(store)).toBe(1);
+    expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
   });
 
   test('non-owner response block ignores Enter', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { container } = render(
+    const { container, store } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="sidebar" />,
     );
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(0);
-    expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+    expect(incorrectCount(store)).toBe(0);
   });
 
   test('Enter pressed inside a textarea does not trigger Check Answer', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { container } = render(
+    const { container, store } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
     );
     const textarea = document.createElement('textarea');
@@ -395,7 +454,7 @@ describe('ResponseBlock keyboard Check Answer', () => {
     try {
       await act(async () => { fireEvent.keyDown(textarea, { key: 'Enter' }); });
       expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(0);
-      expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+      expect(incorrectCount(store)).toBe(0);
     } finally {
       document.body.removeChild(textarea);
     }
@@ -404,16 +463,17 @@ describe('ResponseBlock keyboard Check Answer', () => {
   test('Enter stops counting attempts once training attempts are exhausted', async () => {
     // uiConfig mock sets trainingAttempts: 2
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    render(<ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />);
+    const { store } = await renderWithStore(<ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />);
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
-    expect(saveIncorrectAnswerSpy).toHaveBeenCalledTimes(2);
+    expect(incorrectCount(store)).toBe(2);
+    expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(2);
   });
 
   test('Enter on the focused Check Answer button defers to its synthesized click (no double handling)', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { container } = render(
+    const { container, store } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
     );
     const checkBtn = Array.from(container.querySelectorAll('button')).find(
@@ -422,13 +482,13 @@ describe('ResponseBlock keyboard Check Answer', () => {
     // the browser synthesizes a click for Enter on a focused button, so the
     // global handler must skip the keydown
     await act(async () => { fireEvent.keyDown(checkBtn, { key: 'Enter' }); });
-    expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+    expect(incorrectCount(store)).toBe(0);
     await act(async () => { fireEvent.click(checkBtn); });
-    expect(saveIncorrectAnswerSpy).toHaveBeenCalledTimes(1);
+    expect(incorrectCount(store)).toBe(1);
   });
 
   test('Enter after a correct answer does not re-run feedback', async () => {
-    const { container } = render(
+    const { container, store } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
     );
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
@@ -438,6 +498,123 @@ describe('ResponseBlock keyboard Check Answer', () => {
     expect(checkBtn).toHaveProperty('disabled', true);
     await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
-    expect(saveIncorrectAnswerSpy).not.toHaveBeenCalled();
+    expect(incorrectCount(store)).toBe(0);
+    expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
+  });
+});
+
+// ── step-level check-answer state (persistence) ───────────────────────────────
+
+describe('ResponseBlock check-answer state persistence', () => {
+  const feedbackConfig = {
+    ...baseConfig,
+    provideFeedback: true,
+    correctAnswer: [{ id: 'q1', answer: 'correct' }],
+  } as IndividualComponent;
+
+  test('attempts survive unmount/remount within the same store', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const studyStore = await makeStudyStore();
+    const first = render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+    const checkBtn = Array.from(first.container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Check Answer',
+    )!;
+    await act(async () => { fireEvent.click(checkBtn); });
+    expect(studyStore.store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
+    first.unmount();
+
+    const second = render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+    expect(studyStore.store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
+    expect(second.container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
+  });
+
+  test('seeds store from a persisted StoredAnswer.checkAnswer (refresh restore)', async () => {
+    const persisted: CheckAnswerState = { attemptsUsed: 2, correct: false, responses: { q1: false } };
+    mockStoredAnswerData.checkAnswer = persisted;
+    const { container, store } = await renderWithStore(
+      <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
+    );
+    expect(store.getState().checkAnswer.trial1_0).toEqual(persisted);
+    const checkBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Check Answer',
+    );
+    expect(checkBtn).toHaveProperty('disabled', true);
+    expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
+  });
+
+  test('legacy stored answers without checkAnswer behave as before (no seed)', async () => {
+    const { container, store } = await renderWithStore(
+      <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
+    );
+    expect(store.getState().checkAnswer.trial1_0).toBeUndefined();
+    const checkBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Check Answer',
+    );
+    expect(checkBtn).toHaveProperty('disabled', false);
+  });
+
+  test('restores mixed per-response feedback in the correct locations', async () => {
+    mockStoredAnswerData.formOrder = { response: ['q1', 'q2'] };
+    mockStoredAnswerData.checkAnswer = { attemptsUsed: 1, correct: false, responses: { q1: true, q2: false } };
+    const multiConfig = {
+      type: 'questionnaire',
+      response: [
+        {
+          type: 'shortText', id: 'q1', prompt: 'Q1', required: false,
+        },
+        {
+          type: 'shortText', id: 'q2', prompt: 'Q2', required: false, location: 'aboveStimulus',
+        },
+      ],
+      provideFeedback: true,
+      correctAnswer: [{ id: 'q1', answer: 'a' }, { id: 'q2', answer: 'b' }],
+    } as IndividualComponent;
+    const studyStore = await makeStudyStore();
+    const { container } = render(withStore(
+      studyStore, (
+        <>
+          <ResponseBlock config={multiConfig} location="aboveStimulus" />
+          <ResponseBlock config={multiConfig} location="belowStimulus" />
+        </>
+      ),
+    ));
+    const above = container.querySelector('.responseBlock-aboveStimulus')!;
+    const below = container.querySelector('.responseBlock-belowStimulus')!;
+    // Each alert renders once, in the block its response lives in
+    expect(above.querySelector('[data-testid="feedback-alert-q2"]')?.getAttribute('data-title')).toBe('Incorrect Answer');
+    expect(above.querySelector('[data-testid="feedback-alert-q1"]')).toBeNull();
+    expect(below.querySelector('[data-testid="feedback-alert-q1"]')?.getAttribute('data-title')).toBe('Correct Answer');
+    expect(below.querySelector('[data-testid="feedback-alert-q2"]')).toBeNull();
+    expect(container.querySelectorAll('[data-testid^="feedback-alert-"]')).toHaveLength(2);
+  });
+});
+
+// ── unlimited attempts (trainingAttempts: -1) ─────────────────────────────────
+
+describe('ResponseBlock unlimited attempts', () => {
+  test('trainingAttempts: -1 never disables Check Answer and Next unlocks after the first check', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const unlimitedConfig = {
+      ...baseConfig,
+      provideFeedback: true,
+      correctAnswer: [{ id: 'q1', answer: 'correct' }],
+      trainingAttempts: -1,
+    } as IndividualComponent;
+    const { container, store } = await renderWithStore(
+      <ResponseBlock config={unlimitedConfig} location="belowStimulus" />,
+    );
+    const checkBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Check Answer',
+    )!;
+    await act(async () => { fireEvent.click(checkBtn); });
+    await act(async () => { fireEvent.click(checkBtn); });
+    await act(async () => { fireEvent.click(checkBtn); });
+    expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(3);
+    expect(checkBtn).toHaveProperty('disabled', false);
+    expect(container.querySelector('[data-testid="feedback-alert-q1"]')?.getAttribute('data-title')).toBe('Incorrect Answer');
+    const nextBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Next',
+    )!;
+    expect(nextBtn).toHaveProperty('disabled', false);
   });
 });

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -17,7 +17,7 @@ import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
 
 // ── mocks ────────────────────────────────────────────────────────────────────
 
-const { mockStoredAnswerData } = vi.hoisted(() => ({
+const { mockStoredAnswerData, capturedNextButtonProps, mockIsAnalysis } = vi.hoisted(() => ({
   mockStoredAnswerData: {
     formOrder: { response: ['q1'] },
     questionOrders: {},
@@ -25,6 +25,10 @@ const { mockStoredAnswerData } = vi.hoisted(() => ({
     responseSubmitAttempted: undefined as boolean | undefined,
     checkAnswer: undefined as { attemptsUsed: number; correct: boolean; responses: Record<string, boolean> } | undefined,
   },
+  capturedNextButtonProps: {
+    onCheckAnswer: undefined as (() => void) | undefined,
+  },
+  mockIsAnalysis: { value: false },
 }));
 
 vi.mock('@mantine/core', () => ({
@@ -83,6 +87,10 @@ vi.mock('../../../store/hooks/useStoredAnswer', () => ({
   useStoredAnswer: vi.fn(() => mockStoredAnswerData),
 }));
 
+vi.mock('../../../store/hooks/useIsAnalysis', () => ({
+  useIsAnalysis: vi.fn(() => mockIsAnalysis.value),
+}));
+
 vi.mock('../../../store/hooks/useWindowEvents', () => ({
   useWindowEvents: vi.fn(() => ({ current: [] })),
 }));
@@ -135,12 +143,17 @@ vi.mock('../FeedbackAlert', () => ({
 }));
 
 vi.mock('../../NextButton', () => ({
-  NextButton: ({ label, disabled, checkAnswer }: { label?: string; disabled?: boolean; checkAnswer?: ReactNode }) => (
-    <div>
-      {checkAnswer}
-      <button type="button" disabled={disabled}>{label}</button>
-    </div>
-  ),
+  NextButton: ({
+    label, disabled, checkAnswer, onCheckAnswer,
+  }: { label?: string; disabled?: boolean; checkAnswer?: ReactNode; onCheckAnswer?: () => void }) => {
+    capturedNextButtonProps.onCheckAnswer = onCheckAnswer;
+    return (
+      <div>
+        {checkAnswer}
+        <button type="button" disabled={disabled}>{label}</button>
+      </div>
+    );
+  },
 }));
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -235,6 +248,8 @@ beforeEach(() => {
   mockStoredAnswerData.formOrder = { response: ['q1'] };
   mockStoredAnswerData.responseSubmitAttempted = undefined;
   mockStoredAnswerData.checkAnswer = undefined;
+  capturedNextButtonProps.onCheckAnswer = undefined;
+  mockIsAnalysis.value = false;
 });
 
 // Unmount between tests so window keydown listeners from prior renders don't leak
@@ -343,18 +358,6 @@ describe('ResponseBlock', () => {
     // After a correct answer the Check Answer button should become disabled
     expect(checkBtn).toHaveProperty('disabled', true);
   });
-
-  test('nextOnEnter=true registers keydown listener that fires checkAnswerProvideFeedback', async () => {
-    const configWithEnter = {
-      ...baseConfig,
-      nextOnEnter: true,
-      provideFeedback: true,
-      correctAnswer: [{ id: 'q1', answer: 'correct' }],
-    } as IndividualComponent;
-    await renderWithStore(<ResponseBlock config={configWithEnter} location="belowStimulus" />);
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
-    // Verifies the listener registered without throwing
-  });
 });
 
 // ── focus recovery on validation errors ──────────────────────────────────────
@@ -410,7 +413,7 @@ describe('ResponseBlock focus recovery', () => {
 
 // ── Check Answer via keyboard ─────────────────────────────────────────────────
 
-describe('ResponseBlock keyboard Check Answer', () => {
+describe('ResponseBlock onCheckAnswer', () => {
   const feedbackEnterConfig = {
     ...baseConfig,
     nextOnEnter: true,
@@ -418,7 +421,7 @@ describe('ResponseBlock keyboard Check Answer', () => {
     correctAnswer: [{ id: 'q1', answer: 'correct' }],
   } as IndividualComponent;
 
-  test('one Enter press shows one feedback alert and saves one incorrect answer across all mounted locations', async () => {
+  test('passes onCheckAnswer to NextButton and grades once when called', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
     const { container, store } = await renderWithStore(
       <>
@@ -427,77 +430,63 @@ describe('ResponseBlock keyboard Check Answer', () => {
         <ResponseBlock config={feedbackEnterConfig} location="sidebar" />
       </>,
     );
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    const nextButtons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next');
+    expect(nextButtons).toHaveLength(1);
+    expect(capturedNextButtonProps.onCheckAnswer).toBeDefined();
+    await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
     expect(incorrectCount(store)).toBe(1);
     expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
   });
 
-  test('non-owner response block ignores Enter', async () => {
-    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { container, store } = await renderWithStore(
+  test('does not pass onCheckAnswer when location does not match nextButtonLocation', async () => {
+    const { container } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="sidebar" />,
     );
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
-    expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(0);
-    expect(incorrectCount(store)).toBe(0);
+    expect(Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next')).toHaveLength(0);
+    expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
   });
 
-  test('Enter pressed inside a textarea does not trigger Check Answer', async () => {
-    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { container, store } = await renderWithStore(
-      <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
-    );
-    const textarea = document.createElement('textarea');
-    document.body.appendChild(textarea);
-    try {
-      await act(async () => { fireEvent.keyDown(textarea, { key: 'Enter' }); });
-      expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(0);
-      expect(incorrectCount(store)).toBe(0);
-    } finally {
-      document.body.removeChild(textarea);
-    }
-  });
-
-  test('Enter stops counting attempts once training attempts are exhausted', async () => {
+  test('does not pass onCheckAnswer after all attempts are used', async () => {
     // uiConfig mock sets trainingAttempts: 2
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
     const { store } = await renderWithStore(<ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />);
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
-    expect(incorrectCount(store)).toBe(2);
+    await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
+    await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
     expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(2);
+    expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
+    expect(incorrectCount(store)).toBe(2);
   });
 
-  test('Enter on the focused Check Answer button defers to its synthesized click (no double handling)', async () => {
-    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+  test('does not pass onCheckAnswer after a correct answer', async () => {
     const { container, store } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
     );
-    const checkBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    )!;
-    // Avoid double-running when Enter on a focused button also triggers click
-    await act(async () => { fireEvent.keyDown(checkBtn, { key: 'Enter' }); });
-    expect(incorrectCount(store)).toBe(0);
-    await act(async () => { fireEvent.click(checkBtn); });
-    expect(incorrectCount(store)).toBe(1);
-  });
-
-  test('Enter after a correct answer does not re-run feedback', async () => {
-    const { container, store } = await renderWithStore(
-      <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
-    );
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
     const checkBtn = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent === 'Check Answer',
     );
     expect(checkBtn).toHaveProperty('disabled', true);
-    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
-    expect(incorrectCount(store)).toBe(0);
     expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
+  });
+
+  test('does not pass onCheckAnswer in analysis mode', async () => {
+    mockIsAnalysis.value = true;
+    const { container } = await renderWithStore(
+      <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
+    );
+    expect(Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next')).toHaveLength(1);
+    expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
+  });
+
+  test('does not pass onCheckAnswer when there is no correct answer feedback', async () => {
+    const { container } = await renderWithStore(
+      <ResponseBlock config={{ ...baseConfig, nextOnEnter: true } as IndividualComponent} location="belowStimulus" />,
+    );
+    expect(Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next')).toHaveLength(1);
+    expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
   });
 });
 

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -8,7 +8,7 @@ import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import type { IndividualComponent, StudyConfig } from '../../../parser/types';
-import type { CheckAnswerState, Sequence } from '../../../store/types';
+import type { CheckAnswerState, Sequence, StoredAnswer } from '../../../store/types';
 import type { REVISIT_MODE } from '../../../storage/engines/types';
 import { studyStoreCreator, StudyStoreContext } from '../../../store/store';
 import { ResponseBlock } from '../ResponseBlock';
@@ -17,7 +17,9 @@ import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
 
 // ── mocks ────────────────────────────────────────────────────────────────────
 
-const { mockStoredAnswerData, capturedNextButtonProps, mockIsAnalysis } = vi.hoisted(() => ({
+const {
+  mockStoredAnswerData, capturedNextButtonProps, capturedSwitcherProps, mockIsAnalysis, mockNavigate, mockSaveAnswers, mockAnswerField,
+} = vi.hoisted(() => ({
   mockStoredAnswerData: {
     formOrder: { response: ['q1'] },
     questionOrders: {},
@@ -28,8 +30,27 @@ const { mockStoredAnswerData, capturedNextButtonProps, mockIsAnalysis } = vi.hoi
   capturedNextButtonProps: {
     onCheckAnswer: undefined as (() => void) | undefined,
   },
+  capturedSwitcherProps: {
+    storedAnswer: undefined as Record<string, unknown> | undefined,
+    answerFinalized: undefined as boolean | undefined,
+  },
   mockIsAnalysis: { value: false },
+  mockNavigate: vi.fn(),
+  mockSaveAnswers: vi.fn(() => Promise.resolve()),
+  mockAnswerField: {
+    values: {} as Record<string, unknown>,
+    isValid: vi.fn(() => true),
+    setValues: vi.fn(),
+    setInitialValues: vi.fn(),
+    reset: vi.fn(),
+    getInputProps: vi.fn(() => ({ value: '', onChange: vi.fn() })),
+  },
 }));
+
+vi.mock('../../../storage/storageEngineHooks', () => {
+  const storageEngine = { saveAnswers: mockSaveAnswers, saveProvenance: vi.fn(() => Promise.resolve()) };
+  return { useStorageEngine: vi.fn(() => ({ storageEngine })) };
+});
 
 vi.mock('@mantine/core', () => ({
   Box: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
@@ -42,7 +63,7 @@ vi.mock('@mantine/core', () => ({
 }));
 
 vi.mock('react-router', () => ({
-  useNavigate: vi.fn(() => vi.fn()),
+  useNavigate: vi.fn(() => mockNavigate),
   useParams: vi.fn(() => ({})),
   useSearchParams: vi.fn(() => [new URLSearchParams()]),
 }));
@@ -101,22 +122,12 @@ vi.mock('../../../routes/utils', () => ({
   useStudyId: vi.fn(() => 'test-study'),
 }));
 
-vi.mock('../utils', () => {
-  const answerField = {
-    values: {},
-    isValid: vi.fn(() => true),
-    setValues: vi.fn(),
-    setInitialValues: vi.fn(),
-    reset: vi.fn(),
-    getInputProps: vi.fn(() => ({ value: '', onChange: vi.fn() })),
-  };
-  return {
-    generateInitFields: vi.fn(() => ({})),
-    mergeReactiveAnswers: vi.fn((_: unknown, values: unknown) => values),
-    useAnswerField: vi.fn(() => answerField),
-    usesStandaloneDontKnowField: vi.fn(() => false),
-  };
-});
+vi.mock('../utils', () => ({
+  generateInitFields: vi.fn(() => ({})),
+  mergeReactiveAnswers: vi.fn((_: unknown, values: unknown) => values),
+  useAnswerField: vi.fn(() => mockAnswerField),
+  usesStandaloneDontKnowField: vi.fn(() => false),
+}));
 
 vi.mock('../../../utils/correctAnswer', () => ({
   responseAnswerIsCorrect: vi.fn(() => true),
@@ -128,12 +139,16 @@ vi.mock('../customResponseModules', () => ({
 }));
 
 vi.mock('../ResponseSwitcher', () => ({
-  ResponseSwitcher: ({ response }: { response: { id: string; type: string } }) => (
-    <div data-testid={`switcher-${response.type}`}>
-      {response.type}
-      <input data-testid={`control-${response.id}`} />
-    </div>
-  ),
+  ResponseSwitcher: ({ response, storedAnswer, answerFinalized }: { response: { id: string; type: string }; storedAnswer?: Record<string, unknown>; answerFinalized?: boolean }) => {
+    capturedSwitcherProps.storedAnswer = storedAnswer;
+    capturedSwitcherProps.answerFinalized = answerFinalized;
+    return (
+      <div data-testid={`switcher-${response.type}`}>
+        {response.type}
+        <input data-testid={`control-${response.id}`} />
+      </div>
+    );
+  },
 }));
 
 vi.mock('../FeedbackAlert', () => ({
@@ -219,8 +234,8 @@ const metadata = {
 
 type StudyStore = Awaited<ReturnType<typeof studyStoreCreator>>;
 
-async function makeStudyStore(): Promise<StudyStore> {
-  return studyStoreCreator('test-study', storeConfig, storeSequence, metadata, {}, modes, 'p1', false, false);
+async function makeStudyStore(modesOverride: Partial<Record<REVISIT_MODE, boolean>> = {}, answers: Record<string, StoredAnswer> = {}): Promise<StudyStore> {
+  return studyStoreCreator('test-study', storeConfig, storeSequence, metadata, answers, { ...modes, ...modesOverride }, 'p1', false, false);
 }
 
 function withStore(studyStore: StudyStore, ui: ReactNode) {
@@ -257,7 +272,12 @@ beforeEach(() => {
   mockStoredAnswerData.responseSubmitAttempted = undefined;
   mockStoredAnswerData.checkAnswer = undefined;
   capturedNextButtonProps.onCheckAnswer = undefined;
+  capturedSwitcherProps.storedAnswer = undefined;
+  capturedSwitcherProps.answerFinalized = undefined;
   mockIsAnalysis.value = false;
+  mockNavigate.mockClear();
+  mockSaveAnswers.mockClear();
+  mockAnswerField.values = {};
 });
 
 // Unmount between tests so window keydown listeners from prior renders don't leak
@@ -348,6 +368,20 @@ describe('ResponseBlock', () => {
       <ResponseBlock config={baseConfig} location="belowStimulus" status={status} />,
     );
     expect(container.querySelector('div')).toBeTruthy();
+  });
+
+  test('passes answerFinalized to ResponseSwitcher when the trial is finished', async () => {
+    const status = makeStoredAnswer({ answer: { q1: 'hello' }, endTime: 100 });
+    await renderWithStore(<ResponseBlock config={baseConfig} location="belowStimulus" status={status} />);
+    expect(capturedSwitcherProps.storedAnswer).toEqual({ q1: 'hello' });
+    expect(capturedSwitcherProps.answerFinalized).toBe(true);
+  });
+
+  test('passes answerFinalized=false to ResponseSwitcher while the trial is in progress', async () => {
+    const status = makeStoredAnswer({ answer: { q1: 'hello' }, endTime: -1 });
+    await renderWithStore(<ResponseBlock config={baseConfig} location="belowStimulus" status={status} />);
+    expect(capturedSwitcherProps.storedAnswer).toEqual({ q1: 'hello' });
+    expect(capturedSwitcherProps.answerFinalized).toBe(false);
   });
 
   test('clicking Check Answer calls checkAnswerProvideFeedback', async () => {
@@ -536,6 +570,94 @@ describe('ResponseBlock check-answer state persistence', () => {
     expect(store.getState().checkAnswer.trial1_0).toBeUndefined();
     const checkBtn = findButton(container, 'Check Answer');
     expect(checkBtn).toHaveProperty('disabled', false);
+  });
+
+  test('persists each grading attempt to storage before Next', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    mockAnswerField.values = { q1: '42' };
+    const { container } = await renderWithStore(
+      <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
+    );
+    await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+    expect(mockSaveAnswers).toHaveBeenCalledTimes(1);
+    await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+    expect(mockSaveAnswers).toHaveBeenCalledTimes(2);
+    expect(mockSaveAnswers).toHaveBeenLastCalledWith(expect.objectContaining({
+      trial1_0: expect.objectContaining({
+        answer: { q1: '42' },
+        checkAnswer: { attemptsUsed: 2, correct: false, responses: { q1: false } },
+      }),
+    }));
+  });
+
+  test('saves the graded draft to Redux', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    mockAnswerField.values = { q1: '42' };
+    const { container, store } = await renderWithStore(
+      <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
+    );
+    await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+    expect(store.getState().answers.trial1_0).toMatchObject({
+      answer: { q1: '42' },
+      checkAnswer: { attemptsUsed: 1, correct: false, responses: { q1: false } },
+    });
+  });
+
+  test('saves the draft to Redux even when data collection is disabled', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const studyStore = await makeStudyStore({ dataCollectionEnabled: false });
+    const { container } = render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+    await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+    expect(studyStore.store.getState().answers.trial1_0.checkAnswer).toEqual({ attemptsUsed: 1, correct: false, responses: { q1: false } });
+    expect(mockSaveAnswers).not.toHaveBeenCalled();
+  });
+
+  test('does not re-persist when restoring a saved checkAnswer', async () => {
+    const persisted: CheckAnswerState = { attemptsUsed: 1, correct: false, responses: { q1: false } };
+    mockStoredAnswerData.checkAnswer = persisted;
+    const studyStore = await makeStudyStore({}, { trial1_0: makeStoredAnswer({ identifier: 'trial1_0', checkAnswer: persisted }) });
+    render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+    expect(mockSaveAnswers).not.toHaveBeenCalled();
+  });
+
+  test('redirects to the training-failed page after the final failed attempt', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+      const noFailConfig = { ...feedbackConfig, allowFailedTraining: false } as IndividualComponent;
+      const { container } = await renderWithStore(<ResponseBlock config={noFailConfig} location="belowStimulus" />);
+      await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+      await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+      await act(async () => { vi.advanceTimersByTime(5000); });
+      expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('__trainingFailed'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('redirects to the training-failed page when restoring a failed training state', async () => {
+    vi.useFakeTimers();
+    try {
+      mockStoredAnswerData.checkAnswer = { attemptsUsed: 2, correct: false, responses: { q1: false } };
+      const noFailConfig = { ...feedbackConfig, allowFailedTraining: false } as IndividualComponent;
+      await renderWithStore(<ResponseBlock config={noFailConfig} location="belowStimulus" />);
+      await act(async () => { vi.advanceTimersByTime(5000); });
+      expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('__trainingFailed'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('does not redirect a restored failure when allowFailedTraining is true', async () => {
+    vi.useFakeTimers();
+    try {
+      mockStoredAnswerData.checkAnswer = { attemptsUsed: 2, correct: false, responses: { q1: false } };
+      await renderWithStore(<ResponseBlock config={feedbackConfig} location="belowStimulus" />);
+      await act(async () => { vi.advanceTimersByTime(5000); });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test('restores mixed per-response feedback in the correct locations', async () => {

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -241,6 +241,14 @@ function incorrectCount(store: StudyStore['store']) {
   return store.getState().answers.trial1_0?.incorrectAnswers?.q1?.value.length ?? 0;
 }
 
+function findButton(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll('button')).find((b) => b.textContent === label)!;
+}
+
+function countButtons(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === label).length;
+}
+
 // ── setup ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -351,10 +359,8 @@ describe('ResponseBlock', () => {
     const { container } = await renderWithStore(
       <ResponseBlock config={configWithFeedback} location="belowStimulus" />,
     );
-    const checkBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    );
-    await act(async () => { fireEvent.click(checkBtn!); });
+    const checkBtn = findButton(container, 'Check Answer');
+    await act(async () => { fireEvent.click(checkBtn); });
     // After a correct answer the Check Answer button should become disabled
     expect(checkBtn).toHaveProperty('disabled', true);
   });
@@ -430,8 +436,7 @@ describe('ResponseBlock onCheckAnswer', () => {
         <ResponseBlock config={feedbackEnterConfig} location="sidebar" />
       </>,
     );
-    const nextButtons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next');
-    expect(nextButtons).toHaveLength(1);
+    expect(countButtons(container, 'Next')).toBe(1);
     expect(capturedNextButtonProps.onCheckAnswer).toBeDefined();
     await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
@@ -443,18 +448,19 @@ describe('ResponseBlock onCheckAnswer', () => {
     const { container } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="sidebar" />,
     );
-    expect(Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next')).toHaveLength(0);
+    expect(countButtons(container, 'Next')).toBe(0);
     expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
   });
 
-  test('does not pass onCheckAnswer after all attempts are used', async () => {
+  test('does not pass onCheckAnswer and disables Check Answer after all attempts are used', async () => {
     // uiConfig mock sets trainingAttempts: 2
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const { store } = await renderWithStore(<ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />);
+    const { container, store } = await renderWithStore(<ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />);
     await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
     await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
     expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(2);
     expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
+    expect(findButton(container, 'Check Answer')).toHaveProperty('disabled', true);
     expect(incorrectCount(store)).toBe(2);
   });
 
@@ -463,9 +469,7 @@ describe('ResponseBlock onCheckAnswer', () => {
       <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
     );
     await act(async () => { capturedNextButtonProps.onCheckAnswer?.(); });
-    const checkBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    );
+    const checkBtn = findButton(container, 'Check Answer');
     expect(checkBtn).toHaveProperty('disabled', true);
     expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
@@ -477,7 +481,7 @@ describe('ResponseBlock onCheckAnswer', () => {
     const { container } = await renderWithStore(
       <ResponseBlock config={feedbackEnterConfig} location="belowStimulus" />,
     );
-    expect(Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next')).toHaveLength(1);
+    expect(countButtons(container, 'Next')).toBe(1);
     expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
   });
 
@@ -485,7 +489,7 @@ describe('ResponseBlock onCheckAnswer', () => {
     const { container } = await renderWithStore(
       <ResponseBlock config={{ ...baseConfig, nextOnEnter: true } as IndividualComponent} location="belowStimulus" />,
     );
-    expect(Array.from(container.querySelectorAll('button')).filter((b) => b.textContent === 'Next')).toHaveLength(1);
+    expect(countButtons(container, 'Next')).toBe(1);
     expect(capturedNextButtonProps.onCheckAnswer).toBeUndefined();
   });
 });
@@ -503,9 +507,7 @@ describe('ResponseBlock check-answer state persistence', () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
     const studyStore = await makeStudyStore();
     const first = render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
-    const checkBtn = Array.from(first.container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    )!;
+    const checkBtn = findButton(first.container, 'Check Answer');
     await act(async () => { fireEvent.click(checkBtn); });
     expect(studyStore.store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(1);
     first.unmount();
@@ -522,9 +524,7 @@ describe('ResponseBlock check-answer state persistence', () => {
       <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
     );
     expect(store.getState().checkAnswer.trial1_0).toEqual(persisted);
-    const checkBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    );
+    const checkBtn = findButton(container, 'Check Answer');
     expect(checkBtn).toHaveProperty('disabled', true);
     expect(container.querySelectorAll('[data-testid="feedback-alert-q1"]')).toHaveLength(1);
   });
@@ -534,9 +534,7 @@ describe('ResponseBlock check-answer state persistence', () => {
       <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
     );
     expect(store.getState().checkAnswer.trial1_0).toBeUndefined();
-    const checkBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    );
+    const checkBtn = findButton(container, 'Check Answer');
     expect(checkBtn).toHaveProperty('disabled', false);
   });
 
@@ -579,29 +577,35 @@ describe('ResponseBlock check-answer state persistence', () => {
 // ── unlimited attempts (trainingAttempts: -1) ─────────────────────────────────
 
 describe('ResponseBlock unlimited attempts', () => {
-  test('trainingAttempts: -1 never disables Check Answer and Next unlocks after the first check', async () => {
+  const unlimitedConfig = {
+    ...baseConfig,
+    provideFeedback: true,
+    correctAnswer: [{ id: 'q1', answer: 'correct' }],
+    trainingAttempts: -1,
+  } as IndividualComponent;
+
+  test('keeps Check Answer enabled and Next disabled after wrong answers', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
-    const unlimitedConfig = {
-      ...baseConfig,
-      provideFeedback: true,
-      correctAnswer: [{ id: 'q1', answer: 'correct' }],
-      trainingAttempts: -1,
-    } as IndividualComponent;
     const { container, store } = await renderWithStore(
       <ResponseBlock config={unlimitedConfig} location="belowStimulus" />,
     );
-    const checkBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Check Answer',
-    )!;
+    const checkBtn = findButton(container, 'Check Answer');
     await act(async () => { fireEvent.click(checkBtn); });
     await act(async () => { fireEvent.click(checkBtn); });
     await act(async () => { fireEvent.click(checkBtn); });
     expect(store.getState().checkAnswer.trial1_0.attemptsUsed).toBe(3);
+    // Unlimited attempts: Check Answer never locks, and Next stays disabled until correct
     expect(checkBtn).toHaveProperty('disabled', false);
     expect(container.querySelector('[data-testid="feedback-alert-q1"]')?.getAttribute('data-title')).toBe('Incorrect Answer');
-    const nextBtn = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Next',
-    )!;
-    expect(nextBtn).toHaveProperty('disabled', false);
+    expect(findButton(container, 'Next')).toHaveProperty('disabled', true);
+  });
+
+  test('enables Next once the answer is correct', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(true);
+    const { container } = await renderWithStore(
+      <ResponseBlock config={unlimitedConfig} location="belowStimulus" />,
+    );
+    await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+    expect(findButton(container, 'Next')).toHaveProperty('disabled', false);
   });
 });

--- a/src/components/response/tests/ResponseSwitcher.spec.tsx
+++ b/src/components/response/tests/ResponseSwitcher.spec.tsx
@@ -1,0 +1,127 @@
+import { ReactNode } from 'react';
+import { render, cleanup } from '@testing-library/react';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import type { IndividualComponent, JsonValue, Response } from '../../../parser/types';
+import { ResponseSwitcher } from '../ResponseSwitcher';
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+const { capturedStringInputProps, mockIsAnalysis, mockStoreState } = vi.hoisted(() => ({
+  capturedStringInputProps: {
+    disabled: undefined as boolean | undefined,
+    answer: undefined as { value?: unknown; readOnly?: boolean } | undefined,
+  },
+  mockIsAnalysis: { value: false },
+  mockStoreState: {
+    sequence: {
+      order: 'fixed', orderPath: 'root', components: ['trial1'], skip: [],
+    },
+    completed: false,
+  },
+}));
+
+vi.mock('@mantine/core', () => ({
+  Box: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Checkbox: () => <input type="checkbox" />,
+  Divider: () => <hr />,
+}));
+
+vi.mock('react-router', () => ({
+  useSearchParams: vi.fn(() => [new URLSearchParams()]),
+}));
+
+vi.mock('../../../store/hooks/useStudyConfig', () => ({
+  useStudyConfig: vi.fn(() => ({ uiConfig: {}, components: {} })),
+}));
+
+vi.mock('../../../store/hooks/useIsAnalysis', () => ({
+  useIsAnalysis: vi.fn(() => mockIsAnalysis.value),
+}));
+
+vi.mock('../../../routes/utils', () => ({
+  useCurrentStep: vi.fn(() => 0),
+}));
+
+vi.mock('../../../utils/fetchStylesheet', () => ({
+  useFetchStylesheet: vi.fn(),
+}));
+
+vi.mock('../../../store/store', () => ({
+  useStoreSelector: vi.fn((selector: (state: unknown) => unknown) => selector(mockStoreState)),
+}));
+
+vi.mock('../CustomResponseInput', () => ({
+  CustomResponseInput: () => null,
+}));
+
+vi.mock('../StringInput', () => ({
+  StringInput: ({ disabled, answer }: { disabled: boolean; answer: { value?: unknown; readOnly?: boolean } }) => {
+    capturedStringInputProps.disabled = disabled;
+    capturedStringInputProps.answer = answer;
+    return <input data-testid="string-input" />;
+  },
+}));
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const response = {
+  id: 'q1', type: 'shortText', prompt: 'Q1', required: false,
+} as Response;
+
+const form = { value: 'live', onChange: vi.fn() } as Parameters<typeof ResponseSwitcher>[0]['form'];
+
+function renderSwitcher({ storedAnswer, answerFinalized }: { storedAnswer?: Record<string, JsonValue>; answerFinalized?: boolean }) {
+  return render(
+    <ResponseSwitcher
+      response={response}
+      form={form}
+      index={1}
+      config={{} as IndividualComponent}
+      storedAnswer={storedAnswer}
+      answerFinalized={answerFinalized}
+    />,
+  );
+}
+
+// ── setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  capturedStringInputProps.disabled = undefined;
+  capturedStringInputProps.answer = undefined;
+  mockIsAnalysis.value = false;
+  mockStoreState.completed = false;
+});
+
+afterEach(() => cleanup());
+
+// ── ResponseSwitcher stored answer locking ────────────────────────────────────
+
+describe('ResponseSwitcher stored answer locking', () => {
+  test('keeps in-progress stored answers editable', () => {
+    renderSwitcher({ storedAnswer: { q1: 'stored' }, answerFinalized: false });
+    expect(capturedStringInputProps.disabled).toBe(false);
+    expect(capturedStringInputProps.answer).toMatchObject({ value: 'live' });
+  });
+
+  test('locks the input once the trial is completed', () => {
+    renderSwitcher({ storedAnswer: { q1: 'stored' }, answerFinalized: true });
+    expect(capturedStringInputProps.disabled).toBe(true);
+    expect(capturedStringInputProps.answer).toMatchObject({ value: 'stored', readOnly: true });
+  });
+
+  test('renders in-progress stored answers in analysis mode', () => {
+    mockIsAnalysis.value = true;
+    renderSwitcher({ storedAnswer: { q1: 'stored' }, answerFinalized: false });
+    expect(capturedStringInputProps.disabled).toBe(true);
+    expect(capturedStringInputProps.answer).toMatchObject({ value: 'stored', readOnly: true });
+  });
+
+  test('locks the input for a completed participant even when the answer is not finalized', () => {
+    mockStoreState.completed = true;
+    renderSwitcher({ storedAnswer: { q1: 'stored' }, answerFinalized: false });
+    expect(capturedStringInputProps.disabled).toBe(true);
+    expect(capturedStringInputProps.answer).toMatchObject({ value: 'stored', readOnly: true });
+  });
+});

--- a/src/components/tests/NextButton.spec.tsx
+++ b/src/components/tests/NextButton.spec.tsx
@@ -274,6 +274,50 @@ describe('NextButton', () => {
     expect(onNext).not.toHaveBeenCalled();
   });
 
+  test('nextOnEnter: Enter runs onCheckAnswer instead of onNext while it is provided', async () => {
+    const onNext = vi.fn();
+    const onCheckAnswer = vi.fn();
+    mockStudyConfig = { uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true } };
+    await act(async () => {
+      render(<NextButton checkAnswer={null} onCheckAnswer={onCheckAnswer} onNext={onNext} />);
+    });
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(onCheckAnswer).toHaveBeenCalledTimes(1);
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  test('nextOnEnter: Enter runs onCheckAnswer even while the Next button is disabled', async () => {
+    const onNext = vi.fn();
+    const onCheckAnswer = vi.fn();
+    mockStudyConfig = { uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true } };
+    await act(async () => {
+      render(<NextButton checkAnswer={null} onCheckAnswer={onCheckAnswer} onNext={onNext} disabled />);
+    });
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(onCheckAnswer).toHaveBeenCalledTimes(1);
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  test('nextOnEnter: the enable timer gates onNext but not onCheckAnswer', async () => {
+    const onNext = vi.fn();
+    const onCheckAnswer = vi.fn();
+    mockStudyConfig = {
+      uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true, nextButtonEnableTime: 5000 },
+    };
+    let rerender!: ReturnType<typeof render>['rerender'];
+    await act(async () => {
+      ({ rerender } = render(<NextButton checkAnswer={null} onCheckAnswer={onCheckAnswer} onNext={onNext} />));
+    });
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(onCheckAnswer).toHaveBeenCalledTimes(1);
+    expect(onNext).not.toHaveBeenCalled();
+    await act(async () => {
+      rerender(<NextButton checkAnswer={null} onNext={onNext} />);
+    });
+    await act(async () => { fireEvent.keyDown(window, { key: 'Enter' }); });
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
   test('resets auto-advance state when the current identifier changes', async () => {
     const config = {
       type: 'questionnaire',

--- a/src/store/hooks/tests/useNextStep.spec.ts
+++ b/src/store/hooks/tests/useNextStep.spec.ts
@@ -21,6 +21,7 @@ let mockIdentifier = 'trial1_0';
 let mockFlatSequence = ['trial1', 'attentionCheck', 'end'];
 let mockAnswers: Record<string, StoredAnswer> = {};
 let mockTrialValidation: Record<string, Record<string, object>> = {};
+let mockCheckAnswer: Record<string, { attemptsUsed: number; correct: boolean; responses: Record<string, boolean> }> = {};
 let mockSequence = defaultSequence;
 let mockModes = { dataCollectionEnabled: true, developmentModeEnabled: false, dataSharingEnabled: false };
 let mockNavigate = vi.fn();
@@ -52,6 +53,7 @@ vi.mock('../../store', () => ({
     modes: mockModes,
     clickedPrevious: false,
     responseSubmitAttempted: { [mockIdentifier]: true },
+    checkAnswer: mockCheckAnswer,
   } as StoreState),
   useStoreDispatch: () => mockDispatch,
   useStoreActions: () => ({
@@ -243,6 +245,7 @@ describe('useNextStep', () => {
     mockSaveProvenance = vi.fn().mockResolvedValue(undefined);
     mockDispatch = vi.fn();
     mockSaveTrialAnswer = vi.fn((payload) => ({ type: 'saveTrialAnswer', payload }));
+    mockCheckAnswer = {};
     mockSetReactiveAnswers.mockClear();
     mockSetMatrixAnswersCheckbox.mockClear();
     mockSetMatrixAnswersRadio.mockClear();
@@ -297,6 +300,14 @@ describe('useNextStep', () => {
     const { result } = renderHook(() => useNextStep());
     act(() => { result.current.goToNextStep(); });
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('goToNextStep persists checkAnswer state with the saved answer', () => {
+    mockCheckAnswer = { trial1_0: { attemptsUsed: 2, correct: true, responses: { q1: true } } };
+    const { result } = renderHook(() => useNextStep());
+    act(() => { result.current.goToNextStep(); });
+    const savedPayload = mockSaveTrialAnswer.mock.calls[0][0] as Record<string, unknown>;
+    expect(savedPayload.checkAnswer).toEqual({ attemptsUsed: 2, correct: true, responses: { q1: true } });
   });
 
   test('goToNextStep(false) marks answer as timed out', () => {

--- a/src/store/hooks/tests/useNextStep.spec.ts
+++ b/src/store/hooks/tests/useNextStep.spec.ts
@@ -336,6 +336,26 @@ describe('useNextStep', () => {
     expect(savedPayload.answer).toEqual({ q1: 'Blue', q2: 'Cat' });
   });
 
+  test('goToNextStep snapshots the provenance graph before saving it', () => {
+    const liveGraph = { nodes: { a: { id: 'a' } } };
+    mockTrialValidation = {
+      trial1_0: {
+        stimulus: { valid: true, values: {} },
+        aboveStimulus: { valid: true, values: { q1: 'Blue' } },
+        belowStimulus: { valid: true, values: {} },
+        sidebar: { valid: true, values: {} },
+        provenanceGraph: {
+          aboveStimulus: liveGraph, belowStimulus: null, stimulus: null, sidebar: null,
+        },
+      },
+    };
+    const { result } = renderHook(() => useNextStep());
+    act(() => { result.current.goToNextStep(); });
+    const savedGraph = mockSaveProvenance.mock.calls[0][0] as Record<string, object | null>;
+    expect(savedGraph.aboveStimulus).toEqual(liveGraph);
+    expect(savedGraph.aboveStimulus).not.toBe(liveGraph);
+  });
+
   test('goToNextStep navigates with funcIndex increment when funcIndex is set', () => {
     mockFuncIndex = '0';
     const { result } = renderHook(() => useNextStep());

--- a/src/store/hooks/tests/useNextStep.spec.tsx
+++ b/src/store/hooks/tests/useNextStep.spec.tsx
@@ -76,6 +76,7 @@ vi.mock('../../store', () => ({
     modes: { dataCollectionEnabled: true },
     clickedPrevious: false,
     responseSubmitAttempted: { intro_0: true },
+    checkAnswer: {},
   }),
   useStoreActions: () => ({
     saveTrialAnswer: mockSaveTrialAnswer,

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -39,6 +39,7 @@ export function useNextStep() {
   const { funcIndex } = useParams();
   const identifier = useCurrentIdentifier();
   const responseSubmitAttempted = useStoreSelector((state) => state.responseSubmitAttempted[identifier] ?? false);
+  const checkAnswerState = useStoreSelector((state) => state.checkAnswer[identifier]);
 
   const storeDispatch = useStoreDispatch();
   const {
@@ -91,6 +92,7 @@ export function useNextStep() {
           windowEvents: currentWindowEvents,
           timedOut: !collectData,
           responseSubmitAttempted,
+          checkAnswer: checkAnswerState,
         };
         const answersToPersist = { ...answers, [identifier]: toSave };
 
@@ -176,7 +178,7 @@ export function useNextStep() {
         color: 'red',
       });
     }
-  }, [currentStep, trialValidation, identifier, storedAnswer, windowEvents, dataCollectionEnabled, clickedPrevious, sequence, answers, startTime, funcIndex, storeDispatch, saveTrialAnswer, storageEngine, setReactiveAnswers, setMatrixAnswersCheckbox, setMatrixAnswersRadio, setRankingAnswers, studyConfig, participantSequence, navigate, studyId, responseSubmitAttempted]);
+  }, [currentStep, trialValidation, identifier, storedAnswer, windowEvents, dataCollectionEnabled, clickedPrevious, sequence, answers, startTime, funcIndex, storeDispatch, saveTrialAnswer, storageEngine, setReactiveAnswers, setMatrixAnswersCheckbox, setMatrixAnswersRadio, setRankingAnswers, studyConfig, participantSequence, navigate, studyId, responseSubmitAttempted, checkAnswerState]);
 
   return {
     isNextDisabled,

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -10,8 +10,8 @@ import {
   useCurrentIdentifier, useCurrentStep, useStudyId,
 } from '../../routes/utils';
 
-import { StoredAnswer, ValidationStatus } from '../types';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
+import { getAnswersFromAllLocations } from '../../utils/getAnswersFromAllLocations';
 import { useStoredAnswer } from './useStoredAnswer';
 import { useWindowEvents } from './useWindowEvents';
 import { findBlockForStep } from '../../utils/getSequenceFlatMap';
@@ -69,14 +69,9 @@ export function useNextStep() {
         return;
       }
       // Get answer from across the 3 response blocks and the provenance graph
-      const trialValidationCopy = structuredClone(trialValidation[identifier]);
-      const answer = trialValidationCopy ? Object.values(trialValidationCopy).reduce((acc, curr) => {
-        if (Object.hasOwn(curr, 'values')) {
-          return { ...acc, ...(curr as ValidationStatus).values };
-        }
-        return acc;
-      }, {}) as StoredAnswer['answer'] : {};
-      const { provenanceGraph } = trialValidationCopy || {};
+      const validation = trialValidation[identifier];
+      const answer = getAnswersFromAllLocations(validation);
+      const provenanceGraph = validation?.provenanceGraph ? structuredClone(validation.provenanceGraph) : undefined;
       const endTime = Date.now();
       const answerToPersist = collectData ? answer : {};
 

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -7,7 +7,7 @@ import {
   ParsedStringOption, ResponseBlockLocation, StudyConfig, ValueOf, Answer, ParticipantData,
 } from '../parser/types';
 import type {
-  AlertModalState, StoredAnswer, TrialValidation, TrrackedProvenance, StoreState, Sequence, ParticipantMetadata, ValidationStatus,
+  AlertModalState, CheckAnswerState, StoredAnswer, TrialValidation, TrrackedProvenance, StoreState, Sequence, ParticipantMetadata, ValidationStatus,
 } from './types';
 import { getSequenceFlatMap } from '../utils/getSequenceFlatMap';
 import { REVISIT_MODE } from '../storage/engines/types';
@@ -111,6 +111,7 @@ export async function studyStoreCreator(
     trialValidation: Object.keys(answers).length > 0 ? allValid : emptyValidation,
     responseSubmitAttempted: {},
     stimulusSubmitAttempted: {},
+    checkAnswer: {},
     reactiveAnswers: {},
     metadata,
     analysisProvState: {
@@ -330,6 +331,9 @@ export async function studyStoreCreator(
       setStimulusSubmitAttempt(state, { payload }: PayloadAction<{ identifier: string; attempted: boolean }>) {
         state.stimulusSubmitAttempted[payload.identifier] = payload.attempted;
       },
+      setCheckAnswerResult(state, { payload }: PayloadAction<{ identifier: string } & CheckAnswerState>) {
+        state.checkAnswer[payload.identifier] = { attemptsUsed: payload.attemptsUsed, correct: payload.correct, responses: payload.responses };
+      },
       saveTrialAnswer(state, { payload }: PayloadAction<{ identifier: string } & StoredAnswer>) {
         state.answers[payload.identifier] = { ...payload };
       },
@@ -371,6 +375,11 @@ export async function studyStoreCreator(
         Object.keys(state.answers).forEach((key) => {
           if (key.match(regex)) {
             delete state.answers[key];
+          }
+        });
+        Object.keys(state.checkAnswer).forEach((key) => {
+          if (key.match(regex)) {
+            delete state.checkAnswer[key];
           }
         });
 

--- a/src/store/tests/store.spec.ts
+++ b/src/store/tests/store.spec.ts
@@ -293,6 +293,19 @@ describe('studyStoreCreator', () => {
     expect(store.getState().reactiveAnswers).toEqual({ r1: 'A' });
   });
 
+  test('checkAnswer state starts empty and setCheckAnswerResult records a result per identifier', async () => {
+    const { store, actions } = await studyStoreCreator('test', minimalConfig, minimalSequence, metadata, emptyAnswers, modes, 'p1', false, false);
+    expect(store.getState().checkAnswer).toEqual({});
+    store.dispatch(actions.setCheckAnswerResult({
+      identifier: 'intro_0', attemptsUsed: 1, correct: false, responses: { q1: false },
+    }));
+    expect(store.getState().checkAnswer.intro_0).toEqual({ attemptsUsed: 1, correct: false, responses: { q1: false } });
+    store.dispatch(actions.setCheckAnswerResult({
+      identifier: 'intro_0', attemptsUsed: 2, correct: true, responses: { q1: true },
+    }));
+    expect(store.getState().checkAnswer.intro_0).toEqual({ attemptsUsed: 2, correct: true, responses: { q1: true } });
+  });
+
   test('saveAnalysisState action updates analysisProvState', async () => {
     const { store, actions } = await studyStoreCreator('test', minimalConfig, minimalSequence, metadata, emptyAnswers, modes, 'p1', false, false);
     store.dispatch(actions.saveAnalysisState({ prov: { nodes: [] }, location: 'stimulus' }));
@@ -441,6 +454,19 @@ describe('studyStoreCreator', () => {
     store.dispatch(actions.deleteDynamicBlockAnswers({ currentStep: 5, funcIndex: 0, funcName: 'myFunc' }));
     expect(store.getState().answers.myFunc_5_intro_0).toBeUndefined();
     expect(store.getState().funcSequence.myFunc).toBeUndefined();
+  });
+
+  test('deleteDynamicBlockAnswers clears checkAnswer state for the deleted steps', async () => {
+    const { store, actions } = await studyStoreCreator('test', minimalConfig, minimalSequence, metadata, emptyAnswers, modes, 'p1', false, false);
+    store.dispatch(actions.setCheckAnswerResult({
+      identifier: 'myFunc_5_intro_0', attemptsUsed: 2, correct: false, responses: { q1: false },
+    }));
+    store.dispatch(actions.setCheckAnswerResult({
+      identifier: 'intro_0', attemptsUsed: 1, correct: true, responses: { q1: true },
+    }));
+    store.dispatch(actions.deleteDynamicBlockAnswers({ currentStep: 5, funcIndex: 0, funcName: 'myFunc' }));
+    expect(store.getState().checkAnswer.myFunc_5_intro_0).toBeUndefined();
+    expect(store.getState().checkAnswer.intro_0).toBeDefined();
   });
 });
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -136,6 +136,32 @@ export interface StoredAnswer {
   formOrder?: Record<string, string[]>;
   /** Whether required-response errors were revealed for this trial after a Next attempt. */
   responseSubmitAttempted?: boolean;
+  /** Check Answer state for this trial: attempts used and per-response correctness at the last check. */
+  checkAnswer?: CheckAnswerState;
+}
+
+/**
+ * The CheckAnswerState object is a data structure describing the participant's interaction with an individual component when they click "Check Answer". It is the data structure used as values of the `checkAnswer` object of [StoreState](../StoreState). The general structure for this is below:
+ *
+ * ```json
+ * {
+ *   "attemptsUsed": 2,
+ *   "correct": false,
+ *   "responses": {
+ *     "barChart": true,
+ *     "lineChart": false
+ *   }
+ * }
+ * ```
+ * In the example above the participant answered `barChart` correctly but `lineChart` incorrectly, so the trial is not yet correct.
+ */
+export interface CheckAnswerState {
+  /** How many times the participant has clicked "Check Answer" for this trial. */
+  attemptsUsed: number;
+  /** Whether every response was correct at the last check. */
+  correct: boolean;
+  /** The correctness of each response at the last check. Keys are the "id"s in the [Response](../BaseResponse) list of the component in your [StudyConfiguration](../StudyConfig); values indicate whether that response was correct. */
+  responses: Record<string, boolean>;
 }
 
 export interface JumpFunctionParameters<T> {
@@ -221,6 +247,7 @@ export interface StoreState {
   trialValidation: TrialValidation;
   responseSubmitAttempted: Record<string, boolean>;
   stimulusSubmitAttempted: Record<string, boolean>;
+  checkAnswer: Record<string, CheckAnswerState>;
   reactiveAnswers: Record<string, ValueOf<StoredAnswer['answer']>>;
   metadata: ParticipantMetadata;
   analysisProvState: Record<ConfigResponseBlockLocation, FormElementProvenance | undefined> & { stimulus: unknown | undefined };

--- a/src/utils/getAnswersFromAllLocations.ts
+++ b/src/utils/getAnswersFromAllLocations.ts
@@ -1,0 +1,16 @@
+import { StoredAnswer, TrialValidation, ValidationStatus } from '../store/types';
+
+// Merge the answer values from all locations of a trial's validation entry into a single answer object
+export function getAnswersFromAllLocations(trialValidationEntry: TrialValidation[string] | undefined): StoredAnswer['answer'] {
+  if (!trialValidationEntry) {
+    return {};
+  }
+  const answers = Object.values(trialValidationEntry).reduce((acc, curr) => {
+    if (Object.hasOwn(curr, 'values')) {
+      return { ...acc, ...(curr as ValidationStatus).values };
+    }
+    return acc;
+  }, {}) as StoredAnswer['answer'];
+
+  return structuredClone(answers);
+}

--- a/src/utils/tests/getAnswersFromAllLocations.spec.ts
+++ b/src/utils/tests/getAnswersFromAllLocations.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import type { TrialValidation } from '../../store/types';
+import { getAnswersFromAllLocations } from '../getAnswersFromAllLocations';
+
+function makeEntry(overrides: Partial<TrialValidation[string]>): TrialValidation[string] {
+  return {
+    aboveStimulus: { valid: true, values: {} },
+    belowStimulus: { valid: true, values: {} },
+    sidebar: { valid: true, values: {} },
+    stimulus: { valid: true, values: {} },
+    provenanceGraph: {
+      aboveStimulus: undefined, belowStimulus: undefined, stimulus: undefined, sidebar: undefined,
+    },
+    ...overrides,
+  };
+}
+
+describe('getAnswersFromAllLocations', () => {
+  test('returns an empty object when the entry is undefined', () => {
+    expect(getAnswersFromAllLocations(undefined)).toEqual({});
+  });
+
+  test('merges values from every response block location', () => {
+    const entry = makeEntry({
+      aboveStimulus: { valid: true, values: { q1: 'a' } },
+      belowStimulus: { valid: true, values: { q2: 'b' } },
+      sidebar: { valid: true, values: { q3: 'c' } },
+    });
+    expect(getAnswersFromAllLocations(entry)).toEqual({ q1: 'a', q2: 'b', q3: 'c' });
+  });
+
+  test('merges stimulus values with response block values', () => {
+    const entry = makeEntry({
+      belowStimulus: { valid: true, values: { q1: 'a' } },
+      stimulus: { valid: true, values: { stimulusAnswer: 42 } },
+    });
+    expect(getAnswersFromAllLocations(entry)).toEqual({ q1: 'a', stimulusAnswer: 42 });
+  });
+
+  test('ignores entries without a values field, like the provenance graph', () => {
+    const entry = makeEntry({ belowStimulus: { valid: true, values: { q1: 'a' } } });
+    expect(getAnswersFromAllLocations(entry)).toEqual({ q1: 'a' });
+  });
+
+  test('does not share references with the source validation entry', () => {
+    const nested = { picked: ['x'] };
+    const entry = makeEntry({ belowStimulus: { valid: true, values: { q1: nested } } });
+    const result = getAnswersFromAllLocations(entry);
+    expect(result.q1).toEqual(nested);
+    expect(result.q1).not.toBe(nested);
+  });
+});

--- a/tests/test-training-feedback.spec.ts
+++ b/tests/test-training-feedback.spec.ts
@@ -91,16 +91,18 @@ test('Check Answer reveals unanswered validation without consuming training atte
   await expect(checkAnswerButton).toBeEnabled();
 });
 
-test('test', async ({ page }) => {
+async function goToClevelandTraining(page: Page) {
+  await resetClientStudyState(page);
   await page.goto('/');
   await page.getByRole('tab', { name: 'Example Studies' }).click();
-
-  // Click on cleveland
   await page.getByLabel('Example Studies').locator('div').filter({ hasText: 'Dynamic React.js Stimuli: A Graphical Perception Experiment' })
     .getByText('Go to Study')
     .click();
-
   await goToTraining(page);
+}
+
+test('blocks a failed participant and lets the next participant pass training', async ({ page }) => {
+  await goToClevelandTraining(page);
 
   // Answer the training question incorrectly
   await page.getByPlaceholder('0-100').fill('50');
@@ -135,4 +137,38 @@ test('test', async ({ page }) => {
   // First non-training trial should not require Check Answer.
   await expect(page.getByPlaceholder('0-100')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Check Answer' })).toBeHidden();
+});
+
+test('a failed training survives a mid-trial refresh', async ({ page }) => {
+  await goToClevelandTraining(page);
+
+  // Fail once and refresh: the attempt is restored from storage, so it cannot be reset
+  await page.getByPlaceholder('0-100').fill('50');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  await expect(page.getByText('Please try again. You have 1 attempt left.')).toBeVisible();
+  await page.reload();
+  await expect(page.getByText('Please try again. You have 1 attempt left.')).toBeVisible();
+
+  // Fail the last attempt, then refresh within the 5s delay: the redirect still fires
+  await page.getByPlaceholder('0-100').fill('52');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  await expect(page.getByText(/after 2 attempts/)).toBeVisible();
+  await page.reload();
+  await expect(page.getByText('you are not eligible to participate')).toBeVisible({ timeout: 15000 });
+});
+
+test('a correct answer survives a mid-trial refresh', async ({ page }) => {
+  await goToClevelandTraining(page);
+
+  await page.getByPlaceholder('0-100').fill('66');
+  await page.getByRole('button', { name: 'Check Answer' }).click();
+  await expect(page.getByText('You have answered the question correctly.')).toBeVisible();
+
+  await page.reload();
+
+  // The graded answer is restored, so the disabled input is not empty and Next works
+  await expect(page.getByPlaceholder('0-100')).toHaveValue('66');
+  await expect(page.getByRole('button', { name: 'Next', exact: true })).toBeEnabled();
+  await nextClick(page);
+  await expect(page.getByPlaceholder('0-100')).toHaveValue('');
 });


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed

- Saves Check Answer progress, including attempts used and correctness, so it does not reset 
- Moves Enter handling into `NextButton`, so Enter runs Check Answer first when available, then falls back to Next

### Documentation

Tracking issue: revisit-studies/reVISit-studies.github.io#238

- [x] Done
- [ ] N/A