### PR TITLE
Fix Download Config button plural label

### DIFF
--- a/src/analysis/individualStudy/config/ConfigView.tsx
+++ b/src/analysis/individualStudy/config/ConfigView.tsx
@@ -217,12 +217,13 @@ export function ConfigView({
     positionToolbarAlertBanner: 'none',
     renderTopToolbarCustomActions: () => {
       const selectedConfigHashes = Object.keys(checked).filter((key) => checked[key]);
+      const downloadConfigLabel = `Download Config${selectedConfigHashes.length === 1 ? '' : 's'}`;
       return (
         <Flex>
           {selectedConfigHashes.length > 0 && (
             <Group>
               <Button onClick={handleDownloadConfigs}>
-                Download Configs (
+                {`${downloadConfigLabel} (`}
                 {selectedConfigHashes.length}
                 )
               </Button>

--- a/src/analysis/individualStudy/config/ConfigView.tsx
+++ b/src/analysis/individualStudy/config/ConfigView.tsx
@@ -223,9 +223,7 @@ export function ConfigView({
           {selectedConfigHashes.length > 0 && (
             <Group>
               <Button onClick={handleDownloadConfigs}>
-                {`${downloadConfigLabel} (`}
-                {selectedConfigHashes.length}
-                )
+                {`${downloadConfigLabel} (${selectedConfigHashes.length})`}
               </Button>
               {selectedConfigHashes.length === 2 && (
                 <Button

--- a/src/analysis/individualStudy/config/tests/ConfigView.spec.tsx
+++ b/src/analysis/individualStudy/config/tests/ConfigView.spec.tsx
@@ -182,7 +182,7 @@ describe('ConfigView', () => {
   test('renderTopToolbarCustomActions renders nothing when no rows are checked', () => {
     renderToStaticMarkup(<ConfigView visibleParticipants={[]} studyId="test-study" />);
     const html = renderToStaticMarkup(capturedTableOptions!.renderTopToolbarCustomActions());
-    expect(html).not.toContain('Download Configs');
+    expect(html).not.toContain('Download Config');
     expect(html).not.toContain('Compare');
   });
 
@@ -279,16 +279,30 @@ describe('ConfigView', () => {
     });
 
     const toolbar = renderToStaticMarkup(capturedTableOptions!.renderTopToolbarCustomActions());
-    expect(toolbar).toContain('Download Configs');
+    expect(toolbar).toContain('Download Config (');
+    expect(toolbar).not.toContain('Download Configs');
 
     const user = userEvent.setup();
     const { getByText } = render(capturedTableOptions!.renderTopToolbarCustomActions());
-    await user.click(getByText(/Download Configs/));
+    await user.click(getByText(/Download Config/));
 
     expect(downloadConfigFilesZip).toHaveBeenCalledWith(expect.objectContaining({
       studyId: 'test-study',
       hashes: [mockConfigInfo.hash],
     }));
+  });
+
+  test('toolbar shows plural label when multiple rows are selected', async () => {
+    const participants = [makeParticipant({ participantConfigHash: mockConfigInfo.hash })];
+    await act(async () => {
+      render(<ConfigView visibleParticipants={participants} studyId="test-study" />);
+    });
+    await act(async () => {
+      capturedTableOptions!.onRowSelectionChange({ hashA: true, hashB: true });
+    });
+
+    const toolbar = renderToStaticMarkup(capturedTableOptions!.renderTopToolbarCustomActions());
+    expect(toolbar).toContain('Download Configs (');
   });
 
   test('handleCompareConfigs opens compare modal when two rows are selected', async () => {

--- a/src/analysis/individualStudy/config/tests/ConfigView.spec.tsx
+++ b/src/analysis/individualStudy/config/tests/ConfigView.spec.tsx
@@ -279,7 +279,7 @@ describe('ConfigView', () => {
     });
 
     const toolbar = renderToStaticMarkup(capturedTableOptions!.renderTopToolbarCustomActions());
-    expect(toolbar).toContain('Download Config (');
+    expect(toolbar).toContain('Download Config ');
     expect(toolbar).not.toContain('Download Configs');
 
     const user = userEvent.setup();
@@ -302,7 +302,7 @@ describe('ConfigView', () => {
     });
 
     const toolbar = renderToStaticMarkup(capturedTableOptions!.renderTopToolbarCustomActions());
-    expect(toolbar).toContain('Download Configs (');
+    expect(toolbar).toContain('Download Configs ');
   });
 
   test('handleCompareConfigs opens compare modal when two rows are selected', async () => {


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed
Fix Download Config button plural label
"Download Configs (1)" to "Download Config (1)"