### PR TITLE
Fix dynamic Study Browser navigation crash

### DIFF
--- a/src/components/interface/StepsPanel.spec.tsx
+++ b/src/components/interface/StepsPanel.spec.tsx
@@ -157,6 +157,26 @@ describe('StepsPanel tree walking', () => {
 
     expect(getDynamicComponentsForBlock(block, participantAnswers, 2)).toEqual(['generatedA']);
   });
+
+  test('does not include malformed dynamic answers without component names', () => {
+    const block: Sequence = {
+      id: 'dynamicDrawing',
+      order: 'dynamic',
+      orderPath: 'root-0',
+      components: [],
+      skip: [],
+      interruptions: [],
+    };
+
+    const participantAnswers = {
+      dynamicDrawing_2_generatedA_0: {
+        componentName: 'generatedA',
+      } as StoredAnswer,
+      dynamicDrawing_2___dynamicLoading_1: {} as StoredAnswer,
+    };
+
+    expect(getDynamicComponentsForBlock(block, participantAnswers, 2)).toEqual(['generatedA']);
+  });
 });
 
 describe('StepsPanel skip summaries', () => {

--- a/src/components/interface/StepsPanel.utils.ts
+++ b/src/components/interface/StepsPanel.utils.ts
@@ -19,7 +19,8 @@ export function getDynamicComponentsForBlock(
 
   return Object.entries(participantAnswers)
     .filter(([key]) => key.startsWith(`${node.id}_${index}_`))
-    .map(([_, value]) => value.componentName);
+    .map(([_, value]) => value.componentName)
+    .filter((componentName): componentName is string => typeof componentName === 'string' && componentName.length > 0);
 }
 
 function formatReference(reference: string) {

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -33,7 +33,7 @@ export function ButtonsInput({
   } = response;
 
   const storedAnswer = useStoredAnswer();
-  const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => (storedAnswer ? storedAnswer.optionOrders : {}), [storedAnswer]);
+  const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => storedAnswer?.optionOrders ?? {}, [storedAnswer]);
 
   const orderedOptions = useMemo(
     () => parseStringOptions(optionOrders[response.id] || options),

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -42,7 +42,7 @@ export function CheckBoxInput({
   } = response;
 
   const storedAnswer = useStoredAnswer();
-  const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => (storedAnswer ? storedAnswer.optionOrders : {}), [storedAnswer]);
+  const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => storedAnswer?.optionOrders ?? {}, [storedAnswer]);
 
   const orderedOptions = useMemo(
     () => parseStringOptions(optionOrders[response.id] || options),

--- a/src/components/response/MatrixInput.spec.tsx
+++ b/src/components/response/MatrixInput.spec.tsx
@@ -35,9 +35,7 @@ vi.mock('../../store/store', () => ({
 }));
 
 vi.mock('../../store/hooks/useStoredAnswer', () => ({
-  useStoredAnswer: () => ({
-    questionOrders: {},
-  }),
+  useStoredAnswer: () => ({}),
 }));
 
 vi.mock('./InputLabel', () => ({

--- a/src/components/response/MatrixInput.tsx
+++ b/src/components/response/MatrixInput.tsx
@@ -143,7 +143,8 @@ export function MatrixInput({
     [questions],
   );
 
-  const { questionOrders } = useStoredAnswer();
+  const storedAnswer = useStoredAnswer();
+  const questionOrders = useMemo(() => storedAnswer?.questionOrders ?? {}, [storedAnswer]);
   const orderedQuestions = useMemo(() => questionOrders[response.id] || questions.map((question) => question.value), [questionOrders, questions, response.id]);
   const answerValue = useMemo(
     () => (answer.value && typeof answer.value === 'object' && !Array.isArray(answer.value) ? answer.value : {}),

--- a/src/components/response/RadioInput.tsx
+++ b/src/components/response/RadioInput.tsx
@@ -44,7 +44,7 @@ export function RadioInput({
   } = response;
 
   const storedAnswer = useStoredAnswer();
-  const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => (storedAnswer ? storedAnswer.optionOrders : {}), [storedAnswer]);
+  const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => storedAnswer?.optionOrders ?? {}, [storedAnswer]);
 
   const orderedOptions = useMemo(
     () => parseStringOptions(optionOrders[response.id] || options),

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -600,13 +600,14 @@ export function ResponseBlock({
   }, [currentCheckAnswer, identifier, isAnalysis, savedCheckAnswer, setCheckAnswerResult, storeDispatch]);
 
   useEffect(() => {
-    // Do not save the check answer result if in analysis, if the buttons are not shown in this location, if there is no current check answer, or if the current check answer has the same number of attempts used as the stored answer
-    if (isAnalysis || !showBtnsInLocation || currentCheckAnswer === undefined || currentCheckAnswer.attemptsUsed === storeAnswers[identifier]?.checkAnswer?.attemptsUsed) {
+    const storedAnswerForIdentifier = storeAnswers[identifier];
+    // Dynamic block navigation briefly uses a loading identifier with no stored answer.
+    if (isAnalysis || !showBtnsInLocation || currentCheckAnswer === undefined || storedAnswerForIdentifier === undefined || currentCheckAnswer.attemptsUsed === storedAnswerForIdentifier.checkAnswer?.attemptsUsed) {
       return;
     }
 
     const draftAnswer = {
-      ...storeAnswers[identifier],
+      ...storedAnswerForIdentifier,
       answer: getAnswersFromAllLocations(trialValidation[identifier]),
       checkAnswer: currentCheckAnswer,
     };

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -103,7 +103,7 @@ export function ResponseBlock({
     ? formOrders.response
       .map((id) => config?.response?.find((r) => r.id === id))
       .filter((r): r is Response => r !== undefined)
-    : []
+    : config?.response ?? []
   ), [config?.response, formOrders]);
 
   const responses = useMemo(() => allResponses.filter((r) => (r.location ? r.location === location : location === 'belowStimulus')), [allResponses, location]);
@@ -601,13 +601,17 @@ export function ResponseBlock({
 
   useEffect(() => {
     const storedAnswerForIdentifier = storeAnswers[identifier];
-    // Dynamic block navigation briefly uses a loading identifier with no stored answer.
-    if (isAnalysis || !showBtnsInLocation || currentCheckAnswer === undefined || storedAnswerForIdentifier === undefined || currentCheckAnswer.attemptsUsed === storedAnswerForIdentifier.checkAnswer?.attemptsUsed) {
+    // Dynamic block navigation briefly uses a loading identifier. Never persist
+    // against it, even if a malformed loading record was restored from storage.
+    if (isAnalysis || !showBtnsInLocation || identifier.includes('__dynamicLoading') || currentCheckAnswer === undefined || storedAnswerForIdentifier === undefined || currentCheckAnswer.attemptsUsed === storedAnswerForIdentifier.checkAnswer?.attemptsUsed) {
       return;
     }
 
     const draftAnswer = {
       ...storedAnswerForIdentifier,
+      // The resolved route key is authoritative for legacy records that were
+      // persisted without their internal identifier.
+      identifier,
       answer: getAnswersFromAllLocations(trialValidation[identifier]),
       checkAnswer: currentCheckAnswer,
     };

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -20,7 +20,7 @@ const {
   mockStoredAnswerData, capturedNextButtonProps, capturedSwitcherProps, mockIsAnalysis, mockCurrentIdentifier, mockNavigate, mockSaveAnswers, mockAnswerField,
 } = vi.hoisted(() => ({
   mockStoredAnswerData: {
-    formOrder: { response: ['q1'] },
+    formOrder: { response: ['q1'] } as { response: string[] } | undefined,
     questionOrders: {},
     optionOrders: {},
     responseSubmitAttempted: undefined as boolean | undefined,
@@ -156,7 +156,7 @@ vi.mock('../ResponseSwitcher', () => ({
     capturedSwitcherProps.storedAnswer = storedAnswer;
     capturedSwitcherProps.answerFinalized = answerFinalized;
     return (
-      <div data-testid={`switcher-${response.type}`}>
+      <div data-testid={`switcher-${response.type}`} data-response-id={response.id}>
         {response.type}
         <input data-testid={`control-${response.id}`} />
       </div>
@@ -312,6 +312,31 @@ describe('ResponseBlock', () => {
     const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
     const html = container.innerHTML;
     expect(html).toContain('switcher-shortText');
+  });
+
+  test('uses configured response order when a legacy answer has no formOrder', async () => {
+    mockStoredAnswerData.formOrder = undefined;
+    const studyStore = await makeStudyStore();
+    const { container } = render(withStore(studyStore, <ResponseBlock config={baseConfig} location="belowStimulus" />));
+
+    expect(container.querySelector('[data-response-id="q1"]')).not.toBeNull();
+  });
+
+  test('preserves persisted randomized response order', async () => {
+    mockStoredAnswerData.formOrder = { response: ['q2', 'q1'] };
+    const config = {
+      ...baseConfig,
+      response: [
+        ...baseConfig.response!,
+        {
+          type: 'shortText', id: 'q2', prompt: 'Question 2', required: false,
+        },
+      ],
+    } as IndividualComponent;
+    const studyStore = await makeStudyStore();
+    const { container } = render(withStore(studyStore, <ResponseBlock config={config} location="belowStimulus" />));
+
+    expect(Array.from(container.querySelectorAll('[data-response-id]')).map((element) => element.getAttribute('data-response-id'))).toEqual(['q2', 'q1']);
   });
 
   test('shows NextButton when location matches nextButtonLocation', async () => {
@@ -616,13 +641,25 @@ describe('ResponseBlock check-answer state persistence', () => {
   test('saves the graded draft to Redux', async () => {
     vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
     mockAnswerField.values = { q1: '42' };
-    const { container, store } = await renderWithStore(
-      <ResponseBlock config={feedbackConfig} location="belowStimulus" />,
-    );
+    const persistedOptionOrders = { q1: [{ label: 'Forty two', value: '42' }] };
+    const persistedQuestionOrders = { matrix: ['row2', 'row1'] };
+    const studyStore = await makeStudyStore({}, {
+      trial1_0: makeStoredAnswer({
+        identifier: 'trial1_0',
+        optionOrders: persistedOptionOrders,
+        questionOrders: persistedQuestionOrders,
+        formOrder: { response: ['q1'] },
+      }),
+    });
+    const { container } = render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
     await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
-    expect(store.getState().answers.trial1_0).toMatchObject({
+    expect(studyStore.store.getState().answers.trial1_0).toMatchObject({
+      identifier: 'trial1_0',
       answer: { q1: '42' },
       checkAnswer: { attemptsUsed: 1, correct: false, responses: { q1: false } },
+      optionOrders: persistedOptionOrders,
+      questionOrders: persistedQuestionOrders,
+      formOrder: { response: ['q1'] },
     });
   });
 
@@ -659,6 +696,47 @@ describe('ResponseBlock check-answer state persistence', () => {
 
     expect(studyStore.store.getState().answers).not.toHaveProperty('undefined');
     expect(studyStore.store.getState().answers).not.toHaveProperty(loadingIdentifier);
+  });
+
+  test('does not persist check-answer state into a restored dynamic loading record', async () => {
+    const loadingIdentifier = 'dynamicBlock_1___dynamicLoading_0';
+    mockCurrentIdentifier.value = loadingIdentifier;
+    const malformedLoadingAnswer = {
+      answer: {},
+      checkAnswer: undefined,
+    } as unknown as StoredAnswer;
+    const studyStore = await makeStudyStore({}, { [loadingIdentifier]: malformedLoadingAnswer });
+    studyStore.store.dispatch(studyStore.actions.setCheckAnswerResult({
+      identifier: loadingIdentifier,
+      attemptsUsed: 1,
+      correct: true,
+      responses: { q1: true },
+    }));
+
+    render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+    await act(async () => {});
+
+    expect(studyStore.store.getState().answers).not.toHaveProperty('undefined');
+    expect(studyStore.store.getState().answers[loadingIdentifier]).toEqual(malformedLoadingAnswer);
+    expect(mockSaveAnswers).not.toHaveBeenCalled();
+  });
+
+  test('repairs a missing internal identifier from the resolved route key', async () => {
+    vi.mocked(responseAnswerIsCorrect).mockReturnValue(false);
+    const answerWithoutIdentifier = {
+      ...makeStoredAnswer({ identifier: 'trial1_0' }),
+      identifier: undefined,
+    } as unknown as StoredAnswer;
+    const studyStore = await makeStudyStore({}, { trial1_0: answerWithoutIdentifier });
+    const { container } = render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+
+    await act(async () => { fireEvent.click(findButton(container, 'Check Answer')); });
+
+    expect(studyStore.store.getState().answers).not.toHaveProperty('undefined');
+    expect(studyStore.store.getState().answers.trial1_0.identifier).toBe('trial1_0');
+    expect(mockSaveAnswers).toHaveBeenLastCalledWith(expect.objectContaining({
+      trial1_0: expect.objectContaining({ identifier: 'trial1_0' }),
+    }));
   });
 
   test('redirects to the training-failed page after the final failed attempt', async () => {

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -17,7 +17,7 @@ import { responseAnswerIsCorrect } from '../../../utils/correctAnswer';
 // ── mocks ────────────────────────────────────────────────────────────────────
 
 const {
-  mockStoredAnswerData, capturedNextButtonProps, capturedSwitcherProps, mockIsAnalysis, mockNavigate, mockSaveAnswers, mockAnswerField,
+  mockStoredAnswerData, capturedNextButtonProps, capturedSwitcherProps, mockIsAnalysis, mockCurrentIdentifier, mockNavigate, mockSaveAnswers, mockAnswerField,
 } = vi.hoisted(() => ({
   mockStoredAnswerData: {
     formOrder: { response: ['q1'] },
@@ -34,6 +34,7 @@ const {
     answerFinalized: undefined as boolean | undefined,
   },
   mockIsAnalysis: { value: false },
+  mockCurrentIdentifier: { value: 'trial1_0' },
   mockNavigate: vi.fn(),
   mockSaveAnswers: vi.fn(() => Promise.resolve()),
   mockAnswerField: {
@@ -130,7 +131,7 @@ vi.mock('../../../store/hooks/useWindowEvents', () => ({
 
 vi.mock('../../../routes/utils', () => ({
   useCurrentStep: vi.fn(() => 0),
-  useCurrentIdentifier: vi.fn(() => 'trial1_0'),
+  useCurrentIdentifier: vi.fn(() => mockCurrentIdentifier.value),
   useStudyId: vi.fn(() => 'test-study'),
 }));
 
@@ -287,6 +288,7 @@ beforeEach(() => {
   capturedSwitcherProps.storedAnswer = undefined;
   capturedSwitcherProps.answerFinalized = undefined;
   mockIsAnalysis.value = false;
+  mockCurrentIdentifier.value = 'trial1_0';
   mockNavigate.mockClear();
   mockSaveAnswers.mockClear();
   mockAnswerField.values = {};
@@ -639,6 +641,24 @@ describe('ResponseBlock check-answer state persistence', () => {
     const studyStore = await makeStudyStore({}, { trial1_0: makeStoredAnswer({ identifier: 'trial1_0', checkAnswer: persisted }) });
     render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
     expect(mockSaveAnswers).not.toHaveBeenCalled();
+  });
+
+  test('does not persist check-answer state while a dynamic component is loading', async () => {
+    const loadingIdentifier = 'dynamicBlock_1___dynamicLoading_0';
+    mockCurrentIdentifier.value = loadingIdentifier;
+    const studyStore = await makeStudyStore();
+    studyStore.store.dispatch(studyStore.actions.setCheckAnswerResult({
+      identifier: loadingIdentifier,
+      attemptsUsed: 1,
+      correct: true,
+      responses: { q1: true },
+    }));
+
+    render(withStore(studyStore, <ResponseBlock config={feedbackConfig} location="belowStimulus" />));
+    await act(async () => {});
+
+    expect(studyStore.store.getState().answers).not.toHaveProperty('undefined');
+    expect(studyStore.store.getState().answers).not.toHaveProperty(loadingIdentifier);
   });
 
   test('redirects to the training-failed page after the final failed attempt', async () => {

--- a/src/components/response/tests/ResponseInput.spec.tsx
+++ b/src/components/response/tests/ResponseInput.spec.tsx
@@ -235,7 +235,7 @@ vi.mock('@dnd-kit/utilities', () => ({
 vi.mock('clsx', () => ({ default: vi.fn((...args: unknown[]) => args.filter(Boolean).join(' ')) }));
 
 vi.mock('../../../store/hooks/useStoredAnswer', () => ({
-  useStoredAnswer: vi.fn(() => ({ questionOrders: {}, optionOrders: {} })),
+  useStoredAnswer: vi.fn(() => ({})),
 }));
 
 vi.mock('../utils', () => ({

--- a/src/routes/tests/utils.spec.tsx
+++ b/src/routes/tests/utils.spec.tsx
@@ -5,6 +5,7 @@ import {
 import { parseTrialOrder } from '../../utils/parseTrialOrder';
 import { getComponent } from '../../utils/handleComponentInheritance';
 import { decryptIndex } from '../../utils/encryptDecryptIndex';
+import { findFuncBlock } from '../../utils/getSequenceFlatMap';
 import type { IndividualComponent } from '../../parser/types';
 import { makeStudyConfig } from '../../tests/utils';
 import {
@@ -86,6 +87,7 @@ beforeEach(() => {
   vi.mocked(parseTrialOrder).mockReturnValue({ step: null, funcIndex: null });
   vi.mocked(getComponent).mockReturnValue({ type: 'markdown', path: '/test.md', response: [] } as IndividualComponent);
   vi.mocked(decryptIndex).mockImplementation((x: string) => parseInt(x, 10));
+  vi.mocked(findFuncBlock).mockReturnValue(undefined);
 });
 
 describe('useStudyId', () => {
@@ -183,7 +185,9 @@ describe('useCurrentComponent', () => {
     mockParams = { studyId: 'test-study', index: '0', funcIndex: '0' };
     mockFlatSequence = ['myFunc', 'end'];
     mockAnswers = { myFunc_0_CompA_0: { componentName: 'CompA' } };
-    vi.mocked(getComponent).mockReturnValue(null);
+    vi.mocked(getComponent).mockImplementation((name) => (name === 'CompA'
+      ? { type: 'markdown', path: 'comp-a.md', response: [] } as IndividualComponent
+      : null));
     vi.mocked(decryptIndex).mockReturnValue(0);
     const { result } = renderHook(() => useCurrentComponent());
     expect(result.current).toBe('CompA');
@@ -196,9 +200,47 @@ describe('useCurrentComponent', () => {
       myFunc_0_CompEleven_11: { componentName: 'CompEleven' },
       myFunc_0_CompOne_1: { componentName: 'CompOne' },
     };
-    vi.mocked(getComponent).mockReturnValue(null);
+    vi.mocked(getComponent).mockImplementation((name) => (name === 'CompEleven' || name === 'CompOne'
+      ? { type: 'markdown', path: 'component.md', response: [] } as IndividualComponent
+      : null));
     const { result } = renderHook(() => useCurrentComponent());
     expect(result.current).toBe('CompOne');
+  });
+
+  test('recreates a dynamic iteration when its only stored answer is malformed', async () => {
+    mockParams = { studyId: 'test-study', index: '0', funcIndex: '0' };
+    mockFlatSequence = ['myFunc', 'end'];
+    mockAnswers = {
+      myFunc_0___dynamicLoading_0: { componentName: undefined },
+    };
+    vi.mocked(findFuncBlock).mockReturnValue({
+      id: 'myFunc',
+      order: 'dynamic',
+      functionPath: 'demo-dynamic/assets/dynamic.tsx',
+    });
+    vi.mocked(getComponent).mockImplementation((name) => (name === 'HSLColorCodes'
+      ? { type: 'react-component', path: 'demo-dynamic/assets/HSL.tsx', response: [] } as IndividualComponent
+      : null));
+
+    const { result } = renderHook(() => useCurrentComponent());
+
+    expect(result.current).toBe('HSLColorCodes');
+  });
+
+  test('skips a malformed answer before a valid configured answer for the same iteration', async () => {
+    mockParams = { studyId: 'test-study', index: '0', funcIndex: '0' };
+    mockFlatSequence = ['myFunc', 'end'];
+    mockAnswers = {
+      myFunc_0___dynamicLoading_0: { componentName: undefined },
+      myFunc_0_CompA_0: { componentName: 'CompA' },
+    };
+    vi.mocked(getComponent).mockImplementation((name) => (name === 'CompA'
+      ? { type: 'markdown', path: 'comp-a.md', response: [] } as IndividualComponent
+      : null));
+
+    const { result } = renderHook(() => useCurrentComponent());
+
+    expect(result.current).toBe('CompA');
   });
 });
 

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -90,10 +90,19 @@ export function useCurrentComponent(): string {
       const funcName = flatSequence[currentStep];
       const decryptedFuncIndex = funcIndex ? decryptIndex(funcIndex) : 0;
 
-      // Check if answer exists for this index, if so get the component name and return early
-      const currentAnswer = Object.entries(_answers).find(([key, _]) => key.startsWith(`${funcName}_${currentStep}_`) && key.endsWith(`_${decryptedFuncIndex}`));
-      const answerCompName = currentAnswer ? currentAnswer[1].componentName : null;
-      if (answerCompName !== null) {
+      // Restore only answers that resolve to a configured component. Malformed
+      // loading records must not prevent the dynamic function from recreating
+      // the requested iteration.
+      const currentAnswer = Object.entries(_answers).find(([key, answer]) => {
+        const answerCompName = answer.componentName;
+        return key.startsWith(`${funcName}_${currentStep}_`)
+          && key.endsWith(`_${decryptedFuncIndex}`)
+          && typeof answerCompName === 'string'
+          && answerCompName.length > 0
+          && Boolean(getComponent(answerCompName, studyConfig));
+      });
+      const answerCompName = currentAnswer?.[1].componentName;
+      if (answerCompName) {
         setCompName(answerCompName);
         setIndexWhenSettingComponentName(decryptedFuncIndex);
         return;

--- a/src/store/tests/store.spec.ts
+++ b/src/store/tests/store.spec.ts
@@ -521,7 +521,14 @@ describe('studyStoreCreator', () => {
       component: 'intro', funcName: 'myFunc', index: 5, funcIndex: 0, parameters: {}, correctAnswer: [],
     }));
     expect(store.getState().funcSequence.myFunc).toEqual(['intro']);
-    expect(store.getState().answers.myFunc_5_intro_0).toBeDefined();
+    expect(store.getState().answers.myFunc_5_intro_0).toMatchObject({
+      identifier: 'myFunc_5_intro_0',
+      componentName: 'intro',
+      trialOrder: '5_0',
+      optionOrders: {},
+      questionOrders: {},
+      formOrder: [],
+    });
     store.dispatch(actions.pushToFuncSequence({
       component: 'intro', funcName: 'myFunc', index: 5, funcIndex: 0, parameters: {}, correctAnswer: [],
     }));


### PR DESCRIPTION
## Summary

- prevent check-answer persistence for unresolved `__dynamicLoading` routes, including restored malformed loading records
- make the resolved route identifier authoritative when repairing legacy records missing their internal identifier
- restore dynamic iterations only from nonempty component names that resolve in the current study config
- skip malformed candidates and rerun the dynamic function when no valid stored iteration exists
- ignore incomplete persisted dynamic answers when building the Study Browser tree
- fall back to configured response, option, and question ordering when legacy records lack ordering metadata
- preserve persisted randomized ordering and complete metadata for valid new answers

## Root cause

When Study Browser navigates from a later dynamic iteration back to an earlier one, the route changes before the dynamic component name has resolved. During that transition, `ResponseBlock` briefly computes an identifier containing `__dynamicLoading` while retaining the prior check-answer state.

The original persistence effect could build a draft from a missing answer. That created incomplete records which subsequently affected Study Browser traversal, dynamic route restoration, and response-order rendering.

The fix prevents writes against loading routes and adds bounded recovery for already-persisted malformed records without changing valid new-answer initialization or randomized ordering.

## Validation

- reproduced the original crash on unmodified `origin/dev` with `demo-dynamic`
- regression coverage for absent and restored loading records
- regression coverage for malformed-only and malformed-plus-valid dynamic route candidates
- regression coverage for missing `formOrder` and preserved persisted randomized order
- regression coverage for complete new dynamic-answer metadata
- focused suites: 172 passed
- `yarn unittest --run` (144 files, 1,969 passed, 1 skipped)
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

Closes #1332