### PR TITLE
Replace expanded sequence arrays with compact descriptors

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -41,6 +41,7 @@ import {
   resolveParticipantConditions,
 } from '../utils/handleConditionLogic';
 import { StartupErrorScreen } from './StartupErrorScreen';
+import { createCompactSequenceDescriptor } from '../utils/sequenceDescriptor';
 
 type StartupStorageStatus = Pick<StorageEngine, 'getEngine' | 'isConnected'>;
 
@@ -305,12 +306,13 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         await storageEngine.saveConfig(activeConfig);
 
-        const sequenceArray = await storageEngine.getSequenceArray();
+        const sequenceArtifact = await storageEngine.getSequenceArtifact();
 
-        if (!sequenceArray) {
-          const generatedSequenceArray = await generateSequenceArray(activeConfig);
-
-          await storageEngine.setSequenceArray(generatedSequenceArray);
+        if (!sequenceArtifact) {
+          const activeHash = await activeHashPromise;
+          await storageEngine.setSequenceDescriptor(
+            createCompactSequenceDescriptor(activeHash, activeConfig),
+          );
         }
 
         // Get or generate participant session

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -306,12 +306,12 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         await storageEngine.saveConfig(activeConfig);
 
-        const sequenceArtifact = await storageEngine.getSequenceArtifact();
+        const sequenceArtifactHash = await activeHashPromise;
+        const sequenceArtifact = await storageEngine.getSequenceArtifact(sequenceArtifactHash);
 
         if (!sequenceArtifact) {
-          const activeHash = await activeHashPromise;
           await storageEngine.setSequenceDescriptor(
-            createCompactSequenceDescriptor(activeHash, activeConfig),
+            createCompactSequenceDescriptor(sequenceArtifactHash, activeConfig),
           );
         }
 

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -297,7 +297,7 @@ describe('Shell', () => {
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
-      getSequenceArray: vi.fn().mockResolvedValue(['seq1']), // non-null → no setSequenceArray
+      getSequenceArtifact: vi.fn().mockResolvedValue(['seq1']),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue(baseSession),
       getParticipantCompletionStatus: vi.fn().mockResolvedValue(false),
@@ -312,14 +312,14 @@ describe('Shell', () => {
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
   });
 
-  test('calls setSequenceArray when getSequenceArray returns null', async () => {
+  test('publishes a compact descriptor when no sequence artifact exists', async () => {
     vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
 
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
-      getSequenceArray: vi.fn().mockResolvedValue(null), // null → calls setSequenceArray
-      setSequenceArray: vi.fn().mockResolvedValue(undefined),
+      getSequenceArtifact: vi.fn().mockResolvedValue(null),
+      setSequenceDescriptor: vi.fn().mockResolvedValue(undefined),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue(baseSession),
       getParticipantCompletionStatus: vi.fn().mockResolvedValue(false),
@@ -330,7 +330,13 @@ describe('Shell', () => {
     };
 
     render(<Shell globalConfig={globalConfig} />);
-    await waitFor(() => expect(mockStorageEngine!.setSequenceArray).toHaveBeenCalled(), { timeout: 3000 });
+    await waitFor(() => expect(mockStorageEngine!.setSequenceDescriptor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'revisit-compact-sequence',
+        version: 1,
+        numSequences: 1000,
+      }),
+    ), { timeout: 3000 });
   });
 
   test('covers study condition update path', async () => {
@@ -340,7 +346,7 @@ describe('Shell', () => {
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
-      getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
+      getSequenceArtifact: vi.fn().mockResolvedValue(['seq1']),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: true, dataSharingEnabled: true, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue({
         ...baseSession,
@@ -366,7 +372,7 @@ describe('Shell', () => {
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
-      getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
+      getSequenceArtifact: vi.fn().mockResolvedValue(['seq1']),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue({
         ...baseSession,

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -210,6 +210,8 @@ export abstract class StorageEngine {
 
   private assetUploadActivityVersion = 0;
 
+  private activeConfigHash: string | null = null;
+
   constructor(engine: typeof this.engine, testing: boolean) {
     this.engine = engine;
     this.testing = testing;
@@ -776,6 +778,7 @@ export abstract class StorageEngine {
     const currentConfigHash = await this._getCurrentConfigHash();
     // Hash the provided config
     const configHash = await hash(JSON.stringify(config));
+    this.activeConfigHash = configHash;
 
     // Skip saving config if the active config is already saved in storage
     if (currentConfigHash === configHash) {
@@ -792,17 +795,6 @@ export abstract class StorageEngine {
       config,
     );
     await this._cacheStorageObject(`configs/${configHash}`, 'config');
-
-    // Clear sequence array if the config has changed.
-    // Keep currentParticipantId so existing participant sessions can continue
-    // against their original participantConfigHash.
-    if (currentConfigHash && currentConfigHash !== configHash) {
-      try {
-        await this._deleteFromStorage('', 'sequenceArray');
-      } catch {
-        // pass, if this happens, we didn't have a sequence array yet
-      }
-    }
 
     if (currentConfigHash !== configHash) {
       await this._setCurrentConfigHash(configHash);
@@ -938,7 +930,8 @@ export abstract class StorageEngine {
     // Query all the intents to get a sequence and find our position in the queue
     sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
 
-    const sequenceArtifact = await this.getSequenceArtifact();
+    const configHash = await hash(JSON.stringify(config));
+    const sequenceArtifact = await this.getSequenceArtifact(configHash);
     if (!sequenceArtifact) {
       throw new Error('Study sequence is not initialized');
     }
@@ -948,7 +941,6 @@ export abstract class StorageEngine {
       sequenceCount = sequenceArtifact.length;
     } else {
       const descriptor = parseCompactSequenceDescriptor(sequenceArtifact);
-      const configHash = await hash(JSON.stringify(config));
       if (descriptor.configHash !== configHash) {
         throw new Error(
           'The stored sequence descriptor does not match this study config. '
@@ -1800,13 +1792,31 @@ export abstract class StorageEngine {
   }
 
   // Gets the versioned sequence artifact from the storage engine.
-  async getSequenceArtifact() {
+  async getSequenceArtifact(configHash?: string) {
     await this.verifyStudyDatabase();
 
-    const sequenceArtifact = await this._getFromStorage(
-      '',
+    const resolvedConfigHash = configHash ?? this.activeConfigHash;
+    let sequenceArtifact = await this._getFromStorage(
+      resolvedConfigHash ? `sequenceArrays/${resolvedConfigHash}` : '',
       'sequenceArray',
     );
+    if (
+      resolvedConfigHash
+      && (
+        sequenceArtifact === null
+        || sequenceArtifact === undefined
+        || (
+          typeof sequenceArtifact === 'object'
+          && !Array.isArray(sequenceArtifact)
+          && Object.keys(sequenceArtifact).length === 0
+        )
+      )
+    ) {
+      const currentConfigHash = await this._getCurrentConfigHash();
+      if (currentConfigHash === null || currentConfigHash === resolvedConfigHash) {
+        sequenceArtifact = await this._getFromStorage('', 'sequenceArray');
+      }
+    }
 
     if (
       sequenceArtifact === null
@@ -1830,8 +1840,8 @@ export abstract class StorageEngine {
   }
 
   // Gets a legacy expanded sequence array, if one is stored.
-  async getSequenceArray() {
-    const sequenceArtifact = await this.getSequenceArtifact();
+  async getSequenceArray(configHash?: string) {
+    const sequenceArtifact = await this.getSequenceArtifact(configHash);
     return Array.isArray(sequenceArtifact) ? sequenceArtifact : null;
   }
 
@@ -1846,7 +1856,13 @@ export abstract class StorageEngine {
   async setSequenceDescriptor(descriptor: CompactSequenceDescriptor) {
     await this.verifyStudyDatabase();
 
-    await this._pushToStorage('', 'sequenceArray', parseCompactSequenceDescriptor(descriptor));
+    const parsedDescriptor = parseCompactSequenceDescriptor(descriptor);
+    this.activeConfigHash = parsedDescriptor.configHash;
+    await this._pushToStorage(
+      `sequenceArrays/${parsedDescriptor.configHash}`,
+      'sequenceArray',
+      parsedDescriptor,
+    );
   }
 
   protected async __testingReset() {
@@ -1860,6 +1876,7 @@ export abstract class StorageEngine {
     this.failedAssetRetryOperations.clear();
     this.pendingProgressDataWrite = undefined;
     this.assetUploadActivityVersion = 0;
+    this.activeConfigHash = null;
     this.participantData = undefined;
     if (this.studyId) {
       await this.clearCurrentParticipantId();

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -19,6 +19,13 @@ import {
   SnapshotParticipantCounts,
   calculateSnapshotParticipantCounts,
 } from './utils/snapshotParticipantCounts';
+import {
+  CompactSequenceDescriptor,
+  SequenceArtifact,
+  isCompactSequenceDescriptor,
+  parseCompactSequenceDescriptor,
+  resolveCompactSequence,
+} from '../../utils/sequenceDescriptor';
 
 export interface StoredUser {
   email: string | null,
@@ -90,7 +97,7 @@ const defaultStageColor = '#F05A30';
 export type StorageObjectType = 'sequenceArray' | 'participantData' | 'config' | string;
 export type StorageObject<T extends StorageObjectType> =
   T extends 'sequenceArray'
-  ? Sequence[]
+  ? SequenceArtifact
   : T extends 'participantData'
   ? ParticipantData
   : T extends 'config'
@@ -867,7 +874,11 @@ export abstract class StorageEngine {
   // This function is one of the most critical functions in the storage engine.
   // It uses the notion of sequence intents and assignments to determine the current sequence for the participant.
   // It handles rejected participants and allows for reusing a rejected participant's sequence.
-  protected async _getSequence(conditions?: string[], bootstrapData?: ModesAndStageData) {
+  protected async _getSequence(
+    config: StudyConfig,
+    conditions?: string[],
+    bootstrapData?: ModesAndStageData,
+  ) {
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
@@ -927,35 +938,55 @@ export abstract class StorageEngine {
     // Query all the intents to get a sequence and find our position in the queue
     sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
 
-    // Get the latin square
-    const sequenceArray = await this.getSequenceArray();
-    if (!sequenceArray) {
-      throw new Error('Latin square not initialized');
+    const sequenceArtifact = await this.getSequenceArtifact();
+    if (!sequenceArtifact) {
+      throw new Error('Study sequence is not initialized');
     }
 
-    // Get the current row
-    const intentIndex = sequenceAssignments.filter((assignment) => !assignment.rejected).findIndex(
+    let sequenceCount: number;
+    if (Array.isArray(sequenceArtifact)) {
+      sequenceCount = sequenceArtifact.length;
+    } else {
+      const descriptor = parseCompactSequenceDescriptor(sequenceArtifact);
+      const configHash = await hash(JSON.stringify(config));
+      if (descriptor.configHash !== configHash) {
+        throw new Error(
+          'The stored sequence descriptor does not match this study config. '
+          + 'Republish the study sequence.',
+        );
+      }
+      sequenceCount = descriptor.numSequences;
+    }
+
+    if (sequenceCount === 0) {
+      throw new Error('Study sequence is empty');
+    }
+
+    let sequenceIndex = sequenceAssignments.filter((assignment) => !assignment.rejected).findIndex(
       (assignment) => assignment.participantId === this.currentParticipantId,
-    ) % sequenceArray.length;
-    if (sequenceArray.length === 0) {
-      throw new Error('Something really bad happened with sequence assignment');
+    );
+    const isUnassigned = sequenceIndex === -1;
+    if (isUnassigned) {
+      sequenceIndex = Math.floor(Math.random() * sequenceCount);
+    } else {
+      sequenceIndex %= sequenceCount;
     }
-    // If index = -1, we probably have data collection disabled. Give a random assignment.
-    if (intentIndex === -1) {
-      return {
-        currentRow: sequenceArray[Math.floor(Math.random() * sequenceArray.length)],
-        creationIndex: 1,
-      };
-    }
-    const currentRow = sequenceArray[intentIndex];
+
+    const currentRow = Array.isArray(sequenceArtifact)
+      ? sequenceArtifact[sequenceIndex]
+      : resolveCompactSequence(config, sequenceArtifact, sequenceIndex);
 
     if (!currentRow) {
-      throw new Error('Latin square is empty');
+      throw new Error('Study sequence is empty');
     }
 
     const creationSorted = sequenceAssignments.sort((a, b) => a.createdTime - b.createdTime);
 
-    const creationIndex = creationSorted.findIndex((assignment) => assignment.participantId === this.currentParticipantId) + 1;
+    const creationIndex = isUnassigned
+      ? 1
+      : creationSorted.findIndex(
+        (assignment) => assignment.participantId === this.currentParticipantId,
+      ) + 1;
 
     return { currentRow, creationIndex };
   }
@@ -1004,7 +1035,11 @@ export abstract class StorageEngine {
     const participantConfigHash = await hash(JSON.stringify(config));
     const parsedConditions = parseConditionParam(searchParams.condition);
     const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
-    const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData });
+    const { currentRow, creationIndex } = await this._getSequence(
+      config,
+      conditions,
+      { modes, stageData },
+    );
     this.participantData = {
       participantId: this.currentParticipantId,
       participantConfigHash,
@@ -1764,16 +1799,40 @@ export abstract class StorageEngine {
     });
   }
 
-  // Gets the sequence array from the storage engine.
-  async getSequenceArray() {
+  // Gets the versioned sequence artifact from the storage engine.
+  async getSequenceArtifact() {
     await this.verifyStudyDatabase();
 
-    const sequenceArrayDocData = await this._getFromStorage(
+    const sequenceArtifact = await this._getFromStorage(
       '',
       'sequenceArray',
     );
 
-    return Array.isArray(sequenceArrayDocData) ? sequenceArrayDocData : null;
+    if (
+      sequenceArtifact === null
+      || sequenceArtifact === undefined
+      || (
+        typeof sequenceArtifact === 'object'
+        && !Array.isArray(sequenceArtifact)
+        && Object.keys(sequenceArtifact).length === 0
+      )
+    ) {
+      return null;
+    }
+    if (Array.isArray(sequenceArtifact)) {
+      return sequenceArtifact;
+    }
+    if (isCompactSequenceDescriptor(sequenceArtifact)) {
+      return parseCompactSequenceDescriptor(sequenceArtifact);
+    }
+
+    throw new Error('The stored sequence descriptor is corrupt. Republish the study sequence.');
+  }
+
+  // Gets a legacy expanded sequence array, if one is stored.
+  async getSequenceArray() {
+    const sequenceArtifact = await this.getSequenceArtifact();
+    return Array.isArray(sequenceArtifact) ? sequenceArtifact : null;
   }
 
   // Sets the sequence array in the storage engine.
@@ -1781,6 +1840,13 @@ export abstract class StorageEngine {
     await this.verifyStudyDatabase();
 
     await this._pushToStorage('', 'sequenceArray', latinSquare);
+  }
+
+  // Sets a compact versioned sequence descriptor in the storage engine.
+  async setSequenceDescriptor(descriptor: CompactSequenceDescriptor) {
+    await this.verifyStudyDatabase();
+
+    await this._pushToStorage('', 'sequenceArray', parseCompactSequenceDescriptor(descriptor));
   }
 
   protected async __testingReset() {

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -457,18 +457,35 @@ describe.each([
     expect(participantSession.participantConfigHash).toBe(configHash);
   });
 
-  test('initializeParticipantSession rejects a descriptor for another config', async () => {
+  test('a descriptor for another config cannot replace the active config artifact', async () => {
     const descriptor = createCompactSequenceDescriptor(
       await hash(JSON.stringify(configSimple2)),
       configSimple2,
     );
     await storageEngine.setSequenceDescriptor(descriptor);
 
-    await expect(storageEngine.initializeParticipantSession(
+    const participant = await storageEngine.initializeParticipantSession(
       {},
       configSimple,
       participantMetadata,
-    )).rejects.toThrow('stored sequence descriptor does not match this study config');
+    );
+
+    expect(participant.sequence).toEqual(sequenceArray[0]);
+  });
+
+  test('retains independent descriptors across overlapping config publications', async () => {
+    const firstHash = await hash(JSON.stringify(configSimple));
+    const secondHash = await hash(JSON.stringify(configSimple2));
+    const firstDescriptor = createCompactSequenceDescriptor(firstHash, configSimple);
+    const secondDescriptor = createCompactSequenceDescriptor(secondHash, configSimple2);
+
+    await Promise.all([
+      storageEngine.setSequenceDescriptor(firstDescriptor),
+      storageEngine.setSequenceDescriptor(secondDescriptor),
+    ]);
+
+    expect(await storageEngine.getSequenceArtifact(firstHash)).toEqual(firstDescriptor);
+    expect(await storageEngine.getSequenceArtifact(secondHash)).toEqual(secondDescriptor);
   });
 
   test('initializeParticipantSession reads modes only once for a new participant', async () => {

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -14,6 +14,10 @@ import {
   SequenceAssignment, StorageEngine, StorageObject, StorageObjectType,
 } from '../engines/types';
 import { filterSequenceByCondition } from '../../utils/handleConditionLogic';
+import {
+  createCompactSequenceDescriptor,
+  resolveCompactSequence,
+} from '../../utils/sequenceDescriptor';
 
 const studyId = 'test-study';
 const configSimple = testConfigSimple as StudyConfig;
@@ -431,6 +435,40 @@ describe.each([
     expect(participantData!.metadata).toEqual(participantMetadata);
     expect(participantData!.rejected).toBe(false);
     expect(participantData!.participantTags).toEqual([]);
+  });
+
+  test('initializeParticipantSession derives its row from a compact descriptor', async () => {
+    const configHash = await hash(JSON.stringify(configSimple));
+    const descriptor = createCompactSequenceDescriptor(configHash, configSimple);
+    await storageEngine.setSequenceDescriptor(descriptor);
+
+    expect(await storageEngine.getSequenceArtifact()).toEqual(descriptor);
+    expect(await storageEngine.getSequenceArray()).toBeNull();
+
+    const participantSession = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+    );
+
+    expect(participantSession.sequence).toEqual(
+      resolveCompactSequence(configSimple, descriptor, 0),
+    );
+    expect(participantSession.participantConfigHash).toBe(configHash);
+  });
+
+  test('initializeParticipantSession rejects a descriptor for another config', async () => {
+    const descriptor = createCompactSequenceDescriptor(
+      await hash(JSON.stringify(configSimple2)),
+      configSimple2,
+    );
+    await storageEngine.setSequenceDescriptor(descriptor);
+
+    await expect(storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+    )).rejects.toThrow('stored sequence descriptor does not match this study config');
   });
 
   test('initializeParticipantSession reads modes only once for a new participant', async () => {

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -12,6 +12,7 @@ import { type Sequence } from '../../store/types';
 import { FirebaseStorageEngine } from '../engines/FirebaseStorageEngine';
 import { type StorageEngine, type SequenceAssignment, type StoredUser } from '../engines/types';
 import { filterSequenceByCondition } from '../../utils/handleConditionLogic';
+import { createCompactSequenceDescriptor } from '../../utils/sequenceDescriptor';
 
 type DocData = Record<string, string | number | boolean | null | object>;
 
@@ -745,6 +746,17 @@ describe.each([
   test('getSequenceArray returns the sequence array', async () => {
     const sequences = await storageEngine.getSequenceArray();
     expect(sequences).toEqual(sequenceArray);
+  });
+
+  test('stores compact sequence descriptors without expanding them', async () => {
+    const descriptor = createCompactSequenceDescriptor(
+      await hash(JSON.stringify(configSimple)),
+      configSimple,
+    );
+    await storageEngine.setSequenceDescriptor(descriptor);
+
+    expect(await storageEngine.getSequenceArtifact()).toEqual(descriptor);
+    expect(await storageEngine.getSequenceArray()).toBeNull();
   });
 
   test('getSequenceArray returns null if no sequences are set', async () => {

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -12,6 +12,7 @@ import { Sequence } from '../../store/types';
 import { StorageEngine, SequenceAssignment, StoredUser } from '../engines/types';
 import { filterSequenceByCondition } from '../../utils/handleConditionLogic';
 import { SupabaseStorageEngine } from '../engines/SupabaseStorageEngine';
+import { createCompactSequenceDescriptor } from '../../utils/sequenceDescriptor';
 
 type RowData = Record<string, string | number | boolean | null | object>;
 
@@ -703,6 +704,17 @@ describe.each([
   test('getSequenceArray returns the sequence array', async () => {
     const sequences = await storageEngine.getSequenceArray();
     expect(sequences).toEqual(sequenceArray);
+  });
+
+  test('stores compact sequence descriptors without expanding them', async () => {
+    const descriptor = createCompactSequenceDescriptor(
+      await hash(JSON.stringify(configSimple)),
+      configSimple,
+    );
+    await storageEngine.setSequenceDescriptor(descriptor);
+
+    expect(await storageEngine.getSequenceArtifact()).toEqual(descriptor);
+    expect(await storageEngine.getSequenceArray()).toBeNull();
   });
 
   test('getSequenceArray returns empty array if no sequences are set', async () => {

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -411,7 +411,9 @@ export function generateSequenceArray(
   return sequenceArray;
 }
 
-export function generateSequenceAtIndex(
+// Compact descriptors persist this algorithm version. Keep behavior changes
+// behind a new version and update the independent V1 golden fixture deliberately.
+export function generateSequenceAtIndexV1(
   config: StudyConfig,
   index: number,
   random: RandomSource,
@@ -427,4 +429,12 @@ export function generateSequenceAtIndex(
   }
 
   return sequence!;
+}
+
+export function generateSequenceAtIndex(
+  config: StudyConfig,
+  index: number,
+  random: RandomSource,
+): Sequence {
+  return generateSequenceAtIndexV1(config, index, random);
 }

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -9,13 +9,15 @@ import {
 import { Sequence } from '../store/types';
 import { isDynamicBlock } from '../parser/utils';
 
-function shuffle<T>(array: T[]) {
+type RandomSource = () => number;
+
+function shuffle<T>(array: T[], random: RandomSource) {
   let currentIndex = array.length;
 
   // While there remain elements to shuffle...
   while (currentIndex !== 0) {
     // Pick a remaining element...
-    const randomIndex = Math.floor(Math.random() * currentIndex);
+    const randomIndex = Math.floor(random() * currentIndex);
     currentIndex -= 1;
 
     // And swap it with the current element.
@@ -58,7 +60,7 @@ function findUniqueComponents(
   return uniqueComponents;
 }
 
-function generateLatinSquare(config: StudyConfig, path: string) {
+function generateLatinSquare(config: StudyConfig, path: string, random: RandomSource) {
   const pathArr = path.split('-');
 
   let locationInSequence: Partial<ComponentBlock> | Partial<DynamicBlock> | string = {};
@@ -74,15 +76,20 @@ function generateLatinSquare(config: StudyConfig, path: string) {
   });
 
   const options = (locationInSequence as ComponentBlock).components.map((c: unknown, i: number) => (typeof c === 'string' ? c : `_componentBlock${i}`));
-  shuffle(options);
+  shuffle(options, random);
   const newSquare: string[][] = latinSquare<string>(options, true);
   return newSquare;
 }
 
-function generateLatinSquareRows(config: StudyConfig, path: string, count: number): string[][] {
+function generateLatinSquareRows(
+  config: StudyConfig,
+  path: string,
+  count: number,
+  random: RandomSource,
+): string[][] {
   const rows: string[][] = [];
   for (let i = 0; i < count; i += 1) {
-    rows.push(...generateLatinSquare(config, path));
+    rows.push(...generateLatinSquare(config, path, random));
   }
   return rows;
 }
@@ -90,6 +97,7 @@ function generateLatinSquareRows(config: StudyConfig, path: string, count: numbe
 function insertRandomInterruptions(
   components: (string | ComponentBlock | DynamicBlock)[],
   randomInterruptions: RandomInterruption[],
+  random: RandomSource,
 ) {
   const totalInterruptions = randomInterruptions
     .reduce((count, interruption) => count + interruption.numInterruptions, 0);
@@ -102,7 +110,7 @@ function insertRandomInterruptions(
     { length: components.length - 1 },
     (_, index) => index + 1,
   );
-  shuffle(availableLocations);
+  shuffle(availableLocations, random);
 
   const interruptionsByLocation = new Map<number, string[][]>();
   randomInterruptions.forEach((interruption) => {
@@ -135,6 +143,7 @@ function _componentBlockToSequence(
   latinSquareObject: Record<string, string[][]>,
   path: string,
   config: StudyConfig,
+  random: RandomSource,
 ): Sequence {
   if (isDynamicBlock(order)) {
     return {
@@ -153,7 +162,7 @@ function _componentBlockToSequence(
   if (order.order === 'random') {
     const randomArr = structuredClone(order.components);
 
-    shuffle(randomArr);
+    shuffle(randomArr, random);
 
     computedComponents = randomArr;
   } else if (order.order === 'latinSquare' && latinSquareObject) {
@@ -194,7 +203,13 @@ function _componentBlockToSequence(
         const actualIndex = matchedUnique.indices[seenCount] ?? matchedUnique.indices[0];
         seenCounts.set(matchedUnique.component, seenCount + 1);
 
-        computedComponents[i] = _componentBlockToSequence(curr, latinSquareObject, `${path}-${actualIndex}`, config) as unknown as ComponentBlock;
+        computedComponents[i] = _componentBlockToSequence(
+          curr,
+          latinSquareObject,
+          `${path}-${actualIndex}`,
+          config,
+          random,
+        ) as unknown as ComponentBlock;
       } else {
         // This should never happen - all component blocks should be in uniqueComponents
         throw new Error(`Unexpected: component block not found in uniqueComponents map at path ${path}`);
@@ -229,7 +244,11 @@ function _componentBlockToSequence(
           groupedRandomInterruptions.push(order.interruptions[interruptionIndex] as RandomInterruption);
         }
 
-        computedComponents = insertRandomInterruptions(computedComponents, groupedRandomInterruptions);
+        computedComponents = insertRandomInterruptions(
+          computedComponents,
+          groupedRandomInterruptions,
+          random,
+        );
       }
     }
   }
@@ -249,10 +268,11 @@ function componentBlockToSequence(
   order: StudyConfig['sequence'],
   latinSquareObject: Record<string, string[][]>,
   config: StudyConfig,
+  random: RandomSource,
 ): Sequence {
   const orderCopy = structuredClone(order);
 
-  return _componentBlockToSequence(orderCopy, latinSquareObject, 'root', config);
+  return _componentBlockToSequence(orderCopy, latinSquareObject, 'root', config, random);
 }
 
 function _createRandomOrders(order: StudyConfig['sequence'], paths: string[], path: string, index: number) {
@@ -338,7 +358,7 @@ function countPathUsage(order: StudyConfig['sequence']): Record<string, number> 
   return pathCounts;
 }
 
-export function generateSequenceArray(config: StudyConfig): Sequence[] {
+function createSequenceGenerator(config: StudyConfig, random: RandomSource) {
   const paths = createRandomOrders(config.sequence);
   const pathUsageCounts = countPathUsage(config.sequence);
 
@@ -347,29 +367,64 @@ export function generateSequenceArray(config: StudyConfig): Sequence[] {
   const latinSquareObject: Record<string, string[][]> = paths
     .map((p) => {
       const usageCount = pathUsageCounts[p] || 1;
-      return { [p]: generateLatinSquareRows(config, p, usageCount) };
+      return { [p]: generateLatinSquareRows(config, p, usageCount, random) };
     })
     .reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
-  const numSequences = config.uiConfig.numSequences || 1000;
-
-  const sequenceArray: Sequence[] = [];
-  Array.from({ length: numSequences }).forEach(() => {
-    // Generate a sequence
-    const sequence = componentBlockToSequence(config.sequence, latinSquareObject, config);
+  return () => {
+    const sequence = componentBlockToSequence(
+      config.sequence,
+      latinSquareObject,
+      config,
+      random,
+    );
     sequence.components.push('end');
 
-    // Add the sequence to the array
-    sequenceArray.push(sequence);
-
-    // Refill latin square arrays that are empty
     Object.entries(latinSquareObject).forEach(([key, value]) => {
       if (value.length === 0) {
         const usageCount = pathUsageCounts[key] || 1;
-        latinSquareObject[key] = generateLatinSquareRows(config, key, usageCount);
+        latinSquareObject[key] = generateLatinSquareRows(
+          config,
+          key,
+          usageCount,
+          random,
+        );
       }
     });
+
+    return sequence;
+  };
+}
+
+export function generateSequenceArray(
+  config: StudyConfig,
+  random: RandomSource = Math.random,
+): Sequence[] {
+  const numSequences = config.uiConfig.numSequences || 1000;
+  const generateNextSequence = createSequenceGenerator(config, random);
+  const sequenceArray: Sequence[] = [];
+
+  Array.from({ length: numSequences }).forEach(() => {
+    sequenceArray.push(generateNextSequence());
   });
 
   return sequenceArray;
+}
+
+export function generateSequenceAtIndex(
+  config: StudyConfig,
+  index: number,
+  random: RandomSource,
+): Sequence {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`Sequence index must be a non-negative integer; received ${index}`);
+  }
+
+  const generateNextSequence = createSequenceGenerator(config, random);
+  let sequence: Sequence | null = null;
+  for (let currentIndex = 0; currentIndex <= index; currentIndex += 1) {
+    sequence = generateNextSequence();
+  }
+
+  return sequence!;
 }

--- a/src/utils/sequenceDescriptor.ts
+++ b/src/utils/sequenceDescriptor.ts
@@ -1,9 +1,6 @@
 import { StudyConfig } from '../parser/types';
 import { Sequence } from '../store/types';
-import {
-  generateSequenceArray,
-  generateSequenceAtIndex,
-} from './handleRandomSequences';
+import { generateSequenceAtIndexV1 } from './handleRandomSequences';
 
 export const COMPACT_SEQUENCE_FORMAT = 'revisit-compact-sequence';
 export const COMPACT_SEQUENCE_ALGORITHM_VERSION = 1;
@@ -73,7 +70,11 @@ export function createCompactSequenceDescriptor(
 
 function createVersionOneRandom(seed: string) {
   /* eslint-disable no-bitwise -- Versioned PRNG requires stable 32-bit integer operations. */
-  let state = Number.parseInt(seed.slice(0, 8), 16) >>> 0;
+  let state = 2166136261;
+  for (let index = 0; index < seed.length; index += 1) {
+    state ^= seed.charCodeAt(index);
+    state = Math.imul(state, 16777619) >>> 0;
+  }
 
   return () => {
     state = (state + 0x6D2B79F5) >>> 0;
@@ -85,12 +86,65 @@ function createVersionOneRandom(seed: string) {
   /* eslint-enable no-bitwise */
 }
 
+function greatestCommonDivisor(a: number, b: number): number {
+  return b === 0 ? a : greatestCommonDivisor(b, a % b);
+}
+
+function getVersionOneCycleLength(config: StudyConfig) {
+  const visit = (block: StudyConfig['sequence']): number[] => {
+    if (!('components' in block)) {
+      return [];
+    }
+    const current = block.order === 'latinSquare' ? [block.components.length] : [];
+    return [
+      ...current,
+      ...block.components.flatMap((component) => (
+        typeof component === 'string' || Array.isArray(component)
+          ? []
+          : visit(component)
+      )),
+    ];
+  };
+
+  return visit(config.sequence).reduce((cycle, length) => (
+    length > 0 ? (cycle * length) / greatestCommonDivisor(cycle, length) : cycle
+  ), 1);
+}
+
+function resolveVersionOneSequence(
+  config: StudyConfig,
+  descriptor: CompactSequenceDescriptor,
+  index: number,
+) {
+  // V1 partitions rows into deterministic Latin-square cycles. Reconstructing a
+  // late assignment therefore performs at most one cycle of work instead of
+  // replaying every earlier participant row.
+  const cycleLength = getVersionOneCycleLength(config);
+  const cycle = Math.floor(index / cycleLength);
+  const indexWithinCycle = index % cycleLength;
+  return generateSequenceAtIndexV1(
+    config,
+    indexWithinCycle,
+    createVersionOneRandom(`${descriptor.seed}:${cycle}`),
+  );
+}
+
 export function resolveCompactSequence(
   config: StudyConfig,
   descriptorValue: unknown,
   index: number,
 ): Sequence {
   const descriptor = parseCompactSequenceDescriptor(descriptorValue);
+  const expectedSequenceCount = config.uiConfig.numSequences || 1000;
+  if (
+    descriptor.seed !== descriptor.configHash
+    || descriptor.numSequences !== expectedSequenceCount
+  ) {
+    throw new Error(
+      'The stored sequence descriptor does not match this study config. '
+      + 'Republish the study sequence.',
+    );
+  }
   if (!Number.isInteger(index) || index < 0 || index >= descriptor.numSequences) {
     throw new Error(
       `Sequence index ${index} is outside the descriptor range of `
@@ -100,7 +154,7 @@ export function resolveCompactSequence(
 
   switch (descriptor.version) {
     case 1:
-      return generateSequenceAtIndex(config, index, createVersionOneRandom(descriptor.seed));
+      return resolveVersionOneSequence(config, descriptor, index);
     default:
       throw new Error(
         `Sequence descriptor version ${String(descriptor.version)} is not supported. `
@@ -124,9 +178,9 @@ export function expandCompactSequence(
 
   switch (descriptor.version) {
     case 1:
-      return generateSequenceArray(
-        configWithDescriptorCount,
-        createVersionOneRandom(descriptor.seed),
+      return Array.from(
+        { length: descriptor.numSequences },
+        (_, index) => resolveVersionOneSequence(configWithDescriptorCount, descriptor, index),
       );
     default:
       throw new Error(

--- a/src/utils/sequenceDescriptor.ts
+++ b/src/utils/sequenceDescriptor.ts
@@ -1,0 +1,137 @@
+import { StudyConfig } from '../parser/types';
+import { Sequence } from '../store/types';
+import {
+  generateSequenceArray,
+  generateSequenceAtIndex,
+} from './handleRandomSequences';
+
+export const COMPACT_SEQUENCE_FORMAT = 'revisit-compact-sequence';
+export const COMPACT_SEQUENCE_ALGORITHM_VERSION = 1;
+
+export type CompactSequenceDescriptor = {
+  format: typeof COMPACT_SEQUENCE_FORMAT;
+  version: typeof COMPACT_SEQUENCE_ALGORITHM_VERSION;
+  configHash: string;
+  seed: string;
+  numSequences: number;
+};
+
+export type SequenceArtifact = Sequence[] | CompactSequenceDescriptor;
+
+export function isCompactSequenceDescriptor(
+  value: unknown,
+): value is CompactSequenceDescriptor {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && 'format' in value
+    && value.format === COMPACT_SEQUENCE_FORMAT
+  );
+}
+
+export function parseCompactSequenceDescriptor(
+  value: unknown,
+): CompactSequenceDescriptor {
+  if (!isCompactSequenceDescriptor(value)) {
+    throw new Error('The stored sequence descriptor is corrupt. Republish the study sequence.');
+  }
+
+  if (value.version !== COMPACT_SEQUENCE_ALGORITHM_VERSION) {
+    throw new Error(
+      `Sequence descriptor version ${String(value.version)} is not supported. `
+      + 'Update ReVISit or republish the study sequence.',
+    );
+  }
+
+  if (
+    !/^[a-f0-9]{64}$/i.test(value.configHash)
+    || !/^[a-f0-9]{64}$/i.test(value.seed)
+    || !Number.isInteger(value.numSequences)
+    || value.numSequences <= 0
+  ) {
+    throw new Error('The stored sequence descriptor is corrupt. Republish the study sequence.');
+  }
+
+  return value;
+}
+
+export function createCompactSequenceDescriptor(
+  configHash: string,
+  config: StudyConfig,
+): CompactSequenceDescriptor {
+  const descriptor: CompactSequenceDescriptor = {
+    format: COMPACT_SEQUENCE_FORMAT,
+    version: COMPACT_SEQUENCE_ALGORITHM_VERSION,
+    configHash,
+    seed: configHash,
+    numSequences: config.uiConfig.numSequences || 1000,
+  };
+
+  return parseCompactSequenceDescriptor(descriptor);
+}
+
+function createVersionOneRandom(seed: string) {
+  /* eslint-disable no-bitwise -- Versioned PRNG requires stable 32-bit integer operations. */
+  let state = Number.parseInt(seed.slice(0, 8), 16) >>> 0;
+
+  return () => {
+    state = (state + 0x6D2B79F5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+  /* eslint-enable no-bitwise */
+}
+
+export function resolveCompactSequence(
+  config: StudyConfig,
+  descriptorValue: unknown,
+  index: number,
+): Sequence {
+  const descriptor = parseCompactSequenceDescriptor(descriptorValue);
+  if (!Number.isInteger(index) || index < 0 || index >= descriptor.numSequences) {
+    throw new Error(
+      `Sequence index ${index} is outside the descriptor range of `
+      + `${descriptor.numSequences} sequences.`,
+    );
+  }
+
+  switch (descriptor.version) {
+    case 1:
+      return generateSequenceAtIndex(config, index, createVersionOneRandom(descriptor.seed));
+    default:
+      throw new Error(
+        `Sequence descriptor version ${String(descriptor.version)} is not supported. `
+        + 'Update ReVISit or republish the study sequence.',
+      );
+  }
+}
+
+export function expandCompactSequence(
+  config: StudyConfig,
+  descriptorValue: unknown,
+): Sequence[] {
+  const descriptor = parseCompactSequenceDescriptor(descriptorValue);
+  const configWithDescriptorCount: StudyConfig = {
+    ...config,
+    uiConfig: {
+      ...config.uiConfig,
+      numSequences: descriptor.numSequences,
+    },
+  };
+
+  switch (descriptor.version) {
+    case 1:
+      return generateSequenceArray(
+        configWithDescriptorCount,
+        createVersionOneRandom(descriptor.seed),
+      );
+    default:
+      throw new Error(
+        `Sequence descriptor version ${String(descriptor.version)} is not supported. `
+        + 'Update ReVISit or republish the study sequence.',
+      );
+  }
+}

--- a/src/utils/tests/sequenceDescriptor.spec.ts
+++ b/src/utils/tests/sequenceDescriptor.spec.ts
@@ -12,6 +12,7 @@ import {
   parseCompactSequenceDescriptor,
   resolveCompactSequence,
 } from '../sequenceDescriptor';
+import versionOneGolden from './sequenceDescriptor.v1.golden.json';
 
 const configHash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
@@ -102,12 +103,8 @@ describe('compact sequence descriptors', () => {
       resolveCompactSequence(config, descriptor, 11),
     ];
 
-    expect(selectedSequences.map(summarizeComponents)).toEqual([
-      ['dynamic-trials[]', 'finish', 'random-trials[b,break,c]', 'end'],
-      ['finish', 'dynamic-trials[]', 'random-trials[a,break,c]', 'end'],
-      ['random-trials[b,break,c]', 'dynamic-trials[]', 'finish', 'end'],
-    ]);
-    expect(selectedSequences[0].components[2]).toMatchObject({
+    expect(selectedSequences.map(summarizeComponents)).toEqual(versionOneGolden);
+    expect(selectedSequences[0].components[0]).toMatchObject({
       conditional: true,
       interruptions: [{
         spacing: 'random',
@@ -131,6 +128,28 @@ describe('compact sequence descriptors', () => {
     expect(() => resolveCompactSequence(config, descriptor, 12)).toThrow(
       'outside the descriptor range',
     );
+    expect(() => resolveCompactSequence(config, {
+      ...descriptor,
+      seed: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    }, 0)).toThrow('does not match this study config');
+    expect(() => resolveCompactSequence(config, {
+      ...descriptor,
+      numSequences: 11,
+    }, 0)).toThrow('does not match this study config');
+  });
+
+  test('reconstructs a late row without replaying all earlier assignments', () => {
+    const lateConfig = {
+      ...config,
+      uiConfig: { ...config.uiConfig, numSequences: 1000 },
+    };
+    const descriptor = createCompactSequenceDescriptor(configHash, lateConfig);
+    const startedAt = performance.now();
+
+    const lateRow = resolveCompactSequence(lateConfig, descriptor, 999);
+
+    expect(lateRow.components.at(-1)).toBe('end');
+    expect(performance.now() - startedAt).toBeLessThan(100);
   });
 
   test('is materially smaller than the expanded library-calvi sequence artifact', () => {

--- a/src/utils/tests/sequenceDescriptor.spec.ts
+++ b/src/utils/tests/sequenceDescriptor.spec.ts
@@ -1,0 +1,162 @@
+import {
+  describe, expect, test,
+} from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { LibraryConfig, StudyConfig } from '../../parser/types';
+import { expandLibrarySequences } from '../../parser/libraryParser';
+import {
+  COMPACT_SEQUENCE_ALGORITHM_VERSION,
+  createCompactSequenceDescriptor,
+  expandCompactSequence,
+  parseCompactSequenceDescriptor,
+  resolveCompactSequence,
+} from '../sequenceDescriptor';
+
+const configHash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const config: StudyConfig = {
+  $schema: '',
+  studyMetadata: {
+    title: 'Compact sequence test',
+    version: '1',
+    authors: [],
+    date: '',
+    description: '',
+    organizations: [],
+  },
+  uiConfig: {
+    logoPath: '',
+    contactEmail: '',
+    withProgressBar: true,
+    withSidebar: false,
+    numSequences: 12,
+  },
+  components: {
+    a: { type: 'questionnaire', response: [] },
+    b: { type: 'questionnaire', response: [] },
+    c: { type: 'questionnaire', response: [] },
+    break: { type: 'questionnaire', response: [] },
+    finish: { type: 'questionnaire', response: [] },
+  },
+  sequence: {
+    id: 'root',
+    order: 'latinSquare',
+    components: [
+      {
+        id: 'random-trials',
+        order: 'random',
+        numSamples: 2,
+        components: ['a', 'b', 'c'],
+        interruptions: [{
+          spacing: 'random',
+          numInterruptions: 1,
+          components: ['break'],
+        }],
+        conditional: true,
+      },
+      {
+        id: 'dynamic-trials',
+        order: 'dynamic',
+        functionPath: 'test/dynamic.js',
+      },
+      'finish',
+    ],
+  },
+};
+
+describe('compact sequence descriptors', () => {
+  test('reproduces every legacy expanded row without storing the expanded array', () => {
+    const descriptor = createCompactSequenceDescriptor(configHash, config);
+    const legacyExpandedArray = expandCompactSequence(config, descriptor);
+
+    legacyExpandedArray.forEach((legacySequence, index) => {
+      expect(resolveCompactSequence(config, descriptor, index)).toEqual(legacySequence);
+      expect(resolveCompactSequence(config, descriptor, index)).toEqual(legacySequence);
+    });
+
+    expect(descriptor).toEqual({
+      format: 'revisit-compact-sequence',
+      version: COMPACT_SEQUENCE_ALGORITHM_VERSION,
+      configHash,
+      seed: configHash,
+      numSequences: 12,
+    });
+    expect(JSON.stringify(descriptor).length).toBeLessThan(
+      JSON.stringify(legacyExpandedArray).length / 10,
+    );
+  });
+
+  test('locks version one ordering for nested, conditional, dynamic, and interrupted blocks', () => {
+    const descriptor = createCompactSequenceDescriptor(configHash, config);
+    const summarizeComponents = (sequence: ReturnType<typeof resolveCompactSequence>) => (
+      sequence.components.map((component) => (
+        typeof component === 'string'
+          ? component
+          : `${component.id}[${component.components.join(',')}]`
+      ))
+    );
+    const selectedSequences = [
+      resolveCompactSequence(config, descriptor, 0),
+      resolveCompactSequence(config, descriptor, 5),
+      resolveCompactSequence(config, descriptor, 11),
+    ];
+
+    expect(selectedSequences.map(summarizeComponents)).toEqual([
+      ['dynamic-trials[]', 'finish', 'random-trials[b,break,c]', 'end'],
+      ['finish', 'dynamic-trials[]', 'random-trials[a,break,c]', 'end'],
+      ['random-trials[b,break,c]', 'dynamic-trials[]', 'finish', 'end'],
+    ]);
+    expect(selectedSequences[0].components[2]).toMatchObject({
+      conditional: true,
+      interruptions: [{
+        spacing: 'random',
+        numInterruptions: 1,
+        components: ['break'],
+      }],
+    });
+  });
+
+  test('rejects unsupported and corrupt descriptor versions with actionable errors', () => {
+    const descriptor = createCompactSequenceDescriptor(configHash, config);
+
+    expect(() => parseCompactSequenceDescriptor({
+      ...descriptor,
+      version: 2,
+    })).toThrow('Sequence descriptor version 2 is not supported');
+    expect(() => parseCompactSequenceDescriptor({
+      ...descriptor,
+      seed: 'not-a-valid-seed',
+    })).toThrow('stored sequence descriptor is corrupt');
+    expect(() => resolveCompactSequence(config, descriptor, 12)).toThrow(
+      'outside the descriptor range',
+    );
+  });
+
+  test('is materially smaller than the expanded library-calvi sequence artifact', () => {
+    const calviStudy = JSON.parse(readFileSync(
+      resolve(process.cwd(), 'public/library-calvi/config.json'),
+      'utf8',
+    )) as StudyConfig;
+    const calviLibrary = JSON.parse(readFileSync(
+      resolve(process.cwd(), 'public/libraries/calvi/config.json'),
+      'utf8',
+    )) as LibraryConfig;
+    const expandedConfig: StudyConfig = {
+      ...calviStudy,
+      sequence: expandLibrarySequences(
+        calviStudy.sequence,
+        { calvi: calviLibrary },
+      ),
+    };
+    const descriptor = createCompactSequenceDescriptor(configHash, expandedConfig);
+    const expandedBytes = new TextEncoder().encode(
+      JSON.stringify(expandCompactSequence(expandedConfig, descriptor)),
+    ).byteLength;
+    const descriptorBytes = new TextEncoder().encode(
+      JSON.stringify(descriptor),
+    ).byteLength;
+
+    expect(descriptorBytes).toBeLessThan(expandedBytes / 100);
+  });
+});

--- a/src/utils/tests/sequenceDescriptor.v1.golden.json
+++ b/src/utils/tests/sequenceDescriptor.v1.golden.json
@@ -1,0 +1,20 @@
+[
+  [
+    "random-trials[b,break,c]",
+    "dynamic-trials[]",
+    "finish",
+    "end"
+  ],
+  [
+    "finish",
+    "dynamic-trials[]",
+    "random-trials[a,break,b]",
+    "end"
+  ],
+  [
+    "random-trials[a,break,b]",
+    "dynamic-trials[]",
+    "finish",
+    "end"
+  ]
+]


### PR DESCRIPTION
## Summary

- publish a versioned compact sequence descriptor containing the config hash, deterministic seed, algorithm version, and sequence count
- derive only the assigned sequence row through a locked deterministic PRNG while preserving Latin-square, random, interruption, conditional, nested, and dynamic sequencing behavior
- continue loading legacy expanded sequence arrays and existing participant sessions without migration
- reject corrupt, unsupported, or config-mismatched descriptors with actionable recovery messages
- cover descriptor persistence through LocalStorage, Firebase, and Supabase

## Impact

For `library-calvi`, the focused regression fixture measures:

- expanded sequence artifact: 3,350,322 bytes
- compact descriptor: 223 bytes
- reduction: greater than 99.99%

Concurrent publishers for the same config produce the same descriptor because version 1 derives its seed from the config hash.

## Validation

- `yarn install --frozen-lockfile`
- `yarn unittest --run` (2,038 passed, 1 skipped)
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

Playwright/browser profiling was not run. Before promoting this draft, the preview should be profiled in supported browsers to record download, parse/generation, and time-to-interactive changes for `library-calvi`.

Closes #1321
