### PR TITLE
Fix Coding page loading for participants without transcripts

### DIFF
--- a/src/analysis/individualStudy/thinkAloud/ThinkAloudAnalysis.tsx
+++ b/src/analysis/individualStudy/thinkAloud/ThinkAloudAnalysis.tsx
@@ -223,13 +223,15 @@ export function ThinkAloudAnalysis({ visibleParticipants, storageEngine } : { vi
       <Group wrap="nowrap" gap={25}>
         <Stack ref={ref} style={{ width: '100%' }} gap={10}>
 
-          {!participantId || !currentTrial ? <Center><Text c="dimmed" size="24">Select a Participant and Trial to Analyze</Text></Center>
-            : !hasAudio || (rawTranscriptStatus === 'success' && rawTranscript === null) ? <Center><Text c="dimmed" size="24">No transcripts found for this task</Text></Center> : (
+          {participantId && participant && Object.keys(participant.answers).length === 0
+            ? <Center><Text c="dimmed" size="24">No components or transcripts to display for this participant</Text></Center>
+            : !participantId || !currentTrial ? <Center><Text c="dimmed" size="24">Select a Participant and Trial to Analyze</Text></Center>
+              : !hasAudio || (rawTranscriptStatus === 'success' && rawTranscript === null) ? <Center><Text c="dimmed" size="24">No transcripts found for this task</Text></Center> : (
 
-              <Stack>
-                <TextEditor onClickLine={changeLine} transcriptList={editedTranscript} setTranscriptList={setEditedTranscript} currentShownTranscription={currentShownTranscription} />
-              </Stack>
-            )}
+                <Stack>
+                  <TextEditor onClickLine={changeLine} transcriptList={editedTranscript} setTranscriptList={setEditedTranscript} currentShownTranscription={currentShownTranscription} />
+                </Stack>
+              )}
 
           <ThinkAloudFooter key={`${participantId}-${currentTrial}`} setHasAudio={setHasAudio} saveProvenance={() => null} studyId={studyId || ''} jumpedToLine={jumpedToLine} editedTranscript={editedTranscript} currentTrial={currentTrial} isReplay={false} visibleParticipants={visibleParticipants.map((v) => v.participantId)} rawTranscript={rawTranscript} onTimeUpdate={onTimeUpdate} currentShownTranscription={currentShownTranscription} width={width} storageEngine={storageEngine} />
         </Stack>

--- a/src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx
@@ -454,6 +454,23 @@ describe('ThinkAloudAnalysis (DOM)', () => {
     expect(container.textContent).toContain('No transcripts found');
   });
 
+  test('shows an empty state and participant controls when a stale task selects a participant with no answers', async () => {
+    vi.mocked(useParams).mockReturnValue({ studyId: 'test-study', trialId: 'stale-trial' });
+    vi.mocked(useAsync).mockImplementation((_fn, args) => ({
+      value: args?.length === 2 ? mockParticipant : null,
+      status: 'success',
+      execute: vi.fn(),
+      error: null,
+    }));
+
+    const { getByText, getByTestId } = await act(async () => render(
+      <ThinkAloudAnalysis visibleParticipants={[mockParticipant]} storageEngine={mockStorageEngine} />,
+    ));
+
+    expect(getByText('No components or transcripts to display for this participant')).toBeDefined();
+    expect(getByTestId('think-aloud-footer')).toBeDefined();
+  });
+
   test('renders ThinkAloudFooter', async () => {
     const { getAllByTestId } = await act(async () => render(
       <ThinkAloudAnalysis visibleParticipants={[mockParticipant]} storageEngine={mockStorageEngine} />,
@@ -559,17 +576,21 @@ describe('ThinkAloudFooter', () => {
     expect(mockFooterStorageEngine.getScreenRecording).toHaveBeenCalled();
   });
 
-  test('nextParticipantCallback via prev/next ActionIcons updates search params', async () => {
-    const { getAllByRole } = await act(async () => render(
-      <RealThinkAloudFooter {...footerDefaultProps} visibleParticipants={['p1', 'p2']} />,
+  test('next participant remains usable when there is no current task', async () => {
+    const updatedParams = new URLSearchParams('participantId=p1');
+    mockSetSearchParams.mockImplementation((updater: (params: URLSearchParams) => void) => {
+      updater(updatedParams);
+    });
+    const { getByTitle } = await act(async () => render(
+      <RealThinkAloudFooter {...footerDefaultProps} currentTrial="" visibleParticipants={['p1', 'p2']} />,
     ));
-    // Click all buttons — at least one should be a participant nav button that triggers setSearchParams
-    const buttons = getAllByRole('button');
-    for (const btn of buttons) {
-      act(() => { fireEvent.click(btn); });
-      if (mockSetSearchParams.mock.calls.length > 0) break;
-    }
+
+    const nextParticipantButton = getByTitle('Next Participant').querySelector('button');
+    expect(nextParticipantButton).not.toBeNull();
+    await act(async () => { fireEvent.click(nextParticipantButton!); });
+
     expect(mockSetSearchParams).toHaveBeenCalled();
+    expect(updatedParams.get('participantId')).toBe('p2');
   });
 
   test('renders all participants in select dropdown', async () => {

--- a/src/components/audioAnalysis/AudioProvenanceVis.tsx
+++ b/src/components/audioAnalysis/AudioProvenanceVis.tsx
@@ -105,6 +105,7 @@ export function AudioProvenanceVis({
   const [waveSurferLoading, setWaveSurferLoading] = useState<boolean>(true);
 
   const trrackForTrial = useRef<Trrack<object, string> | null>(null);
+  const hasLoadableTask = Boolean(participantId && taskName && answers[taskName]);
 
   useEffect(() => {
     let canceled = false;
@@ -296,7 +297,7 @@ export function AudioProvenanceVis({
       audioRef.current = null;
       updateReplayRef();
 
-      if (waveSurfer && isAnalysis && taskName && storageEngine) {
+      if (waveSurfer && isAnalysis && hasLoadableTask && storageEngine) {
         try {
           if (!participantId) {
             throw new Error('Participant ID is required to load audio');
@@ -355,9 +356,9 @@ export function AudioProvenanceVis({
   return (
     <Group wrap="nowrap" gap={0} mx={0}>
       <Stack ref={ref} style={{ width: '100%' }} gap={0}>
-        <LoadingOverlay visible={waveSurferLoading} overlayProps={{ blur: 5, backgroundOpacity: 0.35 }} />
+        <LoadingOverlay visible={waveSurferLoading && hasLoadableTask} overlayProps={{ blur: 5, backgroundOpacity: 0.35 }} />
 
-        {participantId !== undefined && taskName
+        {hasLoadableTask
           ? (
             <Box pos="relative" ml={margin.left} mr={margin.right}>
               <Box

--- a/src/components/audioAnalysis/tests/AudioProvenanceVis.spec.tsx
+++ b/src/components/audioAnalysis/tests/AudioProvenanceVis.spec.tsx
@@ -42,7 +42,7 @@ vi.mock('react-router', () => ({
   useNavigate: () => vi.fn(),
   useParams: () => ({ studyId: 'test-study' }),
   useSearchParams: () => {
-    const params = new URLSearchParams();
+    const params = new URLSearchParams('participantId=p1');
     const setParams = vi.fn((updater: (p: URLSearchParams) => void) => {
       if (typeof updater === 'function') updater(params);
     });
@@ -387,14 +387,25 @@ const answersWithStimulus: Record<string, StoredAnswer & { provenanceGraph: Stor
 };
 
 describe('AudioProvenanceVis', () => {
-  test('renders wavesurfer element', async () => {
-    const { getByTestId } = await act(async () => render(<AudioProvenanceVis {...defaultProps} />));
+  test('does not load a stale task that is absent from the participant answers', async () => {
+    const { queryByTestId } = await act(async () => render(
+      <AudioProvenanceVis {...defaultProps} />,
+    ));
+    expect(queryByTestId('loading-overlay')).toBeNull();
+    expect(queryByTestId('wavesurfer')).toBeNull();
+  });
+
+  test('shows the loading overlay and renders wavesurfer for a stored task', async () => {
+    const { getByTestId } = await act(async () => render(
+      <AudioProvenanceVis {...defaultProps} answers={answersWithTask} />,
+    ));
+    expect(getByTestId('loading-overlay')).toBeDefined();
     expect(getByTestId('wavesurfer')).toBeDefined();
   });
 
   test('renders in provenanceVis context', async () => {
     const { getByTestId } = await act(async () => render(
-      <AudioProvenanceVis {...defaultProps} context="provenanceVis" />,
+      <AudioProvenanceVis {...defaultProps} context="provenanceVis" answers={answersWithTask} />,
     ));
     expect(getByTestId('wavesurfer')).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- show a participant-level empty state when Coding has no component or transcript data
- keep the Coding footer and participant navigation available in that state
- only mount the waveform and show its loading overlay when the selected Participant actually has the routed task
- cover absent and stale task IDs, genuine task loading, and participant switching with regression tests

## Root cause

The waveform loading state started as active even when there was no task to mount. A stale task ID could also be treated as loadable after switching to a Participant whose answers did not contain that task, allowing the footer overlay to obscure participant navigation indefinitely.

## Validation

- `yarn unittest --run src/analysis/individualStudy/thinkAloud/tests/ThinkAloudAnalysis.spec.tsx src/components/audioAnalysis/tests/AudioProvenanceVis.spec.tsx` — 90 passed
- `yarn unittest --run` — 2,032 passed, 1 skipped
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`
- independent adversarial review completed; both reported stale-route and test-coverage findings were fixed and revalidated

Fixes #1335
