### PR TITLE
Distinguish unknown response status

### DIFF
--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -9,7 +9,7 @@ import { ParticipantData } from '../../../storage/types';
 import { SingleTaskLabelLines } from './SingleTaskLabelLines';
 import { SingleTask } from './SingleTask';
 import { StoredAnswer, StudyConfig } from '../../../parser/types';
-import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
+import { getComponentAnswerStatus } from '../../../utils/correctAnswer';
 import { parseConditionParam } from '../../../utils/handleConditionLogic';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 
@@ -118,8 +118,10 @@ export function AllTasksTimeline({
       const resolvedComponent = component && studyConfig
         ? studyComponentToIndividualComponent(component, studyConfig)
         : undefined;
-      const isCorrect = componentAnswersAreCorrect(answer.answer, answer.correctAnswer, resolvedComponent?.response);
-      const hasCorrect = !!((resolvedComponent && resolvedComponent.correctAnswer) || answer.correctAnswer.length > 0);
+      const correctAnswers = answer.correctAnswer.length > 0
+        ? answer.correctAnswer
+        : resolvedComponent?.correctAnswer;
+      const answerStatus = getComponentAnswerStatus(answer, correctAnswers, resolvedComponent?.response);
       const hasAudio = resolvedComponent?.recordAudio ?? studyConfig?.uiConfig?.recordAudio ?? false;
       const hasScreenRecording = resolvedComponent?.recordScreen ?? studyConfig?.uiConfig?.recordScreen ?? false;
 
@@ -151,7 +153,7 @@ export function AllTasksTimeline({
             )}
           >
             <g>
-              <SingleTask incomplete={answer.startTime === 0} isCorrect={isCorrect} hasCorrect={hasCorrect} hasAudio={hasAudio} hasScreenRecording={hasScreenRecording} key={identifier} labelHeight={currentHeight * LABEL_GAP} height={maxHeight} identifier={identifier} xScale={scale} scaleStart={scaleStart} scaleEnd={scaleEnd} trialOrder={answer.trialOrder} participantId={participantData.participantId} studyId={studyId} condition={conditionParam} isHovered={hoveredTaskIdentifier === identifier} isDimmed={hoveredTaskIdentifier !== null && hoveredTaskIdentifier !== identifier} onHover={() => setHoveredTaskIdentifier(identifier)} onHoverEnd={() => setHoveredTaskIdentifier(null)} />
+              <SingleTask incomplete={answer.startTime === 0} answerStatus={answerStatus} hasAudio={hasAudio} hasScreenRecording={hasScreenRecording} key={identifier} labelHeight={currentHeight * LABEL_GAP} height={maxHeight} identifier={identifier} xScale={scale} scaleStart={scaleStart} scaleEnd={scaleEnd} trialOrder={answer.trialOrder} participantId={participantData.participantId} studyId={studyId} condition={conditionParam} isHovered={hoveredTaskIdentifier === identifier} isDimmed={hoveredTaskIdentifier !== null && hoveredTaskIdentifier !== identifier} onHover={() => setHoveredTaskIdentifier(identifier)} onHoverEnd={() => setHoveredTaskIdentifier(null)} />
             </g>
           </Tooltip>),
       };

--- a/src/analysis/individualStudy/replay/SingleTask.tsx
+++ b/src/analysis/individualStudy/replay/SingleTask.tsx
@@ -6,6 +6,8 @@ import {
   IconCheck, IconDeviceDesktop, IconMicrophone, IconProgress, IconX,
 } from '@tabler/icons-react';
 import { useNavigateToTrial } from '../../../utils/useNavigateToTrial';
+import type { ComponentAnswerStatus } from '../../../utils/correctAnswer';
+import { UnknownAnswerIcon } from '../../../components/interface/UnknownAnswerIcon';
 
 const LABEL_MARGIN = 3;
 const TIMELINE_HEIGHT = 25;
@@ -21,8 +23,7 @@ export function SingleTask({
   identifier,
   height,
   labelHeight = 0,
-  isCorrect,
-  hasCorrect,
+  answerStatus,
   hasAudio,
   hasScreenRecording,
   scaleStart,
@@ -41,8 +42,7 @@ export function SingleTask({
   height: number,
   xScale: d3.ScaleLinear<number, number>,
   labelHeight?: number,
-  isCorrect: boolean,
-  hasCorrect: boolean,
+  answerStatus: ComponentAnswerStatus | null,
   hasAudio: boolean,
   hasScreenRecording: boolean,
   scaleStart: number,
@@ -60,9 +60,29 @@ export function SingleTask({
   const [ref, { width: labelWidth }] = useResizeObserver();
 
   const navigateToTrial = useNavigateToTrial();
-  const iconCount = (incomplete || hasCorrect ? 1 : 0) + (hasAudio ? 1 : 0) + (hasScreenRecording ? 1 : 0);
+  const iconCount = (incomplete || answerStatus ? 1 : 0) + (hasAudio ? 1 : 0) + (hasScreenRecording ? 1 : 0);
   const iconsWidth = iconCount * (ICON_SIZE + ICON_GAP);
   const labelOpacity = isDimmed ? 0.35 : 1;
+
+  const answerStatusIcon = answerStatus === 'correct'
+    ? (
+      <IconCheck
+        color="var(--mantine-color-green-6)"
+        style={{ marginTop: 2, strokeWidth: 4 }}
+        size="14"
+      />
+    )
+    : answerStatus === 'incorrect'
+      ? (
+        <IconX
+          color="var(--mantine-color-red-6)"
+          style={{ marginTop: 2, strokeWidth: 4 }}
+          size={14}
+        />
+      )
+      : answerStatus === 'unknown'
+        ? <UnknownAnswerIcon size={14} style={{ marginTop: 2 }} />
+        : null;
 
   return (
     <g
@@ -120,24 +140,12 @@ export function SingleTask({
                 size="14"
               />
             )}
-            {(incomplete ? (
+            {incomplete ? (
               <IconProgress
                 color="orange"
                 size="14"
               />
-            ) : hasCorrect ? isCorrect ? (
-              <IconCheck
-                color="var(--mantine-color-green-6)"
-                style={{ marginTop: 2, strokeWidth: 4 }}
-                size="14"
-              />
-            ) : (
-              <IconX
-                color="var(--mantine-color-red-6)"
-                style={{ marginTop: 2, strokeWidth: 4 }}
-                size={14}
-              />
-            ) : '')}
+            ) : answerStatusIcon}
           </Group>
 
         </Center>

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -29,10 +29,15 @@ vi.mock('@mantine/core', () => ({
 }));
 
 vi.mock('@tabler/icons-react', () => ({
-  IconCheck: () => <span>icon-check</span>,
+  IconCheck: ({
+    'aria-label': ariaLabel,
+    color,
+  }: {
+    'aria-label'?: string;
+    color?: string;
+  }) => <span aria-label={ariaLabel} data-color={color}>icon-check</span>,
   IconMicrophone: () => <span>icon-microphone</span>,
   IconProgress: () => <span>icon-progress</span>,
-  IconSquareFilled: ({ 'aria-label': ariaLabel }: { 'aria-label'?: string }) => <span aria-label={ariaLabel}>icon-square-filled</span>,
   IconX: () => <span>icon-x</span>,
 }));
 
@@ -141,11 +146,12 @@ describe('SingleTask', () => {
     expect(html).toContain('icon-x');
   });
 
-  test('shows an accessible blue square for an unknown response', () => {
+  test('shows an accessible grey checkmark for an unknown response', () => {
     const html = renderToStaticMarkup(
       <svg><SingleTask {...baseProps} answerStatus="unknown" /></svg>,
     );
-    expect(html).toContain('icon-square-filled');
+    expect(html).toContain('icon-check');
+    expect(html).toContain('var(--mantine-color-gray-6)');
     expect(html).toContain('Response recorded; correctness not configured.');
   });
 
@@ -167,7 +173,7 @@ describe('SingleTask', () => {
     const html = renderToStaticMarkup(<svg><SingleTask {...baseProps} /></svg>);
     expect(html).not.toContain('icon-check');
     expect(html).not.toContain('icon-x');
-    expect(html).not.toContain('icon-square-filled');
+    expect(html).not.toContain('Response recorded; correctness not configured.');
   });
 });
 
@@ -218,7 +224,8 @@ describe('AllTasksTimeline', () => {
     );
     expect(html).toContain('q1');
     expect(html).toContain('yes');
-    expect(html).toContain('icon-square-filled');
+    expect(html).toContain('icon-check');
+    expect(html).toContain('var(--mantine-color-gray-6)');
     expect(html).toContain('Response recorded; correctness not configured.');
   });
 

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -32,6 +32,7 @@ vi.mock('@tabler/icons-react', () => ({
   IconCheck: () => <span>icon-check</span>,
   IconMicrophone: () => <span>icon-microphone</span>,
   IconProgress: () => <span>icon-progress</span>,
+  IconSquareFilled: ({ 'aria-label': ariaLabel }: { 'aria-label'?: string }) => <span aria-label={ariaLabel}>icon-square-filled</span>,
   IconX: () => <span>icon-x</span>,
 }));
 
@@ -41,10 +42,6 @@ vi.mock('@mantine/hooks', () => ({
 
 vi.mock('../../../../utils/useNavigateToTrial', () => ({
   useNavigateToTrial: () => vi.fn(),
-}));
-
-vi.mock('../../../../utils/correctAnswer', () => ({
-  componentAnswersAreCorrect: vi.fn(() => true),
 }));
 
 vi.mock('../../../../utils/handleConditionLogic', () => ({
@@ -120,8 +117,7 @@ describe('SingleTask', () => {
     participantId: 'pid-1',
     studyId: 'test-study',
     incomplete: false,
-    isCorrect: false,
-    hasCorrect: false,
+    answerStatus: null,
     hasAudio: false,
     hasScreenRecording: false,
   };
@@ -131,18 +127,26 @@ describe('SingleTask', () => {
     expect(html).toContain('trial1_0');
   });
 
-  test('shows check icon when hasCorrect and isCorrect', () => {
+  test('shows check icon for a correct response', () => {
     const html = renderToStaticMarkup(
-      <svg><SingleTask {...baseProps} hasCorrect isCorrect /></svg>,
+      <svg><SingleTask {...baseProps} answerStatus="correct" /></svg>,
     );
     expect(html).toContain('icon-check');
   });
 
-  test('shows x icon when hasCorrect and not isCorrect', () => {
+  test('shows x icon for an incorrect response', () => {
     const html = renderToStaticMarkup(
-      <svg><SingleTask {...baseProps} hasCorrect isCorrect={false} /></svg>,
+      <svg><SingleTask {...baseProps} answerStatus="incorrect" /></svg>,
     );
     expect(html).toContain('icon-x');
+  });
+
+  test('shows an accessible blue square for an unknown response', () => {
+    const html = renderToStaticMarkup(
+      <svg><SingleTask {...baseProps} answerStatus="unknown" /></svg>,
+    );
+    expect(html).toContain('icon-square-filled');
+    expect(html).toContain('Response recorded; correctness not configured.');
   });
 
   test('shows microphone icon when hasAudio', () => {
@@ -159,10 +163,11 @@ describe('SingleTask', () => {
     expect(html).toContain('icon-progress');
   });
 
-  test('no correctness icon when hasCorrect is false', () => {
+  test('shows no answer-status icon when status is null', () => {
     const html = renderToStaticMarkup(<svg><SingleTask {...baseProps} /></svg>);
     expect(html).not.toContain('icon-check');
     expect(html).not.toContain('icon-x');
+    expect(html).not.toContain('icon-square-filled');
   });
 });
 
@@ -195,7 +200,7 @@ describe('AllTasksTimeline', () => {
     expect(html).toContain('trial1_0');
   });
 
-  test('handles participant with answer values (tooltip shows answer)', () => {
+  test('shows an unknown indicator and tooltip value for an answer without configured correctness', () => {
     const participant = makeParticipant({
       answers: {
         trial1_0: makeAnswer({ startTime: t0, endTime: t0 + 5_000, answer: { q1: 'yes' } }),
@@ -213,6 +218,8 @@ describe('AllTasksTimeline', () => {
     );
     expect(html).toContain('q1');
     expect(html).toContain('yes');
+    expect(html).toContain('icon-square-filled');
+    expect(html).toContain('Response recorded; correctness not configured.');
   });
 
   test('handles participant with incomplete answer (startTime === 0)', () => {

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -26,8 +26,9 @@ import { addPathToComponentBlock } from '../../utils/getSequenceFlatMap';
 import { useStudyId } from '../../routes/utils';
 import { encryptIndex } from '../../utils/encryptDecryptIndex';
 import { isDynamicBlock } from '../../parser/utils';
-import { componentAnswersAreCorrect } from '../../utils/correctAnswer';
+import { getComponentAnswerStatus } from '../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../utils/handleComponentInheritance';
+import { UnknownAnswerIcon } from './UnknownAnswerIcon';
 import {
   getDynamicComponentsForBlock,
   getSkipConditionSummariesForBlock,
@@ -753,17 +754,19 @@ export function StepsPanel({
           const correctAnswer = componentAnswer?.correctAnswer?.length
             ? componentAnswer.correctAnswer
             : resolvedComponent?.correctAnswer;
-          const correct = correctAnswer
-            && componentAnswer
-            && Object.keys(componentAnswer.answer).length > 0
-            && componentAnswersAreCorrect(componentAnswer.answer, correctAnswer, resolvedComponent?.response);
-          const correctIncorrectIcon = correctAnswer && componentAnswer && componentAnswer?.endTime > -1
-            ? (correct
-              ? <IconCheck size={16} style={{ marginRight: 4, flexShrink: 0 }} color="green" />
-              : <IconX size={16} style={{ marginRight: 4, flexShrink: 0 }} color="red" />
-            )
-            : null;
-          const correctAnswerJSONText = correctAnswer
+          const answerStatus = getComponentAnswerStatus(
+            componentAnswer,
+            correctAnswer,
+            resolvedComponent?.response,
+          );
+          const answerStatusIcon = answerStatus === 'correct'
+            ? <IconCheck size={16} style={{ marginRight: 4, flexShrink: 0 }} color="green" />
+            : answerStatus === 'incorrect'
+              ? <IconX size={16} style={{ marginRight: 4, flexShrink: 0 }} color="red" />
+              : answerStatus === 'unknown'
+                ? <UnknownAnswerIcon size={16} style={{ marginRight: 4, flexShrink: 0 }} />
+                : null;
+          const correctAnswerJSONText = correctAnswer?.length
             ? JSON.stringify(correctAnswer, null, 2)
             : undefined;
           const responseJSONText = resolvedComponent && JSON.stringify(resolvedComponent.response, null, 2);
@@ -856,7 +859,7 @@ export function StepsPanel({
                           <IconDice5 size={16} opacity={0.8} style={{ marginRight: 4, flexShrink: 0 }} color="black" />
                         </Tooltip>
                       )}
-                      {correctIncorrectIcon}
+                      {answerStatusIcon}
                       <Text
                         size="sm"
                         title={orderPath ?? label}
@@ -941,7 +944,7 @@ export function StepsPanel({
                       {componentAnswer && Object.keys(componentAnswer.answer).length > 0 && (
                         <Box>
                           <Text fw={900} display="inline-block" mr={2}>
-                            {correctIncorrectIcon}
+                            {answerStatusIcon}
                             Participant Answer:
                           </Text>
                           {' '}

--- a/src/components/interface/UnknownAnswerIcon.tsx
+++ b/src/components/interface/UnknownAnswerIcon.tsx
@@ -1,0 +1,24 @@
+import { Tooltip } from '@mantine/core';
+import { IconSquareFilled } from '@tabler/icons-react';
+import type { CSSProperties } from 'react';
+
+export const UNKNOWN_ANSWER_LABEL = 'Response recorded; correctness not configured.';
+
+export function UnknownAnswerIcon({
+  size,
+  style,
+}: {
+  size: number;
+  style?: CSSProperties;
+}) {
+  return (
+    <Tooltip label={UNKNOWN_ANSWER_LABEL} withArrow>
+      <IconSquareFilled
+        aria-label={UNKNOWN_ANSWER_LABEL}
+        color="var(--mantine-color-blue-6)"
+        size={size}
+        style={style}
+      />
+    </Tooltip>
+  );
+}

--- a/src/components/interface/UnknownAnswerIcon.tsx
+++ b/src/components/interface/UnknownAnswerIcon.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@mantine/core';
-import { IconSquareFilled } from '@tabler/icons-react';
+import { IconCheck } from '@tabler/icons-react';
 import type { CSSProperties } from 'react';
 
 export const UNKNOWN_ANSWER_LABEL = 'Response recorded; correctness not configured.';
@@ -13,9 +13,9 @@ export function UnknownAnswerIcon({
 }) {
   return (
     <Tooltip label={UNKNOWN_ANSWER_LABEL} withArrow>
-      <IconSquareFilled
+      <IconCheck
         aria-label={UNKNOWN_ANSWER_LABEL}
-        color="var(--mantine-color-blue-6)"
+        color="var(--mantine-color-gray-6)"
         size={size}
         style={style}
       />

--- a/src/components/interface/tests/StepsPanel.spec.tsx
+++ b/src/components/interface/tests/StepsPanel.spec.tsx
@@ -10,6 +10,7 @@ import { Sequence, StoredAnswer } from '../../../store/types';
 import { makeStudyConfig, makeStoredAnswer } from '../../../tests/utils';
 import { getDynamicComponentsForBlock } from '../StepsPanel.utils';
 import { StepsPanel } from '../StepsPanel';
+import { UNKNOWN_ANSWER_LABEL } from '../UnknownAnswerIcon';
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
 
@@ -50,10 +51,6 @@ vi.mock('../../../parser/utils', () => ({
   isInheritedComponent: () => false,
 }));
 
-vi.mock('../../../utils/correctAnswer', () => ({
-  componentAnswersAreCorrect: vi.fn(() => true),
-}));
-
 vi.mock('@mantine/core', () => ({
   Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -84,13 +81,14 @@ vi.mock('@tabler/icons-react', () => ({
   IconArrowsShuffle: () => null,
   IconBinaryTree: () => null,
   IconBrain: () => null,
-  IconCheck: () => null,
+  IconCheck: () => <span>icon-check</span>,
   IconChevronUp: () => null,
   IconDice3: () => null,
   IconDice5: () => null,
   IconInfoCircle: () => null,
   IconPackageImport: () => null,
-  IconX: () => null,
+  IconSquareFilled: ({ 'aria-label': ariaLabel }: { 'aria-label'?: string }) => <span aria-label={ariaLabel}>icon-square-filled</span>,
+  IconX: () => <span>icon-x</span>,
 }));
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -155,6 +153,108 @@ describe('StepsPanel rendering', () => {
       />,
     ));
     expect(container).toBeDefined();
+  });
+});
+
+describe('StepsPanel answer status indicators', () => {
+  const makeStatusConfig = (correctAnswer?: Answer[]) => makeStudyConfig({
+    uiConfig: {
+      withSidebar: true,
+      sidebarWidth: 300,
+      showTitleBar: true,
+    },
+    components: {
+      intro: {
+        type: 'questionnaire',
+        response: [{
+          id: 'q1',
+          type: 'radio',
+          prompt: 'Question',
+          options: ['A', 'B'],
+        }],
+        correctAnswer,
+      },
+    },
+    sequence: minimalSequence,
+  });
+
+  const makeCompletedAnswer = (answer: StoredAnswer['answer'], endTime = 100) => makeStoredAnswer({
+    answer,
+    identifier: 'intro_0',
+    componentName: 'intro',
+    trialOrder: 'root_0',
+    startTime: 1,
+    endTime,
+  });
+
+  test('shows an accessible unknown indicator for a submitted response without correct answers', async () => {
+    const participantAnswer = makeCompletedAnswer({ q1: 'A' });
+    const { getAllByLabelText, container } = await act(async () => render(
+      <StepsPanel
+        participantSequence={minimalSequence}
+        participantAnswers={{ intro_0: participantAnswer }}
+        studyConfig={makeStatusConfig()}
+      />,
+    ));
+
+    expect(getAllByLabelText(UNKNOWN_ANSWER_LABEL).length).toBeGreaterThan(0);
+    expect(container.textContent).toContain('icon-square-filled');
+    expect(container.textContent).not.toContain('icon-check');
+    expect(container.textContent).not.toContain('icon-x');
+  });
+
+  test('preserves correct and incorrect indicators when correct answers are configured', async () => {
+    const { container } = await act(async () => render(
+      <StepsPanel
+        participantSequence={minimalSequence}
+        participantAnswers={{ intro_0: makeCompletedAnswer({ q1: 'A' }) }}
+        studyConfig={makeStatusConfig([{ id: 'q1', answer: 'A' }])}
+      />,
+    ));
+
+    expect(container.textContent).toContain('icon-check');
+    expect(container.textContent).not.toContain('icon-square-filled');
+
+    cleanup();
+
+    const incorrect = await act(async () => render(
+      <StepsPanel
+        participantSequence={minimalSequence}
+        participantAnswers={{ intro_0: makeCompletedAnswer({ q1: 'B' }) }}
+        studyConfig={makeStatusConfig([{ id: 'q1', answer: 'A' }])}
+      />,
+    ));
+
+    expect(incorrect.container.textContent).toContain('icon-x');
+    expect(incorrect.container.textContent).not.toContain('icon-square-filled');
+  });
+
+  test('shows no answer-status indicator for incomplete or unanswered components', async () => {
+    const { container } = await act(async () => render(
+      <StepsPanel
+        participantSequence={minimalSequence}
+        participantAnswers={{ intro_0: makeCompletedAnswer({ q1: 'A' }, -1) }}
+        studyConfig={makeStatusConfig()}
+      />,
+    ));
+
+    expect(container.textContent).not.toContain('icon-square-filled');
+    expect(container.textContent).not.toContain('icon-check');
+    expect(container.textContent).not.toContain('icon-x');
+
+    cleanup();
+
+    const unanswered = await act(async () => render(
+      <StepsPanel
+        participantSequence={minimalSequence}
+        participantAnswers={{ intro_0: makeCompletedAnswer({}) }}
+        studyConfig={makeStatusConfig()}
+      />,
+    ));
+
+    expect(unanswered.container.textContent).not.toContain('icon-square-filled');
+    expect(unanswered.container.textContent).not.toContain('icon-check');
+    expect(unanswered.container.textContent).not.toContain('icon-x');
   });
 });
 

--- a/src/components/interface/tests/StepsPanel.spec.tsx
+++ b/src/components/interface/tests/StepsPanel.spec.tsx
@@ -81,13 +81,18 @@ vi.mock('@tabler/icons-react', () => ({
   IconArrowsShuffle: () => null,
   IconBinaryTree: () => null,
   IconBrain: () => null,
-  IconCheck: () => <span>icon-check</span>,
+  IconCheck: ({
+    'aria-label': ariaLabel,
+    color,
+  }: {
+    'aria-label'?: string;
+    color?: string;
+  }) => <span aria-label={ariaLabel} data-color={color}>icon-check</span>,
   IconChevronUp: () => null,
   IconDice3: () => null,
   IconDice5: () => null,
   IconInfoCircle: () => null,
   IconPackageImport: () => null,
-  IconSquareFilled: ({ 'aria-label': ariaLabel }: { 'aria-label'?: string }) => <span aria-label={ariaLabel}>icon-square-filled</span>,
   IconX: () => <span>icon-x</span>,
 }));
 
@@ -187,7 +192,7 @@ describe('StepsPanel answer status indicators', () => {
     endTime,
   });
 
-  test('shows an accessible unknown indicator for a submitted response without correct answers', async () => {
+  test('shows an accessible grey checkmark for a submitted response without correct answers', async () => {
     const participantAnswer = makeCompletedAnswer({ q1: 'A' });
     const { getAllByLabelText, container } = await act(async () => render(
       <StepsPanel
@@ -197,9 +202,10 @@ describe('StepsPanel answer status indicators', () => {
       />,
     ));
 
-    expect(getAllByLabelText(UNKNOWN_ANSWER_LABEL).length).toBeGreaterThan(0);
-    expect(container.textContent).toContain('icon-square-filled');
-    expect(container.textContent).not.toContain('icon-check');
+    const unknownIcons = getAllByLabelText(UNKNOWN_ANSWER_LABEL);
+    expect(unknownIcons.length).toBeGreaterThan(0);
+    expect(unknownIcons[0].getAttribute('data-color')).toBe('var(--mantine-color-gray-6)');
+    expect(container.textContent).toContain('icon-check');
     expect(container.textContent).not.toContain('icon-x');
   });
 
@@ -213,7 +219,7 @@ describe('StepsPanel answer status indicators', () => {
     ));
 
     expect(container.textContent).toContain('icon-check');
-    expect(container.textContent).not.toContain('icon-square-filled');
+    expect(container.querySelector(`[aria-label="${UNKNOWN_ANSWER_LABEL}"]`)).toBeNull();
 
     cleanup();
 
@@ -226,7 +232,7 @@ describe('StepsPanel answer status indicators', () => {
     ));
 
     expect(incorrect.container.textContent).toContain('icon-x');
-    expect(incorrect.container.textContent).not.toContain('icon-square-filled');
+    expect(incorrect.container.querySelector(`[aria-label="${UNKNOWN_ANSWER_LABEL}"]`)).toBeNull();
   });
 
   test('shows no answer-status indicator for incomplete or unanswered components', async () => {
@@ -238,7 +244,7 @@ describe('StepsPanel answer status indicators', () => {
       />,
     ));
 
-    expect(container.textContent).not.toContain('icon-square-filled');
+    expect(container.querySelector(`[aria-label="${UNKNOWN_ANSWER_LABEL}"]`)).toBeNull();
     expect(container.textContent).not.toContain('icon-check');
     expect(container.textContent).not.toContain('icon-x');
 
@@ -252,7 +258,7 @@ describe('StepsPanel answer status indicators', () => {
       />,
     ));
 
-    expect(unanswered.container.textContent).not.toContain('icon-square-filled');
+    expect(unanswered.container.querySelector(`[aria-label="${UNKNOWN_ANSWER_LABEL}"]`)).toBeNull();
     expect(unanswered.container.textContent).not.toContain('icon-check');
     expect(unanswered.container.textContent).not.toContain('icon-x');
   });

--- a/src/utils/correctAnswer.ts
+++ b/src/utils/correctAnswer.ts
@@ -100,3 +100,29 @@ export function componentAnswersAreCorrect(
 
   return allCorrect;
 }
+
+export type ComponentAnswerStatus = 'correct' | 'incorrect' | 'unknown';
+
+export function getComponentAnswerStatus(
+  componentAnswer: StoredAnswer | undefined,
+  componentCorrectAnswers: IndividualComponent['correctAnswer'],
+  responses?: Response[],
+): ComponentAnswerStatus | null {
+  if (
+    !componentAnswer
+    || componentAnswer.endTime < 0
+    || Object.keys(componentAnswer.answer).length === 0
+  ) {
+    return null;
+  }
+
+  if (!componentCorrectAnswers?.length) {
+    return 'unknown';
+  }
+
+  return componentAnswersAreCorrect(
+    componentAnswer.answer,
+    componentCorrectAnswers,
+    responses,
+  ) ? 'correct' : 'incorrect';
+}

--- a/src/utils/tests/correctAnswer.spec.ts
+++ b/src/utils/tests/correctAnswer.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'vitest';
 import {
   Answer, Response, StoredAnswer,
 } from '../../parser/types';
-import { componentAnswersAreCorrect, responseAnswerIsCorrect } from '../correctAnswer';
+import { makeStoredAnswer } from '../../tests/utils';
+import {
+  componentAnswersAreCorrect, getComponentAnswerStatus, responseAnswerIsCorrect,
+} from '../correctAnswer';
 
 type TestStoredAnswer = StoredAnswer['answer'][string];
 type TestCorrectAnswer = Answer['answer'];
@@ -231,6 +234,41 @@ describe('correctAnswer utilities', () => {
 
       expect(componentAnswersAreCorrect(userAnswers, correctAnswers, responses)).toBe(false);
       expect(componentAnswersAreCorrect({ customSequence: ['A', 'B'] }, correctAnswers, responses)).toBe(true);
+    });
+  });
+
+  describe('getComponentAnswerStatus', () => {
+    test('returns null for missing, incomplete, and unanswered components', () => {
+      expect(getComponentAnswerStatus(undefined, [])).toBeNull();
+      expect(getComponentAnswerStatus(makeStoredAnswer({
+        answer: { q1: 'A' },
+        endTime: -1,
+      }), [])).toBeNull();
+      expect(getComponentAnswerStatus(makeStoredAnswer({
+        answer: {},
+        endTime: 100,
+      }), [])).toBeNull();
+    });
+
+    test('returns unknown for a completed submitted response without correct answers', () => {
+      expect(getComponentAnswerStatus(makeStoredAnswer({
+        answer: { q1: 'A' },
+        endTime: 100,
+      }), [])).toBe('unknown');
+    });
+
+    test('returns correct or incorrect when correct answers are configured', () => {
+      const componentAnswer = makeStoredAnswer({
+        answer: { q1: 'A', notes: 'Participant explanation' },
+        endTime: 100,
+      });
+      const correctAnswers = [{ id: 'q1', answer: 'A' }];
+
+      expect(getComponentAnswerStatus(componentAnswer, correctAnswers)).toBe('correct');
+      expect(getComponentAnswerStatus(
+        { ...componentAnswer, answer: { ...componentAnswer.answer, q1: 'B' } },
+        correctAnswers,
+      )).toBe('incorrect');
     });
   });
 });


### PR DESCRIPTION
## Summary

- add an explicit component answer status for correct, incorrect, unknown, or no status
- show an accessible grey checkmark for completed responses without configured correct answers
- apply the same status semantics in the participant/analysis sidebar and analyst task timeline
- preserve existing answer evaluation, skip logic, stored data, and aggregate correctness behavior

## Root cause

Empty correct-answer arrays are truthy, while the boolean correctness evaluator intentionally returns true when there are no configured comparisons. The UI therefore rendered some unevaluable responses as correct.

## User impact

Submitted responses that cannot be automatically evaluated are now clearly distinguished from correct answers. The neutral indicator includes the accessible label and tooltip: `Response recorded; correctness not configured.`

## Validation

- `yarn unittest --run src/utils/tests/correctAnswer.spec.ts src/components/interface/tests/StepsPanel.spec.tsx src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx` (67 tests)
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

Closes #1084

## Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [x] Done
- [ ] N/A