### PR TITLE
Fix broken image in example-mvnv

### DIFF
--- a/public/example-mvnv/assets/js/adjMatrix/view.js
+++ b/public/example-mvnv/assets/js/adjMatrix/view.js
@@ -699,7 +699,7 @@ var View = /** @class */ (function () {
         var yOffset = 30;
         var xOffset = 10;
         if (this.controller.configuration.adjMatrix.edgeBars && this.controller.configuration.isMultiEdge) {
-            var legendFile = 'assets/adj-matrix/';
+            var legendFile = 'adj-matrix/';
             legendFile += this.controller.configuration.isMultiEdge ? 'nestedSquaresLegend' : 'edgeBarsLegendSingleEdge';
             legendFile += '.png';
             d3.select('#legend-svg').append('g').append('svg:image')

--- a/public/example-mvnv/assets/js/adjMatrix/view.ts
+++ b/public/example-mvnv/assets/js/adjMatrix/view.ts
@@ -819,7 +819,7 @@ class View {
     let xOffset = 10;
 
     if (this.controller.configuration.adjMatrix.edgeBars && this.controller.configuration.isMultiEdge) {
-      let legendFile = 'assets/adj-matrix/';
+      let legendFile = 'adj-matrix/';
       legendFile += this.controller.configuration.isMultiEdge ? 'nestedSquaresLegend' : 'edgeBarsLegendSingleEdge';
       legendFile += '.png';
       d3.select('#legend-svg').append('g').append('svg:image')


### PR DESCRIPTION
## Summary

- correct the multivariate adjacency-matrix legend URL in the maintained TypeScript source
- apply the same correction to the checked-in browser JavaScript

## Root cause

The iframe document is already served from `example-mvnv/assets/`, but the legend URL added another `assets/` segment. The browser therefore requested `example-mvnv/assets/assets/adj-matrix/nestedSquaresLegend.png`, which does not exist.

## Impact

The nested-squares legend now loads from `example-mvnv/assets/adj-matrix/nestedSquaresLegend.png` in the `example-mvnv` study.

## Validation

- corrected static resource: `200 image/png`
- previous duplicated resource: `404`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

The unit suite could not execute in the isolated worktree because Vitest resolved `vitest-localstorage-mock` through the shared `node_modules` symlink as an invalid `/@fs/...` path; zero tests were collected.

Fixes #1334
