### PR TITLE
Render the study interface while participant startup resolves

### DIFF
--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_AUTO_ADVANCE_WARNING_TIME,
   getAutoAdvanceWarning,
 } from './nextButtonTimeout';
+import { useStartupInteractionBlocked } from './StartupContext';
 
 const nextButtonJustify = {
   left: 'flex-start',
@@ -45,6 +46,7 @@ export function NextButton({
   const studyConfig = useStudyConfig();
   const navigate = useNavigate();
   const identifier = useCurrentIdentifier();
+  const startupInteractionBlocked = useStartupInteractionBlocked();
 
   const nextButtonDisableTime = config?.nextButtonDisableTime ?? studyConfig.uiConfig.nextButtonDisableTime;
   const nextButtonEnableTime = config?.nextButtonEnableTime ?? studyConfig.uiConfig.nextButtonEnableTime ?? 0;
@@ -56,6 +58,11 @@ export function NextButton({
   const autoAdvanceTriggered = useRef(false);
   // Use the current identifier so nested function-sequence items reset their timer state.
   useEffect(() => {
+    if (startupInteractionBlocked) {
+      setTimer(undefined);
+      return undefined;
+    }
+
     autoAdvanceTriggered.current = false;
     const start = Date.now();
     setTimer(0);
@@ -65,25 +72,25 @@ export function NextButton({
     return () => {
       clearInterval(interval);
     };
-  }, [identifier]);
+  }, [identifier, startupInteractionBlocked]);
 
   useEffect(() => {
-    if (timer === undefined) {
+    if (startupInteractionBlocked || timer === undefined) {
       return;
     }
     if (nextButtonDisableTime && timer >= nextButtonDisableTime && studyConfig.uiConfig.timeoutReject) {
       navigate(`./../__timedOut${window.location.search}`);
     }
-  }, [nextButtonDisableTime, timer, navigate, studyConfig.uiConfig.timeoutReject]);
+  }, [nextButtonDisableTime, timer, navigate, startupInteractionBlocked, studyConfig.uiConfig.timeoutReject]);
 
   useEffect(() => {
-    if (timer === undefined || nextButtonAutoAdvanceTime === undefined || timer < nextButtonAutoAdvanceTime || autoAdvanceTriggered.current) {
+    if (startupInteractionBlocked || timer === undefined || nextButtonAutoAdvanceTime === undefined || timer < nextButtonAutoAdvanceTime || autoAdvanceTriggered.current) {
       return;
     }
 
     autoAdvanceTriggered.current = true;
     goToNextStep(false);
-  }, [goToNextStep, nextButtonAutoAdvanceTime, timer]);
+  }, [goToNextStep, nextButtonAutoAdvanceTime, startupInteractionBlocked, timer]);
 
   const buttonTimerSatisfied = useMemo(
     () => {
@@ -121,15 +128,16 @@ export function NextButton({
       }
     };
 
-    if (nextOnEnter) {
+    if (nextOnEnter && !startupInteractionBlocked) {
       window.addEventListener('keydown', handleKeyDown);
     }
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [disabled, isNextDisabled, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter]);
+  }, [disabled, isNextDisabled, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter, startupInteractionBlocked]);
 
-  const nextButtonDisabled = disabled || isNextDisabled || !buttonTimerSatisfied;
+  const nextButtonDisabled = startupInteractionBlocked
+    || disabled || isNextDisabled || !buttonTimerSatisfied;
   const previousButtonText = config?.previousButtonText ?? studyConfig.uiConfig.previousButtonText ?? 'Previous';
   const nextButtonAlignment = config?.nextButtonAlignment ?? studyConfig.uiConfig.nextButtonAlignment ?? 'right';
 

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useState,
   useMemo,
+  useRef,
 } from 'react';
 import { Provider } from 'react-redux';
 import { RouteObject, useRoutes, useSearchParams } from 'react-router';
@@ -41,8 +42,10 @@ import {
   resolveParticipantConditions,
 } from '../utils/handleConditionLogic';
 import { StartupErrorScreen } from './StartupErrorScreen';
+import { StartupInteractionProvider } from './StartupContext';
 
 type StartupStorageStatus = Pick<StorageEngine, 'getEngine' | 'isConnected'>;
+type StartupPhase = 'config-loading' | 'participant-loading' | 'ready' | 'error';
 
 const GENERIC_STARTUP_ERROR = 'There was a problem loading the study.';
 const RESUME_STARTUP_ERROR = 'This study session could not be resumed.';
@@ -67,7 +70,19 @@ export function StudyLoadingOverlay({ visible }: { visible: boolean }) {
 
   return (
     <>
-      <LoadingOverlay visible={visible} />
+      {visible && (
+        <div
+          data-testid="study-loading-barrier"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 1000,
+            pointerEvents: 'all',
+          }}
+        >
+          <LoadingOverlay visible />
+        </div>
+      )}
       {visible && showMessage && (
         <Text
           role="status"
@@ -186,7 +201,11 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   // Pull study config
   const routeStudyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedConfig<StudyConfig> | null>(null);
-  const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
+  const [startupError, setStartupError] = useState<{
+    error: unknown;
+    retryParticipantStartup?: boolean;
+  } | null>(null);
+  const [startupPhase, setStartupPhase] = useState<StartupPhase>('config-loading');
   const canonicalStudyId = useMemo(() => {
     if (routeStudyId === '__revisit-widget') {
       return routeStudyId;
@@ -205,11 +224,13 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           const config = await getStudyConfig(routeStudyId, globalConfig);
           if (!cancelled) {
             setActiveConfig(config);
+            setStartupPhase('participant-loading');
           }
         } catch (error) {
           console.error('Error loading study config:', error);
           if (!cancelled) {
             setStartupError({ error });
+            setStartupPhase('error');
           }
         }
       };
@@ -228,6 +249,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
               const config = await parseStudyConfig(event.data.payload);
               if (!cancelled) {
                 setActiveConfig(config);
+                setStartupPhase('participant-loading');
               }
 
               const sequenceArray = await generateSequenceArray(config);
@@ -238,6 +260,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
               console.error('Error loading widget study config:', error);
               if (!cancelled) {
                 setStartupError({ error });
+                setStartupPhase('error');
               }
             }
           };
@@ -260,17 +283,109 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   }, [globalConfig, routeStudyId]);
 
   const [routes, setRoutes] = useState<RouteObject[]>([]);
+  const [previewStore, setPreviewStore] = useState<Nullable<StudyStore>>(null);
   const [store, setStore] = useState<Nullable<StudyStore>>(null);
   const [isCompletionCheckResolved, setIsCompletionCheckResolved] = useState(false);
   const [completionCheckError, setCompletionCheckError] = useState<string | null>(null);
+  const [startupAttempt, setStartupAttempt] = useState(0);
+  const initializationKeyRef = useRef<string | null>(null);
+  const interfaceRef = useRef<HTMLDivElement>(null);
   const { storageEngine } = useStorageEngine();
-  const [searchParams] = useSearchParams();
+  const [rawSearchParams] = useSearchParams();
 
-  const participantId = useMemo(() => searchParams.get('participantId'), [searchParams]);
-  const studyCondition = useMemo(() => parseConditionParam(searchParams.get('condition')), [searchParams]);
+  const searchParamsString = rawSearchParams.toString();
+  const searchParams = useMemo(
+    () => new URLSearchParams(searchParamsString),
+    [searchParamsString],
+  );
+  const participantId = useMemo(
+    () => searchParams.get('participantId'),
+    [searchParams],
+  );
+  const studyCondition = useMemo(
+    () => parseConditionParam(searchParams.get('condition')),
+    [searchParams],
+  );
 
   useEffect(() => {
     let isCancelled = false;
+
+    async function initializePreviewStore() {
+      if (!activeConfig || !canonicalStudyId || (activeConfig.errors?.length ?? 0) > 0) {
+        return;
+      }
+
+      setRoutes([
+        {
+          element: <StepRenderer />,
+          children: [
+            {
+              path: '/',
+              element: <NavigateWithParams to={encryptIndex(0)} replace />,
+            },
+            {
+              path: '/:index/:funcIndex?',
+              element: <ComponentController />,
+            },
+          ],
+        },
+      ]);
+
+      const generatedSequences = await generateSequenceArray(activeConfig);
+      const generatedSequence = filterSequenceByCondition(
+        generatedSequences[0],
+        studyCondition,
+      );
+      const localPreviewStore = await studyStoreCreator(
+        canonicalStudyId,
+        activeConfig,
+        generatedSequence,
+        createEmptyParticipantMetadata(),
+        {},
+        {
+          developmentModeEnabled: false,
+          dataSharingEnabled: false,
+          dataCollectionEnabled: false,
+        },
+        '',
+        true,
+        false,
+      );
+
+      if (!isCancelled) {
+        setPreviewStore(localPreviewStore);
+      }
+    }
+
+    initializePreviewStore().catch((error) => {
+      console.error('Error initializing preview study store:', error);
+      if (!isCancelled) {
+        setStartupError({ error });
+        setStartupPhase('error');
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [activeConfig, canonicalStudyId, studyCondition]);
+
+  useEffect(() => {
+    const startupKey = storageEngine && activeConfig && canonicalStudyId
+      ? [
+        canonicalStudyId,
+        participantId ?? '',
+        searchParamsString,
+        startupAttempt,
+      ].join(':')
+      : null;
+
+    if (!startupKey || initializationKeyRef.current === startupKey) {
+      return undefined;
+    }
+    initializationKeyRef.current = startupKey;
+
+    const isCurrentStartup = () => initializationKeyRef.current === startupKey;
 
     async function fetchParticipantIp() {
       const ipTimeoutController = new AbortController();
@@ -292,6 +407,8 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       if (!storageEngine || !activeConfig || !canonicalStudyId || (activeConfig.errors?.length ?? 0) > 0) return;
       setIsCompletionCheckResolved(false);
       setCompletionCheckError(null);
+      setStartupError(null);
+      setStartupPhase('participant-loading');
 
       let modes: Record<REVISIT_MODE, boolean> | null = null;
       const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam
@@ -374,7 +491,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           participantSession.participantConfigHash !== activeHash,
         );
 
-        if (isCancelled) {
+        if (!isCurrentStartup()) {
           return;
         }
 
@@ -382,7 +499,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         if (resolvedModes.dataCollectionEnabled) {
           fetchParticipantIp().then(async (ip) => {
-            if (isCancelled || !ip.ip || participantSession.metadata.ip === ip.ip) {
+            if (!isCurrentStartup() || !ip.ip || participantSession.metadata.ip === ip.ip) {
               return;
             }
 
@@ -394,7 +511,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
             await storageEngine.updateParticipantMetadata(metadataWithIp);
 
-            if (!isCancelled) {
+            if (isCurrentStartup()) {
               newStore.store.dispatch(newStore.actions.setMetadata(metadataWithIp));
             }
           }).catch((error) => {
@@ -404,17 +521,18 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         if (!resolvedModes.dataCollectionEnabled) {
           setIsCompletionCheckResolved(true);
+          setStartupPhase('ready');
         } else {
           storageEngine.getParticipantCompletionStatus(participantSession.participantId).then((participantCompleted) => {
-            if (!isCancelled) {
+            if (isCurrentStartup()) {
               newStore.store.dispatch(newStore.actions.setParticipantCompleted(participantCompleted));
               setIsCompletionCheckResolved(true);
+              setStartupPhase('ready');
             }
           }).catch((error) => {
             console.error('Error fetching participant completion status:', error);
-            if (!isCancelled) {
+            if (isCurrentStartup()) {
               setCompletionCheckError('We could not verify whether this study session was already completed. Please reload this page and try again.');
-              // A transient completion-status lookup failure should not block study entry.
               setIsCompletionCheckResolved(true);
             }
           });
@@ -463,55 +581,44 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
             initialAlertModal,
           );
 
-          if (isCancelled) {
+          if (!isCurrentStartup()) {
             return;
           }
 
           setStore(emptyStore);
           setIsCompletionCheckResolved(true);
+          setStartupPhase('ready');
         } catch (fallbackError) {
           console.error('Error initializing fallback study store:', fallbackError);
-          if (!isCancelled) {
-            setStartupError({ error });
+          if (isCurrentStartup()) {
+            setStartupError({ error, retryParticipantStartup: true });
+            setStartupPhase('error');
           }
-          return;
         }
       }
-
-      if (isCancelled) {
-        return;
-      }
-
-      // Initialize the routing
-      setRoutes([
-        {
-          element: <StepRenderer />,
-          children: [
-            {
-              path: '/',
-              element: <NavigateWithParams to={encryptIndex(0)} replace />,
-            },
-            {
-              path: '/:index/:funcIndex?',
-              element: <ComponentController />,
-            },
-          ],
-        },
-      ]);
     }
     initializeUserStoreRouting().catch((error) => {
       console.error('Unhandled error initializing user store routing:', error);
-      if (!isCancelled) {
-        setStartupError({ error });
+      if (isCurrentStartup()) {
+        setStartupError({ error, retryParticipantStartup: true });
+        setStartupPhase('error');
       }
     });
-    return () => {
-      isCancelled = true;
-    };
-  }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
+    return undefined;
+  }, [
+    storageEngine,
+    activeConfig,
+    canonicalStudyId,
+    searchParams,
+    searchParamsString,
+    participantId,
+    studyCondition,
+    startupAttempt,
+  ]);
 
   const routing = useRoutes(routes);
   const hasConfigErrors = (activeConfig?.errors?.length ?? 0) > 0;
+  const renderedStore = store ?? previewStore;
   const { isLoading, showCompletionCheckError } = getShellUiState({
     isValidStudyId,
     hasRoutes: routes.length > 0,
@@ -519,11 +626,33 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     isCompletionCheckResolved,
     completionCheckError,
   });
+  const isInteractionBlocked = isValidStudyId && !startupError && !hasConfigErrors
+    && (startupPhase !== 'ready' || isLoading || showCompletionCheckError);
+
+  useEffect(() => {
+    if (isInteractionBlocked) {
+      interfaceRef.current?.setAttribute('inert', '');
+    } else {
+      interfaceRef.current?.removeAttribute('inert');
+    }
+  }, [isInteractionBlocked]);
 
   let content: ReactNode = null;
 
   if (startupError) {
-    content = <StartupErrorScreen error={startupError.error} />;
+    content = (
+      <StartupErrorScreen
+        error={startupError.error}
+        actionLabel={startupError.retryParticipantStartup ? 'Retry' : 'Reload'}
+        onReload={startupError.retryParticipantStartup
+          ? () => {
+            initializationKeyRef.current = null;
+            setStartupPhase('participant-loading');
+            setStartupAttempt((attempt) => attempt + 1);
+          }
+          : undefined}
+      />
+    );
   } else if (activeConfig && hasConfigErrors) {
     content = (
       <>
@@ -538,10 +667,10 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     );
   } else if (!isValidStudyId) {
     content = <ResourceNotFound />;
-  } else if (routing && store) {
+  } else if (routing && renderedStore) {
     content = (
-      <StudyStoreContext.Provider value={store}>
-        <Provider store={store.store}>{routing}</Provider>
+      <StudyStoreContext.Provider value={renderedStore}>
+        <Provider store={renderedStore.store}>{routing}</Provider>
       </StudyStoreContext.Provider>
     );
   } else if (!isLoading) {
@@ -550,7 +679,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   return (
     <>
-      <StudyLoadingOverlay visible={!startupError && !hasConfigErrors && isLoading} />
+      <StudyLoadingOverlay visible={isInteractionBlocked} />
       {!startupError && !hasConfigErrors && showCompletionCheckError && (
         <Stack
           align="center"
@@ -571,7 +700,17 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           </Button>
         </Stack>
       )}
-      {content}
+      <div
+        ref={interfaceRef}
+        data-testid="study-interface"
+        aria-busy={isInteractionBlocked}
+        aria-hidden={isInteractionBlocked || undefined}
+        style={isInteractionBlocked ? { pointerEvents: 'none', userSelect: 'none' } : undefined}
+      >
+        <StartupInteractionProvider value={isInteractionBlocked}>
+          {content}
+        </StartupInteractionProvider>
+      </div>
     </>
   );
 }

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -668,8 +668,9 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   } else if (!isValidStudyId) {
     content = <ResourceNotFound />;
   } else if (routing && renderedStore) {
+    const startupStoreKey = store ? 'authoritative' : 'preview';
     content = (
-      <StudyStoreContext.Provider value={renderedStore}>
+      <StudyStoreContext.Provider key={startupStoreKey} value={renderedStore}>
         <Provider store={renderedStore.store}>{routing}</Provider>
       </StudyStoreContext.Provider>
     );

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -42,7 +42,10 @@ import {
   resolveParticipantConditions,
 } from '../utils/handleConditionLogic';
 import { StartupErrorScreen } from './StartupErrorScreen';
-import { StartupInteractionProvider } from './StartupContext';
+import {
+  StartupInteractionProvider,
+  useStartupInteractionBlocked,
+} from './StartupContext';
 
 type StartupStorageStatus = Pick<StorageEngine, 'getEngine' | 'isConnected'>;
 type StartupPhase = 'config-loading' | 'participant-loading' | 'ready' | 'error';
@@ -73,6 +76,11 @@ export function StudyLoadingOverlay({ visible }: { visible: boolean }) {
       {visible && (
         <div
           data-testid="study-loading-barrier"
+          role="dialog"
+          aria-modal="true"
+          aria-busy="true"
+          aria-live="polite"
+          aria-label={STUDY_LOADING_MESSAGE}
           style={{
             position: 'fixed',
             inset: 0,
@@ -105,6 +113,14 @@ export function StudyLoadingOverlay({ visible }: { visible: boolean }) {
       )}
     </>
   );
+}
+
+export function StudyIndexRoute() {
+  const startupInteractionBlocked = useStartupInteractionBlocked();
+
+  return startupInteractionBlocked
+    ? <ComponentController />
+    : <NavigateWithParams to={encryptIndex(0)} replace />;
 }
 
 export function getScreenOrientationType(screen: Screen) {
@@ -321,7 +337,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           children: [
             {
               path: '/',
-              element: <NavigateWithParams to={encryptIndex(0)} replace />,
+              element: <StudyIndexRoute />,
             },
             {
               path: '/:index/:funcIndex?',
@@ -495,9 +511,15 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           return;
         }
 
-        setStore(newStore);
+        const finishStartup = (participantCompleted: boolean) => {
+          newStore.store.dispatch(newStore.actions.setParticipantCompleted(participantCompleted));
+          setStore(newStore);
+          setIsCompletionCheckResolved(true);
+          setStartupPhase('ready');
 
-        if (resolvedModes.dataCollectionEnabled) {
+          if (!resolvedModes.dataCollectionEnabled) {
+            return;
+          }
           fetchParticipantIp().then(async (ip) => {
             if (!isCurrentStartup() || !ip.ip || participantSession.metadata.ip === ip.ip) {
               return;
@@ -517,23 +539,20 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           }).catch((error) => {
             console.error('Error fetching participant IP:', error);
           });
-        }
+        };
 
         if (!resolvedModes.dataCollectionEnabled) {
-          setIsCompletionCheckResolved(true);
-          setStartupPhase('ready');
+          finishStartup(false);
         } else {
           storageEngine.getParticipantCompletionStatus(participantSession.participantId).then((participantCompleted) => {
             if (isCurrentStartup()) {
-              newStore.store.dispatch(newStore.actions.setParticipantCompleted(participantCompleted));
-              setIsCompletionCheckResolved(true);
-              setStartupPhase('ready');
+              finishStartup(participantCompleted);
             }
           }).catch((error) => {
             console.error('Error fetching participant completion status:', error);
             if (isCurrentStartup()) {
-              setCompletionCheckError('We could not verify whether this study session was already completed. Please reload this page and try again.');
-              setIsCompletionCheckResolved(true);
+              setStartupError({ error, retryParticipantStartup: true });
+              setStartupPhase('error');
             }
           });
         }
@@ -556,6 +575,14 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         const initialAlertModal = !isStorageFailure
           ? getInitialStartupAlert(error, developmentModeEnabledForAlert, resumeParticipantId)
           : undefined;
+
+        if (!isStorageFailure) {
+          if (isCurrentStartup()) {
+            setStartupError({ error, retryParticipantStartup: true });
+            setStartupPhase('error');
+          }
+          return;
+        }
 
         try {
           // Preserve the existing disconnected-storage and participant alert recovery paths.

--- a/src/components/StartupContext.tsx
+++ b/src/components/StartupContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+const StartupInteractionContext = createContext(false);
+
+export const StartupInteractionProvider = StartupInteractionContext.Provider;
+
+export function useStartupInteractionBlocked() {
+  return useContext(StartupInteractionContext);
+}

--- a/src/components/StartupErrorScreen.tsx
+++ b/src/components/StartupErrorScreen.tsx
@@ -16,10 +16,12 @@ export function StartupErrorScreen({
   error,
   showDetails = import.meta.env.DEV,
   onReload = () => window.location.reload(),
+  actionLabel = 'Reload',
 }: {
   error: unknown;
   showDetails?: boolean;
   onReload?: () => void;
+  actionLabel?: string;
 }) {
   const headingRef = useRef<HTMLHeadingElement>(null);
 
@@ -58,7 +60,7 @@ export function StartupErrorScreen({
             Something went wrong while loading this page. Please reload and try again.
           </Text>
           <Button size="md" onClick={onReload}>
-            Reload
+            {actionLabel}
           </Button>
           {showDetails && (
             <Code block w="100%" style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>

--- a/src/components/StudyEnd.tsx
+++ b/src/components/StudyEnd.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_STUDY_END_FINALIZE_STATE,
   StudyEndFinalizeLoopState,
 } from './StudyEnd.utils';
+import { useStartupInteractionBlocked } from './StartupContext';
 
 export function StudyEnd() {
   const studyConfig = useStudyConfig();
@@ -26,6 +27,7 @@ export function StudyEnd() {
 
   const isAnalysis = useIsAnalysis();
   const dataCollectionEnabled = useStoreSelector((state) => state.modes.dataCollectionEnabled);
+  const startupInteractionBlocked = useStartupInteractionBlocked();
 
   const [completed, setCompleted] = useState(false);
   const [finalizeState, setFinalizeState] = useState<StudyEndFinalizeLoopState>(DEFAULT_STUDY_END_FINALIZE_STATE);
@@ -37,6 +39,10 @@ export function StudyEnd() {
   }, [storageEngine]);
 
   useEffect(() => {
+    if (startupInteractionBlocked) {
+      return undefined;
+    }
+
     // Don't save to the storage engine in analysis
     if (!isAnalysis) {
       const finalizeLoop = createStudyEndFinalizeLoop({
@@ -69,7 +75,7 @@ export function StudyEnd() {
     dispatch(setIsSubmittingFinal(false));
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [startupInteractionBlocked]);
 
   // Disable browser back button on study end
   useDisableBrowserBack();

--- a/src/components/interface/DeviceWarning.tsx
+++ b/src/components/interface/DeviceWarning.tsx
@@ -11,6 +11,7 @@ import {
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { useStudyConfig } from '../../store/hooks/useStudyConfig';
 import { useDeviceRules } from '../../utils/useDeviceRules';
+import { useStartupInteractionBlocked } from '../StartupContext';
 
 export function DeviceWarning({
   developmentModeEnabled,
@@ -22,6 +23,7 @@ export function DeviceWarning({
   const navigate = useNavigate();
   const [timeLeft, setTimeLeft] = useState(60);
   const [isRejected, setIsRejected] = useState(false);
+  const startupInteractionBlocked = useStartupInteractionBlocked();
   const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const storageEngineRef = useRef(storageEngine);
   const navigateRef = useRef(navigate);
@@ -67,7 +69,8 @@ export function DeviceWarning({
     (display?.minWidth !== undefined && currentDisplay.width < display.minWidth)
     || (display?.minHeight !== undefined && currentDisplay.height < display.minHeight)
   );
-  const shouldRunDisplayCountdown = !developmentModeEnabled && !isRejected && isDisplayRequirementNotMet;
+  const shouldRunDisplayCountdown = !startupInteractionBlocked
+    && !developmentModeEnabled && !isRejected && isDisplayRequirementNotMet;
 
   useEffect(() => {
     if (shouldRunDisplayCountdown) {

--- a/src/components/interface/DeviceWarning.tsx
+++ b/src/components/interface/DeviceWarning.tsx
@@ -123,7 +123,7 @@ export function DeviceWarning({
     };
   }, [shouldRunDisplayCountdown]);
 
-  if (developmentModeEnabled || (!isRejected && !hasAnyViolation)) {
+  if (startupInteractionBlocked || developmentModeEnabled || (!isRejected && !hasAnyViolation)) {
     return null;
   }
 

--- a/src/components/tests/NextButton.spec.tsx
+++ b/src/components/tests/NextButton.spec.tsx
@@ -8,6 +8,7 @@ import {
 } from 'vitest';
 import type { IndividualComponent } from '../../parser/types';
 import { NextButton } from '../NextButton';
+import { StartupInteractionProvider } from '../StartupContext';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -149,6 +150,37 @@ describe('NextButton', () => {
     mockIsNextDisabled = true;
     const html = renderToStaticMarkup(<NextButton checkAnswer={null} onNext={vi.fn()} />);
     expect(html).toContain('disabled');
+  });
+
+  test('does not start timers or handle Enter while participant startup is blocked', () => {
+    vi.useFakeTimers();
+    mockStudyConfig.uiConfig.nextOnEnter = true;
+    mockStudyConfig.uiConfig.timeoutReject = true;
+    const onNext = vi.fn();
+
+    const { getByRole } = render(
+      <StartupInteractionProvider value>
+        <NextButton
+          config={{
+            type: 'questionnaire',
+            response: [],
+            nextButtonDisableTime: 100,
+            nextButtonAutoAdvanceTime: 100,
+          }}
+          checkAnswer={null}
+          onNext={onNext}
+        />
+      </StartupInteractionProvider>,
+    );
+    act(() => {
+      vi.advanceTimersByTime(500);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    expect(getByRole('button', { name: 'Next' }).hasAttribute('disabled')).toBe(true);
+    expect(onNext).not.toHaveBeenCalled();
+    expect(mockGoToNextStep).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   test('renders checkAnswer element when provided', () => {

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import { StrictMode, type HTMLAttributes, type ReactNode } from 'react';
 import {
   render, act, cleanup, waitFor,
 } from '@testing-library/react';
@@ -108,6 +108,10 @@ vi.mock('react-redux', () => ({
 vi.mock('../../store/store', () => ({
   studyStoreCreator: vi.fn().mockResolvedValue({
     store: { getState: vi.fn(), dispatch: vi.fn(), subscribe: vi.fn() },
+    actions: {
+      setMetadata: vi.fn((metadata) => ({ type: 'setMetadata', payload: metadata })),
+      setParticipantCompleted: vi.fn((completed) => ({ type: 'setParticipantCompleted', payload: completed })),
+    },
   }),
   StudyStoreContext: {
     Provider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -218,6 +222,27 @@ describe('Shell', () => {
     expect(getByTestId('loading-overlay')).toBeDefined();
   });
 
+  test('mounts the study interface behind an inert barrier while participant startup resolves once', async () => {
+    vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    const pendingInitialization = new Promise<void>(() => {});
+
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn(() => pendingInitialization),
+    };
+
+    const { getByTestId } = render(
+      <StrictMode>
+        <Shell globalConfig={globalConfig} />
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(getByTestId('routing')).toBeDefined());
+    expect(getByTestId('study-loading-barrier')).toBeDefined();
+    expect(getByTestId('study-interface').getAttribute('aria-busy')).toBe('true');
+    expect(getByTestId('study-interface').hasAttribute('inert')).toBe(true);
+    expect(mockStorageEngine.initializeStudyDb).toHaveBeenCalledTimes(1);
+  });
+
   test('shows startup fallback when study config loading rejects', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     vi.mocked(getStudyConfig).mockRejectedValue(new Error('study config failed'));
@@ -307,9 +332,12 @@ describe('Shell', () => {
       getEngine: vi.fn().mockReturnValue('firebase'),
     };
 
-    render(<Shell globalConfig={globalConfig} />);
+    const { queryByTestId, getByTestId } = render(<Shell globalConfig={globalConfig} />);
     await waitFor(() => expect(mockStorageEngine!.initializeStudyDb).toHaveBeenCalled(), { timeout: 3000 });
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
+    await waitFor(() => expect(queryByTestId('study-loading-barrier')).toBeNull(), { timeout: 3000 });
+    expect(getByTestId('study-interface').getAttribute('aria-busy')).toBe('false');
+    expect(getByTestId('study-interface').hasAttribute('inert')).toBe(false);
   });
 
   test('calls setSequenceArray when getSequenceArray returns null', async () => {
@@ -405,7 +433,15 @@ describe('Shell', () => {
   test('shows startup fallback when participant-store recovery also fails', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
-    vi.mocked(studyStoreCreator).mockRejectedValueOnce(new Error('fallback store failed'));
+    vi.mocked(studyStoreCreator)
+      .mockResolvedValueOnce({
+        store: { getState: vi.fn(), dispatch: vi.fn(), subscribe: vi.fn() },
+        actions: {
+          setMetadata: vi.fn(),
+          setParticipantCompleted: vi.fn(),
+        },
+      } as never)
+      .mockRejectedValueOnce(new Error('fallback store failed'));
 
     mockStorageEngine = {
       initializeStudyDb: vi.fn().mockRejectedValue(new Error('participant init failed')),

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -1,4 +1,6 @@
-import { StrictMode, type HTMLAttributes, type ReactNode } from 'react';
+import {
+  StrictMode, useEffect, type HTMLAttributes, type ReactNode,
+} from 'react';
 import {
   render, act, cleanup, waitFor,
 } from '@testing-library/react';
@@ -18,6 +20,19 @@ import { parseStudyConfig } from '../../parser/parser';
 
 let mockStudyId = 'test-study';
 let mockStorageEngine: Record<string, ReturnType<typeof vi.fn>> | null = null;
+let routingMountCount = 0;
+let routingUnmountCount = 0;
+
+function RoutingMountProbe() {
+  useEffect(() => {
+    routingMountCount += 1;
+    return () => {
+      routingUnmountCount += 1;
+    };
+  }, []);
+
+  return <div data-testid="routing" />;
+}
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
 
@@ -149,6 +164,8 @@ describe('Shell', () => {
   beforeEach(() => {
     mockStudyId = 'test-study';
     mockStorageEngine = null;
+    routingMountCount = 0;
+    routingUnmountCount = 0;
     vi.mocked(getStudyConfig).mockResolvedValue(null);
     vi.mocked(resolveConfigKey).mockReturnValue('test-study');
     vi.mocked(parseConditionParam).mockReturnValue([]);
@@ -318,9 +335,14 @@ describe('Shell', () => {
 
   test('happy path: initializeUserStoreRouting runs and renders study', async () => {
     vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    vi.mocked(useRoutes).mockReturnValue(<RoutingMountProbe />);
+    let resolveStudyInitialization: (() => void) | undefined;
+    const studyInitialization = new Promise<void>((resolve) => {
+      resolveStudyInitialization = resolve;
+    });
 
     mockStorageEngine = {
-      initializeStudyDb: vi.fn().mockResolvedValue(undefined),
+      initializeStudyDb: vi.fn(() => studyInitialization),
       saveConfig: vi.fn().mockResolvedValue(undefined),
       getSequenceArray: vi.fn().mockResolvedValue(['seq1']), // non-null → no setSequenceArray
       getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
@@ -334,10 +356,14 @@ describe('Shell', () => {
 
     const { queryByTestId, getByTestId } = render(<Shell globalConfig={globalConfig} />);
     await waitFor(() => expect(mockStorageEngine!.initializeStudyDb).toHaveBeenCalled(), { timeout: 3000 });
+    await waitFor(() => expect(routingMountCount).toBe(1), { timeout: 3000 });
+    await act(async () => resolveStudyInitialization?.());
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
     await waitFor(() => expect(queryByTestId('study-loading-barrier')).toBeNull(), { timeout: 3000 });
     expect(getByTestId('study-interface').getAttribute('aria-busy')).toBe('false');
     expect(getByTestId('study-interface').hasAttribute('inert')).toBe(false);
+    expect(routingMountCount).toBe(2);
+    expect(routingUnmountCount).toBe(1);
   });
 
   test('calls setSequenceArray when getSequenceArray returns null', async () => {

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -8,13 +8,14 @@ import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { useRoutes } from 'react-router';
-import { Shell, StudyLoadingOverlay } from '../Shell';
+import { Shell, StudyIndexRoute, StudyLoadingOverlay } from '../Shell';
 import type { ParsedConfig, StudyConfig } from '../../parser/types';
 import { getStudyConfig, resolveConfigKey } from '../../utils/fetchConfig';
 import { makeGlobalConfig, makeStudyConfig } from '../../tests/utils';
 import { studyStoreCreator } from '../../store/store';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
 import { parseStudyConfig } from '../../parser/parser';
+import { StartupInteractionProvider } from '../StartupContext';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -258,6 +259,64 @@ describe('Shell', () => {
     expect(getByTestId('study-interface').getAttribute('aria-busy')).toBe('true');
     expect(getByTestId('study-interface').hasAttribute('inert')).toBe(true);
     expect(mockStorageEngine.initializeStudyDb).toHaveBeenCalledTimes(1);
+  });
+
+  test('mounts the first stimulus provisionally at the root route', () => {
+    const { getByTestId } = render(
+      <StartupInteractionProvider value>
+        <StudyIndexRoute />
+      </StartupInteractionProvider>,
+    );
+
+    expect(getByTestId('component-controller')).toBeDefined();
+  });
+
+  test('keeps the preview store mounted until participant completion is authoritative', async () => {
+    vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    const pendingCompletion = new Promise<boolean>(() => {});
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
+      getModes: vi.fn().mockResolvedValue({
+        developmentModeEnabled: false,
+        dataSharingEnabled: false,
+        dataCollectionEnabled: true,
+      }),
+      initializeParticipantSession: vi.fn().mockResolvedValue(baseSession),
+      getParticipantCompletionStatus: vi.fn(() => pendingCompletion),
+      peekCurrentParticipantId: vi.fn().mockResolvedValue(undefined),
+      getAllConfigsFromHash: vi.fn().mockResolvedValue({}),
+      isConnected: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+    };
+
+    const { getByTestId } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(mockStorageEngine!.getParticipantCompletionStatus).toHaveBeenCalled());
+    expect(getByTestId('study-loading-barrier')).toBeDefined();
+    expect(getByTestId('study-interface').hasAttribute('inert')).toBe(true);
+  });
+
+  test('routes transient provider startup failures to blocking retry', async () => {
+    vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn().mockRejectedValue(new Error('provider unavailable')),
+      getModes: vi.fn().mockResolvedValue({
+        developmentModeEnabled: false,
+        dataSharingEnabled: false,
+        dataCollectionEnabled: true,
+      }),
+      peekCurrentParticipantId: vi.fn().mockResolvedValue(undefined),
+      isConnected: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue(import.meta.env.VITE_STORAGE_ENGINE),
+    };
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { getByRole } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(getByRole('alert')).toBeDefined());
+    expect(vi.mocked(studyStoreCreator)).toHaveBeenCalledTimes(1);
   });
 
   test('shows startup fallback when study config loading rejects', async () => {

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -39,6 +39,7 @@ import { useRecordingConfig } from '../store/hooks/useRecordingConfig';
 import { getComponentContainerStyle } from '../utils/componentStyle';
 import { generateStimulusErrorMessage } from '../components/response/stimulusErrors';
 import { getStimulusProvenanceState, getStimulusShowErrorsFromState } from '../components/response/stimulusProvenance';
+import { useStartupInteractionBlocked } from '../components/StartupContext';
 
 // current active stimuli presented to the user
 export function ComponentController() {
@@ -71,6 +72,7 @@ export function ComponentController() {
   const currentStimulusSubmitAttempted = useStoreSelector((state) => state.stimulusSubmitAttempted[currentIdentifier]);
   const sequence = useStoreSelector((state) => state.sequence);
   const modes = useStoreSelector((state) => state.modes);
+  const startupInteractionBlocked = useStartupInteractionBlocked();
 
   const [searchParams] = useSearchParams();
 
@@ -121,6 +123,10 @@ export function ComponentController() {
     }
 
     async function addParticipantTag() {
+      if (startupInteractionBlocked) {
+        return;
+      }
+
       const prevBlockForStep = prevBlockForStepRef.current;
 
       // Check if blockForStep has actually changed
@@ -136,7 +142,7 @@ export function ComponentController() {
 
     updateBlockForStep().then(addParticipantTag);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentStep, storageEngine, sequence]);
+  }, [currentStep, startupInteractionBlocked, storageEngine, sequence]);
 
   const currentConfig = useMemo(() => {
     const toReturn = currentComponent && currentComponent !== 'end' && !currentComponent.startsWith('__') && studyComponentToIndividualComponent(stepConfig, studyConfig) as IndividualComponent;
@@ -222,7 +228,7 @@ export function ComponentController() {
 
   // Automatically forward a user to their last completed trial if they are returning to the study
   useEffect(() => {
-    if (status && status.endTime > 0 && !isAnalysis && !modes.developmentModeEnabled && currentComponent !== 'end' && !currentComponent.startsWith('__') && typeof currentStep === 'number') {
+    if (!startupInteractionBlocked && status && status.endTime > 0 && !isAnalysis && !modes.developmentModeEnabled && currentComponent !== 'end' && !currentComponent.startsWith('__') && typeof currentStep === 'number') {
       let lastAnsweredTrialOrder = '0';
       Object.values(answers).forEach((a) => {
         if (a.endTime > 0) {
@@ -237,7 +243,7 @@ export function ComponentController() {
         navigate(`/${studyId}/${encryptIndex(indexNumber)}${funcIndexNumber !== undefined ? `/${encryptIndex(funcIndexNumber)}` : ''}${window.location.search}`);
       }
     }
-  }, [answers, currentComponent, currentStep, funcIndex, isAnalysis, modes.developmentModeEnabled, navigate, status, studyId]);
+  }, [answers, currentComponent, currentStep, funcIndex, isAnalysis, modes.developmentModeEnabled, navigate, startupInteractionBlocked, status, studyId]);
 
   // We're not using hooks below here, so we can return early if we're at the end of the study.
   // This avoids issues with the component config being undefined for the end of the study.

--- a/src/routes/utils.tsx
+++ b/src/routes/utils.tsx
@@ -11,6 +11,7 @@ import { JumpFunctionParameters, JumpFunctionReturnVal } from '../store/types';
 import { findFuncBlock } from '../utils/getSequenceFlatMap';
 import { useStudyConfig } from '../store/hooks/useStudyConfig';
 import { getComponent } from '../utils/handleComponentInheritance';
+import { useStartupInteractionBlocked } from '../components/StartupContext';
 
 export function useStudyId(): string {
   const { studyId } = useParams();
@@ -54,6 +55,7 @@ export function useCurrentComponent(): string {
   const studyId = useStudyId();
   const storeDispatch = useStoreDispatch();
   const { pushToFuncSequence } = useStoreActions();
+  const startupInteractionBlocked = useStartupInteractionBlocked();
 
   const [indexWhenSettingComponentName, setIndexWhenSettingComponentName] = useState<number | null>(null);
 
@@ -78,10 +80,10 @@ export function useCurrentComponent(): string {
   }, [currentComponent, currentStep, flatSequence, studyConfig.sequence]);
 
   useEffect(() => {
-    if (!funcIndex && nextFunc && typeof currentStep === 'number') {
+    if (!startupInteractionBlocked && !funcIndex && nextFunc && typeof currentStep === 'number') {
       navigate(`/${studyId}/${encryptIndex(currentStep)}/${encryptIndex(0)}${window.location.search}`);
     }
-  }, [currentStep, funcIndex, navigate, nextFunc, studyId]);
+  }, [currentStep, funcIndex, navigate, nextFunc, startupInteractionBlocked, studyId]);
 
   useEffect(() => {
     if (typeof currentStep === 'number') {
@@ -135,12 +137,14 @@ export function useCurrentComponent(): string {
           setCompName('__dynamicLoading');
           setIndexWhenSettingComponentName(null);
 
-          navigate(`/${studyId}/${encryptIndex(currentStep + 1)}${window.location.search}`);
+          if (!startupInteractionBlocked) {
+            navigate(`/${studyId}/${encryptIndex(currentStep + 1)}${window.location.search}`);
+          }
         }
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentStep, funcIndex]);
+  }, [currentStep, funcIndex, startupInteractionBlocked]);
 
   if (typeof currentStep === 'number' && flatSequence[currentStep] === 'end') {
     return 'end';

--- a/src/store/hooks/useNextStep.ts
+++ b/src/store/hooks/useNextStep.ts
@@ -24,6 +24,7 @@ import {
   getConditionTargetIndex,
   getStoredAnswersForSkipEvaluation,
 } from '../../utils/skipConditions';
+import { useStartupInteractionBlocked } from '../../components/StartupContext';
 
 export function useNextStep() {
   const currentStep = useCurrentStep();
@@ -48,6 +49,7 @@ export function useNextStep() {
   const { storageEngine } = useStorageEngine();
 
   const studyId = useStudyId();
+  const startupInteractionBlocked = useStartupInteractionBlocked();
 
   const { dataCollectionEnabled } = modes;
 
@@ -64,6 +66,10 @@ export function useNextStep() {
 
   const windowEvents = useWindowEvents();
   const goToNextStep = useCallback((collectData = true) => {
+    if (startupInteractionBlocked) {
+      return;
+    }
+
     try {
       if (typeof currentStep !== 'number') {
         return;
@@ -168,10 +174,10 @@ export function useNextStep() {
         color: 'red',
       });
     }
-  }, [currentStep, trialValidation, identifier, storedAnswer, windowEvents, dataCollectionEnabled, clickedPrevious, sequence, answers, startTime, funcIndex, storeDispatch, saveTrialAnswer, storageEngine, setReactiveAnswers, setMatrixAnswersCheckbox, setMatrixAnswersRadio, setRankingAnswers, setAlertModal, studyConfig, participantSequence, navigate, studyId, responseSubmitAttempted, checkAnswerState]);
+  }, [currentStep, trialValidation, identifier, storedAnswer, windowEvents, dataCollectionEnabled, clickedPrevious, sequence, answers, startTime, funcIndex, storeDispatch, saveTrialAnswer, storageEngine, setReactiveAnswers, setMatrixAnswersCheckbox, setMatrixAnswersRadio, setRankingAnswers, setAlertModal, studyConfig, participantSequence, navigate, studyId, responseSubmitAttempted, checkAnswerState, startupInteractionBlocked]);
 
   return {
-    isNextDisabled,
+    isNextDisabled: isNextDisabled || startupInteractionBlocked,
     goToNextStep,
   };
 }

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -13,6 +13,7 @@ import {
   shouldMonitorMutedAudio,
   SPEECH_DETECTION_HOLD_MS,
 } from '../../utils/recordingWarnings';
+import { useStartupInteractionBlocked } from '../../components/StartupContext';
 
 /**
  * Captures and records the screen and audio.
@@ -52,6 +53,7 @@ export function useRecording() {
   const identifier = useCurrentIdentifier();
   const status = useStoredAnswer();
   const isAnalysis = useIsAnalysis();
+  const startupInteractionBlocked = useStartupInteractionBlocked();
 
   const { storageEngine } = useStorageEngine();
 
@@ -306,7 +308,7 @@ export function useRecording() {
       return;
     }
 
-    if (!studyConfig || studyHasScreenRecording || !studyHasAudioRecording || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
+    if (startupInteractionBlocked || !studyConfig || studyHasScreenRecording || !studyHasAudioRecording || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
       return;
     }
 
@@ -321,11 +323,11 @@ export function useRecording() {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentComponent, identifier, currentComponentHasAudioRecording]);
+  }, [currentComponent, identifier, currentComponentHasAudioRecording, startupInteractionBlocked]);
 
   // For study with screen recording
   useEffect(() => {
-    if (!studyConfig || !(studyHasScreenRecording) || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
+    if (startupInteractionBlocked || !studyConfig || !(studyHasScreenRecording) || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
       return;
     }
 
@@ -344,7 +346,11 @@ export function useRecording() {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentComponent, identifier, currentComponentHasAudioRecording, currentComponentHasScreenRecording, isMediaCapturing]);
+  }, [currentComponent, identifier, currentComponentHasAudioRecording, currentComponentHasScreenRecording, isMediaCapturing, startupInteractionBlocked]);
+
+  useEffect(() => () => {
+    stopScreenCapture();
+  }, [stopScreenCapture]);
 
   // Start screen capture. This does not begin recording.
   const startScreenCapture = useCallback(() => {

--- a/src/utils/NavigateWithParams.tsx
+++ b/src/utils/NavigateWithParams.tsx
@@ -1,9 +1,15 @@
 import { Navigate, NavigateProps, useSearchParams } from 'react-router';
+import { useStartupInteractionBlocked } from '../components/StartupContext';
 
 export function NavigateWithParams(
   props: Omit<NavigateProps, 'to'> & { to: string },
 ) {
   const [url] = useSearchParams();
+  const startupInteractionBlocked = useStartupInteractionBlocked();
+
+  if (startupInteractionBlocked) {
+    return null;
+  }
 
   return (
     <Navigate

--- a/src/utils/tests/NavigateWithParams.spec.tsx
+++ b/src/utils/tests/NavigateWithParams.spec.tsx
@@ -3,6 +3,7 @@ import {
   describe, expect, test, vi,
 } from 'vitest';
 import { NavigateWithParams } from '../NavigateWithParams';
+import { StartupInteractionProvider } from '../../components/StartupContext';
 
 vi.mock('react-router', () => ({
   useSearchParams: vi.fn(() => [new URLSearchParams({ step: '2', participantId: 'pid-1' })]),
@@ -21,5 +22,15 @@ describe('NavigateWithParams', () => {
     const html = renderToStaticMarkup(<NavigateWithParams to="/next" />);
     expect(html).toContain('step=2');
     expect(html).toContain('participantId=pid-1');
+  });
+
+  test('does not navigate while participant startup blocks interaction', () => {
+    const html = renderToStaticMarkup(
+      <StartupInteractionProvider value>
+        <NavigateWithParams to="/next" />
+      </StartupInteractionProvider>,
+    );
+
+    expect(html).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- mount the normal study routes and layout from a local non-collecting preview store as soon as the study config is parsed
- keep the entire interface inert, busy, and covered by the existing startup spinner until participant and completion state is authoritative
- pause startup-time writes, device rejection, and programmatic navigation while the barrier is active
- make participant startup idempotent across StrictMode effect replay and support safe in-place retry after recoverable initialization failures

## Why

Participant startup previously withheld the complete study interface until authentication, restoration, assignment, and completion checks finished. Mounting a provisional non-interactive shell starts layout and study-resource loading earlier without exposing an incorrect task for interaction.

## Validation

- `yarn unittest --run` (2,031 passed, 1 skipped)
- focused Shell, startup error, component controller, route, device warning, and navigation tests (92 passed)
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

Browser profiling and the large-study Playwright startup scenarios remain appropriate follow-up validation before moving this draft to ready.

Closes #1320