### PR TITLE
Move sequence-array publication off participant startup's critical path

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -305,22 +305,15 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         await storageEngine.saveConfig(activeConfig);
 
-        const sequenceArray = await storageEngine.getSequenceArray();
-
-        if (!sequenceArray) {
-          const generatedSequenceArray = await generateSequenceArray(activeConfig);
-
-          await storageEngine.setSequenceArray(generatedSequenceArray);
-        }
+        const activeHash = await activeHashPromise;
+        const [resolvedModes] = await Promise.all([
+          storageEngine.getModes(canonicalStudyId),
+          storageEngine.prepareSequenceArray(activeConfig, activeHash),
+        ]);
+        modes = resolvedModes;
 
         // Get or generate participant session
         const searchParamsObject = Object.fromEntries(searchParams.entries());
-
-        const [resolvedModes, activeHash] = await Promise.all([
-          storageEngine.getModes(canonicalStudyId),
-          activeHashPromise,
-        ]);
-        modes = resolvedModes;
 
         const initialMetadata = createParticipantMetadata();
 

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -297,6 +297,7 @@ describe('Shell', () => {
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
+      prepareSequenceArray: vi.fn().mockResolvedValue(['seq1']),
       getSequenceArray: vi.fn().mockResolvedValue(['seq1']), // non-null → no setSequenceArray
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue(baseSession),
@@ -312,14 +313,13 @@ describe('Shell', () => {
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
   });
 
-  test('calls setSequenceArray when getSequenceArray returns null', async () => {
+  test('prepares the active config sequence array before participant startup', async () => {
     vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
 
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
-      getSequenceArray: vi.fn().mockResolvedValue(null), // null → calls setSequenceArray
-      setSequenceArray: vi.fn().mockResolvedValue(undefined),
+      prepareSequenceArray: vi.fn().mockResolvedValue(['seq1']),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue(baseSession),
       getParticipantCompletionStatus: vi.fn().mockResolvedValue(false),
@@ -330,7 +330,10 @@ describe('Shell', () => {
     };
 
     render(<Shell globalConfig={globalConfig} />);
-    await waitFor(() => expect(mockStorageEngine!.setSequenceArray).toHaveBeenCalled(), { timeout: 3000 });
+    await waitFor(() => expect(mockStorageEngine!.prepareSequenceArray).toHaveBeenCalledWith(
+      mockActiveConfig,
+      expect.any(String),
+    ), { timeout: 3000 });
   });
 
   test('covers study condition update path', async () => {
@@ -340,6 +343,7 @@ describe('Shell', () => {
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
+      prepareSequenceArray: vi.fn().mockResolvedValue(['seq1']),
       getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: true, dataSharingEnabled: true, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue({
@@ -366,6 +370,7 @@ describe('Shell', () => {
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockResolvedValue(undefined),
       saveConfig: vi.fn().mockResolvedValue(undefined),
+      prepareSequenceArray: vi.fn().mockResolvedValue(['seq1']),
       getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
       initializeParticipantSession: vi.fn().mockResolvedValue({

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -27,6 +27,7 @@ import {
   onSnapshot,
   serverTimestamp,
   setDoc,
+  runTransaction,
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
@@ -44,6 +45,8 @@ import {
   SnapshotDocContent,
   StoredUser,
   cleanupModes,
+  SequenceBuildClaim,
+  SequenceBuildRecord,
 } from './types';
 import { EditedText, TaglessEditedText } from '../../analysis/individualStudy/thinkAloud/types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
@@ -108,7 +111,12 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     return storageObj;
   }
 
-  protected async _pushToStorage<T extends StorageObjectType>(prefix: string, type: T, objectToUpload: StorageObject<T>) {
+  protected async _pushToStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    objectToUpload: StorageObject<T>,
+    options?: { cache?: boolean },
+  ) {
     const storageRef = ref(
       this.storage,
       `${this.collectionPrefix}${this.studyId}/${prefix}_${type}`,
@@ -120,7 +128,11 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       const blob = new Blob([JSON.stringify(objectToUpload)], {
         type: 'application/json',
       });
-      await uploadBytes(storageRef, blob);
+      await uploadBytes(
+        storageRef,
+        blob,
+        options?.cache ? { cacheControl: 'public,max-age=31536000' } : undefined,
+      );
     }
   }
 
@@ -169,6 +181,49 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       'configHash',
     );
     await setDoc(configHashDoc, { configHash });
+  }
+
+  protected async _claimSequenceBuild(
+    configHash: string,
+    candidate: SequenceBuildRecord,
+    now: number,
+  ): Promise<SequenceBuildClaim> {
+    const buildDoc = doc(this.studyCollection, `sequenceBuild_${configHash}`);
+    return runTransaction(this.firestore, async (transaction) => {
+      const snapshot = await transaction.get(buildDoc);
+      const existing = snapshot.exists() ? snapshot.data() as SequenceBuildRecord : null;
+      if (existing?.status === 'ready'
+        || (existing?.status === 'building' && existing.leaseExpiresAt > now)) {
+        return { record: existing, shouldPublish: false };
+      }
+
+      const claimed = existing
+        ? {
+          ...existing,
+          status: 'building' as const,
+          publisherId: candidate.publisherId,
+          leaseExpiresAt: candidate.leaseExpiresAt,
+          attempts: existing.attempts + 1,
+          updatedAt: now,
+        }
+        : candidate;
+      transaction.set(buildDoc, claimed);
+      return { record: claimed, shouldPublish: true };
+    });
+  }
+
+  protected async _updateSequenceBuild(
+    configHash: string,
+    publisherId: string,
+    updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+  ) {
+    const buildDoc = doc(this.studyCollection, `sequenceBuild_${configHash}`);
+    await runTransaction(this.firestore, async (transaction) => {
+      const snapshot = await transaction.get(buildDoc);
+      if (snapshot.exists() && snapshot.data().publisherId === publisherId) {
+        transaction.update(buildDoc, updates);
+      }
+    });
   }
 
   public async getAllSequenceAssignments(studyId: string) {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -102,7 +102,15 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       const blob = await getBlob(storageRef);
       const fullProvStr = await blob.text();
       storageObj = JSON.parse(fullProvStr);
-    } catch {
+    } catch (error) {
+      if (
+        typeof error !== 'object'
+        || error === null
+        || !('code' in error)
+        || error.code !== 'storage/object-not-found'
+      ) {
+        throw error;
+      }
       console.warn(
         `${prefix} does not have ${type} for ${this.collectionPrefix}${this.studyId}.`,
       );
@@ -115,11 +123,11 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     prefix: string,
     type: T,
     objectToUpload: StorageObject<T>,
-    options?: { cache?: boolean },
+    options?: { cache?: boolean; studyId?: string },
   ) {
     const storageRef = ref(
       this.storage,
-      `${this.collectionPrefix}${this.studyId}/${prefix}_${type}`,
+      `${this.collectionPrefix}${options?.studyId ?? this.studyId}/${prefix}_${type}`,
     );
 
     if (objectToUpload instanceof Blob) {
@@ -187,8 +195,13 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     configHash: string,
     candidate: SequenceBuildRecord,
     now: number,
+    studyId: string = this.studyId!,
   ): Promise<SequenceBuildClaim> {
-    const buildDoc = doc(this.studyCollection, `sequenceBuild_${configHash}`);
+    const studyCollection = collection(
+      this.firestore,
+      `${this.collectionPrefix}${studyId}`,
+    );
+    const buildDoc = doc(studyCollection, `sequenceBuild_${configHash}`);
     return runTransaction(this.firestore, async (transaction) => {
       const snapshot = await transaction.get(buildDoc);
       const existing = snapshot.exists() ? snapshot.data() as SequenceBuildRecord : null;
@@ -216,14 +229,43 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     configHash: string,
     publisherId: string,
     updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+    studyId: string = this.studyId!,
   ) {
-    const buildDoc = doc(this.studyCollection, `sequenceBuild_${configHash}`);
+    const studyCollection = collection(
+      this.firestore,
+      `${this.collectionPrefix}${studyId}`,
+    );
+    const buildDoc = doc(studyCollection, `sequenceBuild_${configHash}`);
     await runTransaction(this.firestore, async (transaction) => {
       const snapshot = await transaction.get(buildDoc);
       if (snapshot.exists() && snapshot.data().publisherId === publisherId) {
         transaction.update(buildDoc, updates);
       }
     });
+  }
+
+  protected override async _getSequenceBuildProviderTime() {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const clockDoc = doc(this.studyCollection, 'sequenceBuildClock');
+    await setDoc(clockDoc, { now: serverTimestamp() });
+    const snapshot = await getDoc(clockDoc);
+    const value = snapshot.data()?.now;
+    if (value instanceof Timestamp) {
+      return value.toMillis();
+    }
+    if (typeof value === 'number') {
+      return value;
+    }
+    throw new Error('Failed to read the Firebase server clock');
+  }
+
+  protected override async _deleteSequenceBuild(configHash: string) {
+    const buildDoc = doc(this.studyCollection, `sequenceBuild_${configHash}`);
+    const batch = writeBatch(this.firestore);
+    batch.delete(buildDoc);
+    await batch.commit();
   }
 
   public async getAllSequenceAssignments(studyId: string) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -25,10 +25,10 @@ export class LocalStorageEngine extends StorageEngine {
     prefix: string,
     type: T,
     objectToUpload: StorageObject<T>,
-    _options?: { cache?: boolean },
+    options?: { cache?: boolean; studyId?: string },
   ) {
     await this.verifyStudyDatabase();
-    const storageKey = `${this.collectionPrefix}${this.studyId}/${prefix}_${type}`;
+    const storageKey = `${this.collectionPrefix}${options?.studyId ?? this.studyId}/${prefix}_${type}`;
     await this.studyDatabase.setItem(storageKey, objectToUpload);
   }
 
@@ -64,8 +64,9 @@ export class LocalStorageEngine extends StorageEngine {
     configHash: string,
     candidate: SequenceBuildRecord,
     now: number,
+    studyId: string = this.studyId!,
   ): Promise<SequenceBuildClaim> {
-    const key = `${this.collectionPrefix}${this.studyId}/sequenceBuild/${configHash}`;
+    const key = `${this.collectionPrefix}${studyId}/sequenceBuild/${configHash}`;
     const existing = await this.studyDatabase.getItem<SequenceBuildRecord>(key);
     if (existing && existing.status !== 'failed' && existing.leaseExpiresAt > now) {
       return { record: existing, shouldPublish: false };
@@ -92,12 +93,18 @@ export class LocalStorageEngine extends StorageEngine {
     configHash: string,
     publisherId: string,
     updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+    studyId: string = this.studyId!,
   ) {
-    const key = `${this.collectionPrefix}${this.studyId}/sequenceBuild/${configHash}`;
+    const key = `${this.collectionPrefix}${studyId}/sequenceBuild/${configHash}`;
     const existing = await this.studyDatabase.getItem<SequenceBuildRecord>(key);
     if (existing?.publisherId === publisherId) {
       await this.studyDatabase.setItem(key, { ...existing, ...updates });
     }
+  }
+
+  protected override async _deleteSequenceBuild(configHash: string) {
+    const key = `${this.collectionPrefix}${this.studyId}/sequenceBuild/${configHash}`;
+    await this.studyDatabase.removeItem(key);
   }
 
   public async getAllSequenceAssignments(studyId: string) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -1,6 +1,6 @@
 import localforage from 'localforage';
 import {
-  REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageEngine, StorageObject, StorageObjectType, cleanupModes,
+  REVISIT_MODE, SequenceAssignment, SequenceBuildClaim, SequenceBuildRecord, SnapshotDocContent, StorageEngine, StorageObject, StorageObjectType, cleanupModes,
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
@@ -21,7 +21,12 @@ export class LocalStorageEngine extends StorageEngine {
     return storedObject;
   }
 
-  protected async _pushToStorage<T extends StorageObjectType>(prefix: string, type: T, objectToUpload: StorageObject<T>) {
+  protected async _pushToStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    objectToUpload: StorageObject<T>,
+    _options?: { cache?: boolean },
+  ) {
     await this.verifyStudyDatabase();
     const storageKey = `${this.collectionPrefix}${this.studyId}/${prefix}_${type}`;
     await this.studyDatabase.setItem(storageKey, objectToUpload);
@@ -53,6 +58,46 @@ export class LocalStorageEngine extends StorageEngine {
     await this.verifyStudyDatabase();
     const key = `${this.collectionPrefix}${this.studyId}/configHash`;
     await this.studyDatabase.setItem(key, configHash);
+  }
+
+  protected async _claimSequenceBuild(
+    configHash: string,
+    candidate: SequenceBuildRecord,
+    now: number,
+  ): Promise<SequenceBuildClaim> {
+    const key = `${this.collectionPrefix}${this.studyId}/sequenceBuild/${configHash}`;
+    const existing = await this.studyDatabase.getItem<SequenceBuildRecord>(key);
+    if (existing && existing.status !== 'failed' && existing.leaseExpiresAt > now) {
+      return { record: existing, shouldPublish: false };
+    }
+    if (existing?.status === 'ready') {
+      return { record: existing, shouldPublish: false };
+    }
+
+    const claimed = existing
+      ? {
+        ...existing,
+        status: 'building' as const,
+        publisherId: candidate.publisherId,
+        leaseExpiresAt: candidate.leaseExpiresAt,
+        attempts: existing.attempts + 1,
+        updatedAt: now,
+      }
+      : candidate;
+    await this.studyDatabase.setItem(key, claimed);
+    return { record: claimed, shouldPublish: true };
+  }
+
+  protected async _updateSequenceBuild(
+    configHash: string,
+    publisherId: string,
+    updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+  ) {
+    const key = `${this.collectionPrefix}${this.studyId}/sequenceBuild/${configHash}`;
+    const existing = await this.studyDatabase.getItem<SequenceBuildRecord>(key);
+    if (existing?.publisherId === publisherId) {
+      await this.studyDatabase.setItem(key, { ...existing, ...updates });
+    }
   }
 
   public async getAllSequenceAssignments(studyId: string) {

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -23,7 +23,13 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .download(`${this.collectionPrefix}${studyId || this.studyId}/${prefix}_${type}`);
 
     if (error) {
-      return {} as StorageObject<T>;
+      if (
+        ('statusCode' in error && String(error.statusCode) === '404')
+        || error.message.toLowerCase().includes('not found')
+      ) {
+        return {} as StorageObject<T>;
+      }
+      throw new Error(`Failed to download from Supabase: ${error.message}`);
     }
 
     const dataToParse = this.testing ? new Blob([data as unknown as string], { type: 'application/json' }) : data;
@@ -40,7 +46,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     prefix: string,
     type: T,
     objectToUpload: StorageObject<T>,
-    options?: { cache?: boolean },
+    options?: { cache?: boolean; studyId?: string },
   ) {
     await this.verifyStudyDatabase();
 
@@ -56,7 +62,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
 
     const { error } = await this.supabase.storage
       .from('revisit')
-      .upload(`${this.collectionPrefix}${this.studyId}/${prefix}_${type}`, uploadObject, {
+      .upload(`${this.collectionPrefix}${options?.studyId ?? this.studyId}/${prefix}_${type}`, uploadObject, {
         upsert: true,
         ...(options?.cache ? { cacheControl: '31536000' } : {}),
       });
@@ -140,11 +146,11 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .eq('docId', 'currentConfigHash');
   }
 
-  private async getSequenceBuild(configHash: string) {
+  private async getSequenceBuild(configHash: string, studyId: string = this.studyId!) {
     const { data } = await this.supabase
       .from('revisit')
       .select('data')
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('studyId', `${this.collectionPrefix}${studyId}`)
       .eq('docId', `sequenceBuild_${configHash}`)
       .maybeSingle();
     return data?.data as SequenceBuildRecord | undefined;
@@ -154,10 +160,11 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     configHash: string,
     candidate: SequenceBuildRecord,
     now: number,
+    studyIdValue: string = this.studyId!,
   ): Promise<SequenceBuildClaim> {
-    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const studyId = `${this.collectionPrefix}${studyIdValue}`;
     const docId = `sequenceBuild_${configHash}`;
-    const existing = await this.getSequenceBuild(configHash);
+    const existing = await this.getSequenceBuild(configHash, studyIdValue);
     if (existing?.status === 'ready'
       || (existing?.status === 'building' && existing.leaseExpiresAt > now)) {
       return { record: existing, shouldPublish: false };
@@ -170,7 +177,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       if (!error) {
         return { record: candidate, shouldPublish: true };
       }
-      const winner = await this.getSequenceBuild(configHash);
+      const winner = await this.getSequenceBuild(configHash, studyIdValue);
       if (!winner) {
         throw new Error('Failed to establish sequence build record');
       }
@@ -198,7 +205,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       return { record: claimed, shouldPublish: true };
     }
 
-    const winner = await this.getSequenceBuild(configHash);
+    const winner = await this.getSequenceBuild(configHash, studyIdValue);
     if (!winner) {
       throw new Error('Failed to claim sequence build record');
     }
@@ -209,17 +216,58 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     configHash: string,
     publisherId: string,
     updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+    studyId: string = this.studyId!,
   ) {
-    const existing = await this.getSequenceBuild(configHash);
+    const existing = await this.getSequenceBuild(configHash, studyId);
     if (!existing || existing.publisherId !== publisherId) {
       return;
     }
     await this.supabase
       .from('revisit')
       .update({ data: { ...existing, ...updates } })
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('studyId', `${this.collectionPrefix}${studyId}`)
       .eq('docId', `sequenceBuild_${configHash}`)
       .eq('data->>publisherId', publisherId);
+  }
+
+  protected override async _getSequenceBuildProviderTime() {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const docId = `sequenceBuildClock_${crypto.randomUUID()}`;
+    const { error: insertError } = await this.supabase
+      .from('revisit')
+      .insert({ studyId, docId, data: {} });
+    if (insertError) {
+      throw new Error('Failed to establish the Supabase server clock');
+    }
+    const { data, error } = await this.supabase
+      .from('revisit')
+      .select('createdAt')
+      .eq('studyId', studyId)
+      .eq('docId', docId)
+      .single();
+    await this.supabase
+      .from('revisit')
+      .delete()
+      .eq('studyId', studyId)
+      .eq('docId', docId);
+    if (error || !data?.createdAt) {
+      throw new Error('Failed to read the Supabase server clock');
+    }
+    return new Date(data.createdAt).getTime();
+  }
+
+  protected override async _deleteSequenceBuild(configHash: string) {
+    const { error } = await this.supabase
+      .from('revisit')
+      .delete()
+      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('docId', `sequenceBuild_${configHash}`);
+    if (error) {
+      throw new Error('Failed to delete Supabase sequence build record');
+    }
   }
 
   public async getAllSequenceAssignments(studyId: string) {

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -2,7 +2,7 @@ import { AuthError, createClient } from '@supabase/supabase-js';
 import localforage from 'localforage';
 import {
   REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageObject, StorageObjectType, StoredUser,
-  CloudStorageEngine, cleanupModes,
+  CloudStorageEngine, cleanupModes, SequenceBuildClaim, SequenceBuildRecord,
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
@@ -36,7 +36,12 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     }
   }
 
-  protected async _pushToStorage<T extends StorageObjectType>(prefix: string, type: T, objectToUpload: StorageObject<T>) {
+  protected async _pushToStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    objectToUpload: StorageObject<T>,
+    options?: { cache?: boolean },
+  ) {
     await this.verifyStudyDatabase();
 
     let uploadObject: Blob | Buffer<ArrayBuffer> = new Blob();
@@ -53,6 +58,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .from('revisit')
       .upload(`${this.collectionPrefix}${this.studyId}/${prefix}_${type}`, uploadObject, {
         upsert: true,
+        ...(options?.cache ? { cacheControl: '31536000' } : {}),
       });
 
     if (error) {
@@ -132,6 +138,88 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       })
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', 'currentConfigHash');
+  }
+
+  private async getSequenceBuild(configHash: string) {
+    const { data } = await this.supabase
+      .from('revisit')
+      .select('data')
+      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('docId', `sequenceBuild_${configHash}`)
+      .maybeSingle();
+    return data?.data as SequenceBuildRecord | undefined;
+  }
+
+  protected async _claimSequenceBuild(
+    configHash: string,
+    candidate: SequenceBuildRecord,
+    now: number,
+  ): Promise<SequenceBuildClaim> {
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const docId = `sequenceBuild_${configHash}`;
+    const existing = await this.getSequenceBuild(configHash);
+    if (existing?.status === 'ready'
+      || (existing?.status === 'building' && existing.leaseExpiresAt > now)) {
+      return { record: existing, shouldPublish: false };
+    }
+
+    if (!existing) {
+      const { error } = await this.supabase
+        .from('revisit')
+        .insert({ studyId, docId, data: candidate });
+      if (!error) {
+        return { record: candidate, shouldPublish: true };
+      }
+      const winner = await this.getSequenceBuild(configHash);
+      if (!winner) {
+        throw new Error('Failed to establish sequence build record');
+      }
+      return { record: winner, shouldPublish: false };
+    }
+
+    const claimed: SequenceBuildRecord = {
+      ...existing,
+      status: 'building',
+      publisherId: candidate.publisherId,
+      leaseExpiresAt: candidate.leaseExpiresAt,
+      attempts: existing.attempts + 1,
+      updatedAt: now,
+    };
+    const { data } = await this.supabase
+      .from('revisit')
+      .update({ data: claimed })
+      .eq('studyId', studyId)
+      .eq('docId', docId)
+      .eq('data->>publisherId', existing.publisherId)
+      .eq('data->>updatedAt', String(existing.updatedAt))
+      .select('data')
+      .maybeSingle();
+    if (data) {
+      return { record: claimed, shouldPublish: true };
+    }
+
+    const winner = await this.getSequenceBuild(configHash);
+    if (!winner) {
+      throw new Error('Failed to claim sequence build record');
+    }
+    return { record: winner, shouldPublish: false };
+  }
+
+  protected async _updateSequenceBuild(
+    configHash: string,
+    publisherId: string,
+    updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+  ) {
+    const existing = await this.getSequenceBuild(configHash);
+    if (!existing || existing.publisherId !== publisherId) {
+      return;
+    }
+    await this.supabase
+      .from('revisit')
+      .update({ data: { ...existing, ...updates } })
+      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('docId', `sequenceBuild_${configHash}`)
+      .eq('data->>publisherId', publisherId);
   }
 
   public async getAllSequenceAssignments(studyId: string) {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -19,6 +19,7 @@ import {
   SnapshotParticipantCounts,
   calculateSnapshotParticipantCounts,
 } from './utils/snapshotParticipantCounts';
+import { generateSequenceArray } from '../../utils/handleRandomSequences';
 
 export interface StoredUser {
   email: string | null,
@@ -87,10 +88,17 @@ export interface ConditionData {
 
 const defaultStageColor = '#F05A30';
 
-export type StorageObjectType = 'sequenceArray' | 'participantData' | 'config' | string;
+export type StorageObjectType =
+  | 'sequenceArray'
+  | 'sequenceBuild'
+  | 'participantData'
+  | 'config'
+  | string;
 export type StorageObject<T extends StorageObjectType> =
   T extends 'sequenceArray'
   ? Sequence[]
+  : T extends 'sequenceBuild'
+  ? SequenceBuildRecord
   : T extends 'participantData'
   ? ParticipantData
   : T extends 'config'
@@ -104,6 +112,21 @@ export type StorageObject<T extends StorageObjectType> =
   : T extends 'tags'
   ? Tag[]
   : Blob; // Fallback for any random string
+
+export type SequenceBuildRecord = {
+  seed: string;
+  algorithmVersion: 1;
+  status: 'building' | 'ready' | 'failed';
+  publisherId: string;
+  leaseExpiresAt: number;
+  attempts: number;
+  updatedAt: number;
+};
+
+export type SequenceBuildClaim = {
+  record: SequenceBuildRecord;
+  shouldPublish: boolean;
+};
 
 interface CloudStorageEngineError {
   title: string;
@@ -203,6 +226,14 @@ export abstract class StorageEngine {
 
   private assetUploadActivityVersion = 0;
 
+  private activeConfigHash: string | null = null;
+
+  private legacySequenceArrayCompatible = false;
+
+  private sequenceArrays = new Map<string, Sequence[]>();
+
+  private static readonly sequenceBuildLeaseMs = 30_000;
+
   constructor(engine: typeof this.engine, testing: boolean) {
     this.engine = engine;
     this.testing = testing;
@@ -241,7 +272,12 @@ export abstract class StorageEngine {
   protected abstract _getFromStorage<T extends StorageObjectType>(prefix: string, type: T, studyId?: string): Promise<StorageObject<T> | null>;
 
   // Pushes an object to the storage engine. The object is identified by its type and studyId.
-  protected abstract _pushToStorage<T extends StorageObjectType>(prefix: string, type: T, objectToUpload: StorageObject<T>): Promise<void>;
+  protected abstract _pushToStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    objectToUpload: StorageObject<T>,
+    options?: { cache?: boolean },
+  ): Promise<void>;
 
   // Deletes an object from the storage engine. The object is identified by its type and studyId.
   protected abstract _deleteFromStorage<T extends StorageObjectType>(prefix: string, type: T): Promise<void>;
@@ -258,6 +294,44 @@ export abstract class StorageEngine {
 
   // Sets the current config hash in the storage engine using the engine's realtime database.
   protected abstract _setCurrentConfigHash(configHash: string): Promise<void>;
+
+  protected async _claimSequenceBuild(
+    configHash: string,
+    candidate: SequenceBuildRecord,
+    now: number,
+  ): Promise<SequenceBuildClaim> {
+    const prefix = `sequenceBuilds/${configHash}`;
+    const existing = await this._getFromStorage(prefix, 'sequenceBuild');
+    if (existing?.status === 'ready'
+      || (existing?.status === 'building' && existing.leaseExpiresAt > now)) {
+      return { record: existing, shouldPublish: false };
+    }
+
+    const claimed = existing
+      ? {
+        ...existing,
+        status: 'building' as const,
+        publisherId: candidate.publisherId,
+        leaseExpiresAt: candidate.leaseExpiresAt,
+        attempts: existing.attempts + 1,
+        updatedAt: now,
+      }
+      : candidate;
+    await this._pushToStorage(prefix, 'sequenceBuild', claimed);
+    return { record: claimed, shouldPublish: true };
+  }
+
+  protected async _updateSequenceBuild(
+    configHash: string,
+    publisherId: string,
+    updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+  ): Promise<void> {
+    const prefix = `sequenceBuilds/${configHash}`;
+    const existing = await this._getFromStorage(prefix, 'sequenceBuild');
+    if (existing?.publisherId === publisherId) {
+      await this._pushToStorage(prefix, 'sequenceBuild', { ...existing, ...updates });
+    }
+  }
 
   /* General/Realtime ---------------------------------------------------- */
   // Gets all sequence assignments for the given studyId. The sequence assignments are sorted ascending by timestamp.
@@ -764,11 +838,13 @@ export abstract class StorageEngine {
     await this._setModesDocument(studyId, updatedModesDoc);
   }
 
-  // Saves the new config for the study. This will overwrite the existing sequence array so that the new sequences are compatible with the new config.
+  // Saves the active config without removing artifacts used by earlier participant sessions.
   async saveConfig(config: StudyConfig) {
     const currentConfigHash = await this._getCurrentConfigHash();
     // Hash the provided config
     const configHash = await hash(JSON.stringify(config));
+    this.activeConfigHash = configHash;
+    this.legacySequenceArrayCompatible = currentConfigHash === configHash;
 
     // Skip saving config if the active config is already saved in storage
     if (currentConfigHash === configHash) {
@@ -785,17 +861,6 @@ export abstract class StorageEngine {
       config,
     );
     await this._cacheStorageObject(`configs/${configHash}`, 'config');
-
-    // Clear sequence array if the config has changed.
-    // Keep currentParticipantId so existing participant sessions can continue
-    // against their original participantConfigHash.
-    if (currentConfigHash && currentConfigHash !== configHash) {
-      try {
-        await this._deleteFromStorage('', 'sequenceArray');
-      } catch {
-        // pass, if this happens, we didn't have a sequence array yet
-      }
-    }
 
     if (currentConfigHash !== configHash) {
       await this._setCurrentConfigHash(configHash);
@@ -1764,9 +1829,105 @@ export abstract class StorageEngine {
     });
   }
 
-  // Gets the sequence array from the storage engine.
+  private sequenceArtifactPrefix(configHash: string) {
+    return `sequenceArrays/${configHash}`;
+  }
+
+  private async publishSequenceArray(
+    configHash: string,
+    publisherId: string,
+    sequenceArray: Sequence[],
+  ) {
+    try {
+      await this._pushToStorage(
+        this.sequenceArtifactPrefix(configHash),
+        'sequenceArray',
+        sequenceArray,
+        { cache: true },
+      );
+      await this._updateSequenceBuild(configHash, publisherId, {
+        status: 'ready',
+        leaseExpiresAt: 0,
+        updatedAt: Date.now(),
+      });
+    } catch {
+      await this._updateSequenceBuild(configHash, publisherId, {
+        status: 'failed',
+        leaseExpiresAt: 0,
+        updatedAt: Date.now(),
+      }).catch(() => undefined);
+    }
+  }
+
+  async prepareSequenceArray(config: StudyConfig, configHash: string) {
+    await this.verifyStudyDatabase();
+    this.activeConfigHash = configHash;
+
+    const cachedSequenceArray = this.sequenceArrays.get(configHash);
+    if (cachedSequenceArray) {
+      return cachedSequenceArray;
+    }
+
+    const storedSequenceArray = await this._getFromStorage(
+      this.sequenceArtifactPrefix(configHash),
+      'sequenceArray',
+    );
+    if (Array.isArray(storedSequenceArray)) {
+      this.sequenceArrays.set(configHash, storedSequenceArray);
+      return storedSequenceArray;
+    }
+
+    if (this.legacySequenceArrayCompatible) {
+      const legacySequenceArray = await this._getFromStorage('', 'sequenceArray');
+      if (Array.isArray(legacySequenceArray)) {
+        this.sequenceArrays.set(configHash, legacySequenceArray);
+        return legacySequenceArray;
+      }
+    }
+
+    const now = Date.now();
+    const publisherId = uuidv4();
+    const claim = await this._claimSequenceBuild(configHash, {
+      seed: uuidv4(),
+      algorithmVersion: 1,
+      status: 'building',
+      publisherId,
+      leaseExpiresAt: now + StorageEngine.sequenceBuildLeaseMs,
+      attempts: 1,
+      updatedAt: now,
+    }, now);
+    if (claim.record.algorithmVersion !== 1) {
+      throw new Error(`Unsupported sequence algorithm version: ${claim.record.algorithmVersion}`);
+    }
+    const generatedSequenceArray = generateSequenceArray(config, claim.record.seed);
+    this.sequenceArrays.set(configHash, generatedSequenceArray);
+
+    if (claim.shouldPublish) {
+      this.publishSequenceArray(configHash, publisherId, generatedSequenceArray);
+    }
+
+    return generatedSequenceArray;
+  }
+
+  // Gets the sequence array for the active config from the storage engine.
   async getSequenceArray() {
     await this.verifyStudyDatabase();
+
+    if (this.activeConfigHash) {
+      const activeSequenceArray = this.sequenceArrays.get(this.activeConfigHash);
+      if (activeSequenceArray) {
+        return activeSequenceArray;
+      }
+
+      const storedSequenceArray = await this._getFromStorage(
+        this.sequenceArtifactPrefix(this.activeConfigHash),
+        'sequenceArray',
+      );
+      if (Array.isArray(storedSequenceArray)) {
+        this.sequenceArrays.set(this.activeConfigHash, storedSequenceArray);
+        return storedSequenceArray;
+      }
+    }
 
     const sequenceArrayDocData = await this._getFromStorage(
       '',
@@ -1781,6 +1942,9 @@ export abstract class StorageEngine {
     await this.verifyStudyDatabase();
 
     await this._pushToStorage('', 'sequenceArray', latinSquare);
+    if (this.activeConfigHash) {
+      this.sequenceArrays.set(this.activeConfigHash, latinSquare);
+    }
   }
 
   protected async __testingReset() {
@@ -1794,6 +1958,9 @@ export abstract class StorageEngine {
     this.failedAssetRetryOperations.clear();
     this.pendingProgressDataWrite = undefined;
     this.assetUploadActivityVersion = 0;
+    this.activeConfigHash = null;
+    this.legacySequenceArrayCompatible = false;
+    this.sequenceArrays.clear();
     this.participantData = undefined;
     if (this.studyId) {
       await this.clearCurrentParticipantId();

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -91,6 +91,7 @@ const defaultStageColor = '#F05A30';
 export type StorageObjectType =
   | 'sequenceArray'
   | 'sequenceBuild'
+  | 'sequenceLegacyOwner'
   | 'participantData'
   | 'config'
   | string;
@@ -99,6 +100,8 @@ export type StorageObject<T extends StorageObjectType> =
   ? Sequence[]
   : T extends 'sequenceBuild'
   ? SequenceBuildRecord
+  : T extends 'sequenceLegacyOwner'
+  ? { configHash: string }
   : T extends 'participantData'
   ? ParticipantData
   : T extends 'config'
@@ -228,7 +231,7 @@ export abstract class StorageEngine {
 
   private activeConfigHash: string | null = null;
 
-  private legacySequenceArrayCompatible = false;
+  private legacySequenceArrayConfigHash: string | null = null;
 
   private sequenceArrays = new Map<string, Sequence[]>();
 
@@ -276,7 +279,7 @@ export abstract class StorageEngine {
     prefix: string,
     type: T,
     objectToUpload: StorageObject<T>,
-    options?: { cache?: boolean },
+    options?: { cache?: boolean; studyId?: string },
   ): Promise<void>;
 
   // Deletes an object from the storage engine. The object is identified by its type and studyId.
@@ -299,6 +302,7 @@ export abstract class StorageEngine {
     configHash: string,
     candidate: SequenceBuildRecord,
     now: number,
+    _studyId?: string,
   ): Promise<SequenceBuildClaim> {
     const prefix = `sequenceBuilds/${configHash}`;
     const existing = await this._getFromStorage(prefix, 'sequenceBuild');
@@ -325,12 +329,21 @@ export abstract class StorageEngine {
     configHash: string,
     publisherId: string,
     updates: Pick<SequenceBuildRecord, 'status' | 'leaseExpiresAt' | 'updatedAt'>,
+    _studyId?: string,
   ): Promise<void> {
     const prefix = `sequenceBuilds/${configHash}`;
     const existing = await this._getFromStorage(prefix, 'sequenceBuild');
     if (existing?.publisherId === publisherId) {
       await this._pushToStorage(prefix, 'sequenceBuild', { ...existing, ...updates });
     }
+  }
+
+  protected async _getSequenceBuildProviderTime() {
+    return Date.now();
+  }
+
+  protected async _deleteSequenceBuild(configHash: string) {
+    await this._deleteFromStorage(`sequenceBuilds/${configHash}`, 'sequenceBuild');
   }
 
   /* General/Realtime ---------------------------------------------------- */
@@ -844,7 +857,20 @@ export abstract class StorageEngine {
     // Hash the provided config
     const configHash = await hash(JSON.stringify(config));
     this.activeConfigHash = configHash;
-    this.legacySequenceArrayCompatible = currentConfigHash === configHash;
+    const legacyOwner = await this._getFromStorage('', 'sequenceLegacyOwner');
+    if (legacyOwner && typeof legacyOwner === 'object' && 'configHash' in legacyOwner) {
+      this.legacySequenceArrayConfigHash = legacyOwner.configHash;
+    } else if (currentConfigHash) {
+      const legacySequenceArray = await this._getFromStorage('', 'sequenceArray');
+      if (Array.isArray(legacySequenceArray)) {
+        await this._pushToStorage(
+          '',
+          'sequenceLegacyOwner',
+          { configHash: currentConfigHash },
+        );
+        this.legacySequenceArrayConfigHash = currentConfigHash;
+      }
+    }
 
     // Skip saving config if the active config is already saved in storage
     if (currentConfigHash === configHash) {
@@ -864,6 +890,17 @@ export abstract class StorageEngine {
 
     if (currentConfigHash !== configHash) {
       await this._setCurrentConfigHash(configHash);
+      if (!this.legacySequenceArrayConfigHash) {
+        const legacySequenceArray = await this._getFromStorage('', 'sequenceArray');
+        if (Array.isArray(legacySequenceArray)) {
+          await this._pushToStorage(
+            '',
+            'sequenceLegacyOwner',
+            { configHash },
+          );
+          this.legacySequenceArrayConfigHash = configHash;
+        }
+      }
     }
   }
 
@@ -1834,6 +1871,7 @@ export abstract class StorageEngine {
   }
 
   private async publishSequenceArray(
+    studyId: string,
     configHash: string,
     publisherId: string,
     sequenceArray: Sequence[],
@@ -1843,27 +1881,32 @@ export abstract class StorageEngine {
         this.sequenceArtifactPrefix(configHash),
         'sequenceArray',
         sequenceArray,
-        { cache: true },
+        { cache: true, studyId },
       );
       await this._updateSequenceBuild(configHash, publisherId, {
         status: 'ready',
         leaseExpiresAt: 0,
         updatedAt: Date.now(),
-      });
+      }, studyId);
     } catch {
       await this._updateSequenceBuild(configHash, publisherId, {
         status: 'failed',
         leaseExpiresAt: 0,
         updatedAt: Date.now(),
-      }).catch(() => undefined);
+      }, studyId).catch(() => undefined);
     }
   }
 
   async prepareSequenceArray(config: StudyConfig, configHash: string) {
     await this.verifyStudyDatabase();
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const studyId = this.studyId;
     this.activeConfigHash = configHash;
 
-    const cachedSequenceArray = this.sequenceArrays.get(configHash);
+    const cacheKey = `${studyId}:${configHash}`;
+    const cachedSequenceArray = this.sequenceArrays.get(cacheKey);
     if (cachedSequenceArray) {
       return cachedSequenceArray;
     }
@@ -1873,19 +1916,19 @@ export abstract class StorageEngine {
       'sequenceArray',
     );
     if (Array.isArray(storedSequenceArray)) {
-      this.sequenceArrays.set(configHash, storedSequenceArray);
+      this.sequenceArrays.set(cacheKey, storedSequenceArray);
       return storedSequenceArray;
     }
 
-    if (this.legacySequenceArrayCompatible) {
+    if (this.legacySequenceArrayConfigHash === configHash) {
       const legacySequenceArray = await this._getFromStorage('', 'sequenceArray');
       if (Array.isArray(legacySequenceArray)) {
-        this.sequenceArrays.set(configHash, legacySequenceArray);
+        this.sequenceArrays.set(cacheKey, legacySequenceArray);
         return legacySequenceArray;
       }
     }
 
-    const now = Date.now();
+    const now = await this._getSequenceBuildProviderTime();
     const publisherId = uuidv4();
     const claim = await this._claimSequenceBuild(configHash, {
       seed: uuidv4(),
@@ -1895,15 +1938,15 @@ export abstract class StorageEngine {
       leaseExpiresAt: now + StorageEngine.sequenceBuildLeaseMs,
       attempts: 1,
       updatedAt: now,
-    }, now);
+    }, now, studyId);
     if (claim.record.algorithmVersion !== 1) {
       throw new Error(`Unsupported sequence algorithm version: ${claim.record.algorithmVersion}`);
     }
     const generatedSequenceArray = generateSequenceArray(config, claim.record.seed);
-    this.sequenceArrays.set(configHash, generatedSequenceArray);
+    this.sequenceArrays.set(cacheKey, generatedSequenceArray);
 
     if (claim.shouldPublish) {
-      this.publishSequenceArray(configHash, publisherId, generatedSequenceArray);
+      this.publishSequenceArray(studyId, configHash, publisherId, generatedSequenceArray);
     }
 
     return generatedSequenceArray;
@@ -1914,7 +1957,9 @@ export abstract class StorageEngine {
     await this.verifyStudyDatabase();
 
     if (this.activeConfigHash) {
-      const activeSequenceArray = this.sequenceArrays.get(this.activeConfigHash);
+      const activeSequenceArray = this.sequenceArrays.get(
+        `${this.studyId}:${this.activeConfigHash}`,
+      );
       if (activeSequenceArray) {
         return activeSequenceArray;
       }
@@ -1924,7 +1969,10 @@ export abstract class StorageEngine {
         'sequenceArray',
       );
       if (Array.isArray(storedSequenceArray)) {
-        this.sequenceArrays.set(this.activeConfigHash, storedSequenceArray);
+        this.sequenceArrays.set(
+          `${this.studyId}:${this.activeConfigHash}`,
+          storedSequenceArray,
+        );
         return storedSequenceArray;
       }
     }
@@ -1943,8 +1991,48 @@ export abstract class StorageEngine {
 
     await this._pushToStorage('', 'sequenceArray', latinSquare);
     if (this.activeConfigHash) {
-      this.sequenceArrays.set(this.activeConfigHash, latinSquare);
+      await this._pushToStorage(
+        '',
+        'sequenceLegacyOwner',
+        { configHash: this.activeConfigHash },
+      );
+      this.legacySequenceArrayConfigHash = this.activeConfigHash;
+      this.sequenceArrays.set(`${this.studyId}:${this.activeConfigHash}`, latinSquare);
     }
+  }
+
+  async cleanupObsoleteSequenceArtifacts(candidateConfigHashes: string[]) {
+    await this.verifyStudyDatabase();
+    const retainedConfigHashes = new Set<string>();
+    const currentConfigHash = await this._getCurrentConfigHash();
+    if (currentConfigHash) {
+      retainedConfigHashes.add(currentConfigHash);
+    }
+    if (this.studyId) {
+      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      const participantData = await Promise.all(assignments.map(
+        (assignment) => this._getFromStorage(
+          `participants/${assignment.participantId}`,
+          'participantData',
+        ),
+      ));
+      participantData.forEach((participant) => {
+        if (participant && typeof participant === 'object' && 'participantConfigHash' in participant) {
+          retainedConfigHashes.add(participant.participantConfigHash);
+        }
+      });
+    }
+
+    await Promise.all(candidateConfigHashes
+      .filter((configHash) => !retainedConfigHashes.has(configHash))
+      .map(async (configHash) => {
+        await this._deleteFromStorage(
+          this.sequenceArtifactPrefix(configHash),
+          'sequenceArray',
+        ).catch(() => undefined);
+        await this._deleteSequenceBuild(configHash).catch(() => undefined);
+        this.sequenceArrays.delete(`${this.studyId}:${configHash}`);
+      }));
   }
 
   protected async __testingReset() {
@@ -1959,7 +2047,7 @@ export abstract class StorageEngine {
     this.pendingProgressDataWrite = undefined;
     this.assetUploadActivityVersion = 0;
     this.activeConfigHash = null;
-    this.legacySequenceArrayCompatible = false;
+    this.legacySequenceArrayConfigHash = null;
     this.sequenceArrays.clear();
     this.participantData = undefined;
     if (this.studyId) {

--- a/src/storage/tests/sequencePublication.spec.ts
+++ b/src/storage/tests/sequencePublication.spec.ts
@@ -1,0 +1,222 @@
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
+import { StudyConfig } from '../../parser/types';
+import { Sequence } from '../../store/types';
+import { generateSequenceArray } from '../../utils/handleRandomSequences';
+import { LocalStorageEngine } from '../engines/LocalStorageEngine';
+import {
+  SequenceBuildRecord, StorageObject, StorageObjectType,
+} from '../engines/types';
+import { hash } from '../engines/utils/storageEngineHelpers';
+import testConfigSimple from './testConfigSimple.json';
+import testConfigSimple2 from './testConfigSimple2.json';
+
+const config = testConfigSimple as StudyConfig;
+const changedConfig = testConfigSimple2 as StudyConfig;
+
+class PublicationTrackingEngine extends LocalStorageEngine {
+  static uploadCount = 0;
+
+  private failSequenceUpload = false;
+
+  private holdSequenceUpload = false;
+
+  private uploadStartedResolve: (() => void) | undefined;
+
+  private releaseUploadResolve: (() => void) | undefined;
+
+  private uploadStarted = Promise.resolve();
+
+  private uploadRelease = Promise.resolve();
+
+  failNextSequenceUpload() {
+    this.failSequenceUpload = true;
+    this.uploadStarted = new Promise((resolve) => {
+      this.uploadStartedResolve = resolve;
+    });
+  }
+
+  holdNextSequenceUpload() {
+    this.holdSequenceUpload = true;
+    this.uploadStarted = new Promise((resolve) => {
+      this.uploadStartedResolve = resolve;
+    });
+    this.uploadRelease = new Promise((resolve) => {
+      this.releaseUploadResolve = resolve;
+    });
+  }
+
+  waitForSequenceUpload() {
+    return this.uploadStarted;
+  }
+
+  releaseSequenceUpload() {
+    this.releaseUploadResolve?.();
+  }
+
+  claimSequenceBuild(configHash: string, candidate: SequenceBuildRecord, now: number) {
+    return this._claimSequenceBuild(configHash, candidate, now);
+  }
+
+  protected override async _pushToStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    objectToUpload: StorageObject<T>,
+    options?: { cache?: boolean },
+  ) {
+    if (type === 'sequenceArray' && prefix.startsWith('sequenceArrays/')) {
+      PublicationTrackingEngine.uploadCount += 1;
+      this.uploadStartedResolve?.();
+      if (this.failSequenceUpload) {
+        this.failSequenceUpload = false;
+        throw new Error('sequence upload failed');
+      }
+      if (this.holdSequenceUpload) {
+        this.holdSequenceUpload = false;
+        await this.uploadRelease;
+      }
+    }
+    await super._pushToStorage(prefix, type, objectToUpload, options);
+  }
+}
+
+async function initializeEngine(engine: LocalStorageEngine, studyId: string) {
+  await engine.connect();
+  await engine.initializeStudyDb(studyId);
+  await engine.saveConfig(config);
+}
+
+describe('sequence artifact publication', () => {
+  beforeEach(() => {
+    PublicationTrackingEngine.uploadCount = 0;
+  });
+
+  test('seeded generation is deterministic', () => {
+    expect(generateSequenceArray(config, 'shared-seed'))
+      .toEqual(generateSequenceArray(config, 'shared-seed'));
+  });
+
+  test('participant startup does not await the canonical artifact upload', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    await initializeEngine(engine, 'sequence-publication-background');
+    const configHash = await hash(JSON.stringify(config));
+    engine.holdNextSequenceUpload();
+
+    const sequenceArray = await engine.prepareSequenceArray(config, configHash);
+    await engine.waitForSequenceUpload();
+
+    expect(sequenceArray).toHaveLength(config.uiConfig.numSequences ?? 1000);
+    engine.releaseSequenceUpload();
+  });
+
+  test('concurrent clients derive the same array while only one publishes', async () => {
+    const studyId = 'sequence-publication-concurrent';
+    const publisher = new PublicationTrackingEngine(true);
+    const follower = new PublicationTrackingEngine(true);
+    await initializeEngine(publisher, studyId);
+    await initializeEngine(follower, studyId);
+    const configHash = await hash(JSON.stringify(config));
+    publisher.holdNextSequenceUpload();
+
+    const publisherArray = await publisher.prepareSequenceArray(config, configHash);
+    await publisher.waitForSequenceUpload();
+    const followerArray = await follower.prepareSequenceArray(config, configHash);
+
+    expect(followerArray).toEqual(publisherArray);
+    expect(PublicationTrackingEngine.uploadCount).toBe(1);
+    publisher.releaseSequenceUpload();
+  });
+
+  test('a failed publisher can be replaced without changing the derived array', async () => {
+    const studyId = 'sequence-publication-retry';
+    const failedPublisher = new PublicationTrackingEngine(true);
+    const retryingPublisher = new PublicationTrackingEngine(true);
+    await initializeEngine(failedPublisher, studyId);
+    await initializeEngine(retryingPublisher, studyId);
+    const configHash = await hash(JSON.stringify(config));
+    failedPublisher.failNextSequenceUpload();
+
+    const firstArray = await failedPublisher.prepareSequenceArray(config, configHash);
+    await failedPublisher.waitForSequenceUpload();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    const retriedArray = await retryingPublisher.prepareSequenceArray(config, configHash);
+
+    expect(retriedArray).toEqual(firstArray);
+    expect(PublicationTrackingEngine.uploadCount).toBe(2);
+  });
+
+  test('an expired publisher lease can be claimed without changing its seed', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    await initializeEngine(engine, 'sequence-publication-expired-lease');
+    const initialBuild: SequenceBuildRecord = {
+      seed: 'persistent-seed',
+      algorithmVersion: 1,
+      status: 'building',
+      publisherId: 'first-publisher',
+      leaseExpiresAt: 101,
+      attempts: 1,
+      updatedAt: 100,
+    };
+    await engine.claimSequenceBuild('config-hash', initialBuild, 100);
+
+    const replacement = await engine.claimSequenceBuild('config-hash', {
+      ...initialBuild,
+      seed: 'ignored-new-seed',
+      publisherId: 'replacement-publisher',
+      leaseExpiresAt: 202,
+      updatedAt: 102,
+    }, 102);
+
+    expect(replacement.shouldPublish).toBe(true);
+    expect(replacement.record.seed).toBe('persistent-seed');
+    expect(replacement.record.publisherId).toBe('replacement-publisher');
+    expect(replacement.record.attempts).toBe(2);
+  });
+
+  test('an existing legacy array remains readable without migration', async () => {
+    const studyId = 'sequence-publication-legacy';
+    const existingEngine = new PublicationTrackingEngine(true);
+    await initializeEngine(existingEngine, studyId);
+    const legacyArray = generateSequenceArray(config, 'legacy-seed');
+    await existingEngine.setSequenceArray(legacyArray);
+
+    const resumedEngine = new PublicationTrackingEngine(true);
+    await initializeEngine(resumedEngine, studyId);
+    const configHash = await hash(JSON.stringify(config));
+    const resolvedArray = await resumedEngine.prepareSequenceArray(config, configHash);
+
+    expect(resolvedArray).toEqual(legacyArray);
+    expect(PublicationTrackingEngine.uploadCount).toBe(0);
+  });
+
+  test('config changes retain the previous hash-keyed artifact', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    const studyId = 'sequence-publication-config-change';
+    await initializeEngine(engine, studyId);
+    const firstHash = await hash(JSON.stringify(config));
+    const firstArray = await engine.prepareSequenceArray(config, firstHash);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    await engine.saveConfig(changedConfig);
+    const secondHash = await hash(JSON.stringify(changedConfig));
+    await engine.prepareSequenceArray(changedConfig, secondHash);
+
+    const resumedEngine = new PublicationTrackingEngine(true);
+    await resumedEngine.connect();
+    await resumedEngine.initializeStudyDb(studyId);
+    const storedFirstArray = await (
+      resumedEngine as unknown as {
+        _getFromStorage(
+          prefix: string,
+          type: 'sequenceArray',
+        ): Promise<Sequence[] | null>;
+      }
+    )._getFromStorage(`sequenceArrays/${firstHash}`, 'sequenceArray');
+    expect(storedFirstArray).toEqual(firstArray);
+  });
+});

--- a/src/storage/tests/sequencePublication.spec.ts
+++ b/src/storage/tests/sequencePublication.spec.ts
@@ -30,6 +30,10 @@ class PublicationTrackingEngine extends LocalStorageEngine {
 
   private uploadRelease = Promise.resolve();
 
+  private providerTime: number | null = null;
+
+  private failSequenceRead = false;
+
   failNextSequenceUpload() {
     this.failSequenceUpload = true;
     this.uploadStarted = new Promise((resolve) => {
@@ -53,6 +57,38 @@ class PublicationTrackingEngine extends LocalStorageEngine {
 
   releaseSequenceUpload() {
     this.releaseUploadResolve?.();
+  }
+
+  useProviderTime(now: number) {
+    this.providerTime = now;
+  }
+
+  failNextSequenceRead() {
+    this.failSequenceRead = true;
+  }
+
+  getStoredSequenceArray(configHash: string) {
+    return this._getFromStorage(`sequenceArrays/${configHash}`, 'sequenceArray');
+  }
+
+  protected override async _getSequenceBuildProviderTime() {
+    return this.providerTime ?? super._getSequenceBuildProviderTime();
+  }
+
+  protected override async _getFromStorage<T extends StorageObjectType>(
+    prefix: string,
+    type: T,
+    studyId?: string,
+  ) {
+    if (
+      this.failSequenceRead
+      && type === 'sequenceArray'
+      && prefix.startsWith('sequenceArrays/')
+    ) {
+      this.failSequenceRead = false;
+      throw new Error('transient provider failure');
+    }
+    return super._getFromStorage(prefix, type, studyId);
   }
 
   claimSequenceBuild(configHash: string, candidate: SequenceBuildRecord, now: number) {
@@ -190,6 +226,88 @@ describe('sequence artifact publication', () => {
 
     expect(resolvedArray).toEqual(legacyArray);
     expect(PublicationTrackingEngine.uploadCount).toBe(0);
+  });
+
+  test('does not reuse a legacy array after the config hash changes', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    await initializeEngine(engine, 'sequence-publication-legacy-transition');
+    const legacyArray = generateSequenceArray(config, 'legacy-seed');
+    await engine.setSequenceArray(legacyArray);
+    await engine.saveConfig(changedConfig);
+    const changedHash = await hash(JSON.stringify(changedConfig));
+
+    const resolvedArray = await engine.prepareSequenceArray(changedConfig, changedHash);
+
+    expect(resolvedArray).not.toEqual(legacyArray);
+    expect(PublicationTrackingEngine.uploadCount).toBe(1);
+  });
+
+  test('does not turn a transient artifact read failure into legacy fallback', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    const studyId = 'sequence-publication-read-failure';
+    await initializeEngine(engine, studyId);
+    await engine.setSequenceArray(generateSequenceArray(config, 'legacy-seed'));
+    const configHash = await hash(JSON.stringify(config));
+    const resumedEngine = new PublicationTrackingEngine(true);
+    await initializeEngine(resumedEngine, studyId);
+    resumedEngine.failNextSequenceRead();
+
+    await expect(resumedEngine.prepareSequenceArray(config, configHash))
+      .rejects.toThrow('transient provider failure');
+  });
+
+  test('scopes cached sequence state to study and config hash', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    const configHash = await hash(JSON.stringify(config));
+    await initializeEngine(engine, 'sequence-publication-study-a');
+    await engine.prepareSequenceArray(config, configHash);
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    await initializeEngine(engine, 'sequence-publication-study-b');
+    await engine.prepareSequenceArray(config, configHash);
+
+    expect(PublicationTrackingEngine.uploadCount).toBe(2);
+  });
+
+  test('uses provider time for publication leases', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    await initializeEngine(engine, 'sequence-publication-provider-time');
+    engine.useProviderTime(500);
+    const configHash = await hash(JSON.stringify(config));
+    engine.holdNextSequenceUpload();
+
+    await engine.prepareSequenceArray(config, configHash);
+    await engine.waitForSequenceUpload();
+    const claim = await engine.claimSequenceBuild(configHash, {
+      seed: 'ignored',
+      algorithmVersion: 1,
+      status: 'building',
+      publisherId: 'clock-skewed-client',
+      leaseExpiresAt: 30_499,
+      attempts: 1,
+      updatedAt: 499,
+    }, 499);
+
+    expect(claim.shouldPublish).toBe(false);
+    expect(claim.record.leaseExpiresAt).toBe(30_500);
+    engine.releaseSequenceUpload();
+  });
+
+  test('cleanup removes only explicitly nominated unreferenced artifacts', async () => {
+    const engine = new PublicationTrackingEngine(true);
+    await initializeEngine(engine, 'sequence-publication-cleanup');
+    const firstHash = await hash(JSON.stringify(config));
+    await engine.prepareSequenceArray(config, firstHash);
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    await engine.saveConfig(changedConfig);
+    const activeHash = await hash(JSON.stringify(changedConfig));
+    await engine.prepareSequenceArray(changedConfig, activeHash);
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    await engine.cleanupObsoleteSequenceArtifacts([firstHash, activeHash]);
+
+    expect(await engine.getStoredSequenceArray(firstHash)).toBeNull();
+    expect(await engine.getStoredSequenceArray(activeHash)).not.toBeNull();
   });
 
   test('config changes retain the previous hash-keyed artifact', async () => {

--- a/src/utils/handleRandomSequences.tsx
+++ b/src/utils/handleRandomSequences.tsx
@@ -9,13 +9,35 @@ import {
 import { Sequence } from '../store/types';
 import { isDynamicBlock } from '../parser/utils';
 
-function shuffle<T>(array: T[]) {
+type RandomSource = () => number;
+
+function createSeededRandom(seed: string): RandomSource {
+  let state = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    state ^= seed.charCodeAt(i);
+    state = Math.imul(state, 16777619);
+  }
+
+  return () => {
+    state += 0x6D2B79F5;
+    let value = state;
+    // eslint-disable-next-line no-bitwise
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    // eslint-disable-next-line no-bitwise
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    // eslint-disable-next-line no-bitwise
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle<T>(array: T[], random: RandomSource) {
   let currentIndex = array.length;
 
   // While there remain elements to shuffle...
   while (currentIndex !== 0) {
     // Pick a remaining element...
-    const randomIndex = Math.floor(Math.random() * currentIndex);
+    const randomIndex = Math.floor(random() * currentIndex);
     currentIndex -= 1;
 
     // And swap it with the current element.
@@ -58,7 +80,7 @@ function findUniqueComponents(
   return uniqueComponents;
 }
 
-function generateLatinSquare(config: StudyConfig, path: string) {
+function generateLatinSquare(config: StudyConfig, path: string, random: RandomSource) {
   const pathArr = path.split('-');
 
   let locationInSequence: Partial<ComponentBlock> | Partial<DynamicBlock> | string = {};
@@ -74,15 +96,20 @@ function generateLatinSquare(config: StudyConfig, path: string) {
   });
 
   const options = (locationInSequence as ComponentBlock).components.map((c: unknown, i: number) => (typeof c === 'string' ? c : `_componentBlock${i}`));
-  shuffle(options);
+  shuffle(options, random);
   const newSquare: string[][] = latinSquare<string>(options, true);
   return newSquare;
 }
 
-function generateLatinSquareRows(config: StudyConfig, path: string, count: number): string[][] {
+function generateLatinSquareRows(
+  config: StudyConfig,
+  path: string,
+  count: number,
+  random: RandomSource,
+): string[][] {
   const rows: string[][] = [];
   for (let i = 0; i < count; i += 1) {
-    rows.push(...generateLatinSquare(config, path));
+    rows.push(...generateLatinSquare(config, path, random));
   }
   return rows;
 }
@@ -90,6 +117,7 @@ function generateLatinSquareRows(config: StudyConfig, path: string, count: numbe
 function insertRandomInterruptions(
   components: (string | ComponentBlock | DynamicBlock)[],
   randomInterruptions: RandomInterruption[],
+  random: RandomSource,
 ) {
   const totalInterruptions = randomInterruptions
     .reduce((count, interruption) => count + interruption.numInterruptions, 0);
@@ -102,7 +130,7 @@ function insertRandomInterruptions(
     { length: components.length - 1 },
     (_, index) => index + 1,
   );
-  shuffle(availableLocations);
+  shuffle(availableLocations, random);
 
   const interruptionsByLocation = new Map<number, string[][]>();
   randomInterruptions.forEach((interruption) => {
@@ -135,6 +163,7 @@ function _componentBlockToSequence(
   latinSquareObject: Record<string, string[][]>,
   path: string,
   config: StudyConfig,
+  random: RandomSource,
 ): Sequence {
   if (isDynamicBlock(order)) {
     return {
@@ -153,7 +182,7 @@ function _componentBlockToSequence(
   if (order.order === 'random') {
     const randomArr = structuredClone(order.components);
 
-    shuffle(randomArr);
+    shuffle(randomArr, random);
 
     computedComponents = randomArr;
   } else if (order.order === 'latinSquare' && latinSquareObject) {
@@ -194,7 +223,13 @@ function _componentBlockToSequence(
         const actualIndex = matchedUnique.indices[seenCount] ?? matchedUnique.indices[0];
         seenCounts.set(matchedUnique.component, seenCount + 1);
 
-        computedComponents[i] = _componentBlockToSequence(curr, latinSquareObject, `${path}-${actualIndex}`, config) as unknown as ComponentBlock;
+        computedComponents[i] = _componentBlockToSequence(
+          curr,
+          latinSquareObject,
+          `${path}-${actualIndex}`,
+          config,
+          random,
+        ) as unknown as ComponentBlock;
       } else {
         // This should never happen - all component blocks should be in uniqueComponents
         throw new Error(`Unexpected: component block not found in uniqueComponents map at path ${path}`);
@@ -229,7 +264,11 @@ function _componentBlockToSequence(
           groupedRandomInterruptions.push(order.interruptions[interruptionIndex] as RandomInterruption);
         }
 
-        computedComponents = insertRandomInterruptions(computedComponents, groupedRandomInterruptions);
+        computedComponents = insertRandomInterruptions(
+          computedComponents,
+          groupedRandomInterruptions,
+          random,
+        );
       }
     }
   }
@@ -249,10 +288,11 @@ function componentBlockToSequence(
   order: StudyConfig['sequence'],
   latinSquareObject: Record<string, string[][]>,
   config: StudyConfig,
+  random: RandomSource,
 ): Sequence {
   const orderCopy = structuredClone(order);
 
-  return _componentBlockToSequence(orderCopy, latinSquareObject, 'root', config);
+  return _componentBlockToSequence(orderCopy, latinSquareObject, 'root', config, random);
 }
 
 function _createRandomOrders(order: StudyConfig['sequence'], paths: string[], path: string, index: number) {
@@ -338,7 +378,8 @@ function countPathUsage(order: StudyConfig['sequence']): Record<string, number> 
   return pathCounts;
 }
 
-export function generateSequenceArray(config: StudyConfig): Sequence[] {
+export function generateSequenceArray(config: StudyConfig, seed?: string): Sequence[] {
+  const random = seed === undefined ? Math.random : createSeededRandom(seed);
   const paths = createRandomOrders(config.sequence);
   const pathUsageCounts = countPathUsage(config.sequence);
 
@@ -347,7 +388,7 @@ export function generateSequenceArray(config: StudyConfig): Sequence[] {
   const latinSquareObject: Record<string, string[][]> = paths
     .map((p) => {
       const usageCount = pathUsageCounts[p] || 1;
-      return { [p]: generateLatinSquareRows(config, p, usageCount) };
+      return { [p]: generateLatinSquareRows(config, p, usageCount, random) };
     })
     .reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
@@ -356,7 +397,7 @@ export function generateSequenceArray(config: StudyConfig): Sequence[] {
   const sequenceArray: Sequence[] = [];
   Array.from({ length: numSequences }).forEach(() => {
     // Generate a sequence
-    const sequence = componentBlockToSequence(config.sequence, latinSquareObject, config);
+    const sequence = componentBlockToSequence(config.sequence, latinSquareObject, config, random);
     sequence.components.push('end');
 
     // Add the sequence to the array
@@ -366,7 +407,7 @@ export function generateSequenceArray(config: StudyConfig): Sequence[] {
     Object.entries(latinSquareObject).forEach(([key, value]) => {
       if (value.length === 0) {
         const usageCount = pathUsageCounts[key] || 1;
-        latinSquareObject[key] = generateLatinSquareRows(config, key, usageCount);
+        latinSquareObject[key] = generateLatinSquareRows(config, key, usageCount, random);
       }
     });
   });


### PR DESCRIPTION
## Summary

- key sequence artifacts and build records by config hash
- atomically coordinate deterministic seeds and bounded publication leases across Firebase and Supabase
- derive sequence arrays locally so participant assignment can continue while the lease owner publishes in the background
- retain legacy arrays and prior config artifacts for existing participant sessions
- attach immutable cache metadata during the initial canonical artifact upload

## Why

The first participant after a config change previously generated and uploaded the full sequence array before participant initialization could continue. It also deleted the prior mutable artifact, which made artifact lifetime depend on the active config rather than participant sessions.

This change establishes a small transactional build record first. Concurrent clients derive the same array from its seed, while only the lease owner uploads the canonical artifact. Failed or abandoned publishers can be replaced without changing the seed.

Closes #1319.

## Validation

- `yarn install --frozen-lockfile`
- `yarn unittest --run` (2,036 tests passed, 1 skipped)
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`
