### PR TITLE
Disable previous button in replay

### DIFF
--- a/src/store/hooks/tests/usePreviousStep.spec.ts
+++ b/src/store/hooks/tests/usePreviousStep.spec.ts
@@ -98,12 +98,12 @@ describe('isPreviousDisabled', () => {
     expect(result.current.isPreviousDisabled).toBe(true);
   });
 
-  test('is false when in analysis mode with valid step', () => {
+  test('is true when in analysis mode with valid step', () => {
     useIsAnalysisMock.mockReturnValue(true);
     useCurrentStepMock.mockReturnValue(1);
     const { result } = renderHook(() => usePreviousStep());
-    // isPreviousDisabled is based on step number, not analysis mode
-    expect(result.current.isPreviousDisabled).toBe(false);
+    // The previous button is disabled during replay, mirroring the next button
+    expect(result.current.isPreviousDisabled).toBe(true);
   });
 });
 
@@ -145,10 +145,10 @@ describe('goToPreviousStep', () => {
 
   // --- Analysis-specific tests from original file ---
 
-  test('keeps the previous button enabled during analysis replay', () => {
+  test('disables the previous button during analysis replay', () => {
     useIsAnalysisMock.mockReturnValue(true);
     const { result } = renderHook(() => usePreviousStep());
-    expect(result.current.isPreviousDisabled).toBe(false);
+    expect(result.current.isPreviousDisabled).toBe(true);
   });
 
   test('keeps previous enabled for the first item inside a dynamic block', () => {

--- a/src/store/hooks/usePreviousStep.ts
+++ b/src/store/hooks/usePreviousStep.ts
@@ -20,7 +20,7 @@ export function usePreviousStep() {
   const answers = useStoreSelector((state) => state.answers);
 
   // Status of the previous button. If true, the previous button should be disabled
-  const isPreviousDisabled = typeof currentStep !== 'number' || (currentStep <= 0 && (!funcIndex || decryptIndex(funcIndex) <= 0));
+  const isPreviousDisabled = typeof currentStep !== 'number' || isAnalysis || (currentStep <= 0 && (!funcIndex || decryptIndex(funcIndex) <= 0));
 
   const buildSearch = useCallback(() => window.location.search, []);
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1331

### Give a longer description of what this PR addresses and why it's needed
The Next button is disabled during replay, but the Previous button was still clickable. 
This PR disables the Previous button in replay as well.