### PR TITLE
Add pairwise ranking validation and disabled state

### DIFF
--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -21,13 +21,16 @@ import cx from 'clsx';
 import {
   Box, Button, Flex, Group, Paper, Stack, Text,
 } from '@mantine/core';
-import { useMemo, useState, useEffect } from 'react';
+import {
+  useCallback, useEffect, useMemo, useState,
+} from 'react';
 import { InputLabel } from './InputLabel';
 import { OptionLabel } from './OptionLabel';
 import classes from './css/RankingDnd.module.css';
 import { ParsedStringOption, RankingResponse, StringOption } from '../../parser/types';
 import { useStoreActions, useStoreDispatch } from '../../store/store';
 import { parseStringOptions } from '../../utils/stringOptions';
+import { getRankingInstanceIndex } from './responseValidation';
 
 type Item = { id: string; symbol: string; option: ParsedStringOption };
 
@@ -351,10 +354,43 @@ function RankingPairwiseComponent({
   const { onChange } = answer as { onChange?: (value: Record<string, string>) => void };
   const { sensors, updateAnswer } = useRankingLogic(responseId, onChange);
   const items = useMemo(() => createItems(options), [options]);
-  const [pairIds, setPairIds] = useState<string[]>(['0']);
+  const optionIds = useMemo(() => new Set(items.map((item) => item.id)), [items]);
+
+  const scanRestoredAnswer = useCallback((value: Record<string, string> | undefined) => {
+    const restoredPairIds = new Set<string>();
+    let maxPairId = -1;
+    let maxInstanceIndex = -1;
+    Object.entries(value || {}).forEach(([itemId, location]) => {
+      const match = location.match(/^pair-(\d+)-(high|low)$/);
+      if (!match) return;
+      restoredPairIds.add(match[1]);
+      maxPairId = Math.max(maxPairId, parseInt(match[1], 10));
+      const instanceIndex = getRankingInstanceIndex(itemId, optionIds);
+      if (instanceIndex !== null) maxInstanceIndex = Math.max(maxInstanceIndex, instanceIndex);
+    });
+    return { restoredPairIds, maxPairId, maxInstanceIndex };
+  }, [optionIds]);
+
+  const [pairIds, setPairIds] = useState<string[]>(() => {
+    const { restoredPairIds } = scanRestoredAnswer(answer?.value);
+    return restoredPairIds.size > 0 ? [...restoredPairIds].sort((a, b) => parseInt(a, 10) - parseInt(b, 10)) : ['0'];
+  });
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [instanceCounter, setInstanceCounter] = useState(0);
-  const [nextPairId, setNextPairId] = useState(1);
+  const [instanceCounter, setInstanceCounter] = useState(() => scanRestoredAnswer(answer?.value).maxInstanceIndex + 1);
+  const [nextPairId, setNextPairId] = useState(() => Math.max(scanRestoredAnswer(answer?.value).maxPairId + 1, 1));
+
+  useEffect(() => {
+    const { restoredPairIds, maxPairId, maxInstanceIndex } = scanRestoredAnswer(answer?.value);
+    setPairIds((prev) => {
+      const merged = [...prev];
+      restoredPairIds.forEach((pairId) => {
+        if (!merged.includes(pairId)) merged.push(pairId);
+      });
+      return merged.length === prev.length ? prev : merged.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
+    });
+    setNextPairId((prev) => Math.max(prev, maxPairId + 1));
+    setInstanceCounter((prev) => Math.max(prev, maxInstanceIndex + 1));
+  }, [answer?.value, scanRestoredAnswer]);
 
   const { pairs, unassigned } = useMemo(() => {
     const pairMap: Record<string, { high: string[], low: string[] }> = {};

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -31,11 +31,12 @@ import { parseStringOptions } from '../../utils/stringOptions';
 
 type Item = { id: string; symbol: string; option: ParsedStringOption };
 
-function SortableItem({ item, index }: { item: Item; index?: number }) {
+function SortableItem({ item, index, disabled }: { item: Item; index?: number; disabled?: boolean }) {
   const {
     attributes, listeners, setNodeRef, transform, transition, isDragging,
   } = useSortable({
     id: item.symbol,
+    disabled,
   });
 
   const style: React.CSSProperties = {
@@ -49,7 +50,7 @@ function SortableItem({ item, index }: { item: Item; index?: number }) {
       style={{
         ...style, margin: '0 auto', minWidth: '200px',
       }}
-      className={cx(classes.item, { [classes.itemDragging]: isDragging })}
+      className={cx(classes.item, { [classes.itemDragging]: isDragging, [classes.itemDisabled]: disabled })}
       {...attributes}
       {...listeners}
       withBorder
@@ -190,7 +191,7 @@ function RankingSublistComponent({
           <SortableContext items={state.selected.map((i) => i.symbol)} strategy={verticalListSortingStrategy}>
             <Stack>
               {state.selected.map((item, index) => (
-                <SortableItem key={item.symbol} item={item} index={index + 1} />
+                <SortableItem key={item.symbol} item={item} index={index + 1} disabled={disabled} />
               ))}
             </Stack>
           </SortableContext>
@@ -201,7 +202,7 @@ function RankingSublistComponent({
           <SortableContext items={state.unassigned.map((i) => i.symbol)} strategy={verticalListSortingStrategy}>
             <Stack>
               {state.unassigned.map((item) => (
-                <SortableItem key={item.symbol} item={item} />
+                <SortableItem key={item.symbol} item={item} disabled={disabled} />
               ))}
             </Stack>
           </SortableContext>
@@ -304,7 +305,7 @@ function RankingCategoricalComponent({
             <SortableContext items={state[category].map((i) => i.symbol)} strategy={verticalListSortingStrategy}>
               <Stack>
                 {state[category].map((item) => (
-                  <SortableItem key={item.symbol} item={item} />
+                  <SortableItem key={item.symbol} item={item} disabled={disabled} />
                 ))}
               </Stack>
             </SortableContext>
@@ -470,6 +471,7 @@ function RankingPairwiseComponent({
       <Flex justify="flex-end" mb="md">
         <Button
           variant="outline"
+          disabled={disabled}
           onClick={() => {
             if (!disabled) {
               setPairIds((prev) => [...prev, nextPairId.toString()]);
@@ -499,6 +501,7 @@ function RankingPairwiseComponent({
                           <SortableItem
                             key={instanceId}
                             item={{ ...item, id: baseItemId, symbol: instanceId }}
+                            disabled={disabled}
                           />
                         ) : null;
                       })}
@@ -523,7 +526,7 @@ function RankingPairwiseComponent({
           <SortableContext items={unassigned.map((i) => i.id)} strategy={verticalListSortingStrategy}>
             <Stack>
               {unassigned.map((item) => (
-                <SortableItem key={item.id} item={item} />
+                <SortableItem key={item.id} item={item} disabled={disabled} />
               ))}
             </Stack>
           </SortableContext>

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -472,40 +472,39 @@ function RankingPairwiseComponent({
     }
 
     const targetMatch = targetId.match(/^pair-(\d+)-(high|low)$/);
+    if (!targetMatch) return;
 
-    if (targetMatch) {
-      const [, targetPairId, targetPosition] = targetMatch;
+    const [, targetPairId, targetPosition] = targetMatch;
 
-      const currentItemsInPosition = Object.entries(newAnswer).filter(
-        ([instId, loc]) => loc === targetId && instId !== draggedKey,
-      ).length;
+    const currentItemsInPosition = Object.entries(newAnswer).filter(
+      ([instId, loc]) => loc === targetId && instId !== draggedKey,
+    ).length;
 
-      if (currentItemsInPosition >= 1) {
-        setError?.('You can only place one item in each box.');
-        return;
-      }
+    if (currentItemsInPosition >= 1) {
+      setError?.('You can only place one item in each box.');
+      return;
+    }
 
-      const oppositePosition = targetPosition === 'high' ? 'low' : 'high';
-      const oppositeLocationId = `pair-${targetPairId}-${oppositePosition}`;
+    const oppositePosition = targetPosition === 'high' ? 'low' : 'high';
+    const oppositeLocationId = `pair-${targetPairId}-${oppositePosition}`;
 
-      const existingInOpposite = Object.entries(newAnswer).some(([instId, loc]) => {
-        const existingBaseId = getRankingBaseItemId(instId, optionIds);
-        const isDraggedInstance = !isFromAvailable && instId === draggedKey;
-        return !isDraggedInstance && loc === oppositeLocationId && existingBaseId === baseItemId;
-      });
+    const existingInOpposite = Object.entries(newAnswer).some(([instId, loc]) => {
+      const existingBaseId = getRankingBaseItemId(instId, optionIds);
+      const isDraggedInstance = !isFromAvailable && instId === draggedKey;
+      return !isDraggedInstance && loc === oppositeLocationId && existingBaseId === baseItemId;
+    });
 
-      if (existingInOpposite) {
-        const itemLabel = items.find((i) => i.id === baseItemId)?.option.label;
-        setError?.(`Item "${itemLabel}" cannot be in both HIGH and LOW.`);
-        return;
-      }
+    if (existingInOpposite) {
+      const itemLabel = items.find((i) => i.id === baseItemId)?.option.label;
+      setError?.(`Item "${itemLabel}" cannot be in both HIGH and LOW.`);
+      return;
+    }
 
-      const answerAfterMove = { ...newAnswer };
-      if (!isFromAvailable) delete answerAfterMove[draggedKey];
-      if (checkForDuplicatePair(answerAfterMove, targetPairId, optionIds, baseItemId)) {
-        setError?.('This would create a duplicate pair.');
-        return;
-      }
+    const answerAfterMove = { ...newAnswer };
+    if (!isFromAvailable) delete answerAfterMove[draggedKey];
+    if (checkForDuplicatePair(answerAfterMove, targetPairId, optionIds, baseItemId)) {
+      setError?.('This would create a duplicate pair.');
+      return;
     }
 
     if (isFromAvailable) {

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -30,7 +30,7 @@ import classes from './css/RankingDnd.module.css';
 import { ParsedStringOption, RankingResponse, StringOption } from '../../parser/types';
 import { useStoreActions, useStoreDispatch } from '../../store/store';
 import { parseStringOptions } from '../../utils/stringOptions';
-import { getRankingBaseItemId, getRankingInstanceIndex } from './responseValidation';
+import { getRankingBaseItemId, getRankingInstanceIndex, makeRankingInstanceKey } from './responseValidation';
 
 type Item = { id: string; symbol: string; option: ParsedStringOption };
 
@@ -501,8 +501,14 @@ function RankingPairwiseComponent({
     }
 
     if (isFromAvailable) {
-      newAnswer[`${draggedKey}_${instanceCounter}`] = targetId;
-      setInstanceCounter((c) => c + 1);
+      let instanceIndex = instanceCounter;
+      let candidateKey = makeRankingInstanceKey(draggedKey, instanceIndex);
+      while (optionIds.has(candidateKey) || candidateKey in newAnswer) {
+        instanceIndex += 1;
+        candidateKey = makeRankingInstanceKey(draggedKey, instanceIndex);
+      }
+      newAnswer[candidateKey] = targetId;
+      setInstanceCounter(instanceIndex + 1);
     } else {
       delete newAnswer[draggedKey];
       newAnswer[draggedKey] = targetId;

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -332,7 +332,7 @@ function checkForDuplicatePair(
   const pairMap: Record<string, Set<string>> = {};
 
   Object.entries(answer).forEach(([itemId, location]) => {
-    const match = location.match(/^pair-(\d+)-(high|low)$/);
+    const match = typeof location === 'string' ? location.match(/^pair-(\d+)-(high|low)$/) : null;
     if (match) {
       const pairId = match[1];
       const baseItemId = getRankingBaseItemId(itemId, optionIds);
@@ -341,15 +341,24 @@ function checkForDuplicatePair(
     }
   });
 
-  if (candidateBaseId) {
+  if (candidateBaseId !== undefined) {
     if (!pairMap[targetPairId]) pairMap[targetPairId] = new Set();
     pairMap[targetPairId].add(candidateBaseId);
   }
 
-  const targetPairSignature = [...(pairMap[targetPairId] || [])].sort().join('|');
-  if (!targetPairSignature) return false;
+  const targetPairItems = pairMap[targetPairId];
+  if (!targetPairItems || targetPairItems.size !== 2) return false;
+  const targetPairSignature = JSON.stringify([...targetPairItems].sort());
 
-  return Object.entries(pairMap).some(([pairId, itemSet]) => pairId !== targetPairId && [...itemSet].sort().join('|') === targetPairSignature);
+  return Object.entries(pairMap).some(([pairId, itemSet]) => (
+    pairId !== targetPairId
+    && itemSet.size === 2
+    && JSON.stringify([...itemSet].sort()) === targetPairSignature
+  ));
+}
+
+function getPairwiseAnswerSignature(value: Record<string, string> | undefined): string {
+  return JSON.stringify(Object.entries(value || {}).sort(([firstKey], [secondKey]) => firstKey.localeCompare(secondKey)));
 }
 
 // 'available' = dragged from Available Items, 'placed' = already in a pair
@@ -390,7 +399,7 @@ function RankingPairwiseComponent({
     let maxPairId = -1;
     let maxInstanceIndex = -1;
     Object.entries(value || {}).forEach(([itemId, location]) => {
-      const match = location.match(/^pair-(\d+)-(high|low)$/);
+      const match = typeof location === 'string' ? location.match(/^pair-(\d+)-(high|low)$/) : null;
       if (!match) return;
       restoredPairIds.add(match[1]);
       maxPairId = Math.max(maxPairId, parseInt(match[1], 10));
@@ -400,37 +409,45 @@ function RankingPairwiseComponent({
     return { restoredPairIds, maxPairId, maxInstanceIndex };
   }, [optionIds]);
 
-  const [pairIds, setPairIds] = useState<string[]>(() => {
-    const { restoredPairIds } = scanRestoredAnswer(answer?.value);
-    return restoredPairIds.size > 0 ? [...restoredPairIds].sort((a, b) => parseInt(a, 10) - parseInt(b, 10)) : ['0'];
-  });
+  const restoredAnswerState = useMemo(() => scanRestoredAnswer(answer?.value), [answer?.value, scanRestoredAnswer]);
+  const [localPairIds, setLocalPairIds] = useState<string[]>(
+    () => (restoredAnswerState.restoredPairIds.size > 0 ? [] : ['0']),
+  );
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [instanceCounter, setInstanceCounter] = useState(() => scanRestoredAnswer(answer?.value).maxInstanceIndex + 1);
-  const [nextPairId, setNextPairId] = useState(() => Math.max(scanRestoredAnswer(answer?.value).maxPairId + 1, 1));
+  const [instanceCounter, setInstanceCounter] = useState(() => restoredAnswerState.maxInstanceIndex + 1);
+  const [nextPairId, setNextPairId] = useState(() => Math.max(restoredAnswerState.maxPairId + 1, 1));
   const hasPlaceholderPairRef = useRef(Object.keys(answer?.value || {}).length === 0);
+  const lastEmittedAnswerSignatureRef = useRef<string | null>(null);
+  const lastObservedAnswerSignatureRef = useRef(getPairwiseAnswerSignature(answer?.value));
+  const pairIds = useMemo(() => (
+    [...new Set([...restoredAnswerState.restoredPairIds, ...localPairIds])]
+      .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+  ), [localPairIds, restoredAnswerState.restoredPairIds]);
 
   useEffect(() => {
-    const { restoredPairIds, maxPairId, maxInstanceIndex } = scanRestoredAnswer(answer?.value);
-    setPairIds((prev) => {
-      if (hasPlaceholderPairRef.current && restoredPairIds.size > 0) {
-        hasPlaceholderPairRef.current = false;
-        return [...restoredPairIds].sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
-      }
-      const merged = [...prev];
-      restoredPairIds.forEach((pairId) => {
-        if (!merged.includes(pairId)) merged.push(pairId);
-      });
-      return merged.length === prev.length ? prev : merged.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
-    });
-    setNextPairId((prev) => Math.max(prev, maxPairId + 1));
-    setInstanceCounter((prev) => Math.max(prev, maxInstanceIndex + 1));
-  }, [answer?.value, scanRestoredAnswer]);
+    const answerSignature = getPairwiseAnswerSignature(answer?.value);
+    const hasSemanticAnswerChange = answerSignature !== lastObservedAnswerSignatureRef.current;
+    const isLocallyEmittedAnswer = answerSignature === lastEmittedAnswerSignatureRef.current;
+    lastObservedAnswerSignatureRef.current = answerSignature;
+    if (isLocallyEmittedAnswer) lastEmittedAnswerSignatureRef.current = null;
+
+    if (hasSemanticAnswerChange && !isLocallyEmittedAnswer) {
+      const isEmptyAnswer = Object.keys(answer?.value || {}).length === 0;
+      hasPlaceholderPairRef.current = isEmptyAnswer;
+      setLocalPairIds(isEmptyAnswer ? ['0'] : []);
+    } else if (hasPlaceholderPairRef.current && restoredAnswerState.restoredPairIds.size > 0) {
+      hasPlaceholderPairRef.current = false;
+      setLocalPairIds((prev) => prev.filter((pairId) => pairId !== '0'));
+    }
+    setNextPairId((prev) => Math.max(prev, restoredAnswerState.maxPairId + 1));
+    setInstanceCounter((prev) => Math.max(prev, restoredAnswerState.maxInstanceIndex + 1));
+  }, [answer?.value, restoredAnswerState]);
 
   const { pairs, unassigned } = useMemo(() => {
     const pairMap: Record<string, { high: string[], low: string[] }> = {};
 
     Object.entries(answer?.value || {}).forEach(([itemId, location]) => {
-      const match = location.match(/^pair-(\d+)-(high|low)$/);
+      const match = typeof location === 'string' ? location.match(/^pair-(\d+)-(high|low)$/) : null;
       if (match) {
         const [, pairId, position] = match;
         if (!pairMap[pairId]) pairMap[pairId] = { high: [], low: [] };
@@ -464,8 +481,16 @@ function RankingPairwiseComponent({
 
     if (targetId === 'unassigned') {
       if (!isFromAvailable) {
+        const sourceLocation = newAnswer[draggedKey];
+        const sourceMatch = typeof sourceLocation === 'string'
+          ? sourceLocation.match(/^pair-(\d+)-(high|low)$/)
+          : null;
+        if (sourceMatch) {
+          setLocalPairIds((prev) => [...new Set([...prev, sourceMatch[1]])]);
+        }
         delete newAnswer[draggedKey];
         setError?.(null);
+        lastEmittedAnswerSignatureRef.current = getPairwiseAnswerSignature(newAnswer);
         updateAnswer(newAnswer);
       }
       return;
@@ -521,7 +546,18 @@ function RankingPairwiseComponent({
       newAnswer[draggedKey] = targetId;
     }
 
+    hasPlaceholderPairRef.current = false;
+    const sourceLocation = !isFromAvailable ? answer.value[draggedKey] : null;
+    const sourceMatch = typeof sourceLocation === 'string'
+      ? sourceLocation.match(/^pair-(\d+)-(high|low)$/)
+      : null;
+    setLocalPairIds((prev) => [...new Set([
+      ...prev,
+      targetPairId,
+      ...(sourceMatch ? [sourceMatch[1]] : []),
+    ])]);
     setError?.(null);
+    lastEmittedAnswerSignatureRef.current = getPairwiseAnswerSignature(newAnswer);
     updateAnswer(newAnswer);
   };
 
@@ -539,13 +575,14 @@ function RankingPairwiseComponent({
     hasPlaceholderPairRef.current = false;
     const newAnswer = { ...answer.value };
     Object.keys(newAnswer).forEach((key) => {
-      if (newAnswer[key].startsWith(`pair-${pairId}-`)) {
+      if (typeof newAnswer[key] === 'string' && newAnswer[key].startsWith(`pair-${pairId}-`)) {
         delete newAnswer[key];
       }
     });
 
-    setPairIds((prev) => prev.filter((id) => id !== pairId));
+    setLocalPairIds((prev) => prev.filter((id) => id !== pairId));
     setError?.(null);
+    lastEmittedAnswerSignatureRef.current = getPairwiseAnswerSignature(newAnswer);
     updateAnswer(newAnswer);
   };
 
@@ -558,7 +595,7 @@ function RankingPairwiseComponent({
           onClick={() => {
             if (!disabled) {
               hasPlaceholderPairRef.current = false;
-              setPairIds((prev) => [...prev, nextPairId.toString()]);
+              setLocalPairIds((prev) => [...prev, nextPairId.toString()]);
               setNextPairId((prev) => prev + 1);
             }
           }}

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -22,7 +22,7 @@ import {
   Box, Button, Flex, Group, Paper, Stack, Text,
 } from '@mantine/core';
 import {
-  useCallback, useEffect, useMemo, useState,
+  useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import { InputLabel } from './InputLabel';
 import { OptionLabel } from './OptionLabel';
@@ -407,10 +407,15 @@ function RankingPairwiseComponent({
   const [activeId, setActiveId] = useState<string | null>(null);
   const [instanceCounter, setInstanceCounter] = useState(() => scanRestoredAnswer(answer?.value).maxInstanceIndex + 1);
   const [nextPairId, setNextPairId] = useState(() => Math.max(scanRestoredAnswer(answer?.value).maxPairId + 1, 1));
+  const hasPlaceholderPairRef = useRef(Object.keys(answer?.value || {}).length === 0);
 
   useEffect(() => {
     const { restoredPairIds, maxPairId, maxInstanceIndex } = scanRestoredAnswer(answer?.value);
     setPairIds((prev) => {
+      if (hasPlaceholderPairRef.current && restoredPairIds.size > 0) {
+        hasPlaceholderPairRef.current = false;
+        return [...restoredPairIds].sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
+      }
       const merged = [...prev];
       restoredPairIds.forEach((pairId) => {
         if (!merged.includes(pairId)) merged.push(pairId);
@@ -530,6 +535,7 @@ function RankingPairwiseComponent({
   const handleRemovePair = (pairId: string) => {
     if (disabled) return;
 
+    hasPlaceholderPairRef.current = false;
     const newAnswer = { ...answer.value };
     Object.keys(newAnswer).forEach((key) => {
       if (newAnswer[key].startsWith(`pair-${pairId}-`)) {
@@ -550,6 +556,7 @@ function RankingPairwiseComponent({
           disabled={disabled}
           onClick={() => {
             if (!disabled) {
+              hasPlaceholderPairRef.current = false;
               setPairIds((prev) => [...prev, nextPairId.toString()]);
               setNextPairId((prev) => prev + 1);
             }

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -485,7 +485,8 @@ function RankingPairwiseComponent({
 
       const existingInOpposite = Object.entries(newAnswer).some(([instId, loc]) => {
         const existingBaseId = getRankingBaseItemId(instId, optionIds);
-        return loc === oppositeLocationId && existingBaseId === baseItemId;
+        const isDraggedInstance = !isFromAvailable && instId === draggedKey;
+        return !isDraggedInstance && loc === oppositeLocationId && existingBaseId === baseItemId;
       });
 
       if (existingInOpposite) {

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -30,7 +30,7 @@ import classes from './css/RankingDnd.module.css';
 import { ParsedStringOption, RankingResponse, StringOption } from '../../parser/types';
 import { useStoreActions, useStoreDispatch } from '../../store/store';
 import { parseStringOptions } from '../../utils/stringOptions';
-import { getRankingInstanceIndex } from './responseValidation';
+import { getRankingBaseItemId, getRankingInstanceIndex } from './responseValidation';
 
 type Item = { id: string; symbol: string; option: ParsedStringOption };
 
@@ -323,18 +323,28 @@ function RankingCategoricalComponent({
   );
 }
 
-function checkForDuplicatePair(answer: Record<string, string>, targetPairId: string): boolean {
+function checkForDuplicatePair(
+  answer: Record<string, string>,
+  targetPairId: string,
+  optionIds: Set<string>,
+  candidateBaseId?: string,
+): boolean {
   const pairMap: Record<string, Set<string>> = {};
 
   Object.entries(answer).forEach(([itemId, location]) => {
     const match = location.match(/^pair-(\d+)-(high|low)$/);
     if (match) {
       const pairId = match[1];
-      const baseItemId = itemId.split('_')[0];
+      const baseItemId = getRankingBaseItemId(itemId, optionIds);
       if (!pairMap[pairId]) pairMap[pairId] = new Set();
       pairMap[pairId].add(baseItemId);
     }
   });
+
+  if (candidateBaseId) {
+    if (!pairMap[targetPairId]) pairMap[targetPairId] = new Set();
+    pairMap[targetPairId].add(candidateBaseId);
+  }
 
   const targetPairSignature = [...(pairMap[targetPairId] || [])].sort().join('|');
   if (!targetPairSignature) return false;
@@ -430,8 +440,8 @@ function RankingPairwiseComponent({
       return;
     }
 
-    const isFromUnassigned = !draggedId.includes('_');
-    const baseItemId = isFromUnassigned ? draggedId : draggedId.split('_')[0];
+    const isFromUnassigned = optionIds.has(draggedId);
+    const baseItemId = getRankingBaseItemId(draggedId, optionIds);
     const targetMatch = targetId.match(/^pair-(\d+)-(high|low)$/);
 
     if (targetMatch) {
@@ -450,7 +460,7 @@ function RankingPairwiseComponent({
       const oppositeLocationId = `pair-${targetPairId}-${oppositePosition}`;
 
       const existingInOpposite = Object.entries(newAnswer).some(([instId, loc]) => {
-        const existingBaseId = instId.split('_')[0];
+        const existingBaseId = getRankingBaseItemId(instId, optionIds);
         return loc === oppositeLocationId && existingBaseId === baseItemId;
       });
 
@@ -460,12 +470,9 @@ function RankingPairwiseComponent({
         return;
       }
 
-      if (isFromUnassigned) {
-        const tempAnswer = { ...newAnswer, [`${draggedId}_temp`]: targetId };
-        if (checkForDuplicatePair(tempAnswer, targetPairId)) {
-          setError?.('This would create a duplicate pair.');
-          return;
-        }
+      if (isFromUnassigned && checkForDuplicatePair(newAnswer, targetPairId, optionIds, baseItemId)) {
+        setError?.('This would create a duplicate pair.');
+        return;
       }
     }
 
@@ -483,9 +490,9 @@ function RankingPairwiseComponent({
 
   const activeItem = useMemo(() => {
     if (!activeId) return null;
-    const baseItemId = activeId.includes('_') ? activeId.split('_')[0] : activeId;
+    const baseItemId = getRankingBaseItemId(activeId, optionIds);
     return items.find((i) => i.id === baseItemId) || null;
-  }, [activeId, items]);
+  }, [activeId, items, optionIds]);
 
   const handleRemovePair = (pairId: string) => {
     if (disabled) return;
@@ -531,7 +538,7 @@ function RankingPairwiseComponent({
                   >
                     <Stack>
                       {pair[position].map((instanceId) => {
-                        const baseItemId = instanceId.split('_')[0];
+                        const baseItemId = getRankingBaseItemId(instanceId, optionIds);
                         const item = items.find((i) => i.id === baseItemId);
                         return item ? (
                           <SortableItem

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -477,7 +477,7 @@ function RankingPairwiseComponent({
     const [, targetPairId, targetPosition] = targetMatch;
 
     const currentItemsInPosition = Object.entries(newAnswer).filter(
-      ([instId, loc]) => loc === targetId && instId !== draggedKey,
+      ([instId, loc]) => loc === targetId && !(!isFromAvailable && instId === draggedKey),
     ).length;
 
     if (currentItemsInPosition >= 1) {

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -352,6 +352,25 @@ function checkForDuplicatePair(
   return Object.entries(pairMap).some(([pairId, itemSet]) => pairId !== targetPairId && [...itemSet].sort().join('|') === targetPairSignature);
 }
 
+// 'available' = dragged from Available Items, 'placed' = already in a pair
+type PairwiseDragSource = 'available' | 'placed';
+
+function makePairwiseDragId(source: PairwiseDragSource, id: string): string {
+  return `${source}:${id}`;
+}
+
+function parsePairwiseDragId(dragId: string): { source: PairwiseDragSource; id: string } | null {
+  if (dragId.startsWith('available:')) {
+    return { source: 'available', id: dragId.slice('available:'.length) };
+  }
+
+  if (dragId.startsWith('placed:')) {
+    return { source: 'placed', id: dragId.slice('placed:'.length) };
+  }
+
+  return null;
+}
+
 function RankingPairwiseComponent({
   options, disabled, answer, responseId, setError,
 }: {
@@ -429,26 +448,31 @@ function RankingPairwiseComponent({
     setActiveId(null);
     if (disabled || !event.over) return;
 
-    const draggedId = event.active.id as string;
+    const draggedRef = parsePairwiseDragId(event.active.id as string);
+    if (!draggedRef) return;
+    const isFromAvailable = draggedRef.source === 'available';
+    const draggedKey = draggedRef.id;
+    const baseItemId = isFromAvailable ? draggedRef.id : getRankingBaseItemId(draggedRef.id, optionIds);
+
     const targetId = event.over.id as string;
     const newAnswer = { ...answer.value };
 
     if (targetId === 'unassigned') {
-      delete newAnswer[draggedId];
-      setError?.(null);
-      updateAnswer(newAnswer);
+      if (!isFromAvailable) {
+        delete newAnswer[draggedKey];
+        setError?.(null);
+        updateAnswer(newAnswer);
+      }
       return;
     }
 
-    const isFromUnassigned = optionIds.has(draggedId);
-    const baseItemId = getRankingBaseItemId(draggedId, optionIds);
     const targetMatch = targetId.match(/^pair-(\d+)-(high|low)$/);
 
     if (targetMatch) {
       const [, targetPairId, targetPosition] = targetMatch;
 
       const currentItemsInPosition = Object.entries(newAnswer).filter(
-        ([instId, loc]) => loc === targetId && instId !== draggedId,
+        ([instId, loc]) => loc === targetId && instId !== draggedKey,
       ).length;
 
       if (currentItemsInPosition >= 1) {
@@ -470,18 +494,18 @@ function RankingPairwiseComponent({
         return;
       }
 
-      if (isFromUnassigned && checkForDuplicatePair(newAnswer, targetPairId, optionIds, baseItemId)) {
+      if (isFromAvailable && checkForDuplicatePair(newAnswer, targetPairId, optionIds, baseItemId)) {
         setError?.('This would create a duplicate pair.');
         return;
       }
     }
 
-    if (isFromUnassigned) {
-      newAnswer[`${draggedId}_${instanceCounter}`] = targetId;
+    if (isFromAvailable) {
+      newAnswer[`${draggedKey}_${instanceCounter}`] = targetId;
       setInstanceCounter((c) => c + 1);
     } else {
-      delete newAnswer[draggedId];
-      newAnswer[draggedId] = targetId;
+      delete newAnswer[draggedKey];
+      newAnswer[draggedKey] = targetId;
     }
 
     setError?.(null);
@@ -490,7 +514,9 @@ function RankingPairwiseComponent({
 
   const activeItem = useMemo(() => {
     if (!activeId) return null;
-    const baseItemId = getRankingBaseItemId(activeId, optionIds);
+    const draggedRef = parsePairwiseDragId(activeId);
+    if (!draggedRef) return null;
+    const baseItemId = draggedRef.source === 'available' ? draggedRef.id : getRankingBaseItemId(draggedRef.id, optionIds);
     return items.find((i) => i.id === baseItemId) || null;
   }, [activeId, items, optionIds]);
 
@@ -533,7 +559,7 @@ function RankingPairwiseComponent({
               <Box key={position} style={{ width: '300px' }}>
                 <DroppableZone id={`pair-${pairId}-${position}`} title={position.toUpperCase()}>
                   <SortableContext
-                    items={pair[position]}
+                    items={pair[position].map((instanceId) => makePairwiseDragId('placed', instanceId))}
                     strategy={verticalListSortingStrategy}
                   >
                     <Stack>
@@ -543,7 +569,7 @@ function RankingPairwiseComponent({
                         return item ? (
                           <SortableItem
                             key={instanceId}
-                            item={{ ...item, id: baseItemId, symbol: instanceId }}
+                            item={{ ...item, id: baseItemId, symbol: makePairwiseDragId('placed', instanceId) }}
                             disabled={disabled}
                           />
                         ) : null;
@@ -566,10 +592,10 @@ function RankingPairwiseComponent({
         ))}
 
         <DroppableZone id="unassigned" title="Available Items">
-          <SortableContext items={unassigned.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext items={unassigned.map((i) => makePairwiseDragId('available', i.id))} strategy={verticalListSortingStrategy}>
             <Stack>
               {unassigned.map((item) => (
-                <SortableItem key={item.id} item={item} disabled={disabled} />
+                <SortableItem key={item.id} item={{ ...item, symbol: makePairwiseDragId('available', item.id) }} disabled={disabled} />
               ))}
             </Stack>
           </SortableContext>

--- a/src/components/response/RankingInput.tsx
+++ b/src/components/response/RankingInput.tsx
@@ -500,7 +500,9 @@ function RankingPairwiseComponent({
         return;
       }
 
-      if (isFromAvailable && checkForDuplicatePair(newAnswer, targetPairId, optionIds, baseItemId)) {
+      const answerAfterMove = { ...newAnswer };
+      if (!isFromAvailable) delete answerAfterMove[draggedKey];
+      if (checkForDuplicatePair(answerAfterMove, targetPairId, optionIds, baseItemId)) {
         setError?.('This would create a duplicate pair.');
         return;
       }

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -32,7 +32,6 @@ import {
 } from './utils';
 import {
   generateErrorMessage,
-  REQUIRED_ERROR_MESSAGE,
   usesStandaloneDontKnowField,
 } from './responseErrors';
 import { CustomResponseField } from '../../store/types';
@@ -190,9 +189,6 @@ export function ResponseSwitcher({
       || response.type === 'custom'
       || response.type === 'textOnly'
       || response.type === 'divider'
-      || response.type === 'ranking-sublist'
-      || response.type === 'ranking-categorical'
-      || response.type === 'ranking-pairwise'
     ) {
       return null;
     }
@@ -204,29 +200,7 @@ export function ResponseSwitcher({
       { showRequiredErrors: errors, values: validationValues },
     );
   }, [response, ans, errorOptions, errors, validationValues]);
-  const rankingError = useMemo(() => {
-    if (
-      response.type !== 'ranking-sublist'
-      && response.type !== 'ranking-categorical'
-      && response.type !== 'ranking-pairwise'
-    ) {
-      return null;
-    }
-
-    return errors
-      && response.required
-      && !dontKnowChecked
-      && Object.keys((ans.value as Record<string, string>) || {}).length === 0
-      ? REQUIRED_ERROR_MESSAGE
-      : null;
-  }, [response, errors, dontKnowChecked, ans.value]);
-  const displayError = response.type === 'custom' ? customError : (
-    response.type === 'ranking-sublist'
-    || response.type === 'ranking-categorical'
-    || response.type === 'ranking-pairwise'
-      ? rankingError
-      : responseError
-  );
+  const displayError = response.type === 'custom' ? customError : responseError;
   const responseWrapperStyle = useMemo(() => {
     if (!displayError) {
       return responseStyle;
@@ -333,7 +307,7 @@ export function ResponseSwitcher({
         response={response}
         disabled={isDisabled || dontKnowChecked}
         answer={ans as { value: Record<string, string> }}
-        error={rankingError}
+        error={responseError}
         index={index}
         enumerateQuestions={enumerateQuestions}
       />

--- a/src/components/response/css/RankingDnd.module.css
+++ b/src/components/response/css/RankingDnd.module.css
@@ -13,6 +13,5 @@
 }
 
 .itemDisabled {
-  color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-2));
   cursor: not-allowed;
 }

--- a/src/components/response/css/RankingDnd.module.css
+++ b/src/components/response/css/RankingDnd.module.css
@@ -11,3 +11,8 @@
 .itemDragging {
   box-shadow: var(--mantine-shadow-sm);
 }
+
+.itemDisabled {
+  color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-2));
+  cursor: not-allowed;
+}

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -181,6 +181,15 @@ export function checkPairwiseRankingResponse(response: RankingResponse, value: R
   if (!pairList.every(isCompletePair)) {
     return 'Please complete or remove unfinished pairs to continue.';
   }
+
+  const pairSignatures = pairList.map((pair) => JSON.stringify([
+    pair.high[0],
+    pair.low[0],
+  ].sort()));
+  if (new Set(pairSignatures).size !== pairSignatures.length) {
+    return 'This would create a duplicate pair.';
+  }
+
   return null;
 }
 

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -103,11 +103,31 @@ export function checkNumericalResponse(response: NumericalResponse, value: numbe
   return null;
 }
 
+// Instance keys (`instance-<index>-<optionValue>`) never collide with option values; legacy keys still parse.
+export function makeRankingInstanceKey(baseItemId: string, instanceIndex: number): string {
+  return `instance-${instanceIndex}-${baseItemId}`;
+}
+
+function parseTaggedRankingInstanceKey(instanceId: string): { baseItemId: string; instanceIndex: number } | null {
+  const match = instanceId.match(/^instance-(\d+)-(.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return { baseItemId: match[2], instanceIndex: parseInt(match[1], 10) };
+}
+
 export function getRankingBaseItemId(instanceId: string, optionValues: Set<string>): string {
+  const tagged = parseTaggedRankingInstanceKey(instanceId);
+  if (tagged) {
+    return tagged.baseItemId;
+  }
+
   if (optionValues.has(instanceId)) {
     return instanceId;
   }
 
+  // Legacy generated keys: `<optionValue>_<counter>`, longest option match first
   const matchingOption = [...optionValues]
     .filter((optionValue) => instanceId.startsWith(`${optionValue}_`))
     .sort((first, second) => second.length - first.length)
@@ -117,6 +137,11 @@ export function getRankingBaseItemId(instanceId: string, optionValues: Set<strin
 }
 
 export function getRankingInstanceIndex(instanceId: string, optionValues: Set<string>): number | null {
+  const tagged = parseTaggedRankingInstanceKey(instanceId);
+  if (tagged) {
+    return tagged.instanceIndex;
+  }
+
   const baseItemId = getRankingBaseItemId(instanceId, optionValues);
   if (!optionValues.has(baseItemId) || baseItemId === instanceId) {
     return null;

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -118,13 +118,13 @@ function parseTaggedRankingInstanceKey(instanceId: string): { baseItemId: string
 }
 
 export function getRankingBaseItemId(instanceId: string, optionValues: Set<string>): string {
+  if (optionValues.has(instanceId)) {
+    return instanceId;
+  }
+
   const tagged = parseTaggedRankingInstanceKey(instanceId);
   if (tagged) {
     return tagged.baseItemId;
-  }
-
-  if (optionValues.has(instanceId)) {
-    return instanceId;
   }
 
   // Legacy generated keys: `<optionValue>_<counter>`, longest option match first
@@ -137,6 +137,10 @@ export function getRankingBaseItemId(instanceId: string, optionValues: Set<strin
 }
 
 export function getRankingInstanceIndex(instanceId: string, optionValues: Set<string>): number | null {
+  if (optionValues.has(instanceId)) {
+    return null;
+  }
+
   const tagged = parseTaggedRankingInstanceKey(instanceId);
   if (tagged) {
     return tagged.instanceIndex;

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -116,6 +116,15 @@ export function getRankingBaseItemId(instanceId: string, optionValues: Set<strin
   return matchingOption ?? instanceId;
 }
 
+export function getRankingInstanceIndex(instanceId: string, optionValues: Set<string>): number | null {
+  const baseItemId = getRankingBaseItemId(instanceId, optionValues);
+  if (!optionValues.has(baseItemId) || baseItemId === instanceId) {
+    return null;
+  }
+
+  return Number(instanceId.slice(baseItemId.length + 1));
+}
+
 export function checkPairwiseRankingResponse(response: RankingResponse, value: Record<string, string>) {
   const optionValues = new Set(parseStringOptions(response.options).map((option) => option.value));
   const pairs: Record<string, { high: string[]; low: string[] }> = {};

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -4,10 +4,11 @@ import {
   DropdownResponse,
   MatrixResponse,
   NumericalResponse,
+  RankingResponse,
   Response,
 } from '../../parser/types';
 import { CustomResponseValidate, StoredAnswer } from '../../store/types';
-import { parseStringOptionValue } from '../../utils/stringOptions';
+import { parseStringOptions, parseStringOptionValue } from '../../utils/stringOptions';
 
 export const REQUIRED_ERROR_MESSAGE = 'Please answer this question to continue.';
 
@@ -102,19 +103,38 @@ export function checkNumericalResponse(response: NumericalResponse, value: numbe
   return null;
 }
 
-export function checkPairwiseRankingResponse(value: Record<string, string>) {
-  const pairs: Record<string, { high: boolean; low: boolean }> = {};
+export function getRankingBaseItemId(instanceId: string, optionValues: Set<string>): string {
+  if (optionValues.has(instanceId)) {
+    return instanceId;
+  }
 
-  Object.values(value).forEach((location) => {
+  const matchingOption = [...optionValues]
+    .filter((optionValue) => instanceId.startsWith(`${optionValue}_`))
+    .sort((first, second) => second.length - first.length)
+    .find((optionValue) => /^\d+$/.test(instanceId.slice(optionValue.length + 1)));
+
+  return matchingOption ?? instanceId;
+}
+
+export function checkPairwiseRankingResponse(response: RankingResponse, value: Record<string, string>) {
+  const optionValues = new Set(parseStringOptions(response.options).map((option) => option.value));
+  const pairs: Record<string, { high: string[]; low: string[] }> = {};
+
+  Object.entries(value).forEach(([itemId, location]) => {
     const match = location.match(/^pair-(\d+)-(high|low)$/);
     if (match) {
       const [, pairId, position] = match;
-      if (!pairs[pairId]) pairs[pairId] = { high: false, low: false };
-      pairs[pairId][position as 'high' | 'low'] = true;
+      if (!pairs[pairId]) pairs[pairId] = { high: [], low: [] };
+      pairs[pairId][position as 'high' | 'low'].push(getRankingBaseItemId(itemId, optionValues));
     }
   });
 
-  const hasCompletePair = Object.values(pairs).some((pair) => pair.high && pair.low);
+  // Check if there is at least one pair that has both a high and low selection, and that both selections are valid option values
+  const hasCompletePair = Object.values(pairs).some((pair) => pair.high.length === 1
+    && pair.low.length === 1
+    && optionValues.has(pair.high[0])
+    && optionValues.has(pair.low[0])
+    && pair.high[0] !== pair.low[0]);
   if (!hasCompletePair) {
     return 'Please complete at least one pair to continue.';
   }
@@ -257,7 +277,7 @@ export function validateResponse(
       }
 
       if (response.type === 'ranking-pairwise') {
-        const pairwiseError = checkPairwiseRankingResponse(value as Record<string, string>);
+        const pairwiseError = checkPairwiseRankingResponse(response, value as Record<string, string>);
         return pairwiseError
           ? createValidationResult(response, 'invalid', { message: pairwiseError })
           : createValidationResult(response, 'none');

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -102,6 +102,25 @@ export function checkNumericalResponse(response: NumericalResponse, value: numbe
   return null;
 }
 
+export function checkPairwiseRankingResponse(value: Record<string, string>) {
+  const pairs: Record<string, { high: boolean; low: boolean }> = {};
+
+  Object.values(value).forEach((location) => {
+    const match = location.match(/^pair-(\d+)-(high|low)$/);
+    if (match) {
+      const [, pairId, position] = match;
+      if (!pairs[pairId]) pairs[pairId] = { high: false, low: false };
+      pairs[pairId][position as 'high' | 'low'] = true;
+    }
+  });
+
+  const hasCompletePair = Object.values(pairs).some((pair) => pair.high && pair.low);
+  if (!hasCompletePair) {
+    return 'Please complete at least one pair to continue.';
+  }
+  return null;
+}
+
 export function checkMatrixResponse(response: MatrixResponse, value: Record<string, string>) {
   const expectedQuestionKeys = response.questionOptions.map((entry) => parseStringOptionValue(entry));
   const unanswered = expectedQuestionKeys.some((questionKey) => {
@@ -233,7 +252,18 @@ export function validateResponse(
     }
 
     if (response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {
-      return createValidationResult(response, Object.keys(value).length === 0 && response.required ? 'unanswered' : 'none');
+      if (Object.keys(value).length === 0) {
+        return createValidationResult(response, response.required ? 'unanswered' : 'none');
+      }
+
+      if (response.type === 'ranking-pairwise') {
+        const pairwiseError = checkPairwiseRankingResponse(value as Record<string, string>);
+        return pairwiseError
+          ? createValidationResult(response, 'invalid', { message: pairwiseError })
+          : createValidationResult(response, 'none');
+      }
+
+      return createValidationResult(response, 'none');
     }
   }
 

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -167,14 +167,19 @@ export function checkPairwiseRankingResponse(response: RankingResponse, value: R
     }
   });
 
-  // Check if there is at least one pair that has both a high and low selection, and that both selections are valid option values
-  const hasCompletePair = Object.values(pairs).some((pair) => pair.high.length === 1
+  // A pair is complete when both sides hold exactly one distinct configured option
+  const isCompletePair = (pair: { high: string[]; low: string[] }) => pair.high.length === 1
     && pair.low.length === 1
     && optionValues.has(pair.high[0])
     && optionValues.has(pair.low[0])
-    && pair.high[0] !== pair.low[0]);
-  if (!hasCompletePair) {
+    && pair.high[0] !== pair.low[0];
+
+  const pairList = Object.values(pairs);
+  if (!pairList.some(isCompletePair)) {
     return 'Please complete at least one pair to continue.';
+  }
+  if (!pairList.every(isCompletePair)) {
+    return 'Please complete or remove unfinished pairs to continue.';
   }
   return null;
 }

--- a/src/components/response/responseValidation.ts
+++ b/src/components/response/responseValidation.ts
@@ -109,7 +109,7 @@ export function makeRankingInstanceKey(baseItemId: string, instanceIndex: number
 }
 
 function parseTaggedRankingInstanceKey(instanceId: string): { baseItemId: string; instanceIndex: number } | null {
-  const match = instanceId.match(/^instance-(\d+)-(.+)$/);
+  const match = instanceId.match(/^instance-(\d+)-(.*)$/);
   if (!match) {
     return null;
   }
@@ -157,15 +157,22 @@ export function getRankingInstanceIndex(instanceId: string, optionValues: Set<st
 export function checkPairwiseRankingResponse(response: RankingResponse, value: Record<string, string>) {
   const optionValues = new Set(parseStringOptions(response.options).map((option) => option.value));
   const pairs: Record<string, { high: string[]; low: string[] }> = {};
+  let hasInvalidLocation = false;
 
   Object.entries(value).forEach(([itemId, location]) => {
-    const match = location.match(/^pair-(\d+)-(high|low)$/);
-    if (match) {
-      const [, pairId, position] = match;
-      if (!pairs[pairId]) pairs[pairId] = { high: [], low: [] };
-      pairs[pairId][position as 'high' | 'low'].push(getRankingBaseItemId(itemId, optionValues));
+    const match = typeof location === 'string' ? location.match(/^pair-(\d+)-(high|low)$/) : null;
+    if (!match) {
+      hasInvalidLocation = true;
+      return;
     }
+    const [, pairId, position] = match;
+    if (!pairs[pairId]) pairs[pairId] = { high: [], low: [] };
+    pairs[pairId][position as 'high' | 'low'].push(getRankingBaseItemId(itemId, optionValues));
   });
+
+  if (hasInvalidLocation) {
+    return 'Please complete or remove invalid pairs to continue.';
+  }
 
   // A pair is complete when both sides hold exactly one distinct configured option
   const isCompletePair = (pair: { high: string[]; low: string[] }) => pair.high.length === 1

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -776,6 +776,27 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('async restoration replaces the untouched default pair 0 row', async () => {
+    const { rerender, getAllByRole } = render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={{ value: {} }} />,
+    );
+    // Empty answer renders the single default pair 0 row
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+
+    await act(async () => {
+      rerender(
+        <RankingInput
+          {...baseProps}
+          response={makeResponse('ranking-pairwise')}
+          answer={{ value: { [rankingInstanceKey('Item A', 0)]: 'pair-1-high' } }}
+        />,
+      );
+    });
+    // The restored pair 1 replaces the untouched placeholder — no phantom
+    // empty pair 0 row remains
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+  });
+
   test('counters resync when answer.value is replaced while mounted', async () => {
     const onChange = vi.fn();
     const emptyAnswer = { value: {}, onChange } as unknown as { value: Record<string, string> };

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -639,6 +639,32 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('dropping onto an item card is ignored', async () => {
+    const onChange = vi.fn();
+    const answer = {
+      value: { [rankingInstanceKey('Item A', 0)]: 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    // Dropping onto another item card (not a zone) must not store the card's
+    // drag id as an answer location
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(
+        pairwiseAvailableDragId('Item B'),
+        pairwisePlacedDragId(rankingInstanceKey('Item A', 0)),
+      ));
+    });
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(
+        pairwisePlacedDragId(rankingInstanceKey('Item A', 0)),
+        pairwiseAvailableDragId('Item B'),
+      ));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   test('moving a placed item cannot create a duplicate pair', async () => {
     const onChange = vi.fn();
     // pair-0 = {A, B}, pair-1 = {A}, pair-2 = {B}; moving B from pair-2 into

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -33,8 +33,8 @@ vi.mock('@dnd-kit/core', () => ({
   DragOverlay: ({ children }: { children?: React.ReactNode }) => (
     React.createElement(React.Fragment, null, children ?? null)
   ),
-  PointerSensor: class {},
-  KeyboardSensor: class {},
+  PointerSensor: class { },
+  KeyboardSensor: class { },
   useSensor: vi.fn(),
   useSensors: vi.fn(() => []),
   useDroppable: vi.fn(() => ({ setNodeRef: vi.fn(), isOver: false })),
@@ -166,6 +166,14 @@ function makeDragStart(activeId: string): DragStartEvent {
     active: { id: activeId, data: { current: undefined }, rect: { current: { initial: null, translated: null } } },
     activatorEvent: new Event('pointerdown'),
   } as DragStartEvent;
+}
+
+function pairwiseAvailableDragId(optionId: string) {
+  return `available:${optionId}`;
+}
+
+function pairwisePlacedDragId(instanceId: string) {
+  return `placed:${instanceId}`;
 }
 
 // ══ RankingSublistComponent ══════════════════════════════════════════════════
@@ -440,7 +448,7 @@ describe('RankingPairwiseComponent', () => {
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={{ value: {} }} />,
     );
     await act(async () => {
-      capturedOnDragStart?.(makeDragStart('Item A'));
+      capturedOnDragStart?.(makeDragStart(pairwiseAvailableDragId('Item A')));
     });
     expect(capturedOnDragStart).toBeDefined();
   });
@@ -450,90 +458,138 @@ describe('RankingPairwiseComponent', () => {
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={{ value: {} }} />,
     );
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A', null));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), null));
     });
     expect(capturedOnDragEnd).toBeDefined();
   });
 
   test('handleDragEnd: drop to unassigned removes item from pair', async () => {
-    const answer = { value: { 'Item A_0': 'pair-0-high' } };
+    const onChange = vi.fn();
+    const answer = {
+      value: { 'Item A_0': 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A_0', 'unassigned'));
+      capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId('Item A_0'), 'unassigned'));
     });
-    expect(capturedOnDragEnd).toBeDefined();
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  test('moving an assigned plain default key moves it instead of duplicating', async () => {
+    const onChange = vi.fn();
+    // Defaults are documented as plain option-value keys; moving the placed
+    // default must relocate it, not treat it as a fresh drop from Available
+    // Items that would leave the original behind.
+    const answer = {
+      value: { 'Item A': 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId('Item A'), 'pair-1-high'));
+    });
+    expect(onChange).toHaveBeenCalledWith({ 'Item A': 'pair-1-high' });
   });
 
   test('handleDragEnd: drop from unassigned to pair-high', async () => {
+    const onChange = vi.fn();
     render(
-      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={{ value: {} }} />,
+      <RankingInput
+        {...baseProps}
+        response={makeResponse('ranking-pairwise')}
+        answer={{ value: {}, onChange } as unknown as { value: Record<string, string> }}
+      />,
     );
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-0-high'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-0-high'));
     });
-    expect(capturedOnDragEnd).toBeDefined();
+    expect(onChange).toHaveBeenCalledWith({ 'Item A_0': 'pair-0-high' });
   });
 
   test('handleDragEnd: position already occupied (one item limit)', async () => {
-    const answer = { value: { 'Item A_0': 'pair-0-high' } };
+    const onChange = vi.fn();
+    const answer = {
+      value: { 'Item A_0': 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
     await act(async () => {
       // Try to drop another item into pair-0-high which already has an item
-      capturedOnDragEnd?.(makeDragEnd('Item B', 'pair-0-high'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item B'), 'pair-0-high'));
     });
-    expect(capturedOnDragEnd).toBeDefined();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('handleDragEnd: same item in opposite position error', async () => {
-    const answer = { value: { 'Item A_0': 'pair-0-high' } };
+    const onChange = vi.fn();
+    const answer = {
+      value: { 'Item A_0': 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
     await act(async () => {
       // Try to drop Item A into the opposite position (pair-0-low)
-      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-0-low'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-0-low'));
     });
-    expect(capturedOnDragEnd).toBeDefined();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('handleDragEnd: duplicate pair detection (covers checkForDuplicatePair)', async () => {
-    // pair-0 has Item A (high) vs Item B (low); try to create pair-1 with same combo
+    const onChange = vi.fn();
+    // pair-0 = {A, B}; pair-1 already holds A, so completing it with B would
+    // duplicate pair-0 and the drop must be rejected
     const answer = {
       value: {
         'Item A_0': 'pair-0-high',
         'Item B_1': 'pair-0-low',
+        'Item A_2': 'pair-1-high',
       },
-    };
+      onChange,
+    } as unknown as { value: Record<string, string> };
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
-    // Add a new pair first
     await act(async () => {
-      const buttons = document.querySelectorAll('button');
-      const addBtn = Array.from(buttons).find((b) => b.textContent === 'Add New Pair');
-      if (addBtn) fireEvent.click(addBtn);
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item B'), 'pair-1-low'));
     });
-    // Now drag Item A to pair-1-high — creates a temp with Item A_temp on pair-1
+    expect(onChange).not.toHaveBeenCalled();
+
+    // A non-duplicating completion (Item C) is accepted
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-1-high'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item C'), 'pair-1-low'));
     });
-    expect(capturedOnDragEnd).toBeDefined();
+    expect(onChange).toHaveBeenCalledWith({
+      'Item A_0': 'pair-0-high',
+      'Item B_1': 'pair-0-low',
+      'Item A_2': 'pair-1-high',
+      'Item C_3': 'pair-1-low',
+    });
   });
 
-  test('handleDragEnd: move existing positioned item to new pair position', async () => {
-    const answer = { value: { 'Item A_0': 'pair-0-high' } };
+  test('handleDragEnd: move existing positioned item to a new pair position', async () => {
+    const onChange = vi.fn();
+    const answer = {
+      value: { 'Item A_0': 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
-    // Move an already-placed item (non-unassigned) to a different position
+    // Move an already-placed instance to a different pair — the key is kept,
+    // only its location changes
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A_0', 'pair-0-low'));
+      capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId('Item A_0'), 'pair-1-high'));
     });
-    expect(capturedOnDragEnd).toBeDefined();
+    expect(onChange).toHaveBeenCalledWith({ 'Item A_0': 'pair-1-high' });
   });
 
   test('restored answer initializes pair rows from answer.value (no phantom pair 0)', async () => {
@@ -583,7 +639,7 @@ describe('RankingPairwiseComponent', () => {
     // Re-adding Item A from unassigned must generate a fresh suffix (_2), not
     // reuse _0 and silently relocate the restored 'Item A_0' entry.
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-2-high'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-2-high'));
     });
     expect(onChange).toHaveBeenCalledWith({
       'Item A_0': 'pair-1-high',
@@ -613,7 +669,7 @@ describe('RankingPairwiseComponent', () => {
     // With includes('_') detection, 'new_york' would be treated as an existing
     // instance and written without a counter suffix.
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('new_york', 'pair-0-high'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('new_york'), 'pair-0-high'));
     });
     expect(onChange).toHaveBeenCalledWith({ new_york_0: 'pair-0-high' });
   });
@@ -632,7 +688,7 @@ describe('RankingPairwiseComponent', () => {
     // If 'route_66' were parsed as instance 66 of 'route', the counter would jump
     // to 67; it must stay at 0 for the first generated instance.
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item B', 'pair-0-low'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item B'), 'pair-0-low'));
     });
     expect(onChange).toHaveBeenCalledWith({
       route_66: 'pair-0-high',
@@ -661,7 +717,7 @@ describe('RankingPairwiseComponent', () => {
     // Without resyncing, the counter would still be 0 and this drag would emit
     // 'Item A_0', overwriting the restored key.
     await act(async () => {
-      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-2-high'));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-2-high'));
     });
     expect(onChange).toHaveBeenCalledWith({
       'Item A_0': 'pair-1-high',

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -176,9 +176,13 @@ function pairwisePlacedDragId(instanceId: string) {
   return `placed:${instanceId}`;
 }
 
-// Generated instance keys are tagged (see makeRankingInstanceKey)
 function rankingInstanceKey(baseItemId: string, instanceIndex: number) {
   return `instance-${instanceIndex}-${baseItemId}`;
+}
+
+function makePairwiseAnswer(value: Record<string, string> = {}) {
+  const onChange = vi.fn();
+  return { answer: { value, onChange }, onChange };
 }
 
 // ══ RankingSublistComponent ══════════════════════════════════════════════════
@@ -434,7 +438,6 @@ describe('RankingPairwiseComponent', () => {
     const addBtn = buttons.find((b) => b.textContent === 'Add New Pair');
     expect(addBtn).toBeDefined();
     await act(async () => { fireEvent.click(addBtn!); });
-    // Should have added a new pair without error
     expect(getAllByRole('button').length).toBeGreaterThan(0);
   });
 
@@ -469,11 +472,7 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('handleDragEnd: drop to unassigned removes item from pair', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { 'Item A_0': 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A_0': 'pair-0-high' });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
@@ -484,7 +483,7 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('instances of "model" are never confused with the option "model_0"', async () => {
-    const onChange = vi.fn();
+    const { answer, onChange } = makePairwiseAnswer();
     const response = makeResponse('ranking-pairwise', {
       options: [
         { label: 'Original model', value: 'model' },
@@ -495,11 +494,9 @@ describe('RankingPairwiseComponent', () => {
       <RankingInput
         {...baseProps}
         response={response}
-        answer={{ value: {}, onChange } as unknown as { value: Record<string, string> }}
+        answer={answer}
       />,
     );
-    // The generated instance key is a tagged tuple, not the legacy 'model_0'
-    // string that would collide with the real option value
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('model'), 'pair-0-high'));
     });
@@ -517,43 +514,45 @@ describe('RankingPairwiseComponent', () => {
     const { getAllByText } = render(
       <RankingInput {...baseProps} response={response} answer={answer} />,
     );
-    // Once in the pair slot, once in Available Items
     expect(getAllByText('Original model').length).toBe(2);
-    // 'Model 0' only appears in Available Items
     expect(getAllByText('Model 0').length).toBe(1);
   });
 
   test('generated keys skip indices that collide with a configured option value', async () => {
-    const onChange = vi.fn();
-    // Pathological config: an option literally named like a generated key
+    const { answer, onChange } = makePairwiseAnswer();
     const response = makeResponse('ranking-pairwise', { options: ['model', 'instance-0-model'] });
     render(
       <RankingInput
         {...baseProps}
         response={response}
-        answer={{ value: {}, onChange } as unknown as { value: Record<string, string> }}
+        answer={answer}
       />,
     );
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('model'), 'pair-0-high'));
     });
-    // index 0 would produce the option value 'instance-0-model'; the guard
-    // bumps to index 1
     expect(onChange).toHaveBeenCalledWith({ 'instance-1-model': 'pair-0-high' });
   });
 
-  test('moving an assigned plain default key moves it instead of duplicating', async () => {
-    const onChange = vi.fn();
-    // Defaults are documented as plain option-value keys; moving the placed
-    // default must relocate it, not treat it as a fresh drop from Available
-    // Items that would leave the original behind.
-    const answer = {
-      value: { 'Item A': 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+  test('an occupied slot rejects the same option dropped from Available Items', async () => {
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A': 'pair-0-high' });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-0-high'));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('moving an assigned plain default key moves it instead of duplicating', async () => {
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A': 'pair-0-high' });
+    const { getByRole } = render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
+    });
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId('Item A'), 'pair-1-high'));
     });
@@ -561,12 +560,12 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('handleDragEnd: drop from unassigned to pair-high', async () => {
-    const onChange = vi.fn();
+    const { answer, onChange } = makePairwiseAnswer();
     render(
       <RankingInput
         {...baseProps}
         response={makeResponse('ranking-pairwise')}
-        answer={{ value: {}, onChange } as unknown as { value: Record<string, string> }}
+        answer={answer}
       />,
     );
     await act(async () => {
@@ -576,49 +575,33 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('handleDragEnd: position already occupied (one item limit)', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { 'Item A_0': 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A_0': 'pair-0-high' });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
     await act(async () => {
-      // Try to drop another item into pair-0-high which already has an item
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item B'), 'pair-0-high'));
     });
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('handleDragEnd: same item in opposite position error', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { 'Item A_0': 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A_0': 'pair-0-high' });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
     await act(async () => {
-      // Try to drop Item A into the opposite position (pair-0-low)
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-0-low'));
     });
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('handleDragEnd: duplicate pair detection (covers checkForDuplicatePair)', async () => {
-    const onChange = vi.fn();
-    // pair-0 = {A, B}; pair-1 already holds A, so completing it with B would
-    // duplicate pair-0 and the drop must be rejected
-    const answer = {
-      value: {
-        'Item A_0': 'pair-0-high',
-        'Item B_1': 'pair-0-low',
-        'Item A_2': 'pair-1-high',
-      },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({
+      'Item A_0': 'pair-0-high',
+      'Item B_1': 'pair-0-low',
+      'Item A_2': 'pair-1-high',
+    });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
@@ -627,7 +610,6 @@ describe('RankingPairwiseComponent', () => {
     });
     expect(onChange).not.toHaveBeenCalled();
 
-    // A non-duplicating completion (Item C) is accepted
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item C'), 'pair-1-low'));
     });
@@ -640,16 +622,12 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('dropping onto an item card is ignored', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { [rankingInstanceKey('Item A', 0)]: 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+    });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
-    // Dropping onto another item card (not a zone) must not store the card's
-    // drag id as an answer location
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(
         pairwiseAvailableDragId('Item B'),
@@ -666,18 +644,14 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('moving a placed item cannot create a duplicate pair', async () => {
-    const onChange = vi.fn();
     // pair-0 = {A, B}, pair-1 = {A}, pair-2 = {B}; moving B from pair-2 into
     // pair-1 would make pair-1 a duplicate of the intact pair-0
-    const answer = {
-      value: {
-        [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
-        [rankingInstanceKey('Item B', 1)]: 'pair-0-low',
-        [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
-        [rankingInstanceKey('Item B', 3)]: 'pair-2-high',
-      },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+      [rankingInstanceKey('Item B', 1)]: 'pair-0-low',
+      [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
+      [rankingInstanceKey('Item B', 3)]: 'pair-2-high',
+    });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
@@ -688,17 +662,13 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('moving a placed item that breaks its source pair is allowed', async () => {
-    const onChange = vi.fn();
     // pair-0 = {A, B}, pair-1 = {A}; moving B out of pair-0 into pair-1 leaves
     // pair-0 = {A}, so the result is not a duplicate
-    const answer = {
-      value: {
-        [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
-        [rankingInstanceKey('Item B', 1)]: 'pair-0-low',
-        [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
-      },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+      [rankingInstanceKey('Item B', 1)]: 'pair-0-low',
+      [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
+    });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
@@ -713,15 +683,12 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('an item can move between HIGH and LOW within its own pair', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { [rankingInstanceKey('Item A', 0)]: 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+    });
     render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
-    // The moving instance itself must not count as "already in the opposite side"
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId(rankingInstanceKey('Item A', 0)), 'pair-0-low'));
     });
@@ -729,16 +696,13 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('handleDragEnd: move existing positioned item to a new pair position', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { 'Item A_0': 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
-    render(
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A_0': 'pair-0-high' });
+    const { getByRole } = render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
-    // Move an already-placed instance to a different pair — the key is kept,
-    // only its location changes
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
+    });
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId('Item A_0'), 'pair-1-high'));
     });
@@ -762,11 +726,7 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('restored answer: Add New Pair targets a fresh pair id, not an existing one', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { 'Item A_0': 'pair-1-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({ 'Item A_0': 'pair-1-high' });
     const { getAllByRole } = render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
@@ -781,16 +741,16 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('restored answer: new instance keys never overwrite existing keys', async () => {
-    const onChange = vi.fn();
-    const answer = {
-      value: { 'Item A_0': 'pair-1-high', 'Item B_1': 'pair-1-low' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
-    render(
+    const { answer, onChange } = makePairwiseAnswer({
+      'Item A_0': 'pair-1-high',
+      'Item B_1': 'pair-1-low',
+    });
+    const { getByRole } = render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
     );
-    // Re-adding Item A from unassigned must generate a fresh suffix (_2), not
-    // reuse _0 and silently relocate the restored 'Item A_0' entry.
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
+    });
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-2-high'));
     });
@@ -813,9 +773,8 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('option values containing underscores drag from unassigned as new instances', async () => {
-    const onChange = vi.fn();
+    const { answer, onChange } = makePairwiseAnswer();
     const response = makeResponse('ranking-pairwise', { options: ['new_york', 'other_option'] });
-    const answer = { value: {}, onChange } as unknown as { value: Record<string, string> };
     render(
       <RankingInput {...baseProps} response={response} answer={answer} />,
     );
@@ -828,13 +787,8 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('option value ending in digits is not mistaken for a generated instance', async () => {
-    const onChange = vi.fn();
     const response = makeResponse('ranking-pairwise', { options: ['route_66', 'Item B'] });
-    // Default-style answer keyed by the plain option value
-    const answer = {
-      value: { route_66: 'pair-0-high' },
-      onChange,
-    } as unknown as { value: Record<string, string> };
+    const { answer, onChange } = makePairwiseAnswer({ route_66: 'pair-0-high' });
     render(
       <RankingInput {...baseProps} response={response} answer={answer} />,
     );
@@ -871,9 +825,8 @@ describe('RankingPairwiseComponent', () => {
   });
 
   test('counters resync when answer.value is replaced while mounted', async () => {
-    const onChange = vi.fn();
-    const emptyAnswer = { value: {}, onChange } as unknown as { value: Record<string, string> };
-    const { rerender } = render(
+    const { answer: emptyAnswer, onChange } = makePairwiseAnswer();
+    const { rerender, getByRole } = render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={emptyAnswer} />,
     );
 
@@ -881,11 +834,14 @@ describe('RankingPairwiseComponent', () => {
     const restoredAnswer = {
       value: { 'Item A_0': 'pair-1-high', 'Item B_1': 'pair-1-low' },
       onChange,
-    } as unknown as { value: Record<string, string> };
+    };
     await act(async () => {
       rerender(
         <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={restoredAnswer} />,
       );
+    });
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
     });
 
     // Without resyncing, the counter would still be 0 and this drag would emit

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -592,6 +592,32 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('option values containing underscores render inside pairs', () => {
+    const response = makeResponse('ranking-pairwise', { options: ['new_york', 'other_option'] });
+    const answer = { value: { new_york_0: 'pair-0-high' } };
+    const { getAllByText } = render(
+      <RankingInput {...baseProps} response={response} answer={answer} />,
+    );
+    // Once in the pair slot, once in the Available Items list — with naive
+    // underscore splitting the pair slot entry resolves to 'new' and disappears.
+    expect(getAllByText('new_york').length).toBe(2);
+  });
+
+  test('option values containing underscores drag from unassigned as new instances', async () => {
+    const onChange = vi.fn();
+    const response = makeResponse('ranking-pairwise', { options: ['new_york', 'other_option'] });
+    const answer = { value: {}, onChange } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={response} answer={answer} />,
+    );
+    // With includes('_') detection, 'new_york' would be treated as an existing
+    // instance and written without a counter suffix.
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd('new_york', 'pair-0-high'));
+    });
+    expect(onChange).toHaveBeenCalledWith({ new_york_0: 'pair-0-high' });
+  });
+
   test('option value ending in digits is not mistaken for a generated instance', async () => {
     const onChange = vi.fn();
     const response = makeResponse('ranking-pairwise', { options: ['route_66', 'Item B'] });

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -621,6 +621,45 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('duplicate pair detection does not collide on delimiter characters in option values', async () => {
+    const response = makeResponse('ranking-pairwise', { options: ['a', 'b|c', 'a|b', 'c'] });
+    const { answer, onChange } = makePairwiseAnswer({
+      [rankingInstanceKey('a', 0)]: 'pair-0-high',
+      [rankingInstanceKey('b|c', 1)]: 'pair-0-low',
+      [rankingInstanceKey('a|b', 2)]: 'pair-1-high',
+    });
+    render(<RankingInput {...baseProps} response={response} answer={answer} />);
+
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('c'), 'pair-1-low'));
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      [rankingInstanceKey('a', 0)]: 'pair-0-high',
+      [rankingInstanceKey('b|c', 1)]: 'pair-0-low',
+      [rankingInstanceKey('a|b', 2)]: 'pair-1-high',
+      [rankingInstanceKey('c', 3)]: 'pair-1-low',
+    });
+  });
+
+  test('matching unfinished pairs remain allowed until both pairs are complete', async () => {
+    const { answer, onChange } = makePairwiseAnswer({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+    });
+    const { getByRole } = render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-1-high'));
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+      [rankingInstanceKey('Item A', 1)]: 'pair-1-high',
+    });
+  });
+
   test('dropping onto an item card is ignored', async () => {
     const { answer, onChange } = makePairwiseAnswer({
       [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
@@ -803,6 +842,30 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('an empty option value remains visible and draggable as a tagged instance', async () => {
+    const response = makeResponse('ranking-pairwise', {
+      options: [{ label: 'No value', value: '' }, 'Item B'],
+    });
+    const { answer, onChange } = makePairwiseAnswer();
+    const { getAllByText, rerender } = render(
+      <RankingInput {...baseProps} response={response} answer={answer} />,
+    );
+
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId(''), 'pair-0-high'));
+    });
+    expect(onChange).toHaveBeenCalledWith({ [rankingInstanceKey('', 0)]: 'pair-0-high' });
+
+    rerender(
+      <RankingInput
+        {...baseProps}
+        response={response}
+        answer={{ value: { [rankingInstanceKey('', 0)]: 'pair-0-high' } }}
+      />,
+    );
+    expect(getAllByText('No value').length).toBe(2);
+  });
+
   test('async restoration replaces the untouched default pair 0 row', async () => {
     const { rerender, getAllByRole } = render(
       <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={{ value: {} }} />,
@@ -822,6 +885,113 @@ describe('RankingPairwiseComponent', () => {
     // The restored pair 1 replaces the untouched placeholder — no phantom
     // empty pair 0 row remains
     expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+  });
+
+  test('authoritative answer replacement removes stale restored pair rows', async () => {
+    const { rerender, getAllByRole } = render(
+      <RankingInput
+        {...baseProps}
+        response={makeResponse('ranking-pairwise')}
+        answer={{ value: { [rankingInstanceKey('Item A', 0)]: 'pair-1-high' } }}
+      />,
+    );
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+
+    await act(async () => {
+      rerender(
+        <RankingInput
+          {...baseProps}
+          response={makeResponse('ranking-pairwise')}
+          answer={{ value: { [rankingInstanceKey('Item B', 1)]: 'pair-2-high' } }}
+        />,
+      );
+    });
+
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+  });
+
+  test('authoritative replacement discards locally added empty rows', async () => {
+    const { rerender, getAllByRole, getByRole } = render(
+      <RankingInput
+        {...baseProps}
+        response={makeResponse('ranking-pairwise')}
+        answer={{ value: { [rankingInstanceKey('Item A', 0)]: 'pair-1-high' } }}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
+    });
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(2);
+
+    await act(async () => {
+      rerender(
+        <RankingInput
+          {...baseProps}
+          response={makeResponse('ranking-pairwise')}
+          answer={{ value: { [rankingInstanceKey('Item B', 1)]: 'pair-3-high' } }}
+        />,
+      );
+    });
+
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+  });
+
+  test('semantically unchanged answer props retain locally added empty rows', async () => {
+    const restoredValue = { [rankingInstanceKey('Item A', 0)]: 'pair-1-high' };
+    const { rerender, getAllByRole, getByRole } = render(
+      <RankingInput
+        {...baseProps}
+        response={makeResponse('ranking-pairwise')}
+        answer={{ value: restoredValue }}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Add New Pair' }));
+    });
+
+    await act(async () => {
+      rerender(
+        <RankingInput
+          {...baseProps}
+          response={makeResponse('ranking-pairwise')}
+          answer={{ value: { ...restoredValue } }}
+        />,
+      );
+    });
+
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(2);
+  });
+
+  test('authoritative replacement with an empty answer restores one placeholder row', async () => {
+    const { rerender, getAllByRole } = render(
+      <RankingInput
+        {...baseProps}
+        response={makeResponse('ranking-pairwise')}
+        answer={{ value: { [rankingInstanceKey('Item A', 0)]: 'pair-1-high' } }}
+      />,
+    );
+
+    await act(async () => {
+      rerender(
+        <RankingInput
+          {...baseProps}
+          response={makeResponse('ranking-pairwise')}
+          answer={{ value: {} }}
+        />,
+      );
+    });
+
+    expect(getAllByRole('button').filter((b) => b.textContent === 'X').length).toBe(1);
+  });
+
+  test('non-string restored locations do not crash pair rendering', () => {
+    expect(() => render(
+      <RankingInput
+        {...baseProps}
+        response={makeResponse('ranking-pairwise')}
+        answer={{ value: { 'Item A': null } as unknown as Record<string, string> }}
+      />,
+    )).not.toThrow();
   });
 
   test('counters resync when answer.value is replaced while mounted', async () => {

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -639,6 +639,53 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('moving a placed item cannot create a duplicate pair', async () => {
+    const onChange = vi.fn();
+    // pair-0 = {A, B}, pair-1 = {A}, pair-2 = {B}; moving B from pair-2 into
+    // pair-1 would make pair-1 a duplicate of the intact pair-0
+    const answer = {
+      value: {
+        [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+        [rankingInstanceKey('Item B', 1)]: 'pair-0-low',
+        [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
+        [rankingInstanceKey('Item B', 3)]: 'pair-2-high',
+      },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId(rankingInstanceKey('Item B', 3)), 'pair-1-low'));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('moving a placed item that breaks its source pair is allowed', async () => {
+    const onChange = vi.fn();
+    // pair-0 = {A, B}, pair-1 = {A}; moving B out of pair-0 into pair-1 leaves
+    // pair-0 = {A}, so the result is not a duplicate
+    const answer = {
+      value: {
+        [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+        [rankingInstanceKey('Item B', 1)]: 'pair-0-low',
+        [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
+      },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId(rankingInstanceKey('Item B', 1)), 'pair-1-low'));
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      [rankingInstanceKey('Item A', 0)]: 'pair-0-high',
+      [rankingInstanceKey('Item A', 2)]: 'pair-1-high',
+      [rankingInstanceKey('Item B', 1)]: 'pair-1-low',
+    });
+  });
+
   test('an item can move between HIGH and LOW within its own pair', async () => {
     const onChange = vi.fn();
     const answer = {

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -536,6 +536,114 @@ describe('RankingPairwiseComponent', () => {
     expect(capturedOnDragEnd).toBeDefined();
   });
 
+  test('restored answer initializes pair rows from answer.value (no phantom pair 0)', async () => {
+    const answer = { value: { 'Item A_0': 'pair-1-high' } };
+    const { getAllByRole } = render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    // Only the restored pair-1 row should render; without restoration a default
+    // empty pair-0 row would appear alongside it.
+    let xButtons = getAllByRole('button').filter((b) => b.textContent === 'X');
+    expect(xButtons.length).toBe(1);
+
+    const addBtn = getAllByRole('button').find((b) => b.textContent === 'Add New Pair');
+    await act(async () => { fireEvent.click(addBtn!); });
+    xButtons = getAllByRole('button').filter((b) => b.textContent === 'X');
+    expect(xButtons.length).toBe(2);
+  });
+
+  test('restored answer: Add New Pair targets a fresh pair id, not an existing one', async () => {
+    const onChange = vi.fn();
+    const answer = {
+      value: { 'Item A_0': 'pair-1-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    const { getAllByRole } = render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    const addBtn = getAllByRole('button').find((b) => b.textContent === 'Add New Pair');
+    await act(async () => { fireEvent.click(addBtn!); });
+
+    // Removing the newly added pair must leave the restored pair-1 data intact;
+    // if Add had reused pair id 1, this would wipe 'Item A_0'.
+    const xButtons = getAllByRole('button').filter((b) => b.textContent === 'X');
+    await act(async () => { fireEvent.click(xButtons[xButtons.length - 1]!); });
+    expect(onChange).toHaveBeenCalledWith({ 'Item A_0': 'pair-1-high' });
+  });
+
+  test('restored answer: new instance keys never overwrite existing keys', async () => {
+    const onChange = vi.fn();
+    const answer = {
+      value: { 'Item A_0': 'pair-1-high', 'Item B_1': 'pair-1-low' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    // Re-adding Item A from unassigned must generate a fresh suffix (_2), not
+    // reuse _0 and silently relocate the restored 'Item A_0' entry.
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-2-high'));
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      'Item A_0': 'pair-1-high',
+      'Item B_1': 'pair-1-low',
+      'Item A_2': 'pair-2-high',
+    });
+  });
+
+  test('option value ending in digits is not mistaken for a generated instance', async () => {
+    const onChange = vi.fn();
+    const response = makeResponse('ranking-pairwise', { options: ['route_66', 'Item B'] });
+    // Default-style answer keyed by the plain option value
+    const answer = {
+      value: { route_66: 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={response} answer={answer} />,
+    );
+    // If 'route_66' were parsed as instance 66 of 'route', the counter would jump
+    // to 67; it must stay at 0 for the first generated instance.
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd('Item B', 'pair-0-low'));
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      route_66: 'pair-0-high',
+      'Item B_0': 'pair-0-low',
+    });
+  });
+
+  test('counters resync when answer.value is replaced while mounted', async () => {
+    const onChange = vi.fn();
+    const emptyAnswer = { value: {}, onChange } as unknown as { value: Record<string, string> };
+    const { rerender } = render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={emptyAnswer} />,
+    );
+
+    // Simulate an async answer restoration after mount
+    const restoredAnswer = {
+      value: { 'Item A_0': 'pair-1-high', 'Item B_1': 'pair-1-low' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    await act(async () => {
+      rerender(
+        <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={restoredAnswer} />,
+      );
+    });
+
+    // Without resyncing, the counter would still be 0 and this drag would emit
+    // 'Item A_0', overwriting the restored key.
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd('Item A', 'pair-2-high'));
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      'Item A_0': 'pair-1-high',
+      'Item B_1': 'pair-1-low',
+      'Item A_2': 'pair-2-high',
+    });
+  });
+
   test('handleRemovePair via X button', async () => {
     const answer = { value: { 'Item A_0': 'pair-0-high' } };
     const { getAllByRole } = render(

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -639,6 +639,22 @@ describe('RankingPairwiseComponent', () => {
     });
   });
 
+  test('an item can move between HIGH and LOW within its own pair', async () => {
+    const onChange = vi.fn();
+    const answer = {
+      value: { [rankingInstanceKey('Item A', 0)]: 'pair-0-high' },
+      onChange,
+    } as unknown as { value: Record<string, string> };
+    render(
+      <RankingInput {...baseProps} response={makeResponse('ranking-pairwise')} answer={answer} />,
+    );
+    // The moving instance itself must not count as "already in the opposite side"
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwisePlacedDragId(rankingInstanceKey('Item A', 0)), 'pair-0-low'));
+    });
+    expect(onChange).toHaveBeenCalledWith({ [rankingInstanceKey('Item A', 0)]: 'pair-0-low' });
+  });
+
   test('handleDragEnd: move existing positioned item to a new pair position', async () => {
     const onChange = vi.fn();
     const answer = {

--- a/src/components/response/tests/RankingInput.spec.tsx
+++ b/src/components/response/tests/RankingInput.spec.tsx
@@ -176,6 +176,11 @@ function pairwisePlacedDragId(instanceId: string) {
   return `placed:${instanceId}`;
 }
 
+// Generated instance keys are tagged (see makeRankingInstanceKey)
+function rankingInstanceKey(baseItemId: string, instanceIndex: number) {
+  return `instance-${instanceIndex}-${baseItemId}`;
+}
+
 // ══ RankingSublistComponent ══════════════════════════════════════════════════
 
 describe('RankingSublistComponent', () => {
@@ -478,6 +483,65 @@ describe('RankingPairwiseComponent', () => {
     expect(onChange).toHaveBeenCalledWith({});
   });
 
+  test('instances of "model" are never confused with the option "model_0"', async () => {
+    const onChange = vi.fn();
+    const response = makeResponse('ranking-pairwise', {
+      options: [
+        { label: 'Original model', value: 'model' },
+        { label: 'Model 0', value: 'model_0' },
+      ],
+    });
+    render(
+      <RankingInput
+        {...baseProps}
+        response={response}
+        answer={{ value: {}, onChange } as unknown as { value: Record<string, string> }}
+      />,
+    );
+    // The generated instance key is a tagged tuple, not the legacy 'model_0'
+    // string that would collide with the real option value
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('model'), 'pair-0-high'));
+    });
+    expect(onChange).toHaveBeenCalledWith({ [rankingInstanceKey('model', 0)]: 'pair-0-high' });
+  });
+
+  test('a placed instance of "model" renders as its own label, not "Model 0"', () => {
+    const response = makeResponse('ranking-pairwise', {
+      options: [
+        { label: 'Original model', value: 'model' },
+        { label: 'Model 0', value: 'model_0' },
+      ],
+    });
+    const answer = { value: { [rankingInstanceKey('model', 0)]: 'pair-0-high' } };
+    const { getAllByText } = render(
+      <RankingInput {...baseProps} response={response} answer={answer} />,
+    );
+    // Once in the pair slot, once in Available Items
+    expect(getAllByText('Original model').length).toBe(2);
+    // 'Model 0' only appears in Available Items
+    expect(getAllByText('Model 0').length).toBe(1);
+  });
+
+  test('generated keys skip indices that collide with a configured option value', async () => {
+    const onChange = vi.fn();
+    // Pathological config: an option literally named like a generated key
+    const response = makeResponse('ranking-pairwise', { options: ['model', 'instance-0-model'] });
+    render(
+      <RankingInput
+        {...baseProps}
+        response={response}
+        answer={{ value: {}, onChange } as unknown as { value: Record<string, string> }}
+      />,
+    );
+    await act(async () => {
+      capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('model'), 'pair-0-high'));
+    });
+    // index 0 would produce the option value 'instance-0-model'; the guard
+    // bumps to index 1
+    expect(onChange).toHaveBeenCalledWith({ 'instance-1-model': 'pair-0-high' });
+  });
+
   test('moving an assigned plain default key moves it instead of duplicating', async () => {
     const onChange = vi.fn();
     // Defaults are documented as plain option-value keys; moving the placed
@@ -508,7 +572,7 @@ describe('RankingPairwiseComponent', () => {
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('Item A'), 'pair-0-high'));
     });
-    expect(onChange).toHaveBeenCalledWith({ 'Item A_0': 'pair-0-high' });
+    expect(onChange).toHaveBeenCalledWith({ [rankingInstanceKey('Item A', 0)]: 'pair-0-high' });
   });
 
   test('handleDragEnd: position already occupied (one item limit)', async () => {
@@ -571,7 +635,7 @@ describe('RankingPairwiseComponent', () => {
       'Item A_0': 'pair-0-high',
       'Item B_1': 'pair-0-low',
       'Item A_2': 'pair-1-high',
-      'Item C_3': 'pair-1-low',
+      [rankingInstanceKey('Item C', 3)]: 'pair-1-low',
     });
   });
 
@@ -644,7 +708,7 @@ describe('RankingPairwiseComponent', () => {
     expect(onChange).toHaveBeenCalledWith({
       'Item A_0': 'pair-1-high',
       'Item B_1': 'pair-1-low',
-      'Item A_2': 'pair-2-high',
+      [rankingInstanceKey('Item A', 2)]: 'pair-2-high',
     });
   });
 
@@ -671,7 +735,7 @@ describe('RankingPairwiseComponent', () => {
     await act(async () => {
       capturedOnDragEnd?.(makeDragEnd(pairwiseAvailableDragId('new_york'), 'pair-0-high'));
     });
-    expect(onChange).toHaveBeenCalledWith({ new_york_0: 'pair-0-high' });
+    expect(onChange).toHaveBeenCalledWith({ [rankingInstanceKey('new_york', 0)]: 'pair-0-high' });
   });
 
   test('option value ending in digits is not mistaken for a generated instance', async () => {
@@ -692,7 +756,7 @@ describe('RankingPairwiseComponent', () => {
     });
     expect(onChange).toHaveBeenCalledWith({
       route_66: 'pair-0-high',
-      'Item B_0': 'pair-0-low',
+      [rankingInstanceKey('Item B', 0)]: 'pair-0-low',
     });
   });
 
@@ -722,7 +786,7 @@ describe('RankingPairwiseComponent', () => {
     expect(onChange).toHaveBeenCalledWith({
       'Item A_0': 'pair-1-high',
       'Item B_1': 'pair-1-low',
-      'Item A_2': 'pair-2-high',
+      [rankingInstanceKey('Item A', 2)]: 'pair-2-high',
     });
   });
 

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -488,14 +488,12 @@ describe('validateResponse', () => {
       blocksProgression: true,
     });
 
-    // Only one half of a pair is filled
     expect(validateResponse(response, { A_0: 'pair-0-high' }, { ranking: { A_0: 'pair-0-high' } })).toMatchObject({
       issueType: 'invalid',
       message: 'Please complete at least one pair to continue.',
       blocksProgression: true,
     });
 
-    // Two halves in different pairs, but no single complete pair
     const splitPairs = { A_0: 'pair-0-high', B_1: 'pair-1-low' };
     expect(validateResponse(response, splitPairs, { ranking: splitPairs })).toMatchObject({
       issueType: 'invalid',
@@ -515,7 +513,6 @@ describe('validateResponse', () => {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C', 'D'],
     };
 
-    // pair-0 is complete but pair-1 only has a HIGH item
     const halfPair = { A_0: 'pair-0-high', B_1: 'pair-0-low', C_2: 'pair-1-high' };
     expect(validateResponse(response, halfPair, { ranking: halfPair })).toMatchObject({
       issueType: 'invalid',
@@ -529,28 +526,16 @@ describe('validateResponse', () => {
     expect(validateResponse(response, twoPairs, { ranking: twoPairs }).valid).toBe(true);
   });
 
-  test('pairwise ranking rejects malformed restored/default answers', () => {
+  test.each([
+    ['self-comparisons', { A_0: 'pair-0-high', A_1: 'pair-0-low' }],
+    ['multiple items in one slot', { A_0: 'pair-0-high', B_1: 'pair-0-high', C_2: 'pair-0-low' }],
+    ['unknown option IDs', { X_0: 'pair-0-high', Y_1: 'pair-0-low' }],
+  ])('pairwise ranking rejects %s in restored/default answers', (_caseName, value) => {
     const response: Response = {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C'],
     };
 
-    // Same option on both sides of a pair (self-comparison)
-    const selfPair = { A_0: 'pair-0-high', A_1: 'pair-0-low' };
-    expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
-      issueType: 'invalid',
-      message: 'Please complete at least one pair to continue.',
-    });
-
-    // Multiple items stuffed into one slot
-    const doubleSlot = { A_0: 'pair-0-high', B_1: 'pair-0-high', C_2: 'pair-0-low' };
-    expect(validateResponse(response, doubleSlot, { ranking: doubleSlot })).toMatchObject({
-      issueType: 'invalid',
-      message: 'Please complete at least one pair to continue.',
-    });
-
-    // Option ids that are not part of the configured options
-    const unknownIds = { X_0: 'pair-0-high', Y_1: 'pair-0-low' };
-    expect(validateResponse(response, unknownIds, { ranking: unknownIds })).toMatchObject({
+    expect(validateResponse(response, value, { ranking: value })).toMatchObject({
       issueType: 'invalid',
       message: 'Please complete at least one pair to continue.',
     });
@@ -561,15 +546,14 @@ describe('validateResponse', () => {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['new_york', 'los_angeles'],
     };
 
-    // Generated instance keys (`<option>_<counter>`) on underscore option values
+    // Legacy instance keys remain valid for option values containing underscores.
     const instanceKeys = { new_york_0: 'pair-0-high', los_angeles_1: 'pair-0-low' };
     expect(validateResponse(response, instanceKeys, { ranking: instanceKeys }).valid).toBe(true);
 
-    // Default answers use plain option values as keys (see RankingResponse docs)
+    // Configured defaults use plain option values as keys.
     const plainKeys = { new_york: 'pair-0-high', los_angeles: 'pair-0-low' };
     expect(validateResponse(response, plainKeys, { ranking: plainKeys }).valid).toBe(true);
 
-    // Self-pair still detected across differing key styles
     const selfPair = { new_york: 'pair-0-high', new_york_1: 'pair-0-low' };
     expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
       issueType: 'invalid',
@@ -581,20 +565,16 @@ describe('validateResponse', () => {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['model', 'model_0'],
     };
 
-    // A tagged instance of 'model' paired against the real option 'model_0' —
-    // two distinct items, valid (the legacy key 'model_0' would have been
-    // ambiguous here)
+    // Tagged keys distinguish a generated model instance from the configured model_0 option.
     const taggedPair = { 'instance-0-model': 'pair-0-high', model_0: 'pair-0-low' };
     expect(validateResponse(response, taggedPair, { ranking: taggedPair }).valid).toBe(true);
 
-    // A tagged instance of 'model' against the plain default key 'model' is a
-    // self-pair
     const selfPair = { 'instance-0-model': 'pair-0-high', model: 'pair-0-low' };
     expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
       issueType: 'invalid',
     });
 
-    // Legacy generated keys are still recognized when unambiguous
+    // Unambiguous legacy instance keys remain supported.
     const legacyPair = { model_66: 'pair-0-high', model_0: 'pair-0-low' };
     expect(validateResponse(response, legacyPair, { ranking: legacyPair }).valid).toBe(true);
   });
@@ -604,8 +584,6 @@ describe('validateResponse', () => {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['model', 'instance-0-model'],
     };
 
-    // Both entries are plain default keys; the configured option
-    // 'instance-0-model' must not be parsed as an instance of 'model'
     const pair = { 'instance-0-model': 'pair-0-high', model: 'pair-0-low' };
     expect(validateResponse(response, pair, { ranking: pair }).valid).toBe(true);
   });
@@ -615,7 +593,6 @@ describe('validateResponse', () => {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['e-bike', 'car'],
     };
 
-    // The option value sits at the end of the key, so its own hyphens are safe
     const pair = { 'instance-0-e-bike': 'pair-0-high', car: 'pair-0-low' };
     expect(validateResponse(response, pair, { ranking: pair }).valid).toBe(true);
 

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -510,6 +510,25 @@ describe('validateResponse', () => {
     });
   });
 
+  test('pairwise ranking requires every pair to be complete', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C', 'D'],
+    };
+
+    // pair-0 is complete but pair-1 only has a HIGH item
+    const halfPair = { A_0: 'pair-0-high', B_1: 'pair-0-low', C_2: 'pair-1-high' };
+    expect(validateResponse(response, halfPair, { ranking: halfPair })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete or remove unfinished pairs to continue.',
+      blocksProgression: true,
+    });
+
+    const twoPairs = {
+      A_0: 'pair-0-high', B_1: 'pair-0-low', C_2: 'pair-1-high', D_3: 'pair-1-low',
+    };
+    expect(validateResponse(response, twoPairs, { ranking: twoPairs }).valid).toBe(true);
+  });
+
   test('pairwise ranking rejects malformed restored/default answers', () => {
     const response: Response = {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C'],

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -526,6 +526,24 @@ describe('validateResponse', () => {
     expect(validateResponse(response, twoPairs, { ranking: twoPairs }).valid).toBe(true);
   });
 
+  test('pairwise ranking rejects duplicate restored/default pairs', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B'],
+    };
+    const duplicatePairs = {
+      A_0: 'pair-0-high',
+      B_1: 'pair-0-low',
+      B_2: 'pair-1-high',
+      A_3: 'pair-1-low',
+    };
+
+    expect(validateResponse(response, duplicatePairs, { ranking: duplicatePairs })).toMatchObject({
+      issueType: 'invalid',
+      message: 'This would create a duplicate pair.',
+      blocksProgression: true,
+    });
+  });
+
   test.each([
     ['self-comparisons', { A_0: 'pair-0-high', A_1: 'pair-0-low' }],
     ['multiple items in one slot', { A_0: 'pair-0-high', B_1: 'pair-0-high', C_2: 'pair-0-low' }],

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -580,6 +580,17 @@ describe('validateResponse', () => {
     expect(validateResponse(response, legacyPair, { ranking: legacyPair }).valid).toBe(true);
   });
 
+  test('an option value that looks like a tagged key resolves as itself', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['model', 'instance-0-model'],
+    };
+
+    // Both entries are plain default keys; the configured option
+    // 'instance-0-model' must not be parsed as an instance of 'model'
+    const pair = { 'instance-0-model': 'pair-0-high', model: 'pair-0-low' };
+    expect(validateResponse(response, pair, { ranking: pair }).valid).toBe(true);
+  });
+
   test('pairwise instance keys keep option values containing hyphens intact', () => {
     const response: Response = {
       id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['e-bike', 'car'],

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -557,6 +557,44 @@ describe('validateResponse', () => {
     });
   });
 
+  test('pairwise ranking distinguishes options "model" and "model_0" from generated instances', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['model', 'model_0'],
+    };
+
+    // A tagged instance of 'model' paired against the real option 'model_0' —
+    // two distinct items, valid (the legacy key 'model_0' would have been
+    // ambiguous here)
+    const taggedPair = { 'instance-0-model': 'pair-0-high', model_0: 'pair-0-low' };
+    expect(validateResponse(response, taggedPair, { ranking: taggedPair }).valid).toBe(true);
+
+    // A tagged instance of 'model' against the plain default key 'model' is a
+    // self-pair
+    const selfPair = { 'instance-0-model': 'pair-0-high', model: 'pair-0-low' };
+    expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
+      issueType: 'invalid',
+    });
+
+    // Legacy generated keys are still recognized when unambiguous
+    const legacyPair = { model_66: 'pair-0-high', model_0: 'pair-0-low' };
+    expect(validateResponse(response, legacyPair, { ranking: legacyPair }).valid).toBe(true);
+  });
+
+  test('pairwise instance keys keep option values containing hyphens intact', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['e-bike', 'car'],
+    };
+
+    // The option value sits at the end of the key, so its own hyphens are safe
+    const pair = { 'instance-0-e-bike': 'pair-0-high', car: 'pair-0-low' };
+    expect(validateResponse(response, pair, { ranking: pair }).valid).toBe(true);
+
+    const selfPair = { 'instance-0-e-bike': 'pair-0-high', 'e-bike': 'pair-0-low' };
+    expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
+      issueType: 'invalid',
+    });
+  });
+
   test('Mantine and progression adapters agree for required response states', () => {
     const response: Response = {
       ...requiredShortText,

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -544,6 +544,36 @@ describe('validateResponse', () => {
     });
   });
 
+  test('pairwise ranking rejects malformed restored/default locations', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C'],
+    };
+    const malformedLocation = {
+      A_0: 'pair-0-high',
+      B_1: 'pair-0-low',
+      C_2: 'bogus',
+    };
+
+    expect(validateResponse(response, malformedLocation, { ranking: malformedLocation })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete or remove invalid pairs to continue.',
+      blocksProgression: true,
+    });
+  });
+
+  test('pairwise ranking rejects non-string restored/default locations', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B'],
+    };
+    const malformedLocation = { A: null } as unknown as Record<string, string>;
+
+    expect(validateResponse(response, malformedLocation, { ranking: malformedLocation })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete or remove invalid pairs to continue.',
+      blocksProgression: true,
+    });
+  });
+
   test.each([
     ['self-comparisons', { A_0: 'pair-0-high', A_1: 'pair-0-low' }],
     ['multiple items in one slot', { A_0: 'pair-0-high', B_1: 'pair-0-high', C_2: 'pair-0-low' }],
@@ -618,6 +648,19 @@ describe('validateResponse', () => {
     expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
       issueType: 'invalid',
     });
+  });
+
+  test('pairwise instance keys support an empty configured option value', () => {
+    const response: Response = {
+      id: 'ranking',
+      prompt: 'Rank',
+      type: 'ranking-pairwise',
+      required: true,
+      options: [{ label: 'No value', value: '' }, 'B'],
+    };
+
+    const pair = { 'instance-0-': 'pair-0-high', B: 'pair-0-low' };
+    expect(validateResponse(response, pair, { ranking: pair }).valid).toBe(true);
   });
 
   test('Mantine and progression adapters agree for required response states', () => {

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -478,6 +478,38 @@ describe('validateResponse', () => {
     });
   });
 
+  test('pairwise ranking requires at least one complete pair', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: [],
+    };
+
+    expect(validateResponse(response, {}, { ranking: {} })).toMatchObject({
+      issueType: 'unanswered',
+      blocksProgression: true,
+    });
+
+    // Only one half of a pair is filled
+    expect(validateResponse(response, { A_0: 'pair-0-high' }, { ranking: { A_0: 'pair-0-high' } })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete at least one pair to continue.',
+      blocksProgression: true,
+    });
+
+    // Two halves in different pairs, but no single complete pair
+    const splitPairs = { A_0: 'pair-0-high', B_1: 'pair-1-low' };
+    expect(validateResponse(response, splitPairs, { ranking: splitPairs })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete at least one pair to continue.',
+    });
+
+    const completePair = { A_0: 'pair-0-high', B_1: 'pair-0-low' };
+    expect(validateResponse(response, completePair, { ranking: completePair })).toEqual({
+      valid: true,
+      issueType: 'none',
+      blocksProgression: false,
+    });
+  });
+
   test('Mantine and progression adapters agree for required response states', () => {
     const response: Response = {
       ...requiredShortText,

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -480,7 +480,7 @@ describe('validateResponse', () => {
 
   test('pairwise ranking requires at least one complete pair', () => {
     const response: Response = {
-      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: [],
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C'],
     };
 
     expect(validateResponse(response, {}, { ranking: {} })).toMatchObject({
@@ -507,6 +507,53 @@ describe('validateResponse', () => {
       valid: true,
       issueType: 'none',
       blocksProgression: false,
+    });
+  });
+
+  test('pairwise ranking rejects malformed restored/default answers', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['A', 'B', 'C'],
+    };
+
+    // Same option on both sides of a pair (self-comparison)
+    const selfPair = { A_0: 'pair-0-high', A_1: 'pair-0-low' };
+    expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete at least one pair to continue.',
+    });
+
+    // Multiple items stuffed into one slot
+    const doubleSlot = { A_0: 'pair-0-high', B_1: 'pair-0-high', C_2: 'pair-0-low' };
+    expect(validateResponse(response, doubleSlot, { ranking: doubleSlot })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete at least one pair to continue.',
+    });
+
+    // Option ids that are not part of the configured options
+    const unknownIds = { X_0: 'pair-0-high', Y_1: 'pair-0-low' };
+    expect(validateResponse(response, unknownIds, { ranking: unknownIds })).toMatchObject({
+      issueType: 'invalid',
+      message: 'Please complete at least one pair to continue.',
+    });
+  });
+
+  test('pairwise ranking handles option values containing underscores and plain default keys', () => {
+    const response: Response = {
+      id: 'ranking', prompt: 'Rank', type: 'ranking-pairwise', required: true, options: ['new_york', 'los_angeles'],
+    };
+
+    // Generated instance keys (`<option>_<counter>`) on underscore option values
+    const instanceKeys = { new_york_0: 'pair-0-high', los_angeles_1: 'pair-0-low' };
+    expect(validateResponse(response, instanceKeys, { ranking: instanceKeys }).valid).toBe(true);
+
+    // Default answers use plain option values as keys (see RankingResponse docs)
+    const plainKeys = { new_york: 'pair-0-high', los_angeles: 'pair-0-low' };
+    expect(validateResponse(response, plainKeys, { ranking: plainKeys }).valid).toBe(true);
+
+    // Self-pair still detected across differing key styles
+    const selfPair = { new_york: 'pair-0-high', new_york_1: 'pair-0-low' };
+    expect(validateResponse(response, selfPair, { ranking: selfPair })).toMatchObject({
+      issueType: 'invalid',
     });
   });
 

--- a/tests/demo-ranking-widget.spec.ts
+++ b/tests/demo-ranking-widget.spec.ts
@@ -244,6 +244,7 @@ test('Test ranking response(sublist, categorical, pairwise) and validation', asy
 
   await page.getByRole('button', { name: 'Add New Pair' }).click();
   await dragFromAvailableInPairwise(page, 'Ball State University', 'HIGH', 1);
+  await settleAfterDrag(page);
   await dragFromAvailableInPairwise(page, 'University of Rochester', 'LOW', 1);
   await settleAfterDrag(page);
   await expect(page.getByText('This would create a duplicate pair.')).toBeVisible();

--- a/tests/demo-ranking-widget.spec.ts
+++ b/tests/demo-ranking-widget.spec.ts
@@ -228,9 +228,19 @@ test('Test ranking response(sublist, categorical, pairwise) and validation', asy
   // Pairwise ranking
   // duplicate pair check, then valid non-duplicate pair and clear validation
   await expect(page.getByText('Rank the following options by pairing them up.')).toBeVisible();
+  const nextButton = page.getByRole('button', { name: 'Next', exact: true });
   await dragFromAvailableInPairwise(page, 'Ball State University', 'HIGH', 0);
+  await settleAfterDrag(page);
+  // An incomplete pair (HIGH filled, LOW empty) should not allow progression
+  await nextButton.click();
+  await expect(page.getByText('Please complete at least one pair to continue.')).toBeVisible();
+  await expect(page.getByText('Rank the following options by pairing them up.')).toBeVisible();
+  // Revealing errors smooth-scrolls to the unresolved question; wait for the
+  // scroll to settle so the next drag's coordinates are stable.
+  await page.waitForTimeout(600);
   await dragFromAvailableInPairwise(page, 'University of Rochester', 'LOW', 0);
   await settleAfterDrag(page);
+  await expect(page.getByText('Please complete at least one pair to continue.')).toHaveCount(0);
 
   await page.getByRole('button', { name: 'Add New Pair' }).click();
   await dragFromAvailableInPairwise(page, 'Ball State University', 'HIGH', 1);


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed
- Pairwise ranking now requires at least one complete pair to proceed
- Ranking widgets are disabled after the answer is finalized 

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="1710" height="948" alt="Screenshot 2026-07-28 at 2 33 37 PM" src="https://github.com/user-attachments/assets/180b1f92-31f8-4c3d-93d6-2ad7e9dbe9a7" />