### PR TITLE
Queue GitHub Pages deployments

### DIFF
--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -10,6 +10,7 @@ on:
 concurrency:
   group: pages-deployment
   cancel-in-progress: false
+  queue: max
 
 # Keep the existing publisher until a maintainer approves the initial force-push cutover.
 jobs:

--- a/.github/workflows/pr_close.yaml
+++ b/.github/workflows/pr_close.yaml
@@ -6,6 +6,7 @@ on:
 concurrency:
   group: pages-deployment
   cancel-in-progress: false
+  queue: max
 
 # Keep the existing publisher until a maintainer approves the initial force-push cutover.
 jobs:


### PR DESCRIPTION
Follow-up to #1317 and #1281.

## What changed

- allow up to 100 pending runs in the shared `pages-deployment` concurrency group
- apply the queue setting to both deployment and PR-close workflows

## Why

The shared group already prevents simultaneous `gh-pages` writers, but GitHub's default single pending slot can replace an older pending deployment during a burst. `queue: max` preserves those events while continuing to serialize writes.

## Validation

- parsed both workflow files as YAML
- `git diff --check`

After this merges, the repository variable will be enabled and a PR deployment will be used to verify the current-only snapshot path.

### Documentation
Tracking issue: https://github.com/revisit-studies/reVISit-studies.github.io/issues/238

- [ ] Done
- [x] N/A