### PR TITLE
Fix participant and task tag creation

### DIFF
--- a/src/analysis/individualStudy/thinkAloud/TextEditor.tsx
+++ b/src/analysis/individualStudy/thinkAloud/TextEditor.tsx
@@ -41,10 +41,13 @@ export function TextEditor({
 
   const { value: tags, execute: pullTags } = useAsync(getTags, [storageEngine]);
 
-  const setTags = useCallback((_tags: Tag[]) => {
-    if (storageEngine) {
-      storageEngine.saveTags(_tags, 'text').then(() => pullTags(storageEngine));
+  const setTags = useCallback(async (_tags: Tag[]) => {
+    if (!storageEngine) {
+      return;
     }
+
+    await storageEngine.saveTags(_tags, 'text');
+    await pullTags(storageEngine);
   }, [pullTags, storageEngine]);
 
   const textRefs = useRef<HTMLTextAreaElement[]>([]);
@@ -128,7 +131,7 @@ export function TextEditor({
     setTags(tagsCopy);
   }, [setTags, tags]);
 
-  const createTagCallback = useCallback((t: Tag) => { setTags([...(tags || []), t]); }, [setTags, tags]);
+  const createTagCallback = useCallback((t: Tag) => setTags([...(tags || []), t]), [setTags, tags]);
 
   const addTextRefCallback = useCallback((i: number, ref: HTMLTextAreaElement) => {
     textRefs.current[i] = ref;

--- a/src/analysis/individualStudy/thinkAloud/TextEditor.tsx
+++ b/src/analysis/individualStudy/thinkAloud/TextEditor.tsx
@@ -119,7 +119,7 @@ export function TextEditor({
     }, 1);
   });
 
-  const editTagCallback = useCallback((oldTag: Tag, newTag: Tag) => {
+  const editTagCallback = useCallback(async (oldTag: Tag, newTag: Tag) => {
     if (!tags) {
       return;
     }
@@ -128,7 +128,7 @@ export function TextEditor({
     const tagsCopy = Array.from(tags);
     tagsCopy[tagIndex] = newTag;
 
-    setTags(tagsCopy);
+    await setTags(tagsCopy);
   }, [setTags, tags]);
 
   const createTagCallback = useCallback((t: Tag) => setTags([...(tags || []), t]), [setTags, tags]);

--- a/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
+++ b/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
@@ -342,7 +342,7 @@ export function ThinkAloudFooter({
     }
   }, [pullAllParticipantTags, pullTags, storageEngine]);
 
-  const editTaskTagCallback = useCallback((oldTag: Tag, newTag: Tag) => {
+  const editTaskTagCallback = useCallback(async (oldTag: Tag, newTag: Tag) => {
     if (!taskTags) {
       return;
     }
@@ -351,10 +351,10 @@ export function ThinkAloudFooter({
     const tagsCopy = Array.from(taskTags);
     tagsCopy[tagIndex] = newTag;
 
-    setTags(tagsCopy, 'task');
+    await setTags(tagsCopy, 'task');
   }, [setTags, taskTags]);
 
-  const editParticipantTagCallback = useCallback((oldTag: Tag, newTag: Tag) => {
+  const editParticipantTagCallback = useCallback(async (oldTag: Tag, newTag: Tag) => {
     if (!allParticipantTags) {
       return;
     }
@@ -363,7 +363,7 @@ export function ThinkAloudFooter({
     const tagsCopy = Array.from(allParticipantTags);
     tagsCopy[tagIndex] = newTag;
 
-    setTags(tagsCopy, 'participant');
+    await setTags(tagsCopy, 'participant');
   }, [setTags, allParticipantTags]);
 
   const createTaskTagCallback = useCallback((t: Tag) => setTags([...(taskTags || []), t], 'task'), [setTags, taskTags]);

--- a/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
+++ b/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
@@ -329,9 +329,16 @@ export function ThinkAloudFooter({
     navigateToTask(orderedAnswers[nextIndex].identifier);
   }, [currentTrial, navigateToTask, orderedAnswers]);
 
-  const setTags = useCallback((_tags: Tag[], type: 'task' | 'participant') => {
-    if (storageEngine) {
-      storageEngine.saveTags(_tags, type).then(() => { type === 'task' ? pullTags(storageEngine, type) : pullAllParticipantTags(storageEngine, type); });
+  const setTags = useCallback(async (_tags: Tag[], type: 'task' | 'participant') => {
+    if (!storageEngine) {
+      return;
+    }
+
+    await storageEngine.saveTags(_tags, type);
+    if (type === 'task') {
+      await pullTags(storageEngine, type);
+    } else {
+      await pullAllParticipantTags(storageEngine, type);
     }
   }, [pullAllParticipantTags, pullTags, storageEngine]);
 
@@ -359,9 +366,9 @@ export function ThinkAloudFooter({
     setTags(tagsCopy, 'participant');
   }, [setTags, allParticipantTags]);
 
-  const createTaskTagCallback = useCallback((t: Tag) => { setTags([...(taskTags || []), t], 'task'); }, [setTags, taskTags]);
+  const createTaskTagCallback = useCallback((t: Tag) => setTags([...(taskTags || []), t], 'task'), [setTags, taskTags]);
 
-  const createParticipantTagCallback = useCallback((t: Tag) => { setTags([...(taskTags || []), t], 'participant'); }, [setTags, taskTags]);
+  const createParticipantTagCallback = useCallback((t: Tag) => setTags([...(allParticipantTags || []), t], 'participant'), [allParticipantTags, setTags]);
 
   useEffect(() => {
     const t = transcriptLines ? transcriptLines[jumpedToLine]?.start || 0 : 0;

--- a/src/analysis/individualStudy/thinkAloud/TranscriptLine.tsx
+++ b/src/analysis/individualStudy/thinkAloud/TranscriptLine.tsx
@@ -10,7 +10,7 @@ import { TagSelector } from './tags/TagSelector';
 
 export function TranscriptLine({
   annotation, setAnnotation, start, current, end, text, tags, selectedTags, onTextChange, deleteRowCallback, addRowCallback, onSelectTags, addRef, index, editTagCallback, createTagCallback, onClickLine,
-} : {annotation: string; setAnnotation: (i: number, s: string) => void; start: number, end: number, current: number, text: string, tags: Tag[], selectedTags: Tag[], onTextChange: (i: number, v: string) => void, deleteRowCallback: (i: number) => void, addRowCallback: (i: number, textIndex: number) => void, onSelectTags: (i: number, t: Tag[]) => void, addRef: (i: number, ref: HTMLTextAreaElement) => void, index: number, editTagCallback: (oldTag: Tag, newTag: Tag) => void, createTagCallback: (t: Tag) => void, onClickLine: (focusedLine: number) => void }) {
+} : {annotation: string; setAnnotation: (i: number, s: string) => void; start: number, end: number, current: number, text: string, tags: Tag[], selectedTags: Tag[], onTextChange: (i: number, v: string) => void, deleteRowCallback: (i: number) => void, addRowCallback: (i: number, textIndex: number) => void, onSelectTags: (i: number, t: Tag[]) => void, addRef: (i: number, ref: HTMLTextAreaElement) => void, index: number, editTagCallback: (oldTag: Tag, newTag: Tag) => void | Promise<void>, createTagCallback: (t: Tag) => void | Promise<void>, onClickLine: (focusedLine: number) => void }) {
   const [annotationVal, setAnnotationVal] = useState<string>(annotation);
 
   const indexRef = useRef<number>(0);

--- a/src/analysis/individualStudy/thinkAloud/tags/AddTagDropdown.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/AddTagDropdown.tsx
@@ -8,32 +8,75 @@ import React, { useCallback, useState } from 'react';
 import { v4 as uuidFunc } from 'uuid';
 import { Tag } from '../types';
 
+const normalizeTagName = (tagName: string) => tagName.trim().toLowerCase();
+
 export function AddTagDropdown({
   addTagCallback, currentNames, editTag = false, editableTag,
-} : {addTagCallback : (tag: Tag) => void, currentNames: string[], editTag?: boolean, editableTag?: Tag}) {
+} : {addTagCallback : (tag: Tag) => void | Promise<void>, currentNames: string[], editTag?: boolean, editableTag?: Tag}) {
   const [name, setName] = useState<string>(editTag ? editableTag!.name : '');
   const [color, setColor] = useState<string>(editTag ? editableTag!.color : '#fd7e14');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const createTag = useCallback(() => {
+  const trimmedName = name.trim();
+  const normalizedName = normalizeTagName(name);
+  const normalizedEditableName = editableTag ? normalizeTagName(editableTag.name) : null;
+  const duplicateName = normalizedName.length > 0 && currentNames.some((currentName) => {
+    const normalizedCurrentName = normalizeTagName(currentName);
+    return normalizedCurrentName === normalizedName
+      && (!editTag || normalizedCurrentName !== normalizedEditableName);
+  });
+  const unchangedTag = editTag && editableTag
+    ? trimmedName === editableTag.name && color === editableTag.color
+    : false;
+  const validationError = duplicateName ? 'Tag with this name already exists' : null;
+  const submitDisabled = trimmedName.length === 0 || duplicateName || unchangedTag || isSubmitting;
+
+  const createTag = useCallback(async () => {
+    if (submitDisabled) {
+      return;
+    }
+
     const uuid = uuidFunc();
 
-    addTagCallback({ color, name, id: editTag && editableTag ? editableTag.id : uuid });
-  }, [addTagCallback, color, editTag, editableTag, name]);
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await addTagCallback({ color, name: trimmedName, id: editTag && editableTag ? editableTag.id : uuid });
+    } catch {
+      setSubmitError('Unable to save tag. Try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [addTagCallback, color, editTag, editableTag, submitDisabled, trimmedName]);
 
   return (
     <Stack gap="xs">
       <Group>
         <ColorSwatch color={color} />
-        <TextInput required placeholder="Enter tag name" value={name} onChange={(e) => setName(e.currentTarget.value)} error={currentNames.includes(name) && (!editTag || editableTag!.name !== name) ? 'Tag with this name already exists' : null} />
+        <TextInput
+          required
+          placeholder="Enter tag name"
+          value={name}
+          onChange={(e) => {
+            setName(e.currentTarget.value);
+            setSubmitError(null);
+          }}
+          error={validationError || submitError}
+        />
       </Group>
       <ColorPicker
         withPicker={editTag}
         style={{ width: '100%' }}
         value={color}
-        onChange={(e) => setColor(e)}
+        onChange={(e) => {
+          setColor(e);
+          setSubmitError(null);
+        }}
         swatches={['#2e2e2e', '#868e96', '#fa5252', '#e64980', '#be4bdb', '#7950f2', '#4c6ef5', '#228be6', '#15aabf', '#12b886', '#40c057', '#82c91e', '#fab005', '#fd7e14']}
       />
-      <Button disabled={(editTag && color === editableTag!.color) && (name.length === 0 || currentNames.includes(name))} size="compact-sm" onClick={() => createTag()}>{editTag ? 'Edit Tag' : 'Add Tag'}</Button>
+      <Button disabled={submitDisabled} loading={isSubmitting} size="compact-sm" onClick={createTag}>{editTag ? 'Edit Tag' : 'Add Tag'}</Button>
     </Stack>
   );
 }

--- a/src/analysis/individualStudy/thinkAloud/tags/EditTagPopover.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/EditTagPopover.tsx
@@ -1,0 +1,49 @@
+import {
+  ActionIcon, Box, Popover,
+} from '@mantine/core';
+import { IconEdit } from '@tabler/icons-react';
+import { useState } from 'react';
+import { Tag } from '../types';
+import { AddTagDropdown } from './AddTagDropdown';
+
+export function EditTagPopover({
+  tag, currentNames, editTagCallback,
+}: {
+  tag: Tag;
+  currentNames: string[];
+  editTagCallback: (oldTag: Tag, newTag: Tag) => void | Promise<void>;
+}) {
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+
+  return (
+    <Box onClick={(event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    }}
+    >
+      <Popover opened={editDialogOpen} onChange={setEditDialogOpen} trapFocus withinPortal={false}>
+        <Popover.Target>
+          <ActionIcon
+            aria-label={`Edit ${tag.name}`}
+            variant="light"
+            size="sm"
+            onClick={() => setEditDialogOpen((open) => !open)}
+          >
+            <IconEdit />
+          </ActionIcon>
+        </Popover.Target>
+        <Popover.Dropdown>
+          <AddTagDropdown
+            editTag
+            currentNames={currentNames}
+            addTagCallback={async (newTag: Tag) => {
+              await editTagCallback(tag, newTag);
+              setEditDialogOpen(false);
+            }}
+            editableTag={tag}
+          />
+        </Popover.Dropdown>
+      </Popover>
+    </Box>
+  );
+}

--- a/src/analysis/individualStudy/thinkAloud/tags/TagEditor.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/TagEditor.tsx
@@ -6,14 +6,14 @@ import { useState } from 'react';
 import { Tag } from '../types';
 import { AddTagDropdown } from './AddTagDropdown';
 
-export function TagEditor({ createTagCallback, tags } : { createTagCallback : (tag: Tag) => void, tags: Tag[] }) {
+export function TagEditor({ createTagCallback, tags } : { createTagCallback : (tag: Tag) => void | Promise<void>, tags: Tag[] }) {
   const [addDialogOpen, setAddDialogOpen] = useState<boolean>(false);
 
   return (
-    <Popover trapFocus withinPortal={false}>
+    <Popover opened={addDialogOpen} onChange={setAddDialogOpen} trapFocus withinPortal={false}>
       <Stack justify="center">
         <Popover.Target>
-          <Button style={{ width: '100%' }} variant="light" onClick={() => setAddDialogOpen(!addDialogOpen)}>
+          <Button style={{ width: '100%' }} variant="light" onClick={() => setAddDialogOpen((open) => !open)}>
             Create new tag
           </Button>
         </Popover.Target>
@@ -21,7 +21,13 @@ export function TagEditor({ createTagCallback, tags } : { createTagCallback : (t
       {tags
         ? (
           <Popover.Dropdown>
-            <AddTagDropdown currentNames={tags.map((t) => t.name)} addTagCallback={(t: Tag) => { setAddDialogOpen(false); createTagCallback(t); }} />
+            <AddTagDropdown
+              currentNames={tags.map((t) => t.name)}
+              addTagCallback={async (t: Tag) => {
+                await createTagCallback(t);
+                setAddDialogOpen(false);
+              }}
+            />
           </Popover.Dropdown>
         ) : <Loader />}
     </Popover>

--- a/src/analysis/individualStudy/thinkAloud/tags/TagSelector.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/TagSelector.tsx
@@ -1,23 +1,19 @@
 import {
   Group, ColorSwatch, useCombobox, Combobox, Pill, PillsInput, Input,
-  Popover,
-  ActionIcon,
-  Box,
   CheckIcon,
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconEdit } from '@tabler/icons-react';
 import { useCallback, useMemo } from 'react';
 import { Tag } from '../types';
 import { Pills } from './Pills';
 import { TagEditor } from './TagEditor';
-import { AddTagDropdown } from './AddTagDropdown';
+import { EditTagPopover } from './EditTagPopover';
 
 export function TagSelector({
   tags, selectedTags, onSelectTags, disabled = false, tagsEmptyText, createTagCallback, editTagCallback, width,
 }: {
-  tags: Tag[], selectedTags: Tag[], onSelectTags: (t: Tag[]) => void, disabled?: boolean, tagsEmptyText: string, editTagCallback: (oldTag: Tag, newTag: Tag) => void, createTagCallback: (t: Tag) => void | Promise<void>, width: number
+  tags: Tag[], selectedTags: Tag[], onSelectTags: (t: Tag[]) => void, disabled?: boolean, tagsEmptyText: string, editTagCallback: (oldTag: Tag, newTag: Tag) => void | Promise<void>, createTagCallback: (t: Tag) => void | Promise<void>, width: number
 }) {
   const combobox = useCombobox();
 
@@ -55,32 +51,7 @@ export function TagSelector({
             <Text style={{ width: width - 120 }} truncate="end">{tag.name}</Text>
           </Group>
         </Tooltip>
-        <Box onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-        }}
-        >
-          <Popover trapFocus withinPortal={false}>
-            <Popover.Target>
-              <ActionIcon
-                variant="light"
-                size="sm"
-              >
-                <IconEdit />
-              </ActionIcon>
-            </Popover.Target>
-            <Popover.Dropdown>
-              <AddTagDropdown
-                editTag
-                currentNames={tags.map((t) => t.id)}
-                addTagCallback={(newTag: Tag) => {
-                  editTagCallback(tag, newTag);
-                }}
-                editableTag={tag}
-              />
-            </Popover.Dropdown>
-          </Popover>
-        </Box>
+        <EditTagPopover tag={tag} currentNames={tags.map((t) => t.name)} editTagCallback={editTagCallback} />
       </Group>
     </Combobox.Option>
   )), [editTagCallback, selectedTags, tags, width]);
@@ -96,36 +67,7 @@ export function TagSelector({
             <Text style={{ width: width - 100 }} truncate="end">{tag.name}</Text>
           </Group>
         </Tooltip>
-        <Box onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-        }}
-        >
-          <Popover trapFocus withinPortal={false}>
-            <Popover.Target>
-              <ActionIcon
-                variant="light"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                }}
-              >
-                <IconEdit />
-              </ActionIcon>
-            </Popover.Target>
-            <Popover.Dropdown>
-              <AddTagDropdown
-                editTag
-                currentNames={tags.map((t) => t.id)}
-                addTagCallback={(newTag: Tag) => {
-                  editTagCallback(tag, newTag);
-                }}
-                editableTag={tag}
-              />
-            </Popover.Dropdown>
-          </Popover>
-        </Box>
+        <EditTagPopover tag={tag} currentNames={tags.map((t) => t.name)} editTagCallback={editTagCallback} />
       </Group>
     </Combobox.Option>
   )), [editTagCallback, selectedTags, tags, width]);

--- a/src/analysis/individualStudy/thinkAloud/tags/TagSelector.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/TagSelector.tsx
@@ -17,7 +17,7 @@ import { AddTagDropdown } from './AddTagDropdown';
 export function TagSelector({
   tags, selectedTags, onSelectTags, disabled = false, tagsEmptyText, createTagCallback, editTagCallback, width,
 }: {
-  tags: Tag[], selectedTags: Tag[], onSelectTags: (t: Tag[]) => void, disabled?: boolean, tagsEmptyText: string, editTagCallback: (oldTag: Tag, newTag: Tag) => void, createTagCallback: (t: Tag) => void, width: number
+  tags: Tag[], selectedTags: Tag[], onSelectTags: (t: Tag[]) => void, disabled?: boolean, tagsEmptyText: string, editTagCallback: (oldTag: Tag, newTag: Tag) => void, createTagCallback: (t: Tag) => void | Promise<void>, width: number
 }) {
   const combobox = useCombobox();
 

--- a/src/analysis/individualStudy/thinkAloud/tags/tests/AddTagDropdown.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/tests/AddTagDropdown.spec.tsx
@@ -1,0 +1,72 @@
+import { MantineProvider } from '@mantine/core';
+import {
+  cleanup, fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import {
+  afterAll, afterEach, beforeAll, describe, expect, test, vi,
+} from 'vitest';
+import { AddTagDropdown } from '../AddTagDropdown';
+
+beforeAll(() => {
+  vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('AddTagDropdown', () => {
+  test('trims a valid tag name before creation and blocks blank names', async () => {
+    const addTagCallback = vi.fn();
+    render(<MantineProvider><AddTagDropdown addTagCallback={addTagCallback} currentNames={[]} /></MantineProvider>);
+
+    const addButton = screen.getByRole('button', { name: 'Add Tag' }) as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter tag name'), { target: { value: '  New Tag  ' } });
+    expect(addButton.disabled).toBe(false);
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(addTagCallback).toHaveBeenCalledWith(expect.objectContaining({ name: 'New Tag' }));
+    });
+  });
+
+  test('blocks duplicate names case-insensitively within the supplied tag type', () => {
+    const addTagCallback = vi.fn();
+    render(<MantineProvider><AddTagDropdown addTagCallback={addTagCallback} currentNames={['Review']} /></MantineProvider>);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter tag name'), { target: { value: ' review ' } });
+
+    expect(screen.getByText('Tag with this name already exists')).toBeDefined();
+    const addButton = screen.getByRole('button', { name: 'Add Tag' }) as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+    fireEvent.click(addButton);
+    expect(addTagCallback).not.toHaveBeenCalled();
+  });
+
+  test('preserves input and shows an inline error when persistence fails', async () => {
+    const addTagCallback = vi.fn().mockRejectedValue(new Error('save failed'));
+    render(<MantineProvider><AddTagDropdown addTagCallback={addTagCallback} currentNames={[]} /></MantineProvider>);
+
+    const nameInput = screen.getByPlaceholderText('Enter tag name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'New Tag' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Tag' }));
+
+    expect(await screen.findByText('Unable to save tag. Try again.')).toBeDefined();
+    expect(nameInput.value).toBe('New Tag');
+  });
+});

--- a/src/analysis/individualStudy/thinkAloud/tags/tests/EditTagPopover.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/tests/EditTagPopover.spec.tsx
@@ -1,0 +1,88 @@
+import { MantineProvider } from '@mantine/core';
+import {
+  act, cleanup, fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import {
+  afterAll, afterEach, beforeAll, describe, expect, test, vi,
+} from 'vitest';
+import { Tag } from '../../types';
+import { EditTagPopover } from '../EditTagPopover';
+
+class ResizeObserverMock {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+const tag: Tag = { id: 'tag-1', name: 'Original Tag', color: '#fd7e14' };
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('EditTagPopover', () => {
+  test('closes only after the edited tag is persisted', async () => {
+    let resolveSave: (() => void) | undefined;
+    const editTagCallback = vi.fn(() => new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    }));
+    render(
+      <MantineProvider>
+        <EditTagPopover tag={tag} currentNames={[tag.name]} editTagCallback={editTagCallback} />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Original Tag' }));
+    const nameInput = await screen.findByPlaceholderText('Enter tag name');
+    fireEvent.change(nameInput, { target: { value: 'Updated Tag' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Tag' }));
+
+    expect(screen.getByPlaceholderText('Enter tag name')).toBeDefined();
+    expect(editTagCallback).toHaveBeenCalledWith(tag, expect.objectContaining({
+      id: tag.id,
+      name: 'Updated Tag',
+    }));
+    await act(async () => {
+      resolveSave?.();
+    });
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Enter tag name')).toBeNull();
+    });
+  });
+
+  test('keeps the edit popover open when persistence fails', async () => {
+    const editTagCallback = vi.fn().mockRejectedValue(new Error('save failed'));
+    render(
+      <MantineProvider>
+        <EditTagPopover tag={tag} currentNames={[tag.name]} editTagCallback={editTagCallback} />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Original Tag' }));
+    fireEvent.change(await screen.findByPlaceholderText('Enter tag name'), { target: { value: 'Updated Tag' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Tag' }));
+
+    expect(await screen.findByText('Unable to save tag. Try again.')).toBeDefined();
+    expect(screen.getByPlaceholderText('Enter tag name')).toBeDefined();
+  });
+});

--- a/src/analysis/individualStudy/thinkAloud/tags/tests/TagEditor.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/tests/TagEditor.spec.tsx
@@ -1,0 +1,73 @@
+import { MantineProvider } from '@mantine/core';
+import {
+  act, cleanup, fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import {
+  afterAll, afterEach, beforeAll, describe, expect, test, vi,
+} from 'vitest';
+import { TagEditor } from '../TagEditor';
+
+class ResizeObserverMock {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('TagEditor', () => {
+  test('closes the creation popover only after persistence succeeds', async () => {
+    let resolveSave: (() => void) | undefined;
+    const createTagCallback = vi.fn(() => new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    }));
+    render(<MantineProvider><TagEditor createTagCallback={createTagCallback} tags={[]} /></MantineProvider>);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create new tag' }));
+    const nameInput = await screen.findByPlaceholderText('Enter tag name');
+    fireEvent.change(nameInput, { target: { value: 'New Tag' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Tag' }));
+
+    expect(screen.getByPlaceholderText('Enter tag name')).toBeDefined();
+    await act(async () => {
+      resolveSave?.();
+    });
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Enter tag name')).toBeNull();
+    });
+  });
+
+  test('keeps the creation popover open when persistence fails', async () => {
+    const createTagCallback = vi.fn().mockRejectedValue(new Error('save failed'));
+    render(<MantineProvider><TagEditor createTagCallback={createTagCallback} tags={[]} /></MantineProvider>);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create new tag' }));
+    fireEvent.change(await screen.findByPlaceholderText('Enter tag name'), { target: { value: 'New Tag' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Tag' }));
+
+    expect(await screen.findByText('Unable to save tag. Try again.')).toBeDefined();
+    expect(screen.getByPlaceholderText('Enter tag name')).toBeDefined();
+  });
+});

--- a/src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
-  render, act, cleanup, fireEvent,
+  render, act, cleanup, fireEvent, waitFor,
 } from '@testing-library/react';
 import {
   afterEach, beforeAll, beforeEach, describe, expect, test, vi,
@@ -62,9 +62,24 @@ const mockTranscriptLine = vi.fn(({
   </div>
 ));
 
-const mockTagSelector = vi.fn(({ onSelectTags, editTagCallback, tags }: { onSelectTags?: (t: Tag[]) => void; editTagCallback?: (oldTag: Tag, newTag: Tag) => void; tags?: Tag[] }) => (
+const mockTagSelector = vi.fn(({
+  onSelectTags, editTagCallback, createTagCallback, tags, tagsEmptyText,
+}: {
+  onSelectTags?: (t: Tag[]) => void;
+  editTagCallback?: (oldTag: Tag, newTag: Tag) => void;
+  createTagCallback?: (tag: Tag) => void | Promise<void>;
+  tags?: Tag[];
+  tagsEmptyText?: string;
+}) => (
   <div data-testid="tag-selector">
     <button type="button" onClick={() => onSelectTags?.([])}>select-tags</button>
+    <button
+      type="button"
+      data-testid={`create-${tagsEmptyText}`}
+      onClick={() => { createTagCallback?.({ id: 'new-tag', name: 'New Tag', color: '#fd7e14' }); }}
+    >
+      create-tag
+    </button>
     {tags && tags.length > 0 && (
       <button type="button" onClick={() => editTagCallback?.(tags[0], { ...tags[0], name: 'edited' })}>edit-tag</button>
     )}
@@ -652,6 +667,42 @@ describe('ThinkAloudFooter', () => {
       await act(async () => { fireEvent.click(taskTagsBtn); });
     }
     expect(mockFooterStorageEngine.saveAllParticipantAndTaskTags).toHaveBeenCalled();
+  });
+
+  test('create tag callbacks append definitions from the matching tag type', async () => {
+    const taskTag = makeTag({ id: 'task-tag', name: 'Task Tag' });
+    const participantTag = makeTag({ id: 'participant-tag', name: 'Participant Tag' });
+    vi.mocked(useAsync).mockImplementation((_fn, args) => ({
+      value: Array.isArray(args) && args[1] === 'task' ? [taskTag]
+        : Array.isArray(args) && args[1] === 'participant' ? [participantTag] : null,
+      status: 'success',
+      execute: vi.fn(),
+      error: null,
+    }));
+    mockFooterStorageEngine.saveTags.mockClear();
+    mockFooterStorageEngine.saveAllParticipantAndTaskTags.mockClear();
+
+    const { getByTestId } = await act(async () => render(
+      <RealThinkAloudFooter {...footerDefaultProps} storageEngine={makeStorageEngine(mockFooterStorageEngine)} />,
+    ));
+    fireEvent.click(getByTestId('create-Add Participant Tags'));
+    fireEvent.click(getByTestId('create-Add Task Tags'));
+
+    await waitFor(() => {
+      expect(mockFooterStorageEngine.saveTags).toHaveBeenCalledWith([
+        participantTag,
+        { id: 'new-tag', name: 'New Tag', color: '#fd7e14' },
+      ], 'participant');
+      expect(mockFooterStorageEngine.saveTags).toHaveBeenCalledWith([
+        taskTag,
+        { id: 'new-tag', name: 'New Tag', color: '#fd7e14' },
+      ], 'task');
+    });
+    expect(mockFooterStorageEngine.saveTags).not.toHaveBeenCalledWith(
+      expect.arrayContaining([taskTag]),
+      'participant',
+    );
+    expect(mockFooterStorageEngine.saveAllParticipantAndTaskTags).not.toHaveBeenCalled();
   });
 
   test('editTagCallback saves updated tags', async () => {


### PR DESCRIPTION
## Summary

- append new participant and task tag definitions from their matching tag collections
- control the shared tag-creation and tag-edit popovers so they close after successful persistence
- trim tag names, reject blank or case-insensitive duplicate names, and preserve input when saving fails
- apply the shared creation and edit behavior to participant, task, and text tags
- add focused interaction and footer callback coverage

## Root cause

Participant tag creation built the saved participant list from the task-tag definitions. Separately, the create and edit tag popovers were uncontrolled, their local open state was not connected consistently to Mantine, and tag callbacks did not propagate persistence completion back to the menus.

## Impact

Analysts can create multiple participant and task tags without replacing definitions from another tag type. Successful creation and editing close their nested popovers after persistence completes, while failed saves keep the entered name and color available for retry. Creating a definition still does not automatically assign it.

## Validation

- `yarn unittest --run` — 1,856 passed, 1 skipped across 138 files
- `yarn typecheck`
- `yarn lint`
- `yarn build`

Closes #1279

## Documentation

Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [ ] Done
- [X] N/A
