### PR TITLE
Add margin bottom to coding page think aloud footer

### DIFF
--- a/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
+++ b/src/analysis/individualStudy/thinkAloud/ThinkAloudFooter.tsx
@@ -418,7 +418,7 @@ export function ThinkAloudFooter({
         <AudioProvenanceVis setHasAudio={setHasAudio} saveProvenance={saveProvenance} setTime={onTimeUpdate} setTimeString={(_t) => setTimeString(_t)} answers={participant ? participant.answers : {}} taskName={currentTrial} context={isReplay ? 'provenanceVis' : 'audioAnalysis'} />
         {xScale && transcriptLines ? <TranscriptSegmentsVis startTime={xScale.domain()[0]} xScale={xScale} transcriptLines={transcriptLines} currentShownTranscription={currentShownTranscription || 0} /> : null}
 
-        <Group gap="xs" style={{ width: '100%' }} justify="center" wrap="nowrap">
+        <Group gap="xs" style={{ width: '100%' }} justify="center" wrap="nowrap" mb={isReplay ? 0 : 'md'}>
           <Group wrap="nowrap">
             <Text ff="monospace" style={{ textAlign: 'right' }} mt="lg" c="dimmed">{timeString}</Text>
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1330

### Give a longer description of what this PR addresses and why it's needed
Add margin bottom to the think aloud coding timeline

### Provide pictures/videos of the behavior before and after these changes (optional)
Before
<img width="1700" height="949" alt="image" src="https://github.com/user-attachments/assets/27e67b48-d488-4530-82a2-af45c2f12160" />


After
<img width="1710" height="948" alt="Screenshot 2026-07-28 at 1 27 12 PM" src="https://github.com/user-attachments/assets/befaea6e-8748-4277-8ffa-aa9c3539f957" />

