### PR TITLE
Remove mismatch count logic from the overview stats

### DIFF
--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -164,16 +164,6 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     };
   }, [selectedParticipants]);
 
-  const showStoredCountMismatch = useMemo(() => {
-    const hasStageFilter = !(selectedStages.length === 1 && selectedStages[0] === 'ALL');
-    const hasConfigFilter = !(selectedConfigs.length === 1 && selectedConfigs[0] === 'ALL');
-    const hasConditionFilter = availableConditions.length > 0 && !(selectedConditions.length === 1 && selectedConditions[0] === 'ALL');
-
-    return !hasStageFilter
-      && !hasConfigFilter
-      && !hasConditionFilter;
-  }, [selectedStages, selectedConfigs, selectedConditions, availableConditions.length]);
-
   const currentConfigHash = currentConfigHashValue ?? undefined;
   const isFirebaseEngine = storageEngine?.getEngine() === 'firebase';
   const codingEnabled = isFirebaseEngine && hasAudioRecording;
@@ -583,9 +573,6 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     studyConfig={studyConfig}
                     visibleParticipants={visibleParticipants}
                     allConfigs={allConfigs}
-                    studyId={canonicalStudyId ?? undefined}
-                    showStoredCountMismatch={showStoredCountMismatch}
-                    includedParticipants={includedParticipants}
                     currentConfigLabel={currentConfigLabel}
                   />
                 )}
@@ -594,7 +581,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="stats" pt="xs">
-                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} studyId={canonicalStudyId ?? undefined} />}
+                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} />}
               </Tabs.Panel>
               <Tabs.Panel value="tagging" pt="xs">
                 {studyConfig && codingEnabled

--- a/src/analysis/individualStudy/stats/StatsView.tsx
+++ b/src/analysis/individualStudy/stats/StatsView.tsx
@@ -15,12 +15,10 @@ export function StatsView(
     studyConfig,
     visibleParticipants,
     allConfigs = {},
-    studyId,
   }: {
     studyConfig: StudyConfig;
     visibleParticipants: ParticipantDataWithStatus[];
     allConfigs?: Record<string, StudyConfig>;
-    studyId?: string;
   },
 ) {
   const { trialId } = useParams();
@@ -33,7 +31,7 @@ export function StatsView(
   return (
     <>
       {overviewData && (
-        <OverviewStats overviewData={overviewData} studyId={studyId} showStoredCountMismatch={false} />
+        <OverviewStats overviewData={overviewData} />
       )}
       <Paper shadow="sm" p="md" mt="md" withBorder>
         {

--- a/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
+++ b/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
@@ -146,7 +146,7 @@ describe('StatsView', () => {
   test('shows OverviewStats when trialId is set and not "end"', () => {
     vi.mocked(useParams).mockReturnValue({ trialId: 'trial1' });
     const html = renderToStaticMarkup(
-      <StatsView studyConfig={emptyConfig} visibleParticipants={[mockParticipant]} studyId="my-study" />,
+      <StatsView studyConfig={emptyConfig} visibleParticipants={[mockParticipant]} />,
     );
     expect(html).toContain('OverviewStats');
   });

--- a/src/analysis/individualStudy/summary/OverviewStats.tsx
+++ b/src/analysis/individualStudy/summary/OverviewStats.tsx
@@ -2,64 +2,16 @@ import {
   Flex, Paper, Text, Title, Tooltip,
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
-import { useMemo } from 'react';
 import { convertNumberToString } from './utils';
 import { OverviewData } from '../../types';
-import { useStorageEngine } from '../../../storage/storageEngineHooks';
-import { useAsync } from '../../../store/hooks/useAsync';
-import { StorageEngine } from '../../../storage/engines/types';
-
-async function getStoredParticipantCounts(storageEngine: StorageEngine, studyId: string | undefined) {
-  if (!storageEngine || !studyId) return null;
-  return storageEngine.getParticipantsStatusCounts(studyId);
-}
 
 export function OverviewStats({
   overviewData,
-  studyId,
-  showStoredCountMismatch = false,
-  includedParticipants = ['completed', 'inProgress', 'rejected'],
 }: {
   overviewData: OverviewData;
-  studyId?: string;
-  showStoredCountMismatch?: boolean;
-  includedParticipants?: string[];
 }) {
   // Check if there are participants with invalid clean time (e.g. due to a window events bug)
   const hasExcluded = overviewData && overviewData.participantsWithInvalidCleanTimeCount > 0;
-
-  const { storageEngine } = useStorageEngine();
-
-  // Get the stored participant counts from the storage engine
-  const { value: storedCounts } = useAsync(
-    getStoredParticipantCounts,
-    showStoredCountMismatch && storageEngine && studyId ? [storageEngine, studyId] : null,
-  );
-
-  const mismatchDetails = useMemo(() => {
-    if (!showStoredCountMismatch || !storedCounts) return null;
-    return {
-      completed: {
-        current: includedParticipants.includes('completed') ? storedCounts.completed : 0,
-        calculated: overviewData.participantCounts.completed,
-      },
-      inProgress: {
-        current: includedParticipants.includes('inProgress') ? storedCounts.inProgress : 0,
-        calculated: overviewData.participantCounts.inProgress,
-      },
-      rejected: {
-        current: includedParticipants.includes('rejected') ? storedCounts.rejected : 0,
-        calculated: overviewData.participantCounts.rejected,
-      },
-    };
-  }, [overviewData.participantCounts, showStoredCountMismatch, storedCounts, includedParticipants]);
-
-  // Check if the stored participant counts match the calculated participant counts
-  const hasMismatch = (type: 'completed' | 'inProgress' | 'rejected') => {
-    if (!mismatchDetails) return false;
-    const details = mismatchDetails[type];
-    return details.current !== details.calculated;
-  };
 
   return (
     <Paper shadow="sm" p="md" withBorder>
@@ -70,36 +22,15 @@ export function OverviewStats({
           <Text size="sm" c="dimmed">Total Participants</Text>
         </Flex>
         <Flex direction="column">
-          <Flex align="center" gap="xs">
-            {hasMismatch('completed') && mismatchDetails && (
-              <Tooltip label={`Calculated: ${mismatchDetails.completed.calculated}, Stored: ${mismatchDetails.completed.current}`}>
-                <IconAlertTriangle size={16} color="orange" />
-              </Tooltip>
-            )}
-            <Text size="xl" fw="bold" c="green">{overviewData.participantCounts.completed}</Text>
-          </Flex>
+          <Text size="xl" fw="bold" c="green">{overviewData.participantCounts.completed}</Text>
           <Text size="sm" c="dimmed">Completed</Text>
         </Flex>
         <Flex direction="column">
-          <Flex align="center" gap="xs">
-            {hasMismatch('inProgress') && mismatchDetails && (
-              <Tooltip label={`Calculated: ${mismatchDetails.inProgress.calculated}, Stored: ${mismatchDetails.inProgress.current}`}>
-                <IconAlertTriangle size={16} color="orange" />
-              </Tooltip>
-            )}
-            <Text size="xl" fw="bold" c="yellow">{overviewData.participantCounts.inProgress}</Text>
-          </Flex>
+          <Text size="xl" fw="bold" c="yellow">{overviewData.participantCounts.inProgress}</Text>
           <Text size="sm" c="dimmed">In Progress</Text>
         </Flex>
         <Flex direction="column">
-          <Flex align="center" gap="xs">
-            {hasMismatch('rejected') && mismatchDetails && (
-              <Tooltip label={`Calculated: ${mismatchDetails.rejected.calculated}, Stored: ${mismatchDetails.rejected.current}`}>
-                <IconAlertTriangle size={16} color="orange" />
-              </Tooltip>
-            )}
-            <Text size="xl" fw="bold" c="red">{overviewData.participantCounts.rejected}</Text>
-          </Flex>
+          <Text size="xl" fw="bold" c="red">{overviewData.participantCounts.rejected}</Text>
           <Text size="sm" c="dimmed">Rejected</Text>
         </Flex>
         <Flex direction="column">

--- a/src/analysis/individualStudy/summary/SummaryView.tsx
+++ b/src/analysis/individualStudy/summary/SummaryView.tsx
@@ -11,17 +11,11 @@ export function SummaryView({
   visibleParticipants,
   studyConfig,
   allConfigs = {},
-  studyId,
-  showStoredCountMismatch = false,
-  includedParticipants = ['completed', 'inProgress', 'rejected'],
   currentConfigLabel,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
   allConfigs?: Record<string, StudyConfig>;
-  studyId?: string;
-  showStoredCountMismatch?: boolean;
-  includedParticipants?: string[];
   currentConfigLabel?: string;
 }) {
   const overviewData = useMemo(
@@ -52,12 +46,7 @@ export function SummaryView({
 
   return (
     <Stack gap="md">
-      <OverviewStats
-        overviewData={overviewData}
-        studyId={studyId}
-        showStoredCountMismatch={showStoredCountMismatch}
-        includedParticipants={includedParticipants}
-      />
+      <OverviewStats overviewData={overviewData} />
       <Group align="flex-start" gap="md" grow>
         <ComponentStats
           visibleParticipants={visibleParticipants}

--- a/src/analysis/individualStudy/summary/tests/SummaryView.spec.tsx
+++ b/src/analysis/individualStudy/summary/tests/SummaryView.spec.tsx
@@ -7,9 +7,6 @@ import { cleanup } from '@testing-library/react';
 import { StudyConfig } from '../../../../parser/types';
 import { ParticipantDataWithStatus } from '../../../../storage/types';
 import { OverviewData } from '../../../types';
-import { useStorageEngine } from '../../../../storage/storageEngineHooks';
-import { useAsync } from '../../../../store/hooks/useAsync';
-import { makeStorageEngine } from '../../../../tests/utils';
 import { createMockStudyConfig } from '../../../tests/testUtils';
 import { SummaryView } from '../SummaryView';
 import { OverviewStats } from '../OverviewStats';
@@ -51,14 +48,6 @@ vi.mock('@tabler/icons-react', () => ({
   IconAlertTriangle: () => <span>alert</span>,
 }));
 
-vi.mock('../../../../storage/storageEngineHooks', () => ({
-  useStorageEngine: vi.fn(() => ({ storageEngine: undefined })),
-}));
-
-vi.mock('../../../../store/hooks/useAsync', () => ({
-  useAsync: vi.fn(() => ({ value: null, status: 'idle', error: null })),
-}));
-
 // ── fixture helpers ──────────────────────────────────────────────────────────
 
 function makeOverviewData(overrides: Partial<OverviewData> = {}): OverviewData {
@@ -91,7 +80,6 @@ describe('SummaryView', () => {
       <SummaryView
         visibleParticipants={noParticipants}
         studyConfig={emptyConfig}
-        studyId="test-study"
       />,
     );
     expect(html).toContain('Overview Statistics');
@@ -110,7 +98,7 @@ describe('OverviewStats', () => {
 
   test('renders participant counts and stat labels', () => {
     const html = renderToStaticMarkup(
-      <OverviewStats overviewData={makeOverviewData()} studyId="test-study" />,
+      <OverviewStats overviewData={makeOverviewData()} />,
     );
     expect(html).toContain('Total Participants');
     expect(html).toContain('Completed');
@@ -121,48 +109,10 @@ describe('OverviewStats', () => {
     expect(html).toContain('Correctness');
   });
 
-  test('shows mismatch alert when stored counts differ from calculated counts', () => {
-    vi.mocked(useAsync).mockReturnValue({
-      execute: vi.fn(), value: { completed: 3, inProgress: 5, rejected: 0 }, status: 'success', error: null,
-    } as ReturnType<typeof useAsync>);
-    vi.mocked(useStorageEngine).mockReturnValue({ storageEngine: makeStorageEngine(), setStorageEngine: vi.fn() });
-
-    const html = renderToStaticMarkup(
-      <OverviewStats
-        overviewData={makeOverviewData({
-          participantCounts: {
-            total: 10, completed: 7, inProgress: 2, rejected: 1,
-          },
-        })}
-        studyId="test-study"
-        showStoredCountMismatch
-      />,
-    );
-    // Alert triangle appears for the mismatched field
-    expect(html).toContain('alert');
-  });
-
-  test('no mismatch alert when stored counts match calculated counts', () => {
-    vi.mocked(useAsync).mockReturnValue({
-      execute: vi.fn(), value: { completed: 7, inProgress: 2, rejected: 1 }, status: 'success', error: null,
-    } as ReturnType<typeof useAsync>);
-    vi.mocked(useStorageEngine).mockReturnValue({ storageEngine: makeStorageEngine(), setStorageEngine: vi.fn() });
-
-    const html = renderToStaticMarkup(
-      <OverviewStats
-        overviewData={makeOverviewData()}
-        studyId="test-study"
-        showStoredCountMismatch
-      />,
-    );
-    expect(html).not.toContain('alert');
-  });
-
   test('shows excluded-participants warning when participantsWithInvalidCleanTimeCount > 0', () => {
     const html = renderToStaticMarkup(
       <OverviewStats
         overviewData={makeOverviewData({ participantsWithInvalidCleanTimeCount: 3 })}
-        studyId="test-study"
       />,
     );
     expect(html).toContain('alert');
@@ -172,18 +122,9 @@ describe('OverviewStats', () => {
     const html = renderToStaticMarkup(
       <OverviewStats
         overviewData={makeOverviewData({ participantsWithInvalidCleanTimeCount: 0 })}
-        studyId="test-study"
       />,
     );
     expect(html).not.toContain('alert');
-  });
-
-  test('no stored counts fetched when studyId is undefined', () => {
-    renderToStaticMarkup(
-      <OverviewStats overviewData={makeOverviewData()} />,
-    );
-    // useAsync should have been called with null as immediate (no fetch)
-    expect(vi.mocked(useAsync).mock.calls[0][1]).toBeNull();
   });
 });
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1211

### Give a longer description of what this PR addresses and why it's needed
Removes the participant count mismatch warning from the analysis summary

Before, completion status was saved in two places: participant data and sequence assignments. Since #1186, it has been saved only in sequence assignments, so mismatches should no longer occur.

### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [ ] Update relevant documentation
- [ ] ...