### PR TITLE
Keep GitHub Pages deployment history minimal

### DIFF
--- a/.github/scripts/publish-pages-snapshot.sh
+++ b/.github/scripts/publish-pages-snapshot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 3 || $# -gt 4 ]]; then
+  echo "Usage: $0 <publish-dir> <destination-dir> <pages-checkout> [publish-branch]" >&2
+  exit 2
+fi
+
+publish_dir="$1"
+destination_dir="$2"
+pages_checkout="$3"
+publish_branch="${4:-gh-pages}"
+
+if [[ ! -d "$publish_dir" ]]; then
+  echo "Publish directory does not exist: $publish_dir" >&2
+  exit 2
+fi
+
+if [[ ! -d "$pages_checkout/.git" ]]; then
+  echo "Pages checkout is not a Git worktree: $pages_checkout" >&2
+  exit 2
+fi
+
+if [[ -n "$destination_dir" && "$destination_dir" != "dev" && ! "$destination_dir" =~ ^PR[0-9]+$ ]]; then
+  echo "Unsupported Pages destination: $destination_dir" >&2
+  exit 2
+fi
+
+publish_dir="$(cd "$publish_dir" && pwd -P)"
+pages_checkout="$(cd "$pages_checkout" && pwd -P)"
+
+git -C "$pages_checkout" config user.name "github-actions[bot]"
+git -C "$pages_checkout" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git -C "$pages_checkout" checkout --orphan pages-snapshot
+
+if [[ -z "$destination_dir" ]]; then
+  rsync -a --delete \
+    --exclude='/.git/' \
+    --exclude='/.nojekyll' \
+    --exclude='/CNAME' \
+    --exclude='/dev/' \
+    --exclude='/PR[0-9]*/' \
+    "$publish_dir/" "$pages_checkout/"
+else
+  destination_path="$pages_checkout/$destination_dir"
+  mkdir -p "$destination_path"
+  rsync -a --delete "$publish_dir/" "$destination_path/"
+  rmdir "$destination_path" 2>/dev/null || true
+fi
+
+touch "$pages_checkout/.nojekyll"
+
+git -C "$pages_checkout" add --all
+git -C "$pages_checkout" commit -m "Deploy current GitHub Pages snapshot"
+git -C "$pages_checkout" push --force origin "HEAD:$publish_branch"

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -7,14 +7,16 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: pages-deployment
+  cancel-in-progress: false
+
+# Keep the existing publisher until a maintainer approves the initial force-push cutover.
 jobs:
   deploy-main:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     if: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
@@ -39,7 +41,19 @@ jobs:
         env:
           VITE_STORAGE_ENGINE: ${{ vars.VITE_STORAGE_ENGINE }}
 
+      - uses: actions/checkout@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        with:
+          ref: gh-pages
+          path: .pages
+          fetch-depth: 1
+
+      - name: Deploy current-only snapshot
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: .github/scripts/publish-pages-snapshot.sh ./dist '' ./.pages
+
       - uses: peaceiris/actions-gh-pages@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
         name: Deploy
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,10 +64,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/dev'}}
     permissions:
       contents: write
-    concurrency:
-      group: dev-deploy
-      cancel-in-progress: true
-
     steps:
       - uses: actions/checkout@v3
 
@@ -69,7 +79,19 @@ jobs:
         env:
           VITE_BASE_PATH: "/dev/"
 
+      - uses: actions/checkout@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        with:
+          ref: gh-pages
+          path: .pages
+          fetch-depth: 1
+
+      - name: Deploy current-only dev snapshot
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: .github/scripts/publish-pages-snapshot.sh ./dist dev ./.pages
+
       - uses: peaceiris/actions-gh-pages@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
         name: Deploy dev branch
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,9 +103,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
     steps:
@@ -113,7 +132,19 @@ jobs:
           VITE_STORAGE_ENGINE: ${{ vars.VITE_STORAGE_ENGINE }}
           VITE_BASE_PATH: "/study/PR${{ github.event.number }}/"
 
+      - uses: actions/checkout@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        with:
+          ref: gh-pages
+          path: .pages
+          fetch-depth: 1
+
+      - name: Push current-only PR deploy preview
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: .github/scripts/publish-pages-snapshot.sh ./dist "PR${{ github.event.number }}" ./.pages
+
       - name: Push PR deploy preview
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_close.yaml
+++ b/.github/workflows/pr_close.yaml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: pages-deployment
+  cancel-in-progress: false
+
+# Keep the existing publisher until a maintainer approves the initial force-push cutover.
 jobs:
   delete_preview:
     runs-on: ubuntu-latest
@@ -10,10 +15,30 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+
+      - uses: actions/checkout@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        with:
+          ref: gh-pages
+          path: .pages
+          fetch-depth: 1
+
+      - name: make empty snapshot directory
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: mkdir empty-pages
+
+      - name: delete preview from current-only snapshot
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: .github/scripts/publish-pages-snapshot.sh ./empty-pages "PR${{ github.event.number }}" ./.pages
+
       - name: make empty dir
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
         run: mkdir public
 
       - name: delete folder
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #1281

## What changed

- add a snapshot publisher that preserves production, `dev`, and unrelated active PR paths while replacing `gh-pages` with one orphan commit
- serialize every workflow that writes to GitHub Pages
- gate the new force-push behavior behind `PAGES_SINGLE_COMMIT=true`; existing publishing remains active until the maintainer-approved cutover
- use the same snapshot mechanism when a PR preview closes

## Why

The current deployment workflows append generated builds to `gh-pages` history. Closed previews disappear from the branch tip but remain reachable in history, substantially increasing normal clone size.

## Validation

- simulated production replacement, PR update, and PR deletion against an isolated Git remote
- confirmed each simulated deployment leaves exactly one commit
- confirmed unrelated production, `dev`, and PR paths remain intact
- `bash -n .github/scripts/publish-pages-snapshot.sh`
- YAML parse validation for both changed workflows
- `git diff --check`

The activation variable remains unset, so this PR cannot rewrite the live `gh-pages` branch before explicit approval.

### Documentation
Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [ ] Done
- [x] N/A