### PR TITLE
Fix missing videos not detected in production

### DIFF
--- a/src/utils/getStaticAsset.ts
+++ b/src/utils/getStaticAsset.ts
@@ -2,8 +2,13 @@ import { PREFIX } from './Prefix';
 
 export async function getStaticAssetByPath(path: string) {
   const res = await fetch(path);
+  // If fetch fails, return undefined to indicate that the asset was not found
+  if (!res.ok) {
+    return undefined;
+  }
   const text = await res.text();
 
+  // If returned text contains the ReVISit title, it means the asset was not found
   if (text.includes('<title>ReVISit</title>')) {
     return undefined;
   }

--- a/src/utils/tests/getStaticAsset.spec.ts
+++ b/src/utils/tests/getStaticAsset.spec.ts
@@ -7,8 +7,9 @@ vi.mock('../Prefix', () => ({ PREFIX: '/prefix/' }));
 
 afterEach(() => vi.restoreAllMocks());
 
-function mockFetch(text: string) {
+function mockFetch(text: string, ok = true) {
   vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+    ok,
     text: () => Promise.resolve(text),
     json: () => Promise.resolve(JSON.parse(text)),
   })));
@@ -22,6 +23,11 @@ describe('getStaticAssetByPath', () => {
 
   test('returns undefined when the response is the ReVISit index page', async () => {
     mockFetch('<html><head><title>ReVISit</title></head></html>');
+    await expect(getStaticAssetByPath('/missing')).resolves.toBeUndefined();
+  });
+
+  test('returns undefined when the response is not ok (e.g. a custom 404 page)', async () => {
+    mockFetch('<html><head></head><body>redirecting…</body></html>', false);
     await expect(getStaticAssetByPath('/missing')).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
### Does this PR close any open issues?
Towards #1350

### Give a longer description of what this PR addresses and why it's needed
In production, an internal (missing) video file did not render at all, so the participant gets stuck and cannot proceed

https://revisit.dev/study/PR1312/demo-video/ZXEwM0I5Nmo5azJjQXh4N29GNVZTUT09

Before

<img width="1713" height="643" alt="Image" src="https://github.com/user-attachments/assets/f893bf88-80bf-41de-b065-208c8b4827fd" />

After

<img width="1713" height="643" alt="Image" src="https://github.com/user-attachments/assets/862b673f-bd5e-4fed-8ae4-17bd3c896d1d" />