### PR TITLE
Fix Trrack undo/redo replay

### DIFF
--- a/public/demo-html-trrack/assets/dots-count.html
+++ b/public/demo-html-trrack/assets/dots-count.html
@@ -5,7 +5,40 @@
     <meta charset="UTF-8">
     <title>Trrack Demo</title>
     <script src="https://d3js.org/d3.v7.js"></script>
+    <style>
+        .limit-control {
+            display: inline-block;
+            position: relative;
+        }
 
+        .limit-tooltip {
+            background: #1f2933;
+            border-radius: 4px;
+            bottom: calc(100% + 8px);
+            color: #ffffff;
+            font: 12px/1.4 Arial, Helvetica, sans-serif;
+            left: 50%;
+            opacity: 0;
+            padding: 6px 8px;
+            pointer-events: none;
+            position: absolute;
+            transform: translateX(-50%);
+            visibility: hidden;
+            white-space: nowrap;
+            z-index: 1;
+        }
+
+        .limit-control:hover .limit-tooltip,
+        .limit-control:focus .limit-tooltip,
+        .limit-control:focus-within .limit-tooltip {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .limit-tooltip[hidden] {
+            display: none;
+        }
+    </style>
 </head>
 
 <body>
@@ -17,8 +50,14 @@
         <div class="non-btns">
             <div id="dots">
                 <div>
-                    <button id="add">Add</button>
-                    <button id="rem">Remove</button>
+                    <span class="limit-control" id="add-control">
+                        <button id="add">Add</button>
+                        <span class="limit-tooltip" id="add-limit-tooltip" role="tooltip" hidden>Maximum of 20 dots reached.</span>
+                    </span>
+                    <span class="limit-control" id="remove-control">
+                        <button id="rem">Remove</button>
+                        <span class="limit-tooltip" id="remove-limit-tooltip" role="tooltip" hidden>Minimum of 0 dots reached.</span>
+                    </span>
                 </div>
             </div>
         </div>
@@ -32,6 +71,7 @@
 
     // Task id should match the task's answer id in the config file
     const taskId = 'circlesCount';
+    const maxDots = 20;
 
     function dots(initialDots) {
         const height = 50;
@@ -107,33 +147,92 @@
         registry
     });
 
+    const rootNodeId = trrack.graph.backend.root;
+    const traversalEvents = [{
+        nodeId: rootNodeId,
+        createdOn: trrack.graph.backend.nodes[rootNodeId].createdOn
+    }];
+
     // Render the dots on screen using state from trrack
     const dotActions = dots(trrack.getState().dots);
 
-    // Register a listener to update the dot chart based on trrack updates.
-    trrack.currentChange(() => {
+    const addButton = document.getElementById("add");
+    const removeButton = document.getElementById("rem");
+    const addControl = document.getElementById("add-control");
+    const removeControl = document.getElementById("remove-control");
+    const addTooltip = document.getElementById("add-limit-tooltip");
+    const removeTooltip = document.getElementById("remove-limit-tooltip");
+
+    function setLimitState(button, control, tooltip, disabled) {
+        button.disabled = disabled;
+        tooltip.hidden = !disabled;
+
+        if (disabled) {
+            button.setAttribute("aria-describedby", tooltip.id);
+            control.tabIndex = 0;
+        } else {
+            button.removeAttribute("aria-describedby");
+            control.removeAttribute("tabindex");
+        }
+    }
+
+    function renderState(currentDots) {
+        dotActions.update(currentDots);
+        setLimitState(addButton, addControl, addTooltip, currentDots.length >= maxDots);
+        setLimitState(removeButton, removeControl, removeTooltip, currentDots.length === 0);
+    }
+
+    function recordTraversal() {
+        const lastCreatedOn = traversalEvents[traversalEvents.length - 1].createdOn;
+        traversalEvents.push({
+            nodeId: trrack.graph.backend.current,
+            createdOn: Math.max(Date.now(), lastCreatedOn + 1)
+        });
+    }
+
+    function publishState(shouldRecordTraversal = false) {
+        if (shouldRecordTraversal) {
+            recordTraversal();
+        }
+
         const dots = trrack.getState().dots;
-        dotActions.update(dots);
+        renderState(dots);
         Revisit.postAnswers({
             [taskId]: dots.length
         });
-        Revisit.postProvenance(trrack.graph.backend);
-    });
+        Revisit.postProvenance({
+            ...trrack.graph.backend,
+            traversalEvents: [...traversalEvents]
+        });
+    }
+
+    // Register a listener to update the dot chart based on trrack updates.
+    trrack.currentChange(() => publishState(true));
 
     // Bind button to update dots
-    document.getElementById("add").onclick = () =>
-        trrack.apply("Add Dot", updateDots("add"));
+    addButton.onclick = () => {
+        if (trrack.getState().dots.length < maxDots) {
+            trrack.apply("Add Dot", updateDots("add"));
+        }
+    };
 
-    document.getElementById("rem").onclick = () =>
-        trrack.apply("Remove Dot", updateDots("remove"));
+    removeButton.onclick = () => {
+        if (trrack.getState().dots.length > 0) {
+            trrack.apply("Remove Dot", updateDots("remove"));
+        }
+    };
 
     // Bind undo/redo
     document.getElementById("undo").onclick = () => trrack.undo();
     document.getElementById("redo").onclick = () => trrack.redo();
 
     Revisit.onProvenanceReceive((prov) => {
-        dotActions.update(prov.dots);
-    })
+        if (Array.isArray(prov?.dots)) {
+            renderState(prov.dots);
+        }
+    });
+
+    publishState();
 
 </script>
 

--- a/public/demo-html-trrack/assets/dots-count.html
+++ b/public/demo-html-trrack/assets/dots-count.html
@@ -147,12 +147,6 @@
         registry
     });
 
-    const rootNodeId = trrack.graph.backend.root;
-    const traversalEvents = [{
-        nodeId: rootNodeId,
-        createdOn: trrack.graph.backend.nodes[rootNodeId].createdOn
-    }];
-
     // Render the dots on screen using state from trrack
     const dotActions = dots(trrack.getState().dots);
 
@@ -182,32 +176,17 @@
         setLimitState(removeButton, removeControl, removeTooltip, currentDots.length === 0);
     }
 
-    function recordTraversal() {
-        const lastCreatedOn = traversalEvents[traversalEvents.length - 1].createdOn;
-        traversalEvents.push({
-            nodeId: trrack.graph.backend.current,
-            createdOn: Math.max(Date.now(), lastCreatedOn + 1)
-        });
-    }
-
-    function publishState(shouldRecordTraversal = false) {
-        if (shouldRecordTraversal) {
-            recordTraversal();
-        }
-
+    function publishState() {
         const dots = trrack.getState().dots;
         renderState(dots);
         Revisit.postAnswers({
             [taskId]: dots.length
         });
-        Revisit.postProvenance({
-            ...trrack.graph.backend,
-            traversalEvents: [...traversalEvents]
-        });
+        Revisit.postProvenance(trrack.graph.backend);
     }
 
     // Register a listener to update the dot chart based on trrack updates.
-    trrack.currentChange(() => publishState(true));
+    trrack.currentChange(publishState);
 
     // Bind button to update dots
     addButton.onclick = () => {

--- a/public/demo-svelte-trrack/assets/DotCounter.svelte
+++ b/public/demo-svelte-trrack/assets/DotCounter.svelte
@@ -6,6 +6,8 @@
   export let redo;
 
   $: visibleDots = Array.isArray(dots) ? dots : [];
+  $: atMaximum = visibleDots.length >= 20;
+  $: atMinimum = visibleDots.length === 0;
 </script>
 
 <div class="container">
@@ -15,8 +17,18 @@
   </div>
 
   <div class="controls">
-    <button type="button" on:click={addDot}>Add</button>
-    <button type="button" on:click={removeDot}>Remove</button>
+    <span class="limit-control" tabindex={atMaximum ? 0 : undefined}>
+      <button type="button" on:click={addDot} disabled={atMaximum} aria-describedby={atMaximum ? 'add-limit-tooltip' : undefined}>Add</button>
+      {#if atMaximum}
+        <span class="limit-tooltip" id="add-limit-tooltip" role="tooltip">Maximum of 20 dots reached.</span>
+      {/if}
+    </span>
+    <span class="limit-control" tabindex={atMinimum ? 0 : undefined}>
+      <button type="button" on:click={removeDot} disabled={atMinimum} aria-describedby={atMinimum ? 'remove-limit-tooltip' : undefined}>Remove</button>
+      {#if atMinimum}
+        <span class="limit-tooltip" id="remove-limit-tooltip" role="tooltip">Minimum of 0 dots reached.</span>
+      {/if}
+    </span>
   </div>
 
   <svg viewBox="0 0 500 50" width="500" height="50" aria-label="Dot count">
@@ -30,3 +42,34 @@
     {/each}
   </svg>
 </div>
+
+<style>
+  .limit-control {
+    display: inline-block;
+    position: relative;
+  }
+
+  .limit-tooltip {
+    background: #1f2933;
+    border-radius: 4px;
+    bottom: calc(100% + 8px);
+    color: #ffffff;
+    font: 12px/1.4 Arial, Helvetica, sans-serif;
+    left: 50%;
+    opacity: 0;
+    padding: 6px 8px;
+    pointer-events: none;
+    position: absolute;
+    transform: translateX(-50%);
+    visibility: hidden;
+    white-space: nowrap;
+    z-index: 1;
+  }
+
+  .limit-control:hover .limit-tooltip,
+  .limit-control:focus .limit-tooltip,
+  .limit-control:focus-within .limit-tooltip {
+    opacity: 1;
+    visibility: visible;
+  }
+</style>

--- a/public/demo-svelte-trrack/assets/dots-count.html
+++ b/public/demo-svelte-trrack/assets/dots-count.html
@@ -59,6 +59,7 @@
         import { Registry, initializeTrrack } from 'https://cdn.jsdelivr.net/npm/@trrack/core@1.3.0/+esm';
 
         const taskId = 'circlesCount';
+        const maxDots = 20;
         const initialState = {
             dots: [1]
         };
@@ -81,6 +82,12 @@
             registry
         });
 
+        const rootNodeId = trrack.graph.backend.root;
+        const traversalEvents = [{
+            nodeId: rootNodeId,
+            createdOn: trrack.graph.backend.nodes[rootNodeId].createdOn
+        }];
+
         async function loadComponent() {
             const response = await fetch('./DotCounter.svelte');
             const source = await response.text();
@@ -97,27 +104,55 @@
 
         try {
             const DotCounter = await loadComponent();
+
+            function addDot() {
+                if (trrack.getState().dots.length < maxDots) {
+                    trrack.apply('Add Dot', updateDots('add'));
+                }
+            }
+
+            function removeDot() {
+                if (trrack.getState().dots.length > 0) {
+                    trrack.apply('Remove Dot', updateDots('remove'));
+                }
+            }
+
             const component = new DotCounter({
                 target: document.getElementById('app'),
                 props: {
                     dots: trrack.getState().dots,
-                    addDot: () => trrack.apply('Add Dot', updateDots('add')),
-                    removeDot: () => trrack.apply('Remove Dot', updateDots('remove')),
+                    addDot,
+                    removeDot,
                     undo: () => trrack.undo(),
                     redo: () => trrack.redo()
                 }
             });
 
-            function updateRevisit() {
+            function recordTraversal() {
+                const lastCreatedOn = traversalEvents[traversalEvents.length - 1].createdOn;
+                traversalEvents.push({
+                    nodeId: trrack.graph.backend.current,
+                    createdOn: Math.max(Date.now(), lastCreatedOn + 1)
+                });
+            }
+
+            function updateRevisit(shouldRecordTraversal = false) {
+                if (shouldRecordTraversal) {
+                    recordTraversal();
+                }
+
                 const dots = trrack.getState().dots;
                 component.$set({ dots });
                 Revisit.postAnswers({
                     [taskId]: dots.length
                 });
-                Revisit.postProvenance(trrack.graph.backend);
+                Revisit.postProvenance({
+                    ...trrack.graph.backend,
+                    traversalEvents: [...traversalEvents]
+                });
             }
 
-            trrack.currentChange(updateRevisit);
+            trrack.currentChange(() => updateRevisit(true));
             updateRevisit();
 
             Revisit.onProvenanceReceive((provenanceState) => {

--- a/public/demo-svelte-trrack/assets/dots-count.html
+++ b/public/demo-svelte-trrack/assets/dots-count.html
@@ -82,12 +82,6 @@
             registry
         });
 
-        const rootNodeId = trrack.graph.backend.root;
-        const traversalEvents = [{
-            nodeId: rootNodeId,
-            createdOn: trrack.graph.backend.nodes[rootNodeId].createdOn
-        }];
-
         async function loadComponent() {
             const response = await fetch('./DotCounter.svelte');
             const source = await response.text();
@@ -128,31 +122,16 @@
                 }
             });
 
-            function recordTraversal() {
-                const lastCreatedOn = traversalEvents[traversalEvents.length - 1].createdOn;
-                traversalEvents.push({
-                    nodeId: trrack.graph.backend.current,
-                    createdOn: Math.max(Date.now(), lastCreatedOn + 1)
-                });
-            }
-
-            function updateRevisit(shouldRecordTraversal = false) {
-                if (shouldRecordTraversal) {
-                    recordTraversal();
-                }
-
+            function updateRevisit() {
                 const dots = trrack.getState().dots;
                 component.$set({ dots });
                 Revisit.postAnswers({
                     [taskId]: dots.length
                 });
-                Revisit.postProvenance({
-                    ...trrack.graph.backend,
-                    traversalEvents: [...traversalEvents]
-                });
+                Revisit.postProvenance(trrack.graph.backend);
             }
 
-            trrack.currentChange(() => updateRevisit(true));
+            trrack.currentChange(updateRevisit);
             updateRevisit();
 
             Revisit.onProvenanceReceive((provenanceState) => {

--- a/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
+++ b/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   beforeEach, describe, expect, test, vi,
@@ -31,7 +31,9 @@ vi.mock('@mantine/core', () => ({
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Divider: () => <hr />,
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  Paper: ({ children, ref: _ref }: { children: ReactNode; ref?: React.Ref<HTMLElement> }) => <div>{children}</div>,
+  Paper: forwardRef<HTMLDivElement, { children: ReactNode }>(function Paper({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  }),
   Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
   Title: ({ children }: { children: ReactNode }) => <h5>{children}</h5>,
   Collapse: ({ children, in: open }: { children: ReactNode; in?: boolean }) => (

--- a/src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   render, act, cleanup, fireEvent, waitFor,
@@ -116,7 +116,11 @@ vi.mock('@mantine/core', () => ({
   ),
   Grid: Object.assign(
     ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    { Col: ({ children, ref: _r, ...rest }: { children: ReactNode; ref?: React.Ref<HTMLElement> }) => <div {...rest}>{children}</div> },
+    {
+      Col: forwardRef<HTMLDivElement, { children: ReactNode }>(function Col({ children, ...rest }, ref) { // eslint-disable-line prefer-arrow-callback
+        return <div ref={ref} {...rest}>{children}</div>;
+      }),
+    },
   ),
   Group: ({ children, style }: { children: ReactNode; style?: object }) => <div style={style}>{children}</div>,
   HoverCard: Object.assign(
@@ -157,17 +161,19 @@ vi.mock('@mantine/core', () => ({
       {rightSection}
     </div>
   ),
-  Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Stack: forwardRef<HTMLDivElement, { children: ReactNode }>(function Stack({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  }),
   Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
-  Textarea: ({
-    value, onChange, onKeyDown, onFocus, placeholder, onBlur, defaultValue,
-  }: {
+  Textarea: forwardRef<HTMLTextAreaElement, {
     value?: string; defaultValue?: string; onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
     onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>; onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
     placeholder?: string; onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
-  }) => (
-    <textarea data-testid="textarea" value={value} defaultValue={defaultValue} onChange={onChange} onKeyDown={onKeyDown} onFocus={onFocus} placeholder={placeholder} onBlur={onBlur} />
-  ),
+  }>(function Textarea({ // eslint-disable-line prefer-arrow-callback
+    value, onChange, onKeyDown, onFocus, placeholder, onBlur, defaultValue,
+  }, ref) {
+    return <textarea ref={ref} data-testid="textarea" value={value} defaultValue={defaultValue} onChange={onChange} onKeyDown={onKeyDown} onFocus={onFocus} placeholder={placeholder} onBlur={onBlur} />;
+  }),
   TextInput: ({ placeholder, value }: { placeholder?: string; value?: string }) => <input placeholder={placeholder} defaultValue={value} />,
   Tooltip: ({ children, label }: { children: ReactNode; label?: ReactNode }) => <div title={String(label)}>{children}</div>,
   useCombobox: () => ({ toggleDropdown: vi.fn(), openDropdown: vi.fn(), closeDropdown: vi.fn() }),

--- a/src/analysis/tests/StudyAnalysisTabs.spec.tsx
+++ b/src/analysis/tests/StudyAnalysisTabs.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   render, act, cleanup, screen, waitFor, fireEvent,
@@ -141,7 +141,9 @@ vi.mock('@mantine/core', () => ({
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   LoadingOverlay: () => null,
-  Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Stack: forwardRef<HTMLDivElement, { children: ReactNode }>(function Stack({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  }),
   Tabs: Object.assign(
     ({ children }: { children: ReactNode }) => <div>{children}</div>,
     {

--- a/src/components/audioAnalysis/AudioProvenanceVis.tsx
+++ b/src/components/audioAnalysis/AudioProvenanceVis.tsx
@@ -11,7 +11,7 @@ import { useResizeObserver, useThrottledCallback } from '@mantine/hooks';
 import { WaveForm, WaveSurfer } from 'wavesurfer-react';
 import * as d3 from 'd3';
 import {
-  Registry, Trrack, initializeTrrack, isRootNode,
+  Registry, Trrack, initializeTrrack,
 } from '@trrack/core';
 import WaveSurferType from 'wavesurfer.js';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
@@ -28,6 +28,7 @@ import { useReplayContext } from '../../store/hooks/useReplay';
 import { syncChannel, syncEmitter } from '../../utils/syncReplay';
 import type { StoredProvenance } from '../../store/types';
 import { getLegacyStoredAnswerProvenance } from '../../store/provenance';
+import { getReplaySelection } from './provenanceReplay';
 
 const margin = {
   left: 20, top: 0, right: 20, bottom: 0,
@@ -133,11 +134,12 @@ export function AudioProvenanceVis({
     };
   }, [legacyProvenanceGraph, participantId, storageEngine, taskName]);
 
-  const _setCurrentResponseNodes = useEvent((node: string | null, location: ResponseBlockLocation) => {
+  const _setCurrentResponseNodes = useEvent((node: string | null, location: ResponseBlockLocation, createdOn?: number) => {
     const graph = provenanceGraph?.[location];
     if (graph && node) {
-      if (!currentGlobalNode || graph.nodes[node].createdOn > currentGlobalNode.time || playTime < currentGlobalNode.time) {
-        setCurrentGlobalNode({ name: node || '', time: graph.nodes[node].createdOn });
+      const replayEventTime = createdOn ?? graph.nodes[node].createdOn;
+      if (!currentGlobalNode || replayEventTime > currentGlobalNode.time || playTime < currentGlobalNode.time) {
+        setCurrentGlobalNode({ name: node || '', time: replayEventTime });
       }
     }
 
@@ -235,7 +237,7 @@ export function AudioProvenanceVis({
     }
   }, [provenanceGraph, taskName]);
 
-  const _setCurrentNode = useCallback((node: string | undefined) => {
+  const _setCurrentNode = useCallback((node: string | undefined, createdOn?: number) => {
     if (!node) {
       return;
     }
@@ -246,7 +248,7 @@ export function AudioProvenanceVis({
       trrackForTrial.current.to(node);
     }
 
-    _setCurrentResponseNodes(node, 'stimulus');
+    _setCurrentResponseNodes(node, 'stimulus', createdOn);
     setCurrentNode(node);
   }, [taskName, context, _setCurrentResponseNodes, saveProvenance, provenanceGraph]);
 
@@ -261,31 +263,13 @@ export function AudioProvenanceVis({
       return;
     }
 
-    if (!currentNode || !provGraph.stimulus.nodes[currentNode]) {
-      _setCurrentNode(provGraph.stimulus.root as string);
-      return;
-    }
+    const replaySelection = getReplaySelection(provGraph.stimulus, playTime, currentNode);
 
-    let tempNode = provGraph.stimulus.nodes[currentNode];
-
-    while (true) {
-      if (playTime < tempNode.createdOn) {
-        if (!isRootNode(tempNode)) {
-          const parentNode = tempNode.parent;
-
-          tempNode = provGraph.stimulus.nodes[parentNode];
-        } else break;
-      } else if (tempNode.children.length > 0) {
-        const child = tempNode.children[0];
-
-        if (playTime > provGraph.stimulus.nodes[child].createdOn) {
-          tempNode = provGraph.stimulus.nodes[child];
-        } else break;
-      } else break;
-    }
-
-    if (tempNode.id !== currentNode) {
-      _setCurrentNode(tempNode.id);
+    if (replaySelection.nodeId !== currentNode) {
+      _setCurrentNode(
+        replaySelection.nodeId,
+        replaySelection.fromTraversal ? replaySelection.createdOn : undefined,
+      );
     }
   }, [_setCurrentNode, currentNode, participantId, playTime, taskName, provenanceGraph]);
 

--- a/src/components/audioAnalysis/provenanceReplay.ts
+++ b/src/components/audioAnalysis/provenanceReplay.ts
@@ -1,43 +1,16 @@
-import type { TrrackedProvenance } from '../../store/types';
-
-export type ProvenanceTraversalEvent = {
-  nodeId: string;
-  createdOn: number;
-};
+import { getProvenanceTraversalEvents } from '../../store/provenance';
+import type { ProvenanceTraversalEvent, TrrackedProvenance } from '../../store/types';
 
 export type ProvenanceReplaySelection = ProvenanceTraversalEvent & {
   fromTraversal: boolean;
 };
-
-type ReplayableProvenance = TrrackedProvenance & {
-  traversalEvents?: unknown;
-};
-
-function getTraversalEvents(provenance: ReplayableProvenance): ProvenanceTraversalEvent[] {
-  if (!Array.isArray(provenance.traversalEvents)) {
-    return [];
-  }
-
-  return provenance.traversalEvents
-    .filter((event): event is ProvenanceTraversalEvent => (
-      typeof event === 'object'
-      && event !== null
-      && 'nodeId' in event
-      && typeof event.nodeId === 'string'
-      && event.nodeId in provenance.nodes
-      && 'createdOn' in event
-      && typeof event.createdOn === 'number'
-      && Number.isFinite(event.createdOn)
-    ))
-    .sort((first, second) => first.createdOn - second.createdOn);
-}
 
 export function getReplaySelection(
   provenance: TrrackedProvenance,
   playTime: number,
   currentNode?: string | null,
 ): ProvenanceReplaySelection {
-  const traversalEvents = getTraversalEvents(provenance as ReplayableProvenance);
+  const traversalEvents = getProvenanceTraversalEvents(provenance);
 
   if (traversalEvents.length > 0) {
     let replaySelection = {

--- a/src/components/audioAnalysis/provenanceReplay.ts
+++ b/src/components/audioAnalysis/provenanceReplay.ts
@@ -1,0 +1,101 @@
+import type { TrrackedProvenance } from '../../store/types';
+
+export type ProvenanceTraversalEvent = {
+  nodeId: string;
+  createdOn: number;
+};
+
+export type ProvenanceReplaySelection = ProvenanceTraversalEvent & {
+  fromTraversal: boolean;
+};
+
+type ReplayableProvenance = TrrackedProvenance & {
+  traversalEvents?: unknown;
+};
+
+function getTraversalEvents(provenance: ReplayableProvenance): ProvenanceTraversalEvent[] {
+  if (!Array.isArray(provenance.traversalEvents)) {
+    return [];
+  }
+
+  return provenance.traversalEvents
+    .filter((event): event is ProvenanceTraversalEvent => (
+      typeof event === 'object'
+      && event !== null
+      && 'nodeId' in event
+      && typeof event.nodeId === 'string'
+      && event.nodeId in provenance.nodes
+      && 'createdOn' in event
+      && typeof event.createdOn === 'number'
+      && Number.isFinite(event.createdOn)
+    ))
+    .sort((first, second) => first.createdOn - second.createdOn);
+}
+
+export function getReplaySelection(
+  provenance: TrrackedProvenance,
+  playTime: number,
+  currentNode?: string | null,
+): ProvenanceReplaySelection {
+  const traversalEvents = getTraversalEvents(provenance as ReplayableProvenance);
+
+  if (traversalEvents.length > 0) {
+    let replaySelection = {
+      nodeId: provenance.root as string,
+      createdOn: provenance.nodes[provenance.root].createdOn,
+      fromTraversal: true,
+    };
+
+    traversalEvents.forEach((event) => {
+      if (event.createdOn <= playTime) {
+        replaySelection = { ...event, fromTraversal: true };
+      }
+    });
+
+    return replaySelection;
+  }
+
+  if (!currentNode || !provenance.nodes[currentNode]) {
+    return {
+      nodeId: provenance.root as string,
+      createdOn: provenance.nodes[provenance.root].createdOn,
+      fromTraversal: false,
+    };
+  }
+
+  let replayNode = provenance.nodes[currentNode];
+
+  while (true) {
+    if (playTime < replayNode.createdOn) {
+      if (replayNode.id === provenance.root || !('parent' in replayNode)) {
+        break;
+      }
+
+      replayNode = provenance.nodes[replayNode.parent];
+    } else if (replayNode.children.length > 0) {
+      const child = provenance.nodes[replayNode.children[0]];
+
+      if (playTime >= child.createdOn) {
+        replayNode = child;
+      } else {
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+
+  return {
+    nodeId: replayNode.id,
+    createdOn: replayNode.createdOn,
+    fromTraversal: false,
+  };
+}
+
+export function getReplayNodeId(
+  provenance: TrrackedProvenance,
+  playTime: number,
+  currentNode?: string | null,
+) {
+  return getReplaySelection(provenance, playTime, currentNode).nodeId;
+}

--- a/src/components/audioAnalysis/tests/AudioProvenanceVis.spec.tsx
+++ b/src/components/audioAnalysis/tests/AudioProvenanceVis.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   render, act, cleanup, renderHook,
@@ -20,12 +20,16 @@ vi.mock('wavesurfer-react', () => ({
 }));
 
 vi.mock('@mantine/core', () => ({
-  Box: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Box: forwardRef<HTMLDivElement, { children?: ReactNode }>(function Box({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  }),
   Group: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   LoadingOverlay: ({ visible }: { visible: boolean }) => (
     visible ? <div data-testid="loading-overlay" /> : null
   ),
-  Stack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Stack: forwardRef<HTMLDivElement, { children?: ReactNode }>(function Stack({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  }),
 }));
 
 vi.mock('@mantine/hooks', () => ({

--- a/src/components/audioAnalysis/tests/provenanceReplay.spec.ts
+++ b/src/components/audioAnalysis/tests/provenanceReplay.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import type { TrrackedProvenance } from '../../../store/types';
-import { getReplayNodeId, getReplaySelection, type ProvenanceTraversalEvent } from '../provenanceReplay';
+import type { ProvenanceTraversalEvent, TrrackedProvenance } from '../../../store/types';
+import { getReplayNodeId, getReplaySelection } from '../provenanceReplay';
 
 function makeNode(id: string, createdOn: number, children: string[], parent?: string) {
   return {

--- a/src/components/audioAnalysis/tests/provenanceReplay.spec.ts
+++ b/src/components/audioAnalysis/tests/provenanceReplay.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest';
+import type { TrrackedProvenance } from '../../../store/types';
+import { getReplayNodeId, getReplaySelection, type ProvenanceTraversalEvent } from '../provenanceReplay';
+
+function makeNode(id: string, createdOn: number, children: string[], parent?: string) {
+  return {
+    id,
+    createdOn,
+    children,
+    parent,
+  } as TrrackedProvenance['nodes'][string];
+}
+
+function makeGraph(traversalEvents?: ProvenanceTraversalEvent[]) {
+  return {
+    root: 'root',
+    current: 'branch',
+    nodes: {
+      root: makeNode('root', 1000, ['two']),
+      two: makeNode('two', 2000, ['three', 'branch'], 'root'),
+      three: makeNode('three', 3000, [], 'two'),
+      branch: makeNode('branch', 5000, [], 'two'),
+    },
+    traversalEvents,
+  } as TrrackedProvenance;
+}
+
+describe('getReplayNodeId', () => {
+  test('replays undo and redo traversal events in chronological order', () => {
+    const graph = makeGraph([
+      { nodeId: 'root', createdOn: 1000 },
+      { nodeId: 'two', createdOn: 2000 },
+      { nodeId: 'three', createdOn: 3000 },
+      { nodeId: 'two', createdOn: 4000 },
+      { nodeId: 'three', createdOn: 4500 },
+    ]);
+
+    expect(getReplayNodeId(graph, 1500)).toBe('root');
+    expect(getReplayNodeId(graph, 2500)).toBe('two');
+    expect(getReplayNodeId(graph, 3500)).toBe('three');
+    expect(getReplayNodeId(graph, 4250)).toBe('two');
+    expect(getReplayNodeId(graph, 4750)).toBe('three');
+    expect(getReplaySelection(graph, 4250)).toEqual({
+      nodeId: 'two',
+      createdOn: 4000,
+      fromTraversal: true,
+    });
+  });
+
+  test('replays a new branch after undo instead of the abandoned redo state', () => {
+    const graph = makeGraph([
+      { nodeId: 'root', createdOn: 1000 },
+      { nodeId: 'two', createdOn: 2000 },
+      { nodeId: 'three', createdOn: 3000 },
+      { nodeId: 'two', createdOn: 4000 },
+      { nodeId: 'branch', createdOn: 5000 },
+    ]);
+
+    expect(getReplayNodeId(graph, 3500)).toBe('three');
+    expect(getReplayNodeId(graph, 4500)).toBe('two');
+    expect(getReplayNodeId(graph, 5500)).toBe('branch');
+  });
+
+  test('falls back to the existing first-child replay for historical graphs', () => {
+    const graph = makeGraph();
+
+    expect(getReplayNodeId(graph, 1500, 'three')).toBe('root');
+    expect(getReplayNodeId(graph, 2500, 'root')).toBe('two');
+    expect(getReplayNodeId(graph, 3500, 'two')).toBe('three');
+  });
+
+  test('ignores malformed traversal events', () => {
+    const graph = {
+      ...makeGraph(),
+      traversalEvents: [{ nodeId: 'missing', createdOn: 4000 }],
+    } as TrrackedProvenance;
+
+    expect(getReplayNodeId(graph, 3500, 'two')).toBe('three');
+  });
+});

--- a/src/components/audioAnalysis/useUpdateProvenance.tsx
+++ b/src/components/audioAnalysis/useUpdateProvenance.tsx
@@ -1,11 +1,12 @@
 // use effect to control the current provenance node based on the changing playtime.
 
 import { useEffect, useMemo } from 'react';
-import { initializeTrrack, isRootNode, Registry } from '@trrack/core';
+import { initializeTrrack, Registry } from '@trrack/core';
 import { TrrackedProvenance } from '../../store/types';
 import { ResponseBlockLocation } from '../../parser/types';
+import { getReplaySelection } from './provenanceReplay';
 
-export function useUpdateProvenance(location: ResponseBlockLocation, playTime: number, provGraph: TrrackedProvenance | undefined, currentNode: string | undefined, setCurrentNode: (node: string | null, _location: ResponseBlockLocation) => void, saveProvenance?: (prov: unknown) => void) {
+export function useUpdateProvenance(location: ResponseBlockLocation, playTime: number, provGraph: TrrackedProvenance | undefined, currentNode: string | undefined, setCurrentNode: (node: string | null, _location: ResponseBlockLocation, createdOn?: number) => void, saveProvenance?: (prov: unknown) => void) {
   const trrackInstance = useMemo(() => {
     const reg = Registry.create();
 
@@ -31,34 +32,15 @@ export function useUpdateProvenance(location: ResponseBlockLocation, playTime: n
       return;
     }
 
-    if (!currentNode || !provGraph.nodes[currentNode]) {
-      setCurrentNode(provGraph.root as string, location);
-      saveProvenance({ prov: trrackInstance.getState(provGraph.nodes[provGraph.root]), location });
+    const replaySelection = getReplaySelection(provGraph, playTime, currentNode);
 
-      return;
-    }
-
-    let tempNode = provGraph.nodes[currentNode];
-
-    while (true) {
-      if (playTime < tempNode.createdOn) {
-        if (!isRootNode(tempNode)) {
-          const parentNode = tempNode.parent;
-
-          tempNode = provGraph.nodes[parentNode];
-        } else break;
-      } else if (tempNode.children.length > 0) {
-        const child = tempNode.children[0];
-
-        if (playTime > provGraph.nodes[child].createdOn) {
-          tempNode = provGraph.nodes[child];
-        } else break;
-      } else break;
-    }
-
-    if (tempNode.id !== currentNode) {
-      setCurrentNode(tempNode.id, location);
-      saveProvenance({ prov: trrackInstance.getState(tempNode), location });
+    if (replaySelection.nodeId !== currentNode) {
+      if (replaySelection.fromTraversal) {
+        setCurrentNode(replaySelection.nodeId, location, replaySelection.createdOn);
+      } else {
+        setCurrentNode(replaySelection.nodeId, location);
+      }
+      saveProvenance({ prov: trrackInstance.getState(provGraph.nodes[replaySelection.nodeId]), location });
     }
   }, [currentNode, playTime, provGraph, location, setCurrentNode, trrackInstance, saveProvenance]);
 }

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -528,12 +528,10 @@ export function DownloadTidy({
         <Progress value={downloadProgress} animated />
       )}
       <Box>
-        <Text size="sm" fw={500} mb="xs">
-          <Flex align="center" gap="xs">
-            <IconLayoutColumns size={16} />
-            Optional columns:
-          </Flex>
-        </Text>
+        <Flex align="center" gap="xs" mb="xs">
+          <IconLayoutColumns size={16} />
+          <Text size="sm" fw={500}>Optional columns:</Text>
+        </Flex>
         <Flex wrap="wrap" gap="4px">
           {OPTIONAL_COMMON_PROPS.filter((prop) => prop !== 'transcript' || transcriptAvailable).map((prop) => {
             const isSelected = selectedProperties.includes(prop);

--- a/src/components/interface/tests/AppHeader.spec.tsx
+++ b/src/components/interface/tests/AppHeader.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   render, act, cleanup,
@@ -72,7 +72,9 @@ vi.mock('@mantine/core', () => ({
   ),
   Progress: ({ value }: { value: number }) => <div data-testid="progress" data-value={value} />,
   Space: () => <span />,
-  Title: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+  Title: forwardRef<HTMLHeadingElement, { children: ReactNode }>(function Title({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <h1 ref={ref}>{children}</h1>;
+  }),
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
 }));

--- a/src/components/interface/tests/StepsPanel.spec.tsx
+++ b/src/components/interface/tests/StepsPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import {
   render, act, cleanup, fireEvent,
 } from '@testing-library/react';
@@ -53,7 +53,9 @@ vi.mock('../../../parser/utils', () => ({
 
 vi.mock('@mantine/core', () => ({
   Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
-  Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Box: forwardRef<HTMLDivElement, { children: ReactNode }>(function Box({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  }),
   Code: ({ children }: { children: ReactNode }) => <code>{children}</code>,
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   HoverCard: Object.assign(
@@ -70,7 +72,7 @@ vi.mock('@mantine/core', () => ({
     </div>
   ),
   Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
-  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tooltip: ({ children }: { children: ReactNode }) => children,
   Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
     <button type="button" onClick={onClick}>{children}</button>
   ),

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -75,7 +75,9 @@ vi.mock('@mantine/core', () => ({
   }) => React.createElement('button', { type: 'button', onClick, disabled }, children),
   Flex: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
   Group: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
-  Paper: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
+  Paper: React.forwardRef<HTMLDivElement, { children?: React.ReactNode }>(function Paper({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return React.createElement('div', { ref }, children);
+  }),
   Stack: ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children),
   Text: ({ children }: { children?: React.ReactNode }) => React.createElement('span', null, children),
 }));

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -3,7 +3,6 @@ import { Provider } from 'react-redux';
 import {
   render, act, fireEvent, cleanup,
 } from '@testing-library/react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
@@ -300,25 +299,29 @@ afterEach(() => cleanup());
 describe('ResponseBlock', () => {
   test('renders without error', async () => {
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).toContain('<div');
   });
 
   test('renders ResponseSwitcher for response at matching location', async () => {
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).toContain('switcher-shortText');
   });
 
   test('shows NextButton when location matches nextButtonLocation', async () => {
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).toContain('Next');
   });
 
   test('omits NextButton when location does not match nextButtonLocation', async () => {
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="sidebar" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="sidebar" />));
+    const html = container.innerHTML;
     expect(html).not.toContain('Next');
   });
 
@@ -332,13 +335,15 @@ describe('ResponseBlock', () => {
       ],
     } as IndividualComponent;
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={hiddenConfig} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={hiddenConfig} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).not.toContain('switcher-shortText');
   });
 
   test('renders with provided style prop without error', async () => {
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" style={{ color: 'red' }} />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" style={{ color: 'red' }} />));
+    const html = container.innerHTML;
     expect(html).toContain('switcher-shortText');
   });
 
@@ -348,7 +353,8 @@ describe('ResponseBlock', () => {
       nextButtonText: 'Submit',
     } as IndividualComponent;
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={configWithText} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={configWithText} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).toContain('Submit');
   });
 
@@ -359,7 +365,8 @@ describe('ResponseBlock', () => {
       correctAnswer: [{ id: 'q1', answer: 'correct' }],
     } as IndividualComponent;
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={configWithFeedback} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={configWithFeedback} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).toContain('Check Answer');
   });
 
@@ -369,7 +376,8 @@ describe('ResponseBlock', () => {
       response: [{ type: 'textOnly', id: 'q1', prompt: 'Read this.' }],
     } as IndividualComponent;
     const studyStore = await makeStudyStore();
-    const html = renderToStaticMarkup(withStore(studyStore, <ResponseBlock config={textOnlyConfig} location="belowStimulus" />));
+    const { container } = render(withStore(studyStore, <ResponseBlock config={textOnlyConfig} location="belowStimulus" />));
+    const html = container.innerHTML;
     expect(html).toContain('switcher-textOnly');
   });
 

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -74,7 +74,19 @@ vi.mock('@trrack/core', () => ({
   },
   initializeTrrack: vi.fn(() => ({
     apply: vi.fn(),
-    graph: { backend: {} },
+    graph: {
+      backend: {
+        root: 'root',
+        current: 'root',
+        nodes: {
+          root: {
+            id: 'root',
+            createdOn: 0,
+            children: [],
+          },
+        },
+      },
+    },
   })),
 }));
 

--- a/src/components/response/tests/ResponseInput.spec.tsx
+++ b/src/components/response/tests/ResponseInput.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   render, act, cleanup,
@@ -42,9 +42,9 @@ import type {
 // ── mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('@mantine/core', () => {
-  function Div({ children }: { children?: ReactNode }) {
-    return <div>{children}</div>;
-  }
+  const Div = forwardRef<HTMLDivElement, { children?: ReactNode }>(function Div({ children }, ref) { // eslint-disable-line prefer-arrow-callback
+    return <div ref={ref}>{children}</div>;
+  });
   function Span({ children }: { children?: ReactNode }) {
     return <span>{children}</span>;
   }

--- a/src/components/tests/ConfigSwitcher.spec.tsx
+++ b/src/components/tests/ConfigSwitcher.spec.tsx
@@ -44,7 +44,9 @@ vi.mock('@mantine/core', () => ({
       Panel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     },
   ),
-  Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  Text: ({ children, span }: { children: ReactNode; span?: boolean }) => (
+    span ? <span>{children}</span> : <p>{children}</p>
+  ),
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 

--- a/src/components/tests/ErrorLoadingConfig.spec.tsx
+++ b/src/components/tests/ErrorLoadingConfig.spec.tsx
@@ -1,10 +1,25 @@
-import { renderToStaticMarkup } from 'react-dom/server';
 import { MantineProvider } from '@mantine/core';
-import { describe, expect, test } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
 import { ParsedConfig, StudyConfig } from '../../parser/types';
 import { ErrorLoadingConfig } from '../ErrorLoadingConfig';
 
 describe('ErrorLoadingConfig', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
   test('separates non-combinable grouped messages on new lines', () => {
     const issues: ParsedConfig<StudyConfig>['errors'] = [
       {
@@ -21,13 +36,14 @@ describe('ErrorLoadingConfig', () => {
       },
     ];
 
-    const html = renderToStaticMarkup(
+    const { container } = render(
       <MantineProvider>
         <ErrorLoadingConfig issues={issues} type="error" />
       </MantineProvider>,
     );
+    const html = container.innerHTML;
 
-    expect(html).toMatch(/First validation issue[\s\S]*<br\/>[\s\S]*Second validation issue/);
+    expect(html).toMatch(/First validation issue[\s\S]*<br>[\s\S]*Second validation issue/);
   });
 
   test('keeps dominant required-property message for anyOf alternatives', () => {
@@ -70,11 +86,12 @@ describe('ErrorLoadingConfig', () => {
       },
     ];
 
-    const html = renderToStaticMarkup(
+    const { container } = render(
       <MantineProvider>
         <ErrorLoadingConfig issues={issues} type="error" />
       </MantineProvider>,
     );
+    const html = container.innerHTML;
     const textOnly = html.replace(/<[^>]*>/g, ' ');
 
     expect(textOnly).toMatch(/Missing required property\s+type/);
@@ -95,11 +112,12 @@ describe('ErrorLoadingConfig', () => {
       },
     ];
 
-    const html = renderToStaticMarkup(
+    const { container } = render(
       <MantineProvider>
         <ErrorLoadingConfig issues={issues} type="error" />
       </MantineProvider>,
     );
+    const html = container.innerHTML;
     const textOnly = html.replace(/<[^>]*>/g, ' ');
 
     expect(textOnly).toContain('Default Contact Email');
@@ -118,11 +136,12 @@ describe('ErrorLoadingConfig', () => {
       },
     ];
 
-    const html = renderToStaticMarkup(
+    const { container } = render(
       <MantineProvider>
         <ErrorLoadingConfig issues={issues} type="warning" />
       </MantineProvider>,
     );
+    const html = container.innerHTML;
     const textOnly = html.replace(/<[^>]*>/g, ' ');
 
     expect(textOnly).toContain('Default Firebase Config');
@@ -141,11 +160,12 @@ describe('ErrorLoadingConfig', () => {
       },
     ];
 
-    const html = renderToStaticMarkup(
+    const { container } = render(
       <MantineProvider>
         <ErrorLoadingConfig issues={issues} type="warning" />
       </MantineProvider>,
     );
+    const html = container.innerHTML;
     const textOnly = html.replace(/<[^>]*>/g, ' ');
 
     expect(textOnly).toContain('Default Supabase Config');

--- a/src/store/provenance.ts
+++ b/src/store/provenance.ts
@@ -1,5 +1,7 @@
 import type { ResponseBlockLocation } from '../parser/types';
-import type { StoredAnswer, StoredProvenance } from './types';
+import type {
+  ProvenanceTraversalEvent, StoredAnswer, StoredProvenance, TrrackedProvenance,
+} from './types';
 
 export const PROVENANCE_LOCATIONS: ResponseBlockLocation[] = [
   'aboveStimulus',
@@ -18,6 +20,58 @@ export function createEmptyProvenance(): StoredProvenance {
     belowStimulus: undefined,
     sidebar: undefined,
     stimulus: undefined,
+  };
+}
+
+export function getProvenanceTraversalEvents(
+  provenance: TrrackedProvenance,
+): ProvenanceTraversalEvent[] {
+  if (!Array.isArray(provenance.traversalEvents)) {
+    return [];
+  }
+
+  return provenance.traversalEvents
+    .filter((event): event is ProvenanceTraversalEvent => (
+      typeof event === 'object'
+      && event !== null
+      && typeof event.nodeId === 'string'
+      && event.nodeId in provenance.nodes
+      && typeof event.createdOn === 'number'
+      && Number.isFinite(event.createdOn)
+    ))
+    .sort((first, second) => first.createdOn - second.createdOn);
+}
+
+export function appendProvenanceTraversalEvent(
+  previousProvenance: TrrackedProvenance | undefined,
+  incomingProvenance: TrrackedProvenance,
+  observedAt: number,
+): TrrackedProvenance {
+  const isSameGraph = previousProvenance?.root === incomingProvenance.root;
+  const previousEvents = isSameGraph && previousProvenance
+    ? getProvenanceTraversalEvents(previousProvenance)
+    : [];
+  const incomingEvents = getProvenanceTraversalEvents(incomingProvenance);
+  const traversalEvents = incomingEvents.length >= previousEvents.length
+    ? incomingEvents
+    : previousEvents;
+  const currentNodeId = incomingProvenance.current as string;
+  const currentNode = incomingProvenance.nodes[currentNodeId];
+
+  if (!currentNode || traversalEvents.at(-1)?.nodeId === currentNodeId) {
+    return traversalEvents.length > 0
+      ? { ...incomingProvenance, traversalEvents }
+      : incomingProvenance;
+  }
+
+  const isNewNode = !isSameGraph || !previousProvenance?.nodes[currentNodeId];
+  const eventTime = isNewNode ? currentNode.createdOn : observedAt;
+  const previousEventTime = traversalEvents.at(-1)?.createdOn ?? Number.NEGATIVE_INFINITY;
+  const createdOn = Math.max(eventTime, previousEventTime + 1);
+
+  return {
+    ...incomingProvenance,
+    traversalEvents: [...traversalEvents, { nodeId: currentNodeId, createdOn }],
   };
 }
 

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -14,6 +14,21 @@ import { REVISIT_MODE } from '../storage/engines/types';
 import { studyComponentToIndividualComponent } from '../utils/handleComponentInheritance';
 import { randomizeOptions, randomizeQuestionOrder, randomizeForm } from '../utils/handleResponseRandomization';
 import { getInitialStimulusValidation } from '../components/response/stimulusErrors';
+import { appendProvenanceTraversalEvent } from './provenance';
+
+type UpdateResponseBlockValidationInput = {
+  location: ResponseBlockLocation;
+  identifier: string;
+  status: boolean;
+  values: object;
+  provenanceGraph?: TrrackedProvenance;
+  reason?: ValidationStatus['reason'];
+  message?: ValidationStatus['message'];
+};
+
+type UpdateResponseBlockValidationPayload = UpdateResponseBlockValidationInput & {
+  provenanceObservedAt: number;
+};
 
 export async function studyStoreCreator(
   studyId: string,
@@ -282,47 +297,49 @@ export async function studyStoreCreator(
           state.rankingAnswers = {};
         }
       },
-      updateResponseBlockValidation: (
-        state,
-        {
-          payload,
-        }: PayloadAction<{
-          location: ResponseBlockLocation;
-          identifier: string;
-          status: boolean;
-          values: object;
-          provenanceGraph?: TrrackedProvenance;
-          reason?: ValidationStatus['reason'];
-          message?: ValidationStatus['message'];
-        }>,
-      ) => {
-        if (!state.trialValidation[payload.identifier]) {
-          return;
-        }
-        const currentValidation = state.trialValidation[payload.identifier]?.[payload.location];
-        const currentValues = currentValidation?.values;
-        const finalReason = payload.status ? undefined : (payload.reason ?? currentValidation?.reason);
-        const finalMessage = payload.status ? undefined : (payload.message ?? currentValidation?.message);
+      updateResponseBlockValidation: {
+        reducer(state, { payload }: PayloadAction<UpdateResponseBlockValidationPayload>) {
+          if (!state.trialValidation[payload.identifier]) {
+            return;
+          }
+          const currentValidation = state.trialValidation[payload.identifier]?.[payload.location];
+          const currentValues = currentValidation?.values;
+          const finalReason = payload.status ? undefined : (payload.reason ?? currentValidation?.reason);
+          const finalMessage = payload.status ? undefined : (payload.message ?? currentValidation?.message);
 
-        if (Object.keys(payload.values).length > 0) {
-          state.trialValidation[payload.identifier][payload.location] = {
-            valid: payload.status,
-            values: { ...currentValues, ...payload.values },
-            reason: finalReason,
-            message: finalMessage,
-          };
-        } else {
-          state.trialValidation[payload.identifier][payload.location] = {
-            valid: payload.status,
-            values: currentValues || {},
-            reason: finalReason,
-            message: finalMessage,
-          };
-        }
+          if (Object.keys(payload.values).length > 0) {
+            state.trialValidation[payload.identifier][payload.location] = {
+              valid: payload.status,
+              values: { ...currentValues, ...payload.values },
+              reason: finalReason,
+              message: finalMessage,
+            };
+          } else {
+            state.trialValidation[payload.identifier][payload.location] = {
+              valid: payload.status,
+              values: currentValues || {},
+              reason: finalReason,
+              message: finalMessage,
+            };
+          }
 
-        if (payload.provenanceGraph) {
-          state.trialValidation[payload.identifier].provenanceGraph[payload.location] = payload.provenanceGraph;
-        }
+          if (payload.provenanceGraph) {
+            const previousProvenance = state.trialValidation[payload.identifier].provenanceGraph[payload.location];
+            state.trialValidation[payload.identifier].provenanceGraph[payload.location] = appendProvenanceTraversalEvent(
+              previousProvenance as TrrackedProvenance | undefined,
+              payload.provenanceGraph,
+              payload.provenanceObservedAt,
+            );
+          }
+        },
+        prepare(payload: UpdateResponseBlockValidationInput) {
+          return {
+            payload: {
+              ...payload,
+              provenanceObservedAt: Date.now(),
+            },
+          };
+        },
       },
       setResponseSubmitAttempt(state, { payload }: PayloadAction<{ identifier: string; attempted: boolean }>) {
         state.responseSubmitAttempted[payload.identifier] = payload.attempted;

--- a/src/store/tests/store.spec.ts
+++ b/src/store/tests/store.spec.ts
@@ -8,7 +8,7 @@ import {
   studyStoreCreator, useAreResponsesValid, useFlatSequence, useStoreActions, StudyStoreContext,
 } from '../store';
 import type { ResponseBlockLocation, StudyConfig } from '../../parser/types';
-import type { Sequence, StoredAnswer } from '../types';
+import type { Sequence, StoredAnswer, TrrackedProvenance } from '../types';
 import type { ParticipantData } from '../../storage/types';
 import type { REVISIT_MODE } from '../../storage/engines/types';
 import { makeStoredAnswer } from '../../tests/utils';
@@ -372,6 +372,70 @@ describe('studyStoreCreator', () => {
       status: true,
       values: {},
     }));
+  });
+
+  test('updateResponseBlockValidation records provenance traversal automatically', async () => {
+    const { store, actions } = await studyStoreCreator('test', minimalConfig, minimalSequence, metadata, emptyAnswers, modes, 'p1', false, false);
+    const rootNode = {
+      id: 'root', createdOn: 100, children: ['child'],
+    } as TrrackedProvenance['nodes'][string];
+    const childNode = {
+      id: 'child', parent: 'root', createdOn: 200, children: [],
+    } as unknown as TrrackedProvenance['nodes'][string];
+    const makeGraph = (current: string, includeChild = true): TrrackedProvenance => ({
+      root: 'root',
+      current,
+      nodes: includeChild
+        ? { root: rootNode, child: childNode }
+        : { root: { ...rootNode, children: [] } },
+    } as TrrackedProvenance);
+    const dispatchProvenance = (provenanceGraph: TrrackedProvenance) => store.dispatch(
+      actions.updateResponseBlockValidation({
+        location: 'stimulus',
+        identifier: 'intro_0',
+        status: true,
+        values: {},
+        provenanceGraph,
+      }),
+    );
+    const now = vi.spyOn(Date, 'now');
+
+    now.mockReturnValueOnce(1000);
+    dispatchProvenance(makeGraph('root', false));
+    now.mockReturnValueOnce(1100);
+    dispatchProvenance(makeGraph('child'));
+    now.mockReturnValueOnce(1200);
+    dispatchProvenance(makeGraph('root'));
+    now.mockReturnValueOnce(1300);
+    dispatchProvenance(makeGraph('child'));
+    now.mockReturnValueOnce(1400);
+    dispatchProvenance(makeGraph('child'));
+    now.mockReturnValueOnce(1500);
+    dispatchProvenance(makeGraph('root'));
+    const branchNode = {
+      id: 'branch', parent: 'root', createdOn: 1600, children: [],
+    } as unknown as TrrackedProvenance['nodes'][string];
+    now.mockReturnValueOnce(1550);
+    dispatchProvenance({
+      root: 'root',
+      current: 'branch',
+      nodes: {
+        root: { ...rootNode, children: ['child', 'branch'] },
+        child: childNode,
+        branch: branchNode,
+      },
+    } as TrrackedProvenance);
+
+    now.mockRestore();
+
+    expect(store.getState().trialValidation.intro_0.provenanceGraph.stimulus?.traversalEvents).toEqual([
+      { nodeId: 'root', createdOn: 100 },
+      { nodeId: 'child', createdOn: 200 },
+      { nodeId: 'root', createdOn: 1200 },
+      { nodeId: 'child', createdOn: 1300 },
+      { nodeId: 'root', createdOn: 1500 },
+      { nodeId: 'branch', createdOn: 1600 },
+    ]);
   });
 
   test('saveTrialAnswer updates answers state', async () => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ProvenanceGraph } from '@trrack/core/graph/graph-slice';
+import type { ProvenanceGraph } from '@trrack/core/graph/graph-slice';
 import type { GetInputPropsReturnType } from '@mantine/form/lib/types';
 import type {
   Answer, ComponentBlock, ConfigResponseBlockLocation, CustomResponse, InterruptionBlock, JsonValue, ParsedStringOption, ParticipantData, ResponseBlockLocation, SkipConditions, StudyConfig, ValueOf,
@@ -21,7 +21,14 @@ export interface ParticipantMetadata {
   ip: string | null;
 }
 
-export type TrrackedProvenance = ProvenanceGraph<any, any>;
+export type ProvenanceTraversalEvent = {
+  nodeId: string;
+  createdOn: number;
+};
+
+export type TrrackedProvenance = ProvenanceGraph<any, any> & {
+  traversalEvents?: ProvenanceTraversalEvent[];
+};
 export type StoredProvenance = Record<ResponseBlockLocation, TrrackedProvenance | undefined>;
 
 // timestamp, event type, event data

--- a/tests/demo-trrack.spec.ts
+++ b/tests/demo-trrack.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-await-in-loop */
+import { expect, test, type FrameLocator } from '@playwright/test';
+import {
+  nextClick,
+  openStudyFromLanding,
+  resetClientStudyState,
+} from './utils';
+
+const demos = [
+  'HTML with Trrack library',
+  'Svelte with Trrack library',
+] as const;
+
+async function expectDotCount(frame: FrameLocator, count: number) {
+  await expect(frame.locator('circle')).toHaveCount(count);
+}
+
+for (const demoTitle of demos) {
+  test(`${demoTitle} initializes its answer and enforces dot limits`, async ({ page }) => {
+    await resetClientStudyState(page);
+    await openStudyFromLanding(page, 'Demo Studies', demoTitle);
+    await nextClick(page);
+
+    const frame = page.frameLocator('#root iframe');
+    const addButton = frame.getByRole('button', { name: 'Add' });
+    const removeButton = frame.getByRole('button', { name: 'Remove' });
+
+    await expectDotCount(frame, 1);
+    await expect(page.getByRole('listitem').filter({ hasText: '1' })).toHaveCount(1);
+
+    for (let count = 1; count < 20; count += 1) {
+      await addButton.click();
+    }
+
+    await expectDotCount(frame, 20);
+    await expect(addButton).toBeDisabled();
+    await addButton.locator('..').hover();
+    await expect(frame.getByRole('tooltip')).toBeVisible();
+    await expect(frame.getByRole('tooltip')).toHaveText('Maximum of 20 dots reached.');
+
+    await removeButton.click();
+    await expect(addButton).toBeEnabled();
+    await addButton.click();
+
+    for (let count = 20; count > 0; count -= 1) {
+      await removeButton.click();
+    }
+
+    await expectDotCount(frame, 0);
+    await expect(removeButton).toBeDisabled();
+    await removeButton.locator('..').hover();
+    await expect(frame.getByRole('tooltip')).toBeVisible();
+    await expect(frame.getByRole('tooltip')).toHaveText('Minimum of 0 dots reached.');
+
+    await frame.getByRole('button', { name: 'Undo' }).click();
+    await expectDotCount(frame, 1);
+    await expect(removeButton).toBeEnabled();
+    await frame.getByRole('button', { name: 'Redo' }).click();
+    await expectDotCount(frame, 0);
+  });
+}

--- a/tests/demo-trrack.spec.ts
+++ b/tests/demo-trrack.spec.ts
@@ -7,7 +7,6 @@ import {
   openStudyFromLanding,
   resetClientStudyState,
 } from './utils';
-import { encryptIndex } from '../src/utils/encryptDecryptIndex';
 
 const demos = [
   {
@@ -149,6 +148,7 @@ for (const demo of demos) {
 
     const participantFrame = page.frameLocator('#root iframe');
     const addButton = participantFrame.getByRole('button', { name: 'Add' });
+    const replayPath = new URL(page.url()).pathname;
 
     await expectDotCount(participantFrame, 1);
     await page.waitForTimeout(150);
@@ -186,7 +186,7 @@ for (const demo of demos) {
     ];
 
     expect(initial).toBeLessThanOrEqual(addTwo);
-    await page.goto(`/${demo.studyId}/${encryptIndex(1)}?participantId=${recording.participantId}&revisitPageId=e2e-trrack-replay`);
+    await page.goto(`${replayPath}?participantId=${recording.participantId}&revisitPageId=e2e-trrack-replay`);
 
     const replayFrame = page.frameLocator('#root iframe');
     for (const target of replayTargets) {

--- a/tests/demo-trrack.spec.ts
+++ b/tests/demo-trrack.spec.ts
@@ -1,24 +1,107 @@
 /* eslint-disable no-await-in-loop */
-import { expect, test, type FrameLocator } from '@playwright/test';
+import {
+  expect, test, type FrameLocator, type Page,
+} from '@playwright/test';
 import {
   nextClick,
   openStudyFromLanding,
   resetClientStudyState,
 } from './utils';
+import { encryptIndex } from '../src/utils/encryptDecryptIndex';
 
 const demos = [
-  'HTML with Trrack library',
-  'Svelte with Trrack library',
+  {
+    title: 'HTML with Trrack library',
+    studyId: 'demo-html-trrack',
+  },
+  {
+    title: 'Svelte with Trrack library',
+    studyId: 'demo-svelte-trrack',
+  },
 ] as const;
+
+type RecordedReplay = {
+  participantId: string;
+  startTime: number;
+  endTime: number;
+  traversalTimes: number[];
+};
 
 async function expectDotCount(frame: FrameLocator, count: number) {
   await expect(frame.locator('circle')).toHaveCount(count);
 }
 
-for (const demoTitle of demos) {
-  test(`${demoTitle} initializes its answer and enforces dot limits`, async ({ page }) => {
+async function readStoredValue(page: Page, key: string) {
+  return page.evaluate(async (storageKey) => new Promise<unknown>((resolve) => {
+    const openRequest = indexedDB.open('revisit');
+
+    openRequest.onerror = () => resolve(null);
+    openRequest.onsuccess = () => {
+      const database = openRequest.result;
+      if (!database.objectStoreNames.contains('keyvaluepairs')) {
+        database.close();
+        resolve(null);
+        return;
+      }
+
+      const transaction = database.transaction('keyvaluepairs', 'readonly');
+      const getRequest = transaction.objectStore('keyvaluepairs').get(storageKey);
+      getRequest.onerror = () => resolve(null);
+      getRequest.onsuccess = () => resolve(getRequest.result ?? null);
+      transaction.oncomplete = () => database.close();
+    };
+  }), key);
+}
+
+async function readRecordedReplay(page: Page, studyId: string): Promise<RecordedReplay | null> {
+  const assignments = await readStoredValue(page, `dev-${studyId}/sequenceAssignment`) as Record<string, unknown> | null;
+  const participantId = Object.keys(assignments ?? {})[0];
+  if (!participantId) {
+    return null;
+  }
+
+  const participant = await readStoredValue(
+    page,
+    `dev-${studyId}/participants/${participantId}_participantData`,
+  ) as { answers?: Record<string, { startTime?: number; endTime?: number }> } | null;
+  const provenance = await readStoredValue(
+    page,
+    `dev-${studyId}/provenance/${participantId}_countDots_1`,
+  ) as { stimulus?: { traversalEvents?: Array<{ createdOn?: number }> } } | null;
+  const answer = participant?.answers?.countDots_1;
+  const traversalTimes = provenance?.stimulus?.traversalEvents
+    ?.map((event) => event.createdOn)
+    .filter((createdOn): createdOn is number => typeof createdOn === 'number') ?? [];
+
+  if (typeof answer?.startTime !== 'number' || typeof answer.endTime !== 'number') {
+    return null;
+  }
+
+  return {
+    participantId,
+    startTime: answer.startTime,
+    endTime: answer.endTime,
+    traversalTimes,
+  };
+}
+
+async function seekReplay(page: Page, recording: RecordedReplay, targetTime: number) {
+  const timer = page.locator('footer svg').last();
+  await expect(timer).toBeVisible();
+  const timerBounds = await timer.boundingBox();
+  if (!timerBounds) {
+    throw new Error('Analysis replay timer has no bounds');
+  }
+
+  const fraction = (targetTime - recording.startTime) / (recording.endTime - recording.startTime);
+  const x = 20 + Math.min(1, Math.max(0, fraction)) * (timerBounds.width - 40);
+  await timer.click({ position: { x, y: timerBounds.height / 2 } });
+}
+
+for (const demo of demos) {
+  test(`${demo.title} initializes its answer and enforces dot limits`, async ({ page }) => {
     await resetClientStudyState(page);
-    await openStudyFromLanding(page, 'Demo Studies', demoTitle);
+    await openStudyFromLanding(page, 'Demo Studies', demo.title);
     await nextClick(page);
 
     const frame = page.frameLocator('#root iframe');
@@ -57,5 +140,63 @@ for (const demoTitle of demos) {
     await expect(removeButton).toBeEnabled();
     await frame.getByRole('button', { name: 'Redo' }).click();
     await expectDotCount(frame, 0);
+  });
+
+  test(`${demo.title} replays Undo and Redo in recorded order`, async ({ page }) => {
+    await resetClientStudyState(page);
+    await openStudyFromLanding(page, 'Demo Studies', demo.title);
+    await nextClick(page);
+
+    const participantFrame = page.frameLocator('#root iframe');
+    const addButton = participantFrame.getByRole('button', { name: 'Add' });
+
+    await expectDotCount(participantFrame, 1);
+    await page.waitForTimeout(150);
+    await addButton.click();
+    await expectDotCount(participantFrame, 2);
+    await page.waitForTimeout(150);
+    await addButton.click();
+    await expectDotCount(participantFrame, 3);
+    await page.waitForTimeout(150);
+    await participantFrame.getByRole('button', { name: 'Undo' }).click();
+    await expectDotCount(participantFrame, 2);
+    await page.waitForTimeout(150);
+    await participantFrame.getByRole('button', { name: 'Redo' }).click();
+    await expectDotCount(participantFrame, 3);
+    await page.waitForTimeout(150);
+    await nextClick(page);
+
+    await expect.poll(async () => {
+      const storedReplay = await readRecordedReplay(page, demo.studyId);
+      return storedReplay?.traversalTimes.length ?? 0;
+    }, { timeout: 15000 }).toBeGreaterThanOrEqual(5);
+
+    const recording = await readRecordedReplay(page, demo.studyId);
+    if (!recording) {
+      throw new Error(`No recorded replay found for ${demo.studyId}`);
+    }
+
+    const [initial, addTwo, addThree, undoTwo, redoThree] = recording.traversalTimes;
+    const replayTargets = [
+      { count: 1, time: (recording.startTime + addTwo) / 2 },
+      { count: 2, time: (addTwo + addThree) / 2 },
+      { count: 3, time: (addThree + undoTwo) / 2 },
+      { count: 2, time: (undoTwo + redoThree) / 2 },
+      { count: 3, time: (redoThree + recording.endTime) / 2 },
+    ];
+
+    expect(initial).toBeLessThanOrEqual(addTwo);
+    await page.goto(`/${demo.studyId}/${encryptIndex(1)}?participantId=${recording.participantId}&revisitPageId=e2e-trrack-replay`);
+
+    const replayFrame = page.frameLocator('#root iframe');
+    for (const target of replayTargets) {
+      await seekReplay(page, recording, target.time);
+      await expectDotCount(replayFrame, target.count);
+    }
+
+    for (const target of [...replayTargets].reverse()) {
+      await seekReplay(page, recording, target.time);
+      await expectDotCount(replayFrame, target.count);
+    }
   });
 }


### PR DESCRIPTION
## Summary

- record Trrack traversal transitions automatically at the shared provenance ingestion boundary used by website, React, Vega, and built-in response components
- preserve the original provenance graph while adding a compact chronological `{ nodeId, createdOn }` traversal history for Undo, Redo, and post-Undo branches
- make analysis replay prefer traversal timestamps while retaining the existing first-child fallback for historical provenance graphs
- keep both demos on the standard `postProvenance(trrack.graph.backend)` integration with no demo-specific traversal code
- initialize the reactive answer at `1`, enforce the `0`-`20` dot limits, and explain disabled Add/Remove controls with hover and keyboard-focus tooltips

## Root cause

Trrack Undo and Redo move the graph's current node without creating a new node timestamp. Analysis replay previously followed node creation order, so it could not reconstruct when participants traversed backward, forward, or onto a new branch.

## Default platform behavior

`updateResponseBlockValidation` now timestamps provenance snapshots as they enter the store and compares each graph's current node with the previously stored snapshot. New nodes retain their Trrack creation time; transitions to existing nodes use the observation time; duplicate snapshots do not add events. This behavior applies automatically to every provenance source using reVISit's existing APIs and requires no traversal-specific study code.

Existing stored graphs without traversal history remain readable through the legacy replay path.

## Validation

- `yarn unittest --run` - 1,853 passed, 1 skipped
- focused store and replay tests - 63 passed
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

The Playwright demo coverage remains in the PR and will run in CI.

Closes #1284

## Documentation
Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [ ] Done
- [x] N/A