### PR TITLE
Improve study startup loading context

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -45,6 +45,51 @@ type StartupStorageStatus = Pick<StorageEngine, 'getEngine' | 'isConnected'>;
 
 const GENERIC_STARTUP_ERROR = 'There was a problem loading the study.';
 const RESUME_STARTUP_ERROR = 'This study session could not be resumed.';
+const STUDY_LOADING_MESSAGE = 'Loading your study. This may take a moment.';
+const STUDY_LOADING_MESSAGE_DELAY_MS = 1500;
+
+export function StudyLoadingOverlay({ visible }: { visible: boolean }) {
+  const [showMessage, setShowMessage] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setShowMessage(false);
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShowMessage(true);
+    }, STUDY_LOADING_MESSAGE_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [visible]);
+
+  return (
+    <>
+      <LoadingOverlay visible={visible} />
+      {visible && showMessage && (
+        <Text
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          style={{
+            position: 'fixed',
+            top: 'calc(50% + 40px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 1001,
+            width: 'calc(100% - 32px)',
+            maxWidth: 420,
+            textAlign: 'center',
+            pointerEvents: 'none',
+          }}
+        >
+          {STUDY_LOADING_MESSAGE}
+        </Text>
+      )}
+    </>
+  );
+}
 
 export function getScreenOrientationType(screen: Screen) {
   return screen.orientation?.type ?? '';
@@ -463,7 +508,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   return (
     <>
-      <LoadingOverlay visible={isLoading} />
+      <StudyLoadingOverlay visible={isLoading} />
       {showCompletionCheckError && (
         <Stack
           align="center"

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import {
   render, act, cleanup, waitFor,
 } from '@testing-library/react';
@@ -6,7 +6,7 @@ import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { useRoutes } from 'react-router';
-import { Shell } from '../Shell';
+import { Shell, StudyLoadingOverlay } from '../Shell';
 import type { ParsedConfig, StudyConfig } from '../../parser/types';
 import { getStudyConfig, resolveConfigKey } from '../../utils/fetchConfig';
 import { makeGlobalConfig, makeStudyConfig } from '../../tests/utils';
@@ -93,7 +93,7 @@ vi.mock('@mantine/core', () => ({
     visible ? <div data-testid="loading-overlay" /> : null
   ),
   Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  Text: ({ children, ...props }: HTMLAttributes<HTMLParagraphElement>) => <p {...props}>{children}</p>,
   Title: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
 }));
 
@@ -161,8 +161,52 @@ describe('Shell', () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  test('shows loading context only after startup remains pending for 1.5 seconds', () => {
+    vi.useFakeTimers();
+
+    const { getByTestId, getByRole, queryByRole } = render(<StudyLoadingOverlay visible />);
+
+    expect(getByTestId('loading-overlay')).toBeDefined();
+    expect(queryByRole('status')).toBeNull();
+
+    act(() => vi.advanceTimersByTime(1499));
+    expect(queryByRole('status')).toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(getByRole('status').textContent).toBe('Loading your study. This may take a moment.');
+    expect(getByRole('status').getAttribute('aria-live')).toBe('polite');
+    expect(getByRole('status').getAttribute('aria-atomic')).toBe('true');
+  });
+
+  test('cancels the loading message when startup completes before the delay', () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+
+    const { queryByRole, queryByTestId, rerender } = render(<StudyLoadingOverlay visible />);
+
+    rerender(<StudyLoadingOverlay visible={false} />);
+    act(() => vi.advanceTimersByTime(1500));
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(queryByTestId('loading-overlay')).toBeNull();
+    expect(queryByRole('status')).toBeNull();
+  });
+
+  test('removes loading context as soon as startup completes', () => {
+    vi.useFakeTimers();
+
+    const { getByRole, queryByRole, rerender } = render(<StudyLoadingOverlay visible />);
+
+    act(() => vi.advanceTimersByTime(1500));
+    expect(getByRole('status')).toBeDefined();
+
+    rerender(<StudyLoadingOverlay visible={false} />);
+    expect(queryByRole('status')).toBeNull();
   });
 
   test('shows loading overlay when routes are not yet initialized', async () => {


### PR DESCRIPTION
## Summary

- keep the existing study-startup spinner visible immediately
- show "Loading your study. This may take a moment." only when startup remains pending for 1.5 seconds
- expose the delayed message as a polite accessible status and remove it immediately when loading completes
- add focused timer-driven coverage for delayed appearance, fast completion, cleanup, and accessibility

## Why

Long-running study initialization currently shows only an indeterminate spinner, which can leave Participants and Study Designers unsure whether startup is still making progress. Delaying the explanatory copy avoids a flash on fast loads while giving slower loads useful context.

## User impact

Participant, preview/development, resume, and embedded-widget study routes receive the same contextual startup message. Other loading indicators and startup error behavior are unchanged.

Fixes #1270

## Validation

- `yarn unittest --run src/components/tests/Shell.spec.tsx` — 12 passed
- `yarn unittest --run` — 1,851 passed, 1 skipped
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- local browser verification on `/__revisit-widget` confirmed the centered spinner/message layout and accessible status attributes

<img width="2560" height="1440" alt="loading-spinner-with-message" src="https://github.com/user-attachments/assets/0d0406fb-91b9-42f6-9332-552b9e9801ba" />

## Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [ ] Done
- [X] N/A