### PR TITLE
Add configurable next button alignment

### DIFF
--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -16,6 +16,12 @@ import {
   getAutoAdvanceWarning,
 } from './nextButtonTimeout';
 
+const nextButtonJustify = {
+  left: 'flex-start',
+  center: 'center',
+  right: 'flex-end',
+} as const;
+
 type Props = {
   label?: string;
   disabled?: boolean;
@@ -115,10 +121,11 @@ export function NextButton({
 
   const nextButtonDisabled = disabled || isNextDisabled || !buttonTimerSatisfied;
   const previousButtonText = config?.previousButtonText ?? studyConfig.uiConfig.previousButtonText ?? 'Previous';
+  const nextButtonAlignment = config?.nextButtonAlignment ?? studyConfig.uiConfig.nextButtonAlignment ?? 'right';
 
   return (
     <>
-      <Group justify="right" gap="xs" mt="sm">
+      <Group justify={nextButtonJustify[nextButtonAlignment]} gap="xs" mt="sm" wrap="wrap">
         {config?.previousButton && (
           <PreviousButton
             label={previousButtonText}

--- a/src/components/tests/NextButton.spec.tsx
+++ b/src/components/tests/NextButton.spec.tsx
@@ -19,6 +19,7 @@ let mockStudyConfig: {
   uiConfig: {
     nextButtonDisableTime: number | undefined;
     nextButtonEnableTime: number | undefined;
+    nextButtonAlignment?: 'left' | 'center' | 'right';
     nextOnEnter: boolean;
     previousButtonText: string;
     timeoutReject: boolean;
@@ -74,7 +75,9 @@ vi.mock('@mantine/core', () => ({
       {children}
     </button>
   ),
-  Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Group: ({ children, justify }: { children: ReactNode; justify?: string }) => (
+    <div data-justify={justify}>{children}</div>
+  ),
 }));
 
 vi.mock('@tabler/icons-react', () => ({
@@ -154,6 +157,64 @@ describe('NextButton', () => {
     );
     expect(html).toContain('Check Answer');
   });
+
+  test('right-aligns the action group by default', () => {
+    const html = renderToStaticMarkup(<NextButton checkAnswer={null} onNext={vi.fn()} />);
+    expect(html).toContain('data-justify="flex-end"');
+  });
+
+  test.each([
+    ['left', 'flex-start'],
+    ['center', 'center'],
+    ['right', 'flex-end'],
+  ] as const)('uses the global %s alignment', (alignment, justify) => {
+    mockStudyConfig = {
+      uiConfig: {
+        ...mockStudyConfig.uiConfig,
+        nextButtonAlignment: alignment,
+      },
+    };
+
+    const html = renderToStaticMarkup(<NextButton checkAnswer={null} onNext={vi.fn()} />);
+    expect(html).toContain(`data-justify="${justify}"`);
+  });
+
+  test('component alignment overrides the global alignment', () => {
+    mockStudyConfig = {
+      uiConfig: {
+        ...mockStudyConfig.uiConfig,
+        nextButtonAlignment: 'left',
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      <NextButton
+        config={{
+          type: 'questionnaire', response: [], nextButtonAlignment: 'center',
+        }}
+        checkAnswer={null}
+        onNext={vi.fn()}
+      />,
+    );
+    expect(html).toContain('data-justify="center"');
+  });
+
+  test.each(['sidebar', 'aboveStimulus', 'belowStimulus'] as const)(
+    'keeps Previous, Check Answer, and Next in order at %s',
+    (location) => {
+      const html = renderToStaticMarkup(
+        <NextButton
+          config={{ type: 'questionnaire', response: [], previousButton: true }}
+          location={location}
+          checkAnswer={<button type="button">Check Answer</button>}
+          onNext={vi.fn()}
+        />,
+      );
+
+      expect(html.indexOf('Previous')).toBeLessThan(html.indexOf('Check Answer'));
+      expect(html.indexOf('Check Answer')).toBeLessThan(html.indexOf('Next'));
+    },
+  );
 
   test('shows "Please wait" alert after render when nextButtonEnableTime is set', async () => {
     mockStudyConfig = {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -80,6 +80,10 @@
             "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "object"
           },
+          "nextButtonAlignment": {
+            "$ref": "#/definitions/NextButtonAlignment",
+            "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+          },
           "nextButtonAutoAdvanceTime": {
             "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
             "type": "number"
@@ -956,6 +960,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1230,6 +1238,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -1761,6 +1773,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -2207,6 +2223,14 @@
         }
       ]
     },
+    "NextButtonAlignment": {
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
+      "type": "string"
+    },
     "NumberOption": {
       "additionalProperties": false,
       "description": "The NumberOption interface is used to define the options for a slider response. The label is the text that is displayed to the user, and the value is the value that is stored in the data file.",
@@ -2360,6 +2384,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -2782,6 +2810,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -3601,6 +3633,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -3767,6 +3803,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -3943,6 +3983,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4113,6 +4157,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -80,6 +80,10 @@
             "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
             "type": "object"
           },
+          "nextButtonAlignment": {
+            "$ref": "#/definitions/NextButtonAlignment",
+            "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+          },
           "nextButtonAutoAdvanceTime": {
             "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
             "type": "number"
@@ -1029,6 +1033,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -1303,6 +1311,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -1785,6 +1797,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -2231,6 +2247,14 @@
         }
       ]
     },
+    "NextButtonAlignment": {
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
+      "type": "string"
+    },
     "NumberOption": {
       "additionalProperties": false,
       "description": "The NumberOption interface is used to define the options for a slider response. The label is the text that is displayed to the user, and the value is the value that is stored in the data file.",
@@ -2384,6 +2408,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -2806,6 +2834,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -3703,7 +3735,7 @@
     },
     "UIConfig": {
       "additionalProperties": false,
-      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the `uiConfig` would look in your study configuration (note, there are optional fields that are not shown here): ```json uiConfig:{   \"logoPath\": \"<study-name>/assets/logo.jpg\",   \"contactEmail\": \"contact@revisit.dev\",   \"withProgressBar\": true,   \"withSidebar\": true,   \"helpTextPath\": \"<study-name>/assets/help.md\",   \"autoDownloadStudy\": true,   \"autoDownloadTime\": 5000,   \"studyEndMsg\": \"Thank you for completing this study. You're the best!\",   \"studyEndAutoRedirectURL\": \"https://app.prolific.com/submissions/complete?cc=abc123\",   \"studyEndAutoRedirectDelay\": 10000,   \"windowEventDebounceTime\": 500,   \"urlParticipantIdParam\": \"PROLIFIC_ID\",   \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
+      "description": "The UIConfig is used to configure the UI of the app. This includes the logo, contact email, and whether to show a progress bar. The UIConfig is also used to configure the sidebar, which can be used to display the task instructions and capture responses. Below is an example of how the `uiConfig` would look in your study configuration (note, there are optional fields that are not shown here): ```json uiConfig:{   \"logoPath\": \"<study-name>/assets/logo.jpg\",   \"contactEmail\": \"contact@revisit.dev\",   \"withProgressBar\": true,   \"withSidebar\": true,   \"nextButtonAlignment\": \"center\",   \"helpTextPath\": \"<study-name>/assets/help.md\",   \"autoDownloadStudy\": true,   \"autoDownloadTime\": 5000,   \"studyEndMsg\": \"Thank you for completing this study. You're the best!\",   \"studyEndAutoRedirectURL\": \"https://app.prolific.com/submissions/complete?cc=abc123\",   \"studyEndAutoRedirectDelay\": 10000,   \"windowEventDebounceTime\": 500,   \"urlParticipantIdParam\": \"PROLIFIC_ID\",   \"numSequences\": 500 } ``` In the above, the `<study-name>/assets/` path is referring to the path to your individual study assets. It is common practice to have your study directory contain an `assets` directory where all components and images relevant to your study reside. Note that this path is relative to the `public` folder of the repository - as is all other paths you define in reVISit (aside from React components whose paths are relative to `src/public`.)",
       "properties": {
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. Defaults to true.",
@@ -3740,6 +3772,10 @@
         "logoPath": {
           "description": "The path to the logo image. This is displayed on the landing page and the header.",
           "type": "string"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. Defaults to right."
         },
         "nextButtonDisableTime": {
           "description": "The time in milliseconds to wait before the next button is disabled.",
@@ -3945,6 +3981,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4111,6 +4151,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
@@ -4287,6 +4331,10 @@
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
         },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
+        },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",
           "type": "number"
@@ -4457,6 +4505,10 @@
           "additionalProperties": {},
           "description": "The meta data for the component. This is used to identify and provide additional information for the component in the admin panel.",
           "type": "object"
+        },
+        "nextButtonAlignment": {
+          "$ref": "#/definitions/NextButtonAlignment",
+          "description": "The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig."
         },
         "nextButtonAutoAdvanceTime": {
           "description": "The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component.",

--- a/src/parser/tests/parser.spec.ts
+++ b/src/parser/tests/parser.spec.ts
@@ -64,6 +64,55 @@ describe('Component auto-advance config parsing', () => {
   });
 });
 
+describe('Next button alignment config parsing', () => {
+  function makeStudyConfig(nextButtonAlignment: string, componentOverride?: string) {
+    return {
+      $schema: '',
+      studyMetadata: {
+        title: 'Next Button Alignment Test',
+        version: '1.0',
+        authors: ['Test'],
+        date: '2026-07-16',
+        description: 'Ensures next button alignment options are validated.',
+        organizations: ['Test Org'],
+      },
+      uiConfig: {
+        contactEmail: 'test@test.com',
+        logoPath: '',
+        withProgressBar: true,
+        withSidebar: true,
+        nextButtonAlignment,
+      },
+      components: {
+        question1: {
+          type: 'questionnaire',
+          response: [],
+          ...(componentOverride === undefined ? {} : { nextButtonAlignment: componentOverride }),
+        },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['question1'],
+      },
+    };
+  }
+
+  test.each(['left', 'center', 'right'])('accepts the %s alignment globally and on a component', async (alignment) => {
+    const result = await parseStudyConfig(JSON.stringify(makeStudyConfig(alignment, alignment)));
+
+    expect(result.errors).toEqual([]);
+  });
+
+  test('rejects an unsupported alignment', async () => {
+    const result = await parseStudyConfig(JSON.stringify(makeStudyConfig('stretch')));
+
+    const hasAlignmentError = result.errors.some(
+      (error) => error.instancePath?.includes('nextButtonAlignment'),
+    );
+    expect(hasAlignmentError).toBe(true);
+  });
+});
+
 describe('BaseComponent Macro Expansion', () => {
   describe('.co. macro expansion in baseComponent references', () => {
     test('expands .co. to .components. in baseComponent field', async () => {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -70,6 +70,7 @@ export interface StudyMetadata {
  */
 export type ResponseBlockLocation = 'sidebar' | 'aboveStimulus' | 'belowStimulus' | 'stimulus';
 export type ConfigResponseBlockLocation = Exclude<ResponseBlockLocation, 'stimulus'>;
+export type NextButtonAlignment = 'left' | 'center' | 'right';
 
 /**
  * UserBrowser is used to define a minimum browser requirement for the study to run.
@@ -234,6 +235,7 @@ export type Styles = {
  *   "contactEmail": "contact@revisit.dev",
  *   "withProgressBar": true,
  *   "withSidebar": true,
+ *   "nextButtonAlignment": "center",
  *   "helpTextPath": "<study-name>/assets/help.md",
  *   "autoDownloadStudy": true,
  *   "autoDownloadTime": 5000,
@@ -275,6 +277,8 @@ export interface UIConfig {
   nextButtonText?: string;
   /** The location of the next button. */
   nextButtonLocation?: ConfigResponseBlockLocation;
+  /** The horizontal alignment of the navigation action group. Defaults to right. */
+  nextButtonAlignment?: NextButtonAlignment;
   /** The time in milliseconds to wait before the next button is enabled. */
   nextButtonEnableTime?: number;
   /** The time in milliseconds to wait before the next button is disabled. */
@@ -1048,6 +1052,8 @@ export interface BaseIndividualComponent {
   nextButtonText?: string;
   /** The location of the next button. If present, will override the  next button location setting in the uiConfig. */
   nextButtonLocation?: ConfigResponseBlockLocation;
+  /** The horizontal alignment of the navigation action group. If present, will override the alignment setting in the uiConfig. */
+  nextButtonAlignment?: NextButtonAlignment;
   /** The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig. */
   nextButtonEnableTime?: number;
   /** The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig. */


### PR DESCRIPTION
## Summary

- add `nextButtonAlignment` (`left`, `center`, or `right`) to global UI and individual component configuration
- align the existing Previous / Check Answer / Next action group while preserving right alignment by default
- preserve component-over-global precedence and existing navigation behavior
- regenerate Study and Library schemas and document the new option
- cover alignment values, defaults, overrides, supported locations, control order, and schema validation

## Why

Participant navigation controls were always right-aligned. Study Designers can now select the horizontal alignment without changing `nextButtonLocation` or introducing overlay positioning.

Resolves #1252.

## Validation

- `yarn unittest --run src/components/tests/NextButton.spec.tsx src/parser/tests/parser.spec.ts` (71 passed)
- `yarn unittest --run` (1,860 passed, 1 skipped)
- `yarn typecheck`
- `yarn lint`
- `yarn build`

## Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [x] Done
- [ ] N/A