### PR TITLE
Show a recoverable error screen when application startup fails

### DIFF
--- a/src/GlobalConfigParser.tsx
+++ b/src/GlobalConfigParser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { ModalsProvider } from '@mantine/modals';
 import { AppShell } from '@mantine/core';
@@ -21,6 +21,7 @@ import { initializeStorageEngine } from './storage/initialize';
 import { useStorageEngine } from './storage/storageEngineHooks';
 import { PageTitle } from './utils/PageTitle';
 import { shouldProtectAnalysisRoute } from './utils/analysisRouteAccess';
+import { StartupErrorScreen } from './components/StartupErrorScreen';
 
 async function fetchGlobalConfigArray() {
   const globalFile = await fetch(`${PREFIX}global.json`);
@@ -28,7 +29,13 @@ async function fetchGlobalConfigArray() {
   return parseGlobalConfig(configs);
 }
 
-function HomeRoute({ globalConfig }: { globalConfig: GlobalConfig }) {
+function HomeRoute({
+  globalConfig,
+  onStartupError,
+}: {
+  globalConfig: GlobalConfig;
+  onStartupError: (error: unknown) => void;
+}) {
   const [studyConfigs, setStudyConfigs] = useState<Record<string, ParsedConfig<StudyConfig> | null>>({});
 
   useEffect(() => {
@@ -41,12 +48,17 @@ function HomeRoute({ globalConfig }: { globalConfig: GlobalConfig }) {
       }
     }
 
-    fetchData(globalConfig);
+    fetchData(globalConfig).catch((error) => {
+      console.error('Error loading study configs:', error);
+      if (!cancelled) {
+        onStartupError(error);
+      }
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [globalConfig]);
+  }, [globalConfig, onStartupError]);
 
   return (
     <>
@@ -67,17 +79,34 @@ function HomeRoute({ globalConfig }: { globalConfig: GlobalConfig }) {
 
 export function GlobalConfigParser() {
   const [globalConfig, setGlobalConfig] = useState<Nullable<GlobalConfig>>(null);
+  const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
+  const handleStartupError = useCallback((error: unknown) => {
+    setStartupError({ error });
+  }, []);
 
   useEffect(() => {
     if (globalConfig) {
       return undefined;
     }
 
-    fetchGlobalConfigArray().then((gc) => {
-      setGlobalConfig(gc);
-    });
+    let cancelled = false;
 
-    return undefined;
+    fetchGlobalConfigArray()
+      .then((gc) => {
+        if (!cancelled) {
+          setGlobalConfig(gc);
+        }
+      })
+      .catch((error) => {
+        console.error('Error loading global config:', error);
+        if (!cancelled) {
+          setStartupError({ error });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [globalConfig]);
 
   // Initialize storage engine
@@ -87,13 +116,24 @@ export function GlobalConfigParser() {
       return undefined;
     }
 
-    async function fn() {
-      const _storageEngine = await initializeStorageEngine();
-      setStorageEngine(_storageEngine);
-    }
-    fn();
+    let cancelled = false;
 
-    return undefined;
+    initializeStorageEngine()
+      .then((_storageEngine) => {
+        if (!cancelled) {
+          setStorageEngine(_storageEngine);
+        }
+      })
+      .catch((error) => {
+        console.error('Error initializing storage engine:', error);
+        if (!cancelled) {
+          setStartupError({ error });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [setStorageEngine, storageEngine]);
 
   const analysisProtectedCallback = async (studyId: string) => {
@@ -104,6 +144,10 @@ export function GlobalConfigParser() {
     return shouldProtectAnalysisRoute(studyId, globalConfig, storageEngine);
   };
 
+  if (startupError) {
+    return <StartupErrorScreen error={startupError.error} />;
+  }
+
   return globalConfig ? (
     <BrowserRouter basename={PREFIX}>
       <AuthProvider>
@@ -111,7 +155,12 @@ export function GlobalConfigParser() {
           <Routes>
             <Route
               path="/"
-              element={<HomeRoute globalConfig={globalConfig} />}
+              element={(
+                <HomeRoute
+                  globalConfig={globalConfig}
+                  onStartupError={handleStartupError}
+                />
+              )}
             />
             <Route
               path="/:studyId/*"

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -15,7 +15,9 @@ import {
 } from 'react';
 import { useResizeObserver } from '@mantine/hooks';
 import { AppHeader } from '../interface/AppHeader';
-import { GlobalConfig, ParticipantDataWithStatus, StudyConfig } from '../../parser/types';
+import {
+  GlobalConfig, ParticipantDataWithStatus, ParsedConfig, StudyConfig,
+} from '../../parser/types';
 import { getStudyConfig, resolveConfigKey } from '../../utils/fetchConfig';
 import { LiveMonitorView } from './LiveMonitor/LiveMonitorView';
 import { SummaryView } from './summary/SummaryView';
@@ -34,6 +36,7 @@ import 'mantine-react-table/styles.css';
 import { ThinkAloudAnalysis } from './thinkAloud/ThinkAloudAnalysis';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 import { ConfigView } from './config/ConfigView';
+import { StartupErrorScreen } from '../../components/StartupErrorScreen';
 
 const TABLE_HEADER_HEIGHT = 37; // Height of the tabs header
 
@@ -80,7 +83,8 @@ async function getCurrentConfigHashForStudy(
 
 export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig; }) {
   const { studyId: routeStudyId } = useParams();
-  const [studyConfig, setStudyConfig] = useState<StudyConfig | undefined>(undefined);
+  const [studyConfig, setStudyConfig] = useState<ParsedConfig<StudyConfig> | undefined>(undefined);
+  const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
 
   const [includedParticipants, setIncludedParticipants] = useState<string[]>(['completed', 'inProgress', 'rejected']);
 
@@ -328,29 +332,58 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   }, [allConditions]);
 
   useEffect(() => {
+    let cancelled = false;
+    setStartupError(null);
+    setStudyConfig(undefined);
+
     if (!routeStudyId) return () => { };
     if (routeStudyId === '__revisit-widget') {
-      const messageListener = async (event: MessageEvent) => {
+      const messageListener = (event: MessageEvent) => {
         if (event.data.type === 'revisitWidget/CONFIG' && storageEngine) {
-          const cf = await parseStudyConfig(event.data.payload);
-          setStudyConfig(cf);
+          parseStudyConfig(event.data.payload)
+            .then((cf) => {
+              if (!cancelled) {
+                setStudyConfig(cf);
+              }
+            })
+            .catch((error) => {
+              console.error('Failed to load widget study config for analysis:', error);
+              if (!cancelled) {
+                setStartupError({ error });
+              }
+            });
         }
       };
 
       window.addEventListener('message', messageListener);
       window.parent.postMessage({ type: 'revisitWidget/READY' }, '*');
       return () => {
+        cancelled = true;
         window.removeEventListener('message', messageListener);
       };
     }
-    getStudyConfig(routeStudyId, globalConfig).then((cf) => {
-      if (cf) {
-        setStudyConfig(cf);
-      }
-    });
 
-    return () => { };
+    getStudyConfig(routeStudyId, globalConfig)
+      .then((cf) => {
+        if (!cancelled && cf) {
+          setStudyConfig(cf);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load study config for analysis:', error);
+        if (!cancelled) {
+          setStartupError({ error });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [routeStudyId, globalConfig, storageEngine]);
+
+  if (startupError) {
+    return <StartupErrorScreen error={startupError.error} />;
+  }
 
   if (!routeStudyId) {
     return (

--- a/src/analysis/tests/StudyAnalysisTabs.spec.tsx
+++ b/src/analysis/tests/StudyAnalysisTabs.spec.tsx
@@ -11,6 +11,7 @@ import type { StudyConfig, ParsedConfig } from '../../parser/types';
 import { getStudyConfig } from '../../utils/fetchConfig';
 import { useAsync } from '../../store/hooks/useAsync';
 import { makeGlobalConfig } from '../../tests/utils';
+import { parseStudyConfig } from '../../parser/parser';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -115,6 +116,10 @@ vi.mock('../individualStudy/config/ConfigView', () => ({
 }));
 vi.mock('../../components/downloader/DownloadButtons', () => ({
   DownloadButtons: () => <div>DownloadButtons</div>,
+}));
+
+vi.mock('../../components/StartupErrorScreen', () => ({
+  StartupErrorScreen: () => <div role="alert">startup fallback</div>,
 }));
 
 vi.mock('react-vega', () => ({
@@ -309,6 +314,38 @@ describe('StudyAnalysisTabs', () => {
     });
     addEventSpy.mockRestore();
     postMessageSpy.mockRestore();
+  });
+
+  test('shows startup fallback when analysis study config loading rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(getStudyConfig).mockRejectedValue(new Error('analysis config failed'));
+
+    render(<StudyAnalysisTabs globalConfig={mockGlobalConfig} />);
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('startup fallback'));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load study config for analysis:',
+      expect.any(Error),
+    );
+  });
+
+  test('shows startup fallback when widget analysis config parsing rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockParams = { studyId: '__revisit-widget', analysisTab: 'summary' };
+    vi.mocked(parseStudyConfig).mockRejectedValue(new Error('widget config failed'));
+
+    render(<StudyAnalysisTabs globalConfig={mockGlobalConfig} />);
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'revisitWidget/CONFIG', payload: '{}' },
+      }));
+    });
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('startup fallback'));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load widget study config for analysis:',
+      expect.any(Error),
+    );
   });
 
   test('firing MultiSelect onChange covers stage/config filter branches', async () => {

--- a/src/components/ApplicationErrorBoundary.tsx
+++ b/src/components/ApplicationErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { StartupErrorScreen } from './StartupErrorScreen';
+
+interface ApplicationErrorBoundaryState {
+  hasError: boolean;
+  error: unknown;
+}
+
+export class ApplicationErrorBoundary extends Component<
+{ children: ReactNode },
+ApplicationErrorBoundaryState
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: unknown): ApplicationErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    console.error('Unexpected application render error:', error, errorInfo);
+  }
+
+  render() {
+    const { error, hasError } = this.state;
+    if (hasError) {
+      return <StartupErrorScreen error={error} />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -289,7 +289,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
     async function initializeUserStoreRouting() {
       // Check that we have a storage engine and active config (studyId is set for config, but typescript complains)
-      if (!storageEngine || !activeConfig || !canonicalStudyId) return;
+      if (!storageEngine || !activeConfig || !canonicalStudyId || (activeConfig.errors?.length ?? 0) > 0) return;
       setIsCompletionCheckResolved(false);
       setCompletionCheckError(null);
 
@@ -493,32 +493,25 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
             },
             {
               path: '/:index/:funcIndex?',
-              element:
-                activeConfig.errors.length > 0 ? (
-                  <>
-                    <Title order={2} mb={8}>
-                      Error loading config
-                    </Title>
-                    <ErrorLoadingConfig
-                      issues={activeConfig.errors}
-                      type="error"
-                    />
-                  </>
-                ) : (
-                  <ComponentController />
-                ),
+              element: <ComponentController />,
             },
           ],
         },
       ]);
     }
-    initializeUserStoreRouting();
+    initializeUserStoreRouting().catch((error) => {
+      console.error('Unhandled error initializing user store routing:', error);
+      if (!isCancelled) {
+        setStartupError({ error });
+      }
+    });
     return () => {
       isCancelled = true;
     };
   }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
 
   const routing = useRoutes(routes);
+  const hasConfigErrors = (activeConfig?.errors?.length ?? 0) > 0;
   const { isLoading, showCompletionCheckError } = getShellUiState({
     isValidStudyId,
     hasRoutes: routes.length > 0,
@@ -531,6 +524,18 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   if (startupError) {
     content = <StartupErrorScreen error={startupError.error} />;
+  } else if (activeConfig && hasConfigErrors) {
+    content = (
+      <>
+        <Title order={2} mb={8}>
+          Error loading config
+        </Title>
+        <ErrorLoadingConfig
+          issues={activeConfig.errors}
+          type="error"
+        />
+      </>
+    );
   } else if (!isValidStudyId) {
     content = <ResourceNotFound />;
   } else if (routing && store) {
@@ -545,8 +550,8 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   return (
     <>
-      <StudyLoadingOverlay visible={!startupError && isLoading} />
-      {showCompletionCheckError && (
+      <StudyLoadingOverlay visible={!startupError && !hasConfigErrors && isLoading} />
+      {!startupError && !hasConfigErrors && showCompletionCheckError && (
         <Stack
           align="center"
           gap="sm"

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -40,6 +40,7 @@ import {
   parseConditionParam,
   resolveParticipantConditions,
 } from '../utils/handleConditionLogic';
+import { StartupErrorScreen } from './StartupErrorScreen';
 
 type StartupStorageStatus = Pick<StorageEngine, 'getEngine' | 'isConnected'>;
 
@@ -185,6 +186,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   // Pull study config
   const routeStudyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedConfig<StudyConfig> | null>(null);
+  const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
   const canonicalStudyId = useMemo(() => {
     if (routeStudyId === '__revisit-widget') {
       return routeStudyId;
@@ -195,25 +197,49 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   const isValidStudyId = routeStudyId === '__revisit-widget' || canonicalStudyId !== null;
 
   useEffect(() => {
+    let cancelled = false;
+
     if (routeStudyId !== '__revisit-widget') {
       const loadStudyConfig = async () => {
-        const config = await getStudyConfig(routeStudyId, globalConfig);
-        setActiveConfig(config);
+        try {
+          const config = await getStudyConfig(routeStudyId, globalConfig);
+          if (!cancelled) {
+            setActiveConfig(config);
+          }
+        } catch (error) {
+          console.error('Error loading study config:', error);
+          if (!cancelled) {
+            setStartupError({ error });
+          }
+        }
       };
 
       loadStudyConfig();
-      return undefined;
+      return () => {
+        cancelled = true;
+      };
     }
 
     if (globalConfig && routeStudyId) {
       const messageListener = (event: MessageEvent) => {
         if (event.data.type === 'revisitWidget/CONFIG') {
           const loadWidgetConfig = async () => {
-            const config = await parseStudyConfig(event.data.payload);
-            setActiveConfig(config);
+            try {
+              const config = await parseStudyConfig(event.data.payload);
+              if (!cancelled) {
+                setActiveConfig(config);
+              }
 
-            const sequenceArray = await generateSequenceArray(config);
-            window.parent.postMessage({ type: 'revisitWidget/SEQUENCE_ARRAY', payload: sequenceArray }, '*');
+              const sequenceArray = await generateSequenceArray(config);
+              if (!cancelled) {
+                window.parent.postMessage({ type: 'revisitWidget/SEQUENCE_ARRAY', payload: sequenceArray }, '*');
+              }
+            } catch (error) {
+              console.error('Error loading widget study config:', error);
+              if (!cancelled) {
+                setStartupError({ error });
+              }
+            }
           };
 
           loadWidgetConfig();
@@ -225,6 +251,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       window.parent.postMessage({ type: 'revisitWidget/READY' }, '*');
 
       return () => {
+        cancelled = true;
         window.removeEventListener('message', messageListener);
       };
     }
@@ -412,35 +439,43 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           ? getInitialStartupAlert(error, developmentModeEnabledForAlert, resumeParticipantId)
           : undefined;
 
-        // Fallback: initialize the store with empty data
-        const generatedSequences = await generateSequenceArray(activeConfig);
+        try {
+          // Preserve the existing disconnected-storage and participant alert recovery paths.
+          const generatedSequences = await generateSequenceArray(activeConfig);
 
-        const matchingSequence = generatedSequences[0];
-        const fallbackSequence = filterSequenceByCondition(
-          matchingSequence,
-          studyCondition,
-        );
+          const matchingSequence = generatedSequences[0];
+          const fallbackSequence = filterSequenceByCondition(
+            matchingSequence,
+            studyCondition,
+          );
 
-        const emptyStore = await studyStoreCreator(
-          canonicalStudyId,
-          activeConfig,
-          fallbackSequence,
-          createEmptyParticipantMetadata(),
-          {},
-          fallbackModes,
-          '',
-          false,
-          isStorageFailure,
-          false,
-          initialAlertModal,
-        );
+          const emptyStore = await studyStoreCreator(
+            canonicalStudyId,
+            activeConfig,
+            fallbackSequence,
+            createEmptyParticipantMetadata(),
+            {},
+            fallbackModes,
+            '',
+            false,
+            isStorageFailure,
+            false,
+            initialAlertModal,
+          );
 
-        if (isCancelled) {
+          if (isCancelled) {
+            return;
+          }
+
+          setStore(emptyStore);
+          setIsCompletionCheckResolved(true);
+        } catch (fallbackError) {
+          console.error('Error initializing fallback study store:', fallbackError);
+          if (!isCancelled) {
+            setStartupError({ error });
+          }
           return;
         }
-
-        setStore(emptyStore);
-        setIsCompletionCheckResolved(true);
       }
 
       if (isCancelled) {
@@ -494,7 +529,9 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   let content: ReactNode = null;
 
-  if (!isValidStudyId) {
+  if (startupError) {
+    content = <StartupErrorScreen error={startupError.error} />;
+  } else if (!isValidStudyId) {
     content = <ResourceNotFound />;
   } else if (routing && store) {
     content = (
@@ -508,7 +545,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   return (
     <>
-      <StudyLoadingOverlay visible={isLoading} />
+      <StudyLoadingOverlay visible={!startupError && isLoading} />
       {showCompletionCheckError && (
         <Stack
           align="center"

--- a/src/components/StartupErrorScreen.tsx
+++ b/src/components/StartupErrorScreen.tsx
@@ -1,0 +1,72 @@
+import {
+  Button, Center, Code, Image, Paper, Stack, Text, Title,
+} from '@mantine/core';
+import { useEffect, useRef } from 'react';
+import { PREFIX } from '../utils/Prefix';
+
+export function getStartupErrorDetails(error: unknown) {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+
+  return String(error);
+}
+
+export function StartupErrorScreen({
+  error,
+  showDetails = import.meta.env.DEV,
+  onReload = () => window.location.reload(),
+}: {
+  error: unknown;
+  showDetails?: boolean;
+  onReload?: () => void;
+}) {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <Center mih="100vh" p="md">
+      <Paper
+        role="alert"
+        aria-labelledby="startup-error-heading"
+        withBorder
+        shadow="md"
+        p="xl"
+        maw={520}
+        w="100%"
+      >
+        <Stack align="center" gap="md">
+          <Image
+            src={`${PREFIX}revisitAssets/revisitLogoSquare.svg`}
+            alt=""
+            aria-hidden="true"
+            w={64}
+          />
+          <Title
+            id="startup-error-heading"
+            order={1}
+            ref={headingRef}
+            tabIndex={-1}
+            ta="center"
+          >
+            ReVISit could not load
+          </Title>
+          <Text ta="center">
+            Something went wrong while loading this page. Please reload and try again.
+          </Text>
+          <Button size="md" onClick={onReload}>
+            Reload
+          </Button>
+          {showDetails && (
+            <Code block w="100%" style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
+              {getStartupErrorDetails(error)}
+            </Code>
+          )}
+        </Stack>
+      </Paper>
+    </Center>
+  );
+}

--- a/src/components/tests/ApplicationErrorBoundary.spec.tsx
+++ b/src/components/tests/ApplicationErrorBoundary.spec.tsx
@@ -1,0 +1,43 @@
+import { MantineProvider } from '@mantine/core';
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import {
+  afterEach, beforeEach, expect, test, vi,
+} from 'vitest';
+import { ApplicationErrorBoundary } from '../ApplicationErrorBoundary';
+
+function ThrowingChild(): ReactElement {
+  throw new Error('render failed');
+}
+
+beforeEach(() => {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+});
+
+test('application boundary replaces an unexpected render error with the startup fallback', () => {
+  const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const { getByRole } = render(
+    <MantineProvider>
+      <ApplicationErrorBoundary>
+        <ThrowingChild />
+      </ApplicationErrorBoundary>
+    </MantineProvider>,
+  );
+
+  expect(getByRole('alert')).toBeDefined();
+  expect(getByRole('heading', { name: 'ReVISit could not load' })).toBeDefined();
+  expect(consoleSpy).toHaveBeenCalledWith(
+    'Unexpected application render error:',
+    expect.any(Error),
+    expect.any(Object),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -228,6 +228,31 @@ describe('Shell', () => {
     expect(consoleSpy).toHaveBeenCalledWith('Error loading study config:', expect.any(Error));
   });
 
+  test('shows detailed config errors without initializing the participant store', async () => {
+    vi.mocked(getStudyConfig).mockResolvedValue({
+      errors: [{
+        message: 'There was an issue validating your config file',
+        instancePath: 'root',
+        params: {},
+        category: 'invalid-config',
+      }],
+      warnings: [],
+    } as unknown as ParsedConfig<StudyConfig>);
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn(),
+    };
+
+    const { getByTestId, getByText, queryByTestId } = render(
+      <Shell globalConfig={globalConfig} />,
+    );
+
+    await waitFor(() => expect(getByTestId('error-loading-config')).toBeDefined());
+    expect(getByText('Error loading config')).toBeDefined();
+    expect(queryByTestId('loading-overlay')).toBeNull();
+    expect(mockStorageEngine.initializeStudyDb).not.toHaveBeenCalled();
+    expect(vi.mocked(studyStoreCreator)).not.toHaveBeenCalled();
+  });
+
   test('shows ResourceNotFound for an invalid study ID', async () => {
     vi.mocked(resolveConfigKey).mockReturnValue(null);
     const { getByTestId } = await act(async () => render(<Shell globalConfig={globalConfig} />));

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -64,6 +64,10 @@ vi.mock('../ErrorLoadingConfig', () => ({
   ErrorLoadingConfig: () => <div data-testid="error-loading-config" />,
 }));
 
+vi.mock('../StartupErrorScreen', () => ({
+  StartupErrorScreen: () => <div role="alert">startup fallback</div>,
+}));
+
 vi.mock('../../ResourceNotFound', () => ({
   ResourceNotFound: () => <div data-testid="resource-not-found" />,
 }));
@@ -214,6 +218,16 @@ describe('Shell', () => {
     expect(getByTestId('loading-overlay')).toBeDefined();
   });
 
+  test('shows startup fallback when study config loading rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    vi.mocked(getStudyConfig).mockRejectedValue(new Error('study config failed'));
+
+    const { getByRole } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(getByRole('alert').textContent).toBe('startup fallback'));
+    expect(consoleSpy).toHaveBeenCalledWith('Error loading study config:', expect.any(Error));
+  });
+
   test('shows ResourceNotFound for an invalid study ID', async () => {
     vi.mocked(resolveConfigKey).mockReturnValue(null);
     const { getByTestId } = await act(async () => render(<Shell globalConfig={globalConfig} />));
@@ -361,5 +375,31 @@ describe('Shell', () => {
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
 
     consoleSpy.mockRestore();
+  });
+
+  test('shows startup fallback when participant-store recovery also fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    vi.mocked(studyStoreCreator).mockRejectedValueOnce(new Error('fallback store failed'));
+
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn().mockRejectedValue(new Error('participant init failed')),
+      isConnected: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+      getModes: vi.fn().mockResolvedValue({
+        developmentModeEnabled: false,
+        dataSharingEnabled: false,
+        dataCollectionEnabled: true,
+      }),
+      peekCurrentParticipantId: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const { getByRole } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(getByRole('alert').textContent).toBe('startup fallback'));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error initializing fallback study store:',
+      expect.any(Error),
+    );
   });
 });

--- a/src/components/tests/StartupErrorScreen.spec.tsx
+++ b/src/components/tests/StartupErrorScreen.spec.tsx
@@ -1,0 +1,65 @@
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { StartupErrorScreen } from '../StartupErrorScreen';
+
+describe('StartupErrorScreen', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test('shows an accessible, sanitized error and moves focus to its heading', () => {
+    const { getByRole, queryByText } = render(
+      <MantineProvider>
+        <StartupErrorScreen error={new Error('private backend detail')} showDetails={false} />
+      </MantineProvider>,
+    );
+
+    expect(getByRole('alert')).toBeDefined();
+    expect(getByRole('heading', { name: 'ReVISit could not load' })).toBe(document.activeElement);
+    expect(getByRole('button', { name: 'Reload' })).toBeDefined();
+    expect(queryByText(/private backend detail/)).toBeNull();
+  });
+
+  test('shows diagnostic details only when requested', () => {
+    const { getByText } = render(
+      <MantineProvider>
+        <StartupErrorScreen error={new Error('development detail')} showDetails />
+      </MantineProvider>,
+    );
+
+    expect(getByText(/development detail/)).toBeDefined();
+  });
+
+  test('reload action is keyboard accessible', async () => {
+    const user = userEvent.setup();
+    const reloadSpy = vi.fn();
+    const { getByRole } = render(
+      <MantineProvider>
+        <StartupErrorScreen
+          error={new Error('failure')}
+          showDetails={false}
+          onReload={reloadSpy}
+        />
+      </MantineProvider>,
+    );
+
+    getByRole('button', { name: 'Reload' }).focus();
+    await user.keyboard('{Enter}');
+
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,14 +7,17 @@ import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/notifications/styles.css';
 import { GlobalConfigParser } from './GlobalConfigParser';
+import { ApplicationErrorBoundary } from './components/ApplicationErrorBoundary';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <StorageEngineProvider>
-      <MantineProvider>
+    <MantineProvider>
+      <ApplicationErrorBoundary>
         <Notifications />
-        <GlobalConfigParser />
-      </MantineProvider>
-    </StorageEngineProvider>
+        <StorageEngineProvider>
+          <GlobalConfigParser />
+        </StorageEngineProvider>
+      </ApplicationErrorBoundary>
+    </MantineProvider>
   </React.StrictMode>,
 );

--- a/src/tests/GlobalConfigParser.spec.tsx
+++ b/src/tests/GlobalConfigParser.spec.tsx
@@ -1,0 +1,114 @@
+import { MantineProvider } from '@mantine/core';
+import { render, waitFor } from '@testing-library/react';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { GlobalConfigParser } from '../GlobalConfigParser';
+import { parseGlobalConfig } from '../parser/parser';
+import { initializeStorageEngine } from '../storage/initialize';
+import { makeGlobalConfig } from './utils';
+
+const setStorageEngine = vi.fn();
+
+vi.mock('../parser/parser', () => ({
+  parseGlobalConfig: vi.fn(),
+}));
+
+vi.mock('../storage/initialize', () => ({
+  initializeStorageEngine: vi.fn(),
+}));
+
+vi.mock('../storage/storageEngineHooks', () => ({
+  useStorageEngine: () => ({
+    storageEngine: undefined,
+    setStorageEngine,
+  }),
+}));
+
+vi.mock('../components/ConfigSwitcher', () => ({
+  ConfigSwitcher: () => null,
+}));
+
+vi.mock('../components/Shell', () => ({
+  Shell: () => null,
+}));
+
+vi.mock('../analysis/individualStudy/StudyAnalysisTabs', () => ({
+  StudyAnalysisTabs: () => null,
+}));
+
+vi.mock('../ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../Login', () => ({
+  Login: () => null,
+}));
+
+vi.mock('../store/hooks/useAuth', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../components/settings/GlobalSettings', () => ({
+  GlobalSettings: () => null,
+}));
+
+vi.mock('../utils/NavigateWithParams', () => ({
+  NavigateWithParams: () => null,
+}));
+
+vi.mock('../analysis/interface/AppHeader', () => ({
+  AppHeader: () => null,
+}));
+
+vi.mock('../utils/PageTitle', () => ({
+  PageTitle: () => null,
+}));
+
+describe('GlobalConfigParser startup failures', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      text: vi.fn().mockResolvedValue('{}'),
+    }));
+    vi.mocked(parseGlobalConfig).mockReturnValue(makeGlobalConfig());
+    vi.mocked(initializeStorageEngine).mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test('shows the fallback when global-config parsing rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(parseGlobalConfig).mockRejectedValue(new Error('invalid global config'));
+
+    const { getByRole } = render(
+      <MantineProvider>
+        <GlobalConfigParser />
+      </MantineProvider>,
+    );
+
+    await waitFor(() => expect(getByRole('alert')).toBeDefined());
+    expect(consoleSpy).toHaveBeenCalledWith('Error loading global config:', expect.any(Error));
+  });
+
+  test('shows the fallback when storage-engine initialization rejects', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(initializeStorageEngine).mockRejectedValue(new Error('storage unavailable'));
+
+    const { getByRole } = render(
+      <MantineProvider>
+        <GlobalConfigParser />
+      </MantineProvider>,
+    );
+
+    await waitFor(() => expect(getByRole('alert')).toBeDefined());
+    expect(consoleSpy).toHaveBeenCalledWith('Error initializing storage engine:', expect.any(Error));
+  });
+});

--- a/src/tests/GlobalConfigParser.spec.tsx
+++ b/src/tests/GlobalConfigParser.spec.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from '@mantine/core';
-import { render, waitFor } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
@@ -80,6 +80,7 @@ describe('GlobalConfigParser startup failures', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/tests/startup-error.spec.ts
+++ b/tests/startup-error.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('shows an actionable fallback when the global config request fails', async ({ page }) => {
+  await page.route('**/global.json', (route) => route.abort('failed'));
+
+  await page.goto('/?startup-error-regression=1');
+
+  const alert = page.getByRole('alert');
+  await expect(alert).toBeVisible();
+  await expect(alert.getByRole('heading', { name: 'ReVISit could not load' })).toBeFocused();
+  const reloadButton = alert.getByRole('button', { name: 'Reload' });
+  await expect(reloadButton).toBeVisible();
+
+  const currentUrl = page.url();
+  await reloadButton.click();
+
+  await expect(alert).toBeVisible();
+  expect(page.url()).toBe(currentUrl);
+});


### PR DESCRIPTION
## Summary

- add a branded, accessible startup failure screen with a URL-preserving reload action
- map global config, storage engine, study config, widget config, analysis config, and unrecoverable participant-store failures into explicit UI state
- add an application-level React error boundary for unexpected synchronous render failures
- preserve detailed configuration validation and disconnected-storage recovery paths
- keep participant-facing details sanitized in production while retaining development diagnostics and console logging

## Root cause

Several asynchronous startup operations were launched without rejection handlers, while the existing React error boundary only covered individual custom components. Rejected startup promises could therefore leave the application with no renderable state and produce a blank screen.

## User impact

Participants, study designers, analysts, and administrators now receive a clear recovery screen instead of a blank page when startup cannot complete. The alert receives focus, exposes a keyboard-accessible Reload button, and does not disclose raw backend or configuration details in production.

## Validation

- `yarn unittest --run` — 1,972 passed, 1 skipped
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- added a focused Playwright regression for a rejected `global.json` request; not run locally per repository guidance

Closes #1343

<img width="1392" height="1522" alt="Screenshot 2026-07-26 at 11 54 52 PM" src="https://github.com/user-attachments/assets/5b2067a6-2940-41ab-96bc-1aa4c96b2f28" />