### PR TITLE
Reduce sequence-assignment allocator round trips

### DIFF
--- a/SEQUENCE_ASSIGNMENT_ALLOCATION.md
+++ b/SEQUENCE_ASSIGNMENT_ALLOCATION.md
@@ -1,0 +1,49 @@
+# Sequence assignment allocation
+
+Participant startup reserves a sequence assignment atomically before participant data is
+persisted. If the later participant-data write fails, retrying startup returns the already
+committed assignment instead of consuming another sequence or creation index.
+
+## Provider operation bounds
+
+### Firebase
+
+For an initialized allocator, a fresh or returning participant performs:
+
+1. One query limited to the oldest unclaimed rejected assignment.
+2. One Firestore transaction, bounded to five attempts, that rechecks the participant,
+   allocator, and candidate assignment before committing the claim, assignment, and counters.
+
+The Firebase Web SDK cannot read a query through a transaction, so the bounded candidate
+query must precede the transaction. The transaction re-reads that one candidate document to
+prevent double claims. Allocator initialization adds two aggregate counts and one transaction
+retry only when a legacy study has no allocator document. Legacy assignments without stable
+indexes add bounded aggregate counts.
+
+Rejected-slot ordering is explicit by ascending `timestamp`. Deploy
+`firestore.indexes.json` to each Firebase project used by ReVISit before releasing this path.
+
+### Supabase
+
+After applying `supabase/migrations/20260730000000_allocate_sequence_assignment.sql`, fresh,
+existing, rejected-reuse, and contended allocations each use one
+`allocate_sequence_assignment` RPC. The database function holds a study-scoped transaction
+lock, caps lock waiting at five seconds, selects at most one reusable row, and commits the
+allocator, claim, and participant assignment together. Existing pre-allocator rows are
+derived lazily with aggregate counts inside that same operation.
+
+The client retains the bounded compare-and-swap allocator as a compatibility fallback when
+the RPC has not yet been installed. The fallback caps conflicts at ten attempts.
+
+## Trace evidence and limitations
+
+Provider-operation Vitest coverage records the permitted query, transaction, retry, and RPC
+counts for fresh, existing, rejected-reuse, and conflict paths. Concurrent-start coverage
+checks unique indexes and single-claim rejected-slot behavior for Firebase, Supabase, and
+LocalStorage.
+
+Live before/after HAR capture was not possible in the development environment because it has
+no authenticated Firebase and Supabase study credentials. The tests therefore verify SDK
+operation boundaries rather than claiming network timing improvements. A production trace
+should confirm the Firebase bounded query plus transaction and the single Supabase RPC after
+the migration and Firestore index are deployed.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "sequenceAssignment",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "rejected",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "sequenceAssignment",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "rejected",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "claimed",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -233,12 +233,12 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
         await storageEngine.saveConfig(activeConfig);
 
-        const sequenceArray = await storageEngine.getSequenceArray();
+        let sequenceArray = await storageEngine.getSequenceArray();
 
         if (!sequenceArray) {
-          const generatedSequenceArray = await generateSequenceArray(activeConfig);
+          sequenceArray = await generateSequenceArray(activeConfig);
 
-          await storageEngine.setSequenceArray(generatedSequenceArray);
+          await storageEngine.setSequenceArray(sequenceArray);
         }
 
         // Get or generate participant session
@@ -257,6 +257,10 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
           activeConfig,
           initialMetadata,
           participantId || urlParticipantId,
+          {
+            modesDocument: resolvedModes,
+            sequenceArray,
+          },
         );
 
         if (studyCondition.length > 0 && resolvedModes.developmentModeEnabled) {

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -227,6 +227,20 @@ describe('Shell', () => {
     render(<Shell globalConfig={globalConfig} />);
     await waitFor(() => expect(mockStorageEngine!.initializeStudyDb).toHaveBeenCalled(), { timeout: 3000 });
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
+    expect(mockStorageEngine.initializeParticipantSession).toHaveBeenCalledWith(
+      expect.any(Object),
+      mockActiveConfig,
+      expect.any(Object),
+      undefined,
+      {
+        modesDocument: {
+          developmentModeEnabled: false,
+          dataSharingEnabled: false,
+          dataCollectionEnabled: true,
+        },
+        sequenceArray: ['seq1'],
+      },
+    );
   });
 
   test('calls setSequenceArray when getSequenceArray returns null', async () => {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -263,10 +263,13 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     const participantSequenceAssignmentDoc = doc(sequenceAssignmentCollection, participantId);
     const allocatorDoc = doc(this.studyCollection, 'sequenceAssignmentAllocator');
 
-    const [existingAssignment, existingAllocatorSnapshot] = await Promise.all([
-      this._getSequenceAssignment(participantId),
+    const [existingAssignmentSnapshot, existingAllocatorSnapshot] = await Promise.all([
+      getDoc(participantSequenceAssignmentDoc),
       getDoc(allocatorDoc),
     ]);
+    const existingAssignment = existingAssignmentSnapshot.exists()
+      ? existingAssignmentSnapshot.data() as SequenceAssignment
+      : null;
     if (existingAssignment) {
       if (
         existingAssignment.sequenceIndex !== undefined
@@ -278,12 +281,20 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
         };
       }
 
-      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      const [sequenceCount, creationCount] = await Promise.all([
+        getCountFromServer(query(
+          sequenceAssignmentCollection,
+          where('rejected', '==', false),
+          where('timestamp', '<', existingAssignment.timestamp),
+        )),
+        getCountFromServer(query(
+          sequenceAssignmentCollection,
+          where('createdTime', '<', existingAssignment.createdTime),
+        )),
+      ]);
       return {
-        sequenceIndex: assignments.filter((assignment) => !assignment.rejected)
-          .findIndex((assignment) => assignment.participantId === participantId),
-        creationIndex: assignments.sort((a, b) => a.createdTime - b.createdTime)
-          .findIndex((assignment) => assignment.participantId === participantId),
+        sequenceIndex: sequenceCount.data().count,
+        creationIndex: creationCount.data().count,
       };
     }
 
@@ -315,14 +326,12 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     const reusableData = reusableDocument?.data() as SequenceAssignment | undefined;
     let legacyReusableIndex: number | undefined;
     if (reusableData && reusableData.sequenceIndex === undefined) {
-      const assignments = await this.getAllSequenceAssignments(this.studyId);
-      const storedTimestamp = (reusableData as { timestamp: unknown }).timestamp;
-      const reusableTimestamp = storedTimestamp instanceof Timestamp
-        ? storedTimestamp.toMillis()
-        : Number(storedTimestamp);
-      legacyReusableIndex = assignments.filter((assignment) => (
-        !assignment.rejected && assignment.timestamp < reusableTimestamp
-      )).length;
+      const sequenceCount = await getCountFromServer(query(
+        sequenceAssignmentCollection,
+        where('rejected', '==', false),
+        where('timestamp', '<', reusableData.timestamp),
+      ));
+      legacyReusableIndex = sequenceCount.data().count;
     }
 
     return runTransaction(this.firestore, async (transaction) => {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -21,13 +21,18 @@ import {
   deleteField,
   doc,
   enableNetwork,
+  getCountFromServer,
   getDoc,
   getDocs,
   initializeFirestore,
+  limit,
   onSnapshot,
+  query,
+  runTransaction,
   serverTimestamp,
   setDoc,
   updateDoc,
+  where,
   writeBatch,
 } from 'firebase/firestore';
 import { ReCaptchaV3Provider, initializeAppCheck } from '@firebase/app-check';
@@ -41,6 +46,7 @@ import {
   StorageObject,
   UserManagementData,
   SequenceAssignment,
+  SequenceAssignmentAllocation,
   SnapshotDocContent,
   StoredUser,
   cleanupModes,
@@ -238,6 +244,148 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
 
     const toUpload = withServerTimestamp ? { ...sequenceAssignment, timestamp: serverTimestamp() } : sequenceAssignment;
     await setDoc(participantSequenceAssignmentDoc, { ...toUpload, createdTime: serverTimestamp() });
+  }
+
+  protected async _allocateSequenceAssignment(
+    participantId: string,
+    sequenceAssignment: SequenceAssignment,
+  ): Promise<SequenceAssignmentAllocation> {
+    await this.verifyStudyDatabase();
+    if (this.studyId === undefined) {
+      throw new Error('Study ID is not set');
+    }
+
+    const sequenceAssignmentDoc = doc(this.studyCollection, 'sequenceAssignment');
+    const sequenceAssignmentCollection = collection(
+      sequenceAssignmentDoc,
+      'sequenceAssignment',
+    );
+    const participantSequenceAssignmentDoc = doc(sequenceAssignmentCollection, participantId);
+    const allocatorDoc = doc(this.studyCollection, 'sequenceAssignmentAllocator');
+
+    const [existingAssignment, existingAllocatorSnapshot] = await Promise.all([
+      this._getSequenceAssignment(participantId),
+      getDoc(allocatorDoc),
+    ]);
+    if (existingAssignment) {
+      if (
+        existingAssignment.sequenceIndex !== undefined
+        && existingAssignment.creationIndex !== undefined
+      ) {
+        return {
+          sequenceIndex: existingAssignment.sequenceIndex,
+          creationIndex: existingAssignment.creationIndex,
+        };
+      }
+
+      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      return {
+        sequenceIndex: assignments.filter((assignment) => !assignment.rejected)
+          .findIndex((assignment) => assignment.participantId === participantId),
+        creationIndex: assignments.sort((a, b) => a.createdTime - b.createdTime)
+          .findIndex((assignment) => assignment.participantId === participantId),
+      };
+    }
+
+    const allocatorSeedPromise = existingAllocatorSnapshot.exists()
+      ? Promise.resolve(existingAllocatorSnapshot.data() as {
+        nextSequenceIndex: number;
+        nextCreationIndex: number;
+      })
+      : Promise.all([
+        getCountFromServer(sequenceAssignmentCollection),
+        getCountFromServer(query(
+          sequenceAssignmentCollection,
+          where('claimedParticipantId', '>', ''),
+        )),
+      ]).then(([totalAssignments, replacementAssignments]) => ({
+        nextSequenceIndex: totalAssignments.data().count - replacementAssignments.data().count,
+        nextCreationIndex: totalAssignments.data().count,
+      }));
+    const [allocatorSeed, reusableSnapshot] = await Promise.all([
+      allocatorSeedPromise,
+      getDocs(query(
+        sequenceAssignmentCollection,
+        where('rejected', '==', true),
+        where('claimed', '==', false),
+        limit(1),
+      )),
+    ]);
+    const reusableDocument = reusableSnapshot.docs[0];
+    const reusableData = reusableDocument?.data() as SequenceAssignment | undefined;
+    let legacyReusableIndex: number | undefined;
+    if (reusableData && reusableData.sequenceIndex === undefined) {
+      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      const storedTimestamp = (reusableData as { timestamp: unknown }).timestamp;
+      const reusableTimestamp = storedTimestamp instanceof Timestamp
+        ? storedTimestamp.toMillis()
+        : Number(storedTimestamp);
+      legacyReusableIndex = assignments.filter((assignment) => (
+        !assignment.rejected && assignment.timestamp < reusableTimestamp
+      )).length;
+    }
+
+    return runTransaction(this.firestore, async (transaction) => {
+      const [currentAssignmentSnapshot, allocatorSnapshot, reusableAssignmentSnapshot] = await Promise.all([
+        transaction.get(participantSequenceAssignmentDoc),
+        transaction.get(allocatorDoc),
+        reusableDocument ? transaction.get(doc(sequenceAssignmentCollection, reusableDocument.id)) : null,
+      ]);
+
+      if (currentAssignmentSnapshot.exists()) {
+        const currentAssignment = currentAssignmentSnapshot.data() as SequenceAssignment;
+        if (
+          currentAssignment.sequenceIndex === undefined
+          || currentAssignment.creationIndex === undefined
+        ) {
+          throw new Error('Existing sequence assignment is missing allocator metadata');
+        }
+        return {
+          sequenceIndex: currentAssignment.sequenceIndex,
+          creationIndex: currentAssignment.creationIndex,
+        };
+      }
+
+      const allocator = allocatorSnapshot.exists()
+        ? allocatorSnapshot.data() as typeof allocatorSeed
+        : allocatorSeed;
+      const reusableAssignment = reusableAssignmentSnapshot?.exists()
+        ? reusableAssignmentSnapshot.data() as SequenceAssignment
+        : undefined;
+      const canReuse = reusableAssignment?.rejected && !reusableAssignment.claimed;
+      const sequenceIndex = canReuse
+        ? reusableAssignment.sequenceIndex ?? legacyReusableIndex
+        : allocator.nextSequenceIndex;
+      if (sequenceIndex === undefined || sequenceIndex < 0) {
+        throw new Error('Unable to determine sequence assignment index');
+      }
+      const creationIndex = allocator.nextCreationIndex;
+
+      if (canReuse && reusableDocument) {
+        transaction.update(doc(sequenceAssignmentCollection, reusableDocument.id), {
+          claimed: true,
+          sequenceIndex,
+        });
+      }
+      transaction.set(participantSequenceAssignmentDoc, {
+        ...sequenceAssignment,
+        ...(canReuse && reusableDocument ? {
+          timestamp: reusableAssignment.timestamp,
+          claimedParticipantId: reusableDocument.id,
+        } : { timestamp: serverTimestamp() }),
+        createdTime: serverTimestamp(),
+        sequenceIndex,
+        creationIndex,
+      });
+      transaction.set(allocatorDoc, {
+        nextSequenceIndex: canReuse
+          ? allocator.nextSequenceIndex
+          : allocator.nextSequenceIndex + 1,
+        nextCreationIndex: allocator.nextCreationIndex + 1,
+      });
+
+      return { sequenceIndex, creationIndex };
+    });
   }
 
   protected async _updateSequenceAssignmentFields(participantId: string, updatedFields: Partial<SequenceAssignment>) {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -55,6 +55,31 @@ import {
 import { EditedText, TaglessEditedText } from '../../analysis/individualStudy/thinkAloud/types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
+type FirebaseSequenceAllocator = {
+  nextSequenceIndex: number;
+  nextCreationIndex: number;
+};
+
+class FirebaseAllocatorSeedRequired extends Error {}
+
+class FirebaseLegacyAssignmentIndexRequired extends Error {
+  constructor(public assignment: SequenceAssignment) {
+    super('Legacy sequence assignment requires bounded index lookup');
+  }
+}
+
+class FirebaseLegacyReusableIndexRequired extends Error {
+  constructor(public timestamp: number) {
+    super('Legacy reusable sequence assignment requires bounded index lookup');
+  }
+}
+
+class FirebaseReusableCandidateConflict extends Error {
+  constructor() {
+    super('Reusable sequence assignment changed during allocation');
+  }
+}
+
 export class FirebaseStorageEngine extends CloudStorageEngine {
   private RECAPTCHAV3TOKEN = import.meta.env.VITE_RECAPTCHAV3TOKEN;
 
@@ -263,88 +288,26 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     );
     const participantSequenceAssignmentDoc = doc(sequenceAssignmentCollection, participantId);
     const allocatorDoc = doc(this.studyCollection, 'sequenceAssignmentAllocator');
-
-    const [existingAssignmentSnapshot, existingAllocatorSnapshot] = await Promise.all([
-      getDoc(participantSequenceAssignmentDoc),
-      getDoc(allocatorDoc),
-    ]);
-    const existingAssignment = existingAssignmentSnapshot.exists()
-      ? existingAssignmentSnapshot.data() as SequenceAssignment
-      : null;
-    if (existingAssignment) {
-      if (
-        existingAssignment.sequenceIndex !== undefined
-        && existingAssignment.creationIndex !== undefined
-      ) {
-        return {
-          sequenceIndex: existingAssignment.sequenceIndex,
-          creationIndex: existingAssignment.creationIndex,
-        };
-      }
-
-      const [sequenceCount, creationCount] = await Promise.all([
-        getCountFromServer(query(
-          sequenceAssignmentCollection,
-          where('rejected', '==', false),
-          where('timestamp', '<', existingAssignment.timestamp),
-        )),
-        getCountFromServer(query(
-          sequenceAssignmentCollection,
-          where('createdTime', '<', existingAssignment.createdTime),
-        )),
-      ]);
-      return {
-        sequenceIndex: sequenceCount.data().count,
-        creationIndex: creationCount.data().count,
-      };
-    }
-
-    const allocatorSeedPromise = existingAllocatorSnapshot.exists()
-      ? Promise.resolve(existingAllocatorSnapshot.data() as {
-        nextSequenceIndex: number;
-        nextCreationIndex: number;
-      })
-      : Promise.all([
-        getCountFromServer(sequenceAssignmentCollection),
-        getCountFromServer(query(
-          sequenceAssignmentCollection,
-          where('claimed', '==', true),
-        )),
-      ]).then(([totalAssignments, claimedAssignments]) => ({
-        nextSequenceIndex: totalAssignments.data().count - claimedAssignments.data().count,
-        nextCreationIndex: totalAssignments.data().count,
-      }));
-    const [allocatorSeed, reusableSnapshot] = await Promise.all([
-      allocatorSeedPromise,
-      getDocs(query(
+    const getReusableDocument = async () => {
+      const reusableSnapshot = await getDocs(query(
         sequenceAssignmentCollection,
         where('rejected', '==', true),
         where('claimed', '==', false),
         orderBy('timestamp', 'asc'),
         limit(1),
-      )),
-    ]);
-    const reusableDocument = reusableSnapshot.docs[0];
-    const reusableData = reusableDocument?.data() as SequenceAssignment | undefined;
-    let legacyReusableIndex: number | undefined;
-    if (
-      reusableData
-      && reusableData.reusableSequenceIndex === undefined
-      && reusableData.sequenceIndex === undefined
-    ) {
-      const sequenceCount = await getCountFromServer(query(
-        sequenceAssignmentCollection,
-        where('rejected', '==', false),
-        where('timestamp', '<', reusableData.timestamp),
       ));
-      legacyReusableIndex = sequenceCount.data().count;
-    }
+      return reusableSnapshot.docs[0];
+    };
 
-    return runTransaction(this.firestore, async (transaction) => {
+    const reserve = (
+      reusableDocument: Awaited<ReturnType<typeof getReusableDocument>>,
+      allocatorSeed?: FirebaseSequenceAllocator,
+      legacyReusableIndex?: number,
+    ) => runTransaction(this.firestore, async (transaction) => {
       const [currentAssignmentSnapshot, allocatorSnapshot, reusableAssignmentSnapshot] = await Promise.all([
         transaction.get(participantSequenceAssignmentDoc),
         transaction.get(allocatorDoc),
-        reusableDocument ? transaction.get(doc(sequenceAssignmentCollection, reusableDocument.id)) : null,
+        reusableDocument ? transaction.get(reusableDocument.ref) : null,
       ]);
 
       if (currentAssignmentSnapshot.exists()) {
@@ -353,7 +316,7 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
           currentAssignment.sequenceIndex === undefined
           || currentAssignment.creationIndex === undefined
         ) {
-          throw new Error('Existing sequence assignment is missing allocator metadata');
+          throw new FirebaseLegacyAssignmentIndexRequired(currentAssignment);
         }
         return {
           sequenceIndex: currentAssignment.sequenceIndex,
@@ -362,24 +325,33 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       }
 
       const allocator = allocatorSnapshot.exists()
-        ? allocatorSnapshot.data() as typeof allocatorSeed
+        ? allocatorSnapshot.data() as FirebaseSequenceAllocator
         : allocatorSeed;
+      if (!allocator) {
+        throw new FirebaseAllocatorSeedRequired();
+      }
       const reusableAssignment = reusableAssignmentSnapshot?.exists()
         ? reusableAssignmentSnapshot.data() as SequenceAssignment
         : undefined;
-      const canReuse = reusableAssignment?.rejected && !reusableAssignment.claimed;
+      const canReuse = !!reusableAssignment?.rejected && !reusableAssignment.claimed;
+      if (reusableDocument && !canReuse) {
+        throw new FirebaseReusableCandidateConflict();
+      }
       const sequenceIndex = canReuse
         ? reusableAssignment.reusableSequenceIndex
           ?? reusableAssignment.sequenceIndex
           ?? legacyReusableIndex
         : allocator.nextSequenceIndex;
+      if (canReuse && sequenceIndex === undefined) {
+        throw new FirebaseLegacyReusableIndexRequired(reusableAssignment.timestamp);
+      }
       if (sequenceIndex === undefined || sequenceIndex < 0) {
         throw new Error('Unable to determine sequence assignment index');
       }
       const creationIndex = allocator.nextCreationIndex;
 
       if (canReuse && reusableDocument) {
-        transaction.update(doc(sequenceAssignmentCollection, reusableDocument.id), {
+        transaction.update(reusableDocument.ref, {
           claimed: true,
           sequenceIndex,
         });
@@ -402,7 +374,74 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       });
 
       return { sequenceIndex, creationIndex };
-    });
+    }, { maxAttempts: 5 });
+
+    const allocateWithLegacyFallback = async (
+      reusableDocument: Awaited<ReturnType<typeof getReusableDocument>>,
+      allocatorSeed?: FirebaseSequenceAllocator,
+      legacyReusableIndex?: number,
+      candidateConflicts: number = 0,
+    ): Promise<SequenceAssignmentAllocation> => {
+      try {
+        return await reserve(reusableDocument, allocatorSeed, legacyReusableIndex);
+      } catch (error) {
+        if (error instanceof FirebaseLegacyAssignmentIndexRequired) {
+          const [sequenceCount, creationCount] = await Promise.all([
+            getCountFromServer(query(
+              sequenceAssignmentCollection,
+              where('rejected', '==', false),
+              where('timestamp', '<', error.assignment.timestamp),
+            )),
+            getCountFromServer(query(
+              sequenceAssignmentCollection,
+              where('createdTime', '<', error.assignment.createdTime),
+            )),
+          ]);
+          return {
+            sequenceIndex: sequenceCount.data().count,
+            creationIndex: creationCount.data().count,
+          };
+        }
+        if (error instanceof FirebaseAllocatorSeedRequired && allocatorSeed === undefined) {
+          const [totalAssignments, claimedAssignments] = await Promise.all([
+            getCountFromServer(sequenceAssignmentCollection),
+            getCountFromServer(query(
+              sequenceAssignmentCollection,
+              where('claimed', '==', true),
+            )),
+          ]);
+          return allocateWithLegacyFallback(reusableDocument, {
+            nextSequenceIndex: totalAssignments.data().count - claimedAssignments.data().count,
+            nextCreationIndex: totalAssignments.data().count,
+          }, legacyReusableIndex, candidateConflicts);
+        }
+        if (error instanceof FirebaseLegacyReusableIndexRequired && legacyReusableIndex === undefined) {
+          const sequenceCount = await getCountFromServer(query(
+            sequenceAssignmentCollection,
+            where('rejected', '==', false),
+            where('timestamp', '<', error.timestamp),
+          ));
+          return allocateWithLegacyFallback(
+            reusableDocument,
+            allocatorSeed,
+            sequenceCount.data().count,
+            candidateConflicts,
+          );
+        }
+        if (error instanceof FirebaseReusableCandidateConflict && candidateConflicts < 5) {
+          const nextReusableDocument = await getReusableDocument();
+          return allocateWithLegacyFallback(
+            nextReusableDocument,
+            allocatorSeed,
+            undefined,
+            candidateConflicts + 1,
+          );
+        }
+        throw error;
+      }
+    };
+
+    return allocateWithLegacyFallback(await getReusableDocument());
   }
 
   protected async _updateSequenceAssignmentFields(participantId: string, updatedFields: Partial<SequenceAssignment>) {

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -27,6 +27,7 @@ import {
   initializeFirestore,
   limit,
   onSnapshot,
+  orderBy,
   query,
   runTransaction,
   serverTimestamp,
@@ -319,6 +320,7 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
         sequenceAssignmentCollection,
         where('rejected', '==', true),
         where('claimed', '==', false),
+        orderBy('timestamp', 'asc'),
         limit(1),
       )),
     ]);

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -307,10 +307,10 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
         getCountFromServer(sequenceAssignmentCollection),
         getCountFromServer(query(
           sequenceAssignmentCollection,
-          where('claimedParticipantId', '>', ''),
+          where('claimed', '==', true),
         )),
-      ]).then(([totalAssignments, replacementAssignments]) => ({
-        nextSequenceIndex: totalAssignments.data().count - replacementAssignments.data().count,
+      ]).then(([totalAssignments, claimedAssignments]) => ({
+        nextSequenceIndex: totalAssignments.data().count - claimedAssignments.data().count,
         nextCreationIndex: totalAssignments.data().count,
       }));
     const [allocatorSeed, reusableSnapshot] = await Promise.all([
@@ -325,7 +325,11 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     const reusableDocument = reusableSnapshot.docs[0];
     const reusableData = reusableDocument?.data() as SequenceAssignment | undefined;
     let legacyReusableIndex: number | undefined;
-    if (reusableData && reusableData.sequenceIndex === undefined) {
+    if (
+      reusableData
+      && reusableData.reusableSequenceIndex === undefined
+      && reusableData.sequenceIndex === undefined
+    ) {
       const sequenceCount = await getCountFromServer(query(
         sequenceAssignmentCollection,
         where('rejected', '==', false),
@@ -363,7 +367,9 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
         : undefined;
       const canReuse = reusableAssignment?.rejected && !reusableAssignment.claimed;
       const sequenceIndex = canReuse
-        ? reusableAssignment.sequenceIndex ?? legacyReusableIndex
+        ? reusableAssignment.reusableSequenceIndex
+          ?? reusableAssignment.sequenceIndex
+          ?? legacyReusableIndex
         : allocator.nextSequenceIndex;
       if (sequenceIndex === undefined || sequenceIndex < 0) {
         throw new Error('Unable to determine sequence assignment index');
@@ -490,13 +496,61 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       sequenceAssignmentDoc,
       'sequenceAssignment',
     );
-    const sequenceAssignmentSnapshot = await getDocs(sequenceAssignmentCollection);
-    const participantSequenceAssignmentSnapshot = sequenceAssignmentSnapshot.docs.find((docSnapshot) => docSnapshot.id === participantId);
-    if (!participantSequenceAssignmentSnapshot) {
+    const participantSequenceAssignmentDoc = doc(
+      sequenceAssignmentCollection,
+      participantId,
+    );
+    const participantSequenceAssignmentSnapshot = await getDoc(participantSequenceAssignmentDoc);
+    if (!participantSequenceAssignmentSnapshot.exists()) {
       throw new Error('Failed to retrieve sequence assignment for current participant');
     }
 
     const participantSequenceAssignment = participantSequenceAssignmentSnapshot.data() as SequenceAssignment;
+    if (participantSequenceAssignment.claimedParticipantId) {
+      const claimedSequenceAssignmentDoc = doc(
+        sequenceAssignmentCollection,
+        participantSequenceAssignment.claimedParticipantId,
+      );
+      const allocatorDoc = doc(this.studyCollection, 'sequenceAssignmentAllocator');
+
+      await runTransaction(this.firestore, async (transaction) => {
+        const [
+          currentParticipantSnapshot,
+          claimedSequenceAssignmentSnapshot,
+          allocatorSnapshot,
+        ] = await Promise.all([
+          transaction.get(participantSequenceAssignmentDoc),
+          transaction.get(claimedSequenceAssignmentDoc),
+          transaction.get(allocatorDoc),
+        ]);
+        if (!currentParticipantSnapshot.exists() || !claimedSequenceAssignmentSnapshot.exists()) {
+          throw new Error('Failed to retrieve claimed sequence assignment for rejection');
+        }
+        if (!allocatorSnapshot.exists()) {
+          throw new Error('Sequence assignment allocator is not initialized');
+        }
+
+        const allocator = allocatorSnapshot.data() as {
+          nextSequenceIndex: number;
+          nextCreationIndex: number;
+        };
+        transaction.update(claimedSequenceAssignmentDoc, {
+          claimed: false,
+          rejected: true,
+        });
+        transaction.update(participantSequenceAssignmentDoc, {
+          rejected: true,
+          timestamp: new Date().getTime(),
+          reusableSequenceIndex: allocator.nextSequenceIndex,
+        });
+        transaction.update(allocatorDoc, {
+          nextSequenceIndex: allocator.nextSequenceIndex + 1,
+        });
+      });
+      return;
+    }
+
+    const sequenceAssignmentSnapshot = await getDocs(sequenceAssignmentCollection);
     const toMillis = (value: unknown) => {
       if (value instanceof Timestamp) {
         return value.toMillis();
@@ -520,13 +574,46 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
 
     if (claimedSequenceAssignmentSnapshot) {
       const claimedSequenceAssignmentDoc = doc(sequenceAssignmentCollection, claimedSequenceAssignmentSnapshot.id);
-      await updateDoc(claimedSequenceAssignmentDoc, { claimed: false, rejected: true });
+      const allocatorDoc = doc(this.studyCollection, 'sequenceAssignmentAllocator');
+      const allocatorSeed = {
+        nextSequenceIndex: sequenceAssignmentSnapshot.docs.filter(
+          (docSnapshot) => !(docSnapshot.data() as SequenceAssignment).claimed,
+        ).length,
+        nextCreationIndex: sequenceAssignmentSnapshot.docs.length,
+      };
+      await runTransaction(this.firestore, async (transaction) => {
+        const [
+          currentParticipantSnapshot,
+          currentClaimedSnapshot,
+          allocatorSnapshot,
+        ] = await Promise.all([
+          transaction.get(participantSequenceAssignmentDoc),
+          transaction.get(claimedSequenceAssignmentDoc),
+          transaction.get(allocatorDoc),
+        ]);
+        if (!currentParticipantSnapshot.exists() || !currentClaimedSnapshot.exists()) {
+          throw new Error('Failed to retrieve claimed sequence assignment for rejection');
+        }
+        const allocator = allocatorSnapshot.exists()
+          ? allocatorSnapshot.data() as typeof allocatorSeed
+          : allocatorSeed;
+        transaction.update(claimedSequenceAssignmentDoc, {
+          claimed: false,
+          rejected: true,
+        });
+        transaction.update(participantSequenceAssignmentDoc, {
+          rejected: true,
+          timestamp: new Date().getTime(),
+          reusableSequenceIndex: allocator.nextSequenceIndex,
+        });
+        transaction.set(allocatorDoc, {
+          nextSequenceIndex: allocator.nextSequenceIndex + 1,
+          nextCreationIndex: allocator.nextCreationIndex,
+        });
+      });
+      return;
     }
 
-    const participantSequenceAssignmentDoc = doc(
-      sequenceAssignmentCollection,
-      participantId,
-    );
     await updateDoc(participantSequenceAssignmentDoc, {
       rejected: true,
       timestamp: new Date().getTime(),
@@ -587,8 +674,12 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     await updateDoc(
       participantSequenceAssignmentDoc,
       restoredTimestamp === undefined
-        ? { rejected: false }
-        : { rejected: false, timestamp: restoredTimestamp },
+        ? { rejected: false, reusableSequenceIndex: deleteField() }
+        : {
+          rejected: false,
+          timestamp: restoredTimestamp,
+          reusableSequenceIndex: deleteField(),
+        },
     );
   }
 

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -1,8 +1,28 @@
 import localforage from 'localforage';
 import {
-  REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageEngine, StorageObject, StorageObjectType, cleanupModes,
+  REVISIT_MODE, SequenceAssignment, SequenceAssignmentAllocation, SnapshotDocContent, StorageEngine, StorageObject, StorageObjectType, cleanupModes,
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
+
+const localAllocationLocks = new Map<string, Promise<void>>();
+
+async function withLocalAllocationLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+  const previous = localAllocationLocks.get(key) ?? Promise.resolve();
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => { release = resolve; });
+  const queued = previous.then(() => current);
+  localAllocationLocks.set(key, queued);
+  await previous;
+
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (localAllocationLocks.get(key) === queued) {
+      localAllocationLocks.delete(key);
+    }
+  }
+}
 
 export class LocalStorageEngine extends StorageEngine {
   private studyDatabase = localforage.createInstance({
@@ -73,6 +93,69 @@ export class LocalStorageEngine extends StorageEngine {
     const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
     sequenceAssignments[participantId] = sequenceAssignment;
     await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
+  }
+
+  protected async _allocateSequenceAssignment(
+    participantId: string,
+    sequenceAssignment: SequenceAssignment,
+  ): Promise<SequenceAssignmentAllocation> {
+    await this.verifyStudyDatabase();
+    if (this.studyId === undefined) {
+      throw new Error('Study ID is not set');
+    }
+
+    const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
+    return withLocalAllocationLock(sequenceAssignmentPath, async () => {
+      const assignmentsByParticipant = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(
+        sequenceAssignmentPath,
+      ) || {};
+      const existingAssignment = assignmentsByParticipant[participantId];
+      const assignments = Object.values(assignmentsByParticipant);
+
+      if (existingAssignment) {
+        const sequenceIndex = existingAssignment.sequenceIndex
+          ?? assignments.filter((assignment) => !assignment.rejected)
+            .sort((a, b) => a.timestamp - b.timestamp)
+            .findIndex((assignment) => assignment.participantId === participantId);
+        const creationIndex = existingAssignment.creationIndex
+          ?? assignments.sort((a, b) => a.createdTime - b.createdTime)
+            .findIndex((assignment) => assignment.participantId === participantId);
+        return { sequenceIndex, creationIndex };
+      }
+
+      const reusableAssignment = assignments
+        .filter((assignment) => assignment.rejected && !assignment.claimed)
+        .sort((a, b) => a.timestamp - b.timestamp)[0];
+      const creationIndex = assignments.length;
+      const logicalSlotCount = assignments
+        .filter((assignment) => !assignment.claimedParticipantId).length;
+      const sequenceIndex = reusableAssignment?.sequenceIndex
+        ?? (reusableAssignment
+          ? assignments.filter((assignment) => (
+            !assignment.rejected && assignment.timestamp < reusableAssignment.timestamp
+          )).length
+          : logicalSlotCount);
+
+      if (reusableAssignment) {
+        assignmentsByParticipant[reusableAssignment.participantId] = {
+          ...reusableAssignment,
+          claimed: true,
+          sequenceIndex,
+        };
+      }
+
+      assignmentsByParticipant[participantId] = {
+        ...sequenceAssignment,
+        ...(reusableAssignment ? {
+          timestamp: reusableAssignment.timestamp,
+          claimedParticipantId: reusableAssignment.participantId,
+        } : {}),
+        sequenceIndex,
+        creationIndex,
+      };
+      await this.studyDatabase.setItem(sequenceAssignmentPath, assignmentsByParticipant);
+      return { sequenceIndex, creationIndex };
+    });
   }
 
   protected async _updateSequenceAssignmentFields(participantId: string, updatedFields: Partial<SequenceAssignment>) {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -7,6 +7,10 @@ import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 const localAllocationLocks = new Map<string, Promise<void>>();
 
 async function withLocalAllocationLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+  if (typeof navigator !== 'undefined' && navigator.locks) {
+    return navigator.locks.request(`revisit-sequence-allocation:${key}`, operation);
+  }
+
   const previous = localAllocationLocks.get(key) ?? Promise.resolve();
   let release: () => void = () => undefined;
   const current = new Promise<void>((resolve) => { release = resolve; });

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -127,9 +127,9 @@ export class LocalStorageEngine extends StorageEngine {
         .filter((assignment) => assignment.rejected && !assignment.claimed)
         .sort((a, b) => a.timestamp - b.timestamp)[0];
       const creationIndex = assignments.length;
-      const logicalSlotCount = assignments
-        .filter((assignment) => !assignment.claimedParticipantId).length;
-      const sequenceIndex = reusableAssignment?.sequenceIndex
+      const logicalSlotCount = assignments.filter((assignment) => !assignment.claimed).length;
+      const sequenceIndex = reusableAssignment?.reusableSequenceIndex
+        ?? reusableAssignment?.sequenceIndex
         ?? (reusableAssignment
           ? assignments.filter((assignment) => (
             !assignment.rejected && assignment.timestamp < reusableAssignment.timestamp
@@ -216,38 +216,54 @@ export class LocalStorageEngine extends StorageEngine {
   protected async _rejectParticipantRealtime(participantId: string) {
     await this.verifyStudyDatabase();
     const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
-    const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
+    await withLocalAllocationLock(sequenceAssignmentPath, async () => {
+      const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(
+        sequenceAssignmentPath,
+      ) || {};
+      const participantSequenceAssignment = sequenceAssignments[participantId];
+      if (!participantSequenceAssignment) {
+        return;
+      }
 
-    const participantSequenceAssignment = sequenceAssignments[participantId];
+      // If this participant reused a rejected slot, release that source slot and create
+      // a distinct vacancy for this rejection.
+      const claimedAssignmentData = participantSequenceAssignment.claimedParticipantId
+        ? sequenceAssignments[participantSequenceAssignment.claimedParticipantId]
+        : Object.values(sequenceAssignments).find(
+          (assignment) => assignment.claimed
+            && assignment.timestamp === participantSequenceAssignment.timestamp,
+        );
+      if (claimedAssignmentData) {
+        const assignments = Object.values(sequenceAssignments);
+        const indexedSlots = assignments.flatMap((assignment) => [
+          assignment.sequenceIndex,
+          assignment.reusableSequenceIndex,
+        ]).filter((index): index is number => index !== undefined);
+        const logicalSlotCount = assignments.filter((assignment) => !assignment.claimed).length;
+        const reusableSequenceIndex = Math.max(
+          logicalSlotCount,
+          indexedSlots.length > 0 ? Math.max(...indexedSlots) + 1 : 0,
+        );
 
-    // If this was a claimed sequence assignment, we need to mark it as available again
-    const claimedAssignmentData = participantSequenceAssignment?.claimedParticipantId
-      ? sequenceAssignments[participantSequenceAssignment.claimedParticipantId]
-      : Object.values(sequenceAssignments).find(
-        (assignment) => assignment.claimed && assignment.timestamp === participantSequenceAssignment.timestamp,
-      );
-    if (participantSequenceAssignment && claimedAssignmentData) {
-      // Mark the claimed assignment as available again
-      claimedAssignmentData.claimed = false;
-      claimedAssignmentData.rejected = true; // Mark it as rejected
+        sequenceAssignments[claimedAssignmentData.participantId] = {
+          ...claimedAssignmentData,
+          claimed: false,
+          rejected: true,
+        };
+        sequenceAssignments[participantId] = {
+          ...participantSequenceAssignment,
+          timestamp: new Date().getTime(),
+          rejected: true,
+          reusableSequenceIndex,
+        };
+      } else {
+        sequenceAssignments[participantId] = {
+          ...participantSequenceAssignment,
+          rejected: true,
+        };
+      }
       await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
-
-      // Delete the participant's sequence assignment
-      // delete sequenceAssignments[participantId];
-      sequenceAssignments[participantId] = {
-        ...participantSequenceAssignment,
-        timestamp: new Date().getTime(),
-        rejected: true,
-      };
-      await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
-      return;
-    }
-
-    // Handle the original participant's sequence assignment
-    if (participantSequenceAssignment) {
-      participantSequenceAssignment.rejected = true;
-      await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
-    }
+    });
   }
 
   protected async _undoRejectParticipantRealtime(participantId: string) {
@@ -257,15 +273,20 @@ export class LocalStorageEngine extends StorageEngine {
 
     const participantSequenceAssignment = sequenceAssignments[participantId];
     if (participantSequenceAssignment) {
-      participantSequenceAssignment.rejected = false;
+      const updatedParticipantSequenceAssignment = {
+        ...participantSequenceAssignment,
+        rejected: false,
+      };
+      delete updatedParticipantSequenceAssignment.reusableSequenceIndex;
       if (participantSequenceAssignment.claimedParticipantId) {
         const claimedAssignmentData = sequenceAssignments[participantSequenceAssignment.claimedParticipantId];
         if (claimedAssignmentData) {
           claimedAssignmentData.claimed = true;
           claimedAssignmentData.rejected = true;
-          participantSequenceAssignment.timestamp = claimedAssignmentData.timestamp;
+          updatedParticipantSequenceAssignment.timestamp = claimedAssignmentData.timestamp;
         }
       }
+      sequenceAssignments[participantId] = updatedParticipantSequenceAssignment;
       await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
     }
   }

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -2,7 +2,7 @@ import { AuthError, createClient } from '@supabase/supabase-js';
 import localforage from 'localforage';
 import {
   REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageObject, StorageObjectType, StoredUser,
-  CloudStorageEngine, cleanupModes,
+  CloudStorageEngine, SequenceAssignmentAllocation, cleanupModes,
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
@@ -102,8 +102,10 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
   protected async _verifyStudyDatabase() {
     const { error } = await this.supabase
       .from('revisit')
-      .select('*')
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`);
+      .select('docId')
+      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .eq('docId', 'connect')
+      .limit(1);
     if (error || !this.studyId) {
       throw new Error('Study database not initialized or does not exist');
     }
@@ -170,6 +172,209 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       })
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', `sequenceAssignment_${participantId}`);
+  }
+
+  private async getSequenceAllocatorSeed() {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const [totalResult, replacementResult] = await Promise.all([
+      this.supabase
+        .from('revisit')
+        .select('docId', { count: 'exact', head: true })
+        .eq('studyId', studyId)
+        .like('docId', 'sequenceAssignment_%'),
+      this.supabase
+        .from('revisit')
+        .select('docId', { count: 'exact', head: true })
+        .eq('studyId', studyId)
+        .like('docId', 'sequenceAssignment_%')
+        .not('data->claimedParticipantId', 'is', null),
+    ]);
+    if (totalResult.error || replacementResult.error) {
+      throw new Error('Failed to initialize sequence assignment allocator');
+    }
+    return {
+      nextSequenceIndex: (totalResult.count ?? 0) - (replacementResult.count ?? 0),
+      nextCreationIndex: totalResult.count ?? 0,
+      version: 0,
+    };
+  }
+
+  private async getOrCreateSequenceAllocator() {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const allocatorPath = 'sequenceAllocator';
+    const { data: existingAllocator } = await this.supabase
+      .from('revisit')
+      .select('data')
+      .eq('studyId', studyId)
+      .eq('docId', allocatorPath)
+      .maybeSingle();
+    if (existingAllocator) {
+      return existingAllocator.data as {
+        nextSequenceIndex: number;
+        nextCreationIndex: number;
+        version: number;
+      };
+    }
+
+    const seed = await this.getSequenceAllocatorSeed();
+    const { error } = await this.supabase
+      .from('revisit')
+      .insert({ studyId, docId: allocatorPath, data: seed });
+    if (error && error.code !== '23505') {
+      throw new Error('Failed to create sequence assignment allocator');
+    }
+
+    const { data: allocator, error: allocatorError } = await this.supabase
+      .from('revisit')
+      .select('data')
+      .eq('studyId', studyId)
+      .eq('docId', allocatorPath)
+      .single();
+    if (allocatorError || !allocator) {
+      throw new Error('Failed to retrieve sequence assignment allocator');
+    }
+    return allocator.data as typeof seed;
+  }
+
+  protected async _allocateSequenceAssignment(
+    participantId: string,
+    sequenceAssignment: SequenceAssignment,
+  ): Promise<SequenceAssignmentAllocation> {
+    await this.verifyStudyDatabase();
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+
+    const existingAssignment = await this._getSequenceAssignment(participantId);
+    if (existingAssignment) {
+      if (
+        existingAssignment.sequenceIndex !== undefined
+        && existingAssignment.creationIndex !== undefined
+      ) {
+        return {
+          sequenceIndex: existingAssignment.sequenceIndex,
+          creationIndex: existingAssignment.creationIndex,
+        };
+      }
+
+      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      return {
+        sequenceIndex: assignments.filter((assignment) => !assignment.rejected)
+          .findIndex((assignment) => assignment.participantId === participantId),
+        creationIndex: assignments.sort((a, b) => a.createdTime - b.createdTime)
+          .findIndex((assignment) => assignment.participantId === participantId),
+      };
+    }
+
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const [{ data: reusableRow }, initialAllocator] = await Promise.all([
+      this.supabase
+        .from('revisit')
+        .select('docId, data, createdAt')
+        .eq('studyId', studyId)
+        .like('docId', 'sequenceAssignment_%')
+        .eq('data->rejected', true)
+        .eq('data->claimed', false)
+        .order('createdAt', { ascending: true })
+        .limit(1)
+        .maybeSingle(),
+      this.getOrCreateSequenceAllocator(),
+    ]);
+
+    let reusableAssignment = reusableRow?.data as SequenceAssignment | undefined;
+    let reusableSequenceIndex = reusableAssignment?.sequenceIndex;
+    if (reusableAssignment && reusableSequenceIndex === undefined) {
+      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      const reusableTimestamp = reusableAssignment.timestamp;
+      reusableSequenceIndex = assignments.filter((assignment) => (
+        !assignment.rejected && assignment.timestamp < reusableTimestamp
+      )).length;
+    }
+
+    if (reusableRow && reusableAssignment && reusableSequenceIndex !== undefined) {
+      const { data: claimedRows } = await this.supabase
+        .from('revisit')
+        .update({
+          data: {
+            ...reusableAssignment,
+            claimed: true,
+            sequenceIndex: reusableSequenceIndex,
+          },
+        })
+        .eq('studyId', studyId)
+        .eq('docId', reusableRow.docId)
+        .eq('data->rejected', true)
+        .eq('data->claimed', false)
+        .select('data');
+      if (!claimedRows || claimedRows.length === 0) {
+        reusableAssignment = undefined;
+        reusableSequenceIndex = undefined;
+      }
+    }
+
+    const allocatorPath = 'sequenceAllocator';
+    let allocation: SequenceAssignmentAllocation | undefined;
+    for (let attempt = 0; attempt < 10 && !allocation; attempt += 1) {
+      // The version predicate makes the JSON counter update an atomic compare-and-swap.
+      let allocator: {
+        nextSequenceIndex: number;
+        nextCreationIndex: number;
+        version: number;
+      };
+      if (attempt === 0) {
+        allocator = initialAllocator;
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        allocator = (await this.supabase
+          .from('revisit')
+          .select('data')
+          .eq('studyId', studyId)
+          .eq('docId', allocatorPath)
+          .single()).data?.data as typeof allocator;
+      }
+      const sequenceIndex = reusableSequenceIndex ?? allocator.nextSequenceIndex;
+      const creationIndex = allocator.nextCreationIndex;
+      const nextAllocator = {
+        nextSequenceIndex: reusableSequenceIndex === undefined
+          ? allocator.nextSequenceIndex + 1
+          : allocator.nextSequenceIndex,
+        nextCreationIndex: allocator.nextCreationIndex + 1,
+        version: allocator.version + 1,
+      };
+      // eslint-disable-next-line no-await-in-loop
+      const { data: updatedAllocatorRows } = await this.supabase
+        .from('revisit')
+        .update({ data: nextAllocator })
+        .eq('studyId', studyId)
+        .eq('docId', allocatorPath)
+        .eq('data->version', allocator.version)
+        .select('data');
+      if (updatedAllocatorRows && updatedAllocatorRows.length === 1) {
+        allocation = { sequenceIndex, creationIndex };
+      }
+    }
+    if (!allocation) {
+      throw new Error('Failed to reserve a sequence assignment after concurrent updates');
+    }
+
+    await this._createSequenceAssignment(participantId, {
+      ...sequenceAssignment,
+      ...(reusableRow && reusableAssignment ? {
+        timestamp: (reusableAssignment as SequenceAssignment & { withServerTimestamp?: boolean }).withServerTimestamp
+          ? new Date(reusableRow.createdAt).getTime()
+          : reusableAssignment.timestamp,
+        claimedParticipantId: reusableAssignment.participantId,
+      } : {}),
+      sequenceIndex: allocation.sequenceIndex,
+      creationIndex: allocation.creationIndex,
+    }, !reusableAssignment);
+    return allocation;
   }
 
   protected async _updateSequenceAssignmentFields(participantId: string, updatedFields: Partial<SequenceAssignment>) {

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -242,6 +242,51 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     return allocator.data as typeof seed;
   }
 
+  private async getLegacySequenceIndex(timestamp: number) {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const [serverTimestampResult, storedTimestampResult] = await Promise.all([
+      this.supabase
+        .from('revisit')
+        .select('docId', { count: 'exact', head: true })
+        .eq('studyId', studyId)
+        .like('docId', 'sequenceAssignment_%')
+        .eq('data->rejected', false)
+        .eq('data->withServerTimestamp', true)
+        .lt('createdAt', new Date(timestamp).toISOString()),
+      this.supabase
+        .from('revisit')
+        .select('docId', { count: 'exact', head: true })
+        .eq('studyId', studyId)
+        .like('docId', 'sequenceAssignment_%')
+        .eq('data->rejected', false)
+        .eq('data->withServerTimestamp', false)
+        .lt('data->timestamp', timestamp),
+    ]);
+    if (serverTimestampResult.error || storedTimestampResult.error) {
+      throw new Error('Failed to derive legacy sequence assignment index');
+    }
+    return (serverTimestampResult.count ?? 0) + (storedTimestampResult.count ?? 0);
+  }
+
+  private async getLegacyCreationIndex(createdTime: number) {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const { count, error } = await this.supabase
+      .from('revisit')
+      .select('docId', { count: 'exact', head: true })
+      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+      .like('docId', 'sequenceAssignment_%')
+      .lt('createdAt', new Date(createdTime).toISOString());
+    if (error) {
+      throw new Error('Failed to derive legacy participant creation index');
+    }
+    return count ?? 0;
+  }
+
   protected async _allocateSequenceAssignment(
     participantId: string,
     sequenceAssignment: SequenceAssignment,
@@ -263,12 +308,13 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
         };
       }
 
-      const assignments = await this.getAllSequenceAssignments(this.studyId);
+      const [sequenceIndex, creationIndex] = await Promise.all([
+        this.getLegacySequenceIndex(existingAssignment.timestamp),
+        this.getLegacyCreationIndex(existingAssignment.createdTime),
+      ]);
       return {
-        sequenceIndex: assignments.filter((assignment) => !assignment.rejected)
-          .findIndex((assignment) => assignment.participantId === participantId),
-        creationIndex: assignments.sort((a, b) => a.createdTime - b.createdTime)
-          .findIndex((assignment) => assignment.participantId === participantId),
+        sequenceIndex,
+        creationIndex,
       };
     }
 
@@ -290,11 +336,12 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     let reusableAssignment = reusableRow?.data as SequenceAssignment | undefined;
     let reusableSequenceIndex = reusableAssignment?.sequenceIndex;
     if (reusableAssignment && reusableSequenceIndex === undefined) {
-      const assignments = await this.getAllSequenceAssignments(this.studyId);
-      const reusableTimestamp = reusableAssignment.timestamp;
-      reusableSequenceIndex = assignments.filter((assignment) => (
-        !assignment.rejected && assignment.timestamp < reusableTimestamp
-      )).length;
+      const reusableTimestamp = (reusableAssignment as SequenceAssignment & {
+        withServerTimestamp?: boolean;
+      }).withServerTimestamp
+        ? new Date(reusableRow!.createdAt).getTime()
+        : reusableAssignment.timestamp;
+      reusableSequenceIndex = await this.getLegacySequenceIndex(reusableTimestamp);
     }
 
     if (reusableRow && reusableAssignment && reusableSequenceIndex !== undefined) {

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -106,13 +106,13 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
   }
 
   protected async _verifyStudyDatabase() {
-    const { error } = await this.supabase
+    const { data, error } = await this.supabase
       .from('revisit')
       .select('docId')
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', 'connect')
-      .limit(1);
-    if (error || !this.studyId) {
+      .maybeSingle();
+    if (error || !data || !this.studyId) {
       throw new Error('Study database not initialized or does not exist');
     }
   }
@@ -214,12 +214,15 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     }
     const studyId = `${this.collectionPrefix}${this.studyId}`;
     const allocatorPath = 'sequenceAllocator';
-    const { data: existingAllocator } = await this.supabase
+    const { data: existingAllocator, error: existingAllocatorError } = await this.supabase
       .from('revisit')
       .select('data')
       .eq('studyId', studyId)
       .eq('docId', allocatorPath)
       .maybeSingle();
+    if (existingAllocatorError) {
+      throw new Error('Failed to retrieve sequence assignment allocator');
+    }
     if (existingAllocator) {
       return existingAllocator.data as SupabaseSequenceAllocator;
     }
@@ -386,7 +389,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
         .like('docId', 'sequenceAssignment_%')
         .eq('data->rejected', true)
         .eq('data->claimed', false)
-        .order('createdAt', { ascending: true })
+        .order('data->timestamp', { ascending: true })
         .limit(1)
         .maybeSingle(),
       this.getOrCreateSequenceAllocator(),

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -15,6 +15,8 @@ type SupabaseSequenceAllocator = {
 export class SupabaseStorageEngine extends CloudStorageEngine {
   private supabase = createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY);
 
+  private allocatorRpcAvailable: boolean | undefined;
+
   protected participantStore = localforage.createInstance({
     name: 'revisit-supabase',
   });
@@ -349,13 +351,63 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     return count ?? 0;
   }
 
+  private async allocateSequenceAssignmentWithRpc(
+    participantId: string,
+    sequenceAssignment: SequenceAssignment,
+  ): Promise<SequenceAssignmentAllocation | null> {
+    if (
+      !this.studyId
+      || this.allocatorRpcAvailable === false
+      || typeof this.supabase.rpc !== 'function'
+    ) {
+      return null;
+    }
+
+    const { data, error } = await this.supabase.rpc('allocate_sequence_assignment', {
+      p_study_id: `${this.collectionPrefix}${this.studyId}`,
+      p_participant_id: participantId,
+      p_assignment: sequenceAssignment,
+    });
+    if (error) {
+      if (error.code === 'PGRST202' || error.code === '42883') {
+        this.allocatorRpcAvailable = false;
+        return null;
+      }
+      throw new Error(`Failed to reserve a sequence assignment: ${error.message}`);
+    }
+
+    const allocation = (Array.isArray(data) ? data[0] : data) as {
+      sequenceIndex?: number;
+      creationIndex?: number;
+    } | null;
+    if (
+      !allocation
+      || typeof allocation.sequenceIndex !== 'number'
+      || typeof allocation.creationIndex !== 'number'
+    ) {
+      throw new Error('Sequence assignment allocator returned an invalid result');
+    }
+    this.allocatorRpcAvailable = true;
+    return {
+      sequenceIndex: allocation.sequenceIndex,
+      creationIndex: allocation.creationIndex,
+    };
+  }
+
   protected async _allocateSequenceAssignment(
     participantId: string,
     sequenceAssignment: SequenceAssignment,
   ): Promise<SequenceAssignmentAllocation> {
-    await this.verifyStudyDatabase();
     if (!this.studyId) {
       throw new Error('Study ID is not set');
+    }
+
+    const rpcAllocation = await this.allocateSequenceAssignmentWithRpc(
+      participantId,
+      sequenceAssignment,
+    );
+    if (rpcAllocation) {
+      return rpcAllocation;
     }
 
     const existingAssignment = await this._getSequenceAssignment(participantId);

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -6,6 +6,12 @@ import {
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
+type SupabaseSequenceAllocator = {
+  nextSequenceIndex: number;
+  nextCreationIndex: number;
+  version: number;
+};
+
 export class SupabaseStorageEngine extends CloudStorageEngine {
   private supabase = createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY);
 
@@ -179,7 +185,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       throw new Error('Study ID is not set');
     }
     const studyId = `${this.collectionPrefix}${this.studyId}`;
-    const [totalResult, replacementResult] = await Promise.all([
+    const [totalResult, claimedResult] = await Promise.all([
       this.supabase
         .from('revisit')
         .select('docId', { count: 'exact', head: true })
@@ -190,13 +196,13 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
         .select('docId', { count: 'exact', head: true })
         .eq('studyId', studyId)
         .like('docId', 'sequenceAssignment_%')
-        .not('data->claimedParticipantId', 'is', null),
+        .eq('data->claimed', true),
     ]);
-    if (totalResult.error || replacementResult.error) {
+    if (totalResult.error || claimedResult.error) {
       throw new Error('Failed to initialize sequence assignment allocator');
     }
     return {
-      nextSequenceIndex: (totalResult.count ?? 0) - (replacementResult.count ?? 0),
+      nextSequenceIndex: (totalResult.count ?? 0) - (claimedResult.count ?? 0),
       nextCreationIndex: totalResult.count ?? 0,
       version: 0,
     };
@@ -215,11 +221,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .eq('docId', allocatorPath)
       .maybeSingle();
     if (existingAllocator) {
-      return existingAllocator.data as {
-        nextSequenceIndex: number;
-        nextCreationIndex: number;
-        version: number;
-      };
+      return existingAllocator.data as SupabaseSequenceAllocator;
     }
 
     const seed = await this.getSequenceAllocatorSeed();
@@ -240,6 +242,63 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       throw new Error('Failed to retrieve sequence assignment allocator');
     }
     return allocator.data as typeof seed;
+  }
+
+  private async reserveSequenceAllocator(
+    initialAllocator: SupabaseSequenceAllocator,
+    reusableSequenceIndex?: number,
+    incrementCreationIndex: boolean = true,
+  ): Promise<SequenceAssignmentAllocation> {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const allocatorPath = 'sequenceAllocator';
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      let allocator = initialAllocator;
+      if (attempt > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        const { data, error } = await this.supabase
+          .from('revisit')
+          .select('data')
+          .eq('studyId', studyId)
+          .eq('docId', allocatorPath)
+          .single();
+        if (error || !data) {
+          throw new Error('Failed to retrieve sequence assignment allocator');
+        }
+        allocator = data.data as SupabaseSequenceAllocator;
+      }
+
+      const sequenceIndex = reusableSequenceIndex ?? allocator.nextSequenceIndex;
+      const creationIndex = allocator.nextCreationIndex;
+      const nextAllocator = {
+        nextSequenceIndex: reusableSequenceIndex === undefined
+          ? allocator.nextSequenceIndex + 1
+          : allocator.nextSequenceIndex,
+        nextCreationIndex: incrementCreationIndex
+          ? allocator.nextCreationIndex + 1
+          : allocator.nextCreationIndex,
+        version: allocator.version + 1,
+      };
+      // eslint-disable-next-line no-await-in-loop
+      const { data: updatedAllocatorRows, error } = await this.supabase
+        .from('revisit')
+        .update({ data: nextAllocator })
+        .eq('studyId', studyId)
+        .eq('docId', allocatorPath)
+        .eq('data->version', allocator.version)
+        .select('data');
+      if (error) {
+        throw new Error('Failed to reserve a sequence assignment');
+      }
+      if (updatedAllocatorRows?.length === 1) {
+        return { sequenceIndex, creationIndex };
+      }
+    }
+
+    throw new Error('Failed to reserve a sequence assignment after concurrent updates');
   }
 
   private async getLegacySequenceIndex(timestamp: number) {
@@ -334,7 +393,8 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     ]);
 
     let reusableAssignment = reusableRow?.data as SequenceAssignment | undefined;
-    let reusableSequenceIndex = reusableAssignment?.sequenceIndex;
+    let reusableSequenceIndex = reusableAssignment?.reusableSequenceIndex
+      ?? reusableAssignment?.sequenceIndex;
     if (reusableAssignment && reusableSequenceIndex === undefined) {
       const reusableTimestamp = (reusableAssignment as SequenceAssignment & {
         withServerTimestamp?: boolean;
@@ -365,50 +425,10 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       }
     }
 
-    const allocatorPath = 'sequenceAllocator';
-    let allocation: SequenceAssignmentAllocation | undefined;
-    for (let attempt = 0; attempt < 10 && !allocation; attempt += 1) {
-      // The version predicate makes the JSON counter update an atomic compare-and-swap.
-      let allocator: {
-        nextSequenceIndex: number;
-        nextCreationIndex: number;
-        version: number;
-      };
-      if (attempt === 0) {
-        allocator = initialAllocator;
-      } else {
-        // eslint-disable-next-line no-await-in-loop
-        allocator = (await this.supabase
-          .from('revisit')
-          .select('data')
-          .eq('studyId', studyId)
-          .eq('docId', allocatorPath)
-          .single()).data?.data as typeof allocator;
-      }
-      const sequenceIndex = reusableSequenceIndex ?? allocator.nextSequenceIndex;
-      const creationIndex = allocator.nextCreationIndex;
-      const nextAllocator = {
-        nextSequenceIndex: reusableSequenceIndex === undefined
-          ? allocator.nextSequenceIndex + 1
-          : allocator.nextSequenceIndex,
-        nextCreationIndex: allocator.nextCreationIndex + 1,
-        version: allocator.version + 1,
-      };
-      // eslint-disable-next-line no-await-in-loop
-      const { data: updatedAllocatorRows } = await this.supabase
-        .from('revisit')
-        .update({ data: nextAllocator })
-        .eq('studyId', studyId)
-        .eq('docId', allocatorPath)
-        .eq('data->version', allocator.version)
-        .select('data');
-      if (updatedAllocatorRows && updatedAllocatorRows.length === 1) {
-        allocation = { sequenceIndex, creationIndex };
-      }
-    }
-    if (!allocation) {
-      throw new Error('Failed to reserve a sequence assignment after concurrent updates');
-    }
+    const allocation = await this.reserveSequenceAllocator(
+      initialAllocator,
+      reusableSequenceIndex,
+    );
 
     await this._createSequenceAssignment(participantId, {
       ...sequenceAssignment,
@@ -465,9 +485,12 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .select('data, createdAt')
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', `sequenceAssignment_${participantId}`)
-      .single();
+      .maybeSingle();
 
-    if (error || !data) {
+    if (error) {
+      throw new Error('Failed to retrieve sequence assignment');
+    }
+    if (!data) {
       return null;
     }
 
@@ -527,53 +550,82 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       throw new Error('Failed to retrieve sequence assignment for current participant');
     }
 
-    // Update the sequence assignment for the participant to mark it as rejected
-    await this.supabase
-      .from('revisit')
-      .update({ data: { ...data.data, rejected: true, timestamp: new Date().getTime() } })
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('docId', sequenceAssignmentPath);
-
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
     const claimedParticipantId = data.data.claimedParticipantId as string | undefined;
+    let claimedSequenceAssignmentPath: string | undefined;
+    let claimedAssignmentData: Record<string, unknown> | undefined;
     if (claimedParticipantId) {
-      const claimedSequenceAssignmentPath = `sequenceAssignment_${claimedParticipantId}`;
+      claimedSequenceAssignmentPath = `sequenceAssignment_${claimedParticipantId}`;
       const { data: claimedData, error: claimedError } = await this.supabase
         .from('revisit')
         .select('data')
-        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .eq('studyId', studyId)
         .eq('docId', claimedSequenceAssignmentPath)
         .single();
 
       if (claimedError || !claimedData) {
         throw new Error('Failed to retrieve claimed sequence assignment for rejection');
       }
-
-      // Update the claimed sequence assignment to mark it as available again
-      // Also mark as rejected so it doesn't get incorrectly reused
-      await this.supabase
+      claimedAssignmentData = claimedData.data as Record<string, unknown>;
+    } else {
+      // Fallback for legacy reused assignments that predate claimedParticipantId.
+      const { data: claimedData, error: claimedError } = await this.supabase
         .from('revisit')
-        .update({ data: { ...claimedData.data, claimed: false, rejected: true } })
-        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .select('docId, data')
+        .eq('studyId', studyId)
+        .like('docId', 'sequenceAssignment_%')
+        .eq('data->claimed', true)
+        .eq('data->timestamp', data.data.timestamp)
+        .maybeSingle();
+      if (claimedError) {
+        throw new Error('Failed to retrieve claimed sequence assignment for rejection');
+      }
+      if (claimedData) {
+        claimedSequenceAssignmentPath = claimedData.docId as string;
+        claimedAssignmentData = claimedData.data as Record<string, unknown>;
+      }
+    }
+
+    let reusableSequenceIndex: number | undefined;
+    if (claimedSequenceAssignmentPath && claimedAssignmentData) {
+      const allocator = await this.getOrCreateSequenceAllocator();
+      reusableSequenceIndex = (
+        await this.reserveSequenceAllocator(allocator, undefined, false)
+      ).sequenceIndex;
+    }
+
+    const { error: participantUpdateError } = await this.supabase
+      .from('revisit')
+      .update({
+        data: {
+          ...data.data,
+          rejected: true,
+          timestamp: new Date().getTime(),
+          ...(reusableSequenceIndex === undefined ? {} : { reusableSequenceIndex }),
+        },
+      })
+      .eq('studyId', studyId)
+      .eq('docId', sequenceAssignmentPath);
+    if (participantUpdateError) {
+      throw new Error('Failed to reject sequence assignment');
+    }
+
+    if (claimedSequenceAssignmentPath && claimedAssignmentData) {
+      const { error: claimedUpdateError } = await this.supabase
+        .from('revisit')
+        .update({
+          data: {
+            ...claimedAssignmentData,
+            claimed: false,
+            rejected: true,
+          },
+        })
+        .eq('studyId', studyId)
         .eq('docId', claimedSequenceAssignmentPath);
-      return;
+      if (claimedUpdateError) {
+        throw new Error('Failed to release claimed sequence assignment');
+      }
     }
-
-    // Fallback for legacy reused assignments that predate claimedParticipantId.
-    const { data: claimedData, error: claimedError } = await this.supabase
-      .from('revisit')
-      .select('data')
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('data->timestamp', data.data.timestamp)
-      .single();
-
-    if (claimedError || !claimedData) {
-      return;
-    }
-    await this.supabase
-      .from('revisit')
-      .update({ data: { ...claimedData.data, claimed: false, rejected: true } })
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('docId', `sequenceAssignment_${claimedData.data.participantId}`);
   }
 
   protected async _undoRejectParticipantRealtime(participantId: string) {
@@ -624,10 +676,13 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
         .eq('docId', claimedSequenceAssignmentPath);
     }
 
+    const updatedParticipantData = { ...data.data, rejected: false, timestamp: restoredTimestamp };
+    delete updatedParticipantData.reusableSequenceIndex;
+
     // Update the sequence assignment for the participant to mark it as un-rejected
     await this.supabase
       .from('revisit')
-      .update({ data: { ...data.data, rejected: false, timestamp: restoredTimestamp } })
+      .update({ data: updatedParticipantData })
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', sequenceAssignmentPath);
   }

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -171,7 +171,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     }
 
     // Create a sequence assignment for the participant in the study collection
-    await this.supabase
+    const { error } = await this.supabase
       .from('revisit')
       .upsert({
         studyId: `${this.collectionPrefix}${this.studyId}`,
@@ -180,6 +180,9 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       })
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', `sequenceAssignment_${participantId}`);
+    if (error) {
+      throw new Error('Failed to create sequence assignment');
+    }
   }
 
   private async getSequenceAllocatorSeed() {
@@ -409,94 +412,10 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     if (rpcAllocation) {
       return rpcAllocation;
     }
-
-    const existingAssignment = await this._getSequenceAssignment(participantId);
-    if (existingAssignment) {
-      if (
-        existingAssignment.sequenceIndex !== undefined
-        && existingAssignment.creationIndex !== undefined
-      ) {
-        return {
-          sequenceIndex: existingAssignment.sequenceIndex,
-          creationIndex: existingAssignment.creationIndex,
-        };
-      }
-
-      const [sequenceIndex, creationIndex] = await Promise.all([
-        this.getLegacySequenceIndex(existingAssignment.timestamp),
-        this.getLegacyCreationIndex(existingAssignment.createdTime),
-      ]);
-      return {
-        sequenceIndex,
-        creationIndex,
-      };
-    }
-
-    const studyId = `${this.collectionPrefix}${this.studyId}`;
-    const [{ data: reusableRow }, initialAllocator] = await Promise.all([
-      this.supabase
-        .from('revisit')
-        .select('docId, data, createdAt')
-        .eq('studyId', studyId)
-        .like('docId', 'sequenceAssignment_%')
-        .eq('data->rejected', true)
-        .eq('data->claimed', false)
-        .order('data->timestamp', { ascending: true })
-        .limit(1)
-        .maybeSingle(),
-      this.getOrCreateSequenceAllocator(),
-    ]);
-
-    let reusableAssignment = reusableRow?.data as SequenceAssignment | undefined;
-    let reusableSequenceIndex = reusableAssignment?.reusableSequenceIndex
-      ?? reusableAssignment?.sequenceIndex;
-    if (reusableAssignment && reusableSequenceIndex === undefined) {
-      const reusableTimestamp = (reusableAssignment as SequenceAssignment & {
-        withServerTimestamp?: boolean;
-      }).withServerTimestamp
-        ? new Date(reusableRow!.createdAt).getTime()
-        : reusableAssignment.timestamp;
-      reusableSequenceIndex = await this.getLegacySequenceIndex(reusableTimestamp);
-    }
-
-    if (reusableRow && reusableAssignment && reusableSequenceIndex !== undefined) {
-      const { data: claimedRows } = await this.supabase
-        .from('revisit')
-        .update({
-          data: {
-            ...reusableAssignment,
-            claimed: true,
-            sequenceIndex: reusableSequenceIndex,
-          },
-        })
-        .eq('studyId', studyId)
-        .eq('docId', reusableRow.docId)
-        .eq('data->rejected', true)
-        .eq('data->claimed', false)
-        .select('data');
-      if (!claimedRows || claimedRows.length === 0) {
-        reusableAssignment = undefined;
-        reusableSequenceIndex = undefined;
-      }
-    }
-
-    const allocation = await this.reserveSequenceAllocator(
-      initialAllocator,
-      reusableSequenceIndex,
+    throw new Error(
+      'Supabase sequence allocation is unavailable. '
+      + 'Apply the allocate_sequence_assignment migration before starting participants.',
     );
-
-    await this._createSequenceAssignment(participantId, {
-      ...sequenceAssignment,
-      ...(reusableRow && reusableAssignment ? {
-        timestamp: (reusableAssignment as SequenceAssignment & { withServerTimestamp?: boolean }).withServerTimestamp
-          ? new Date(reusableRow.createdAt).getTime()
-          : reusableAssignment.timestamp,
-        claimedParticipantId: reusableAssignment.participantId,
-      } : {}),
-      sequenceIndex: allocation.sequenceIndex,
-      creationIndex: allocation.creationIndex,
-    }, !reusableAssignment);
-    return allocation;
   }
 
   protected async _updateSequenceAssignmentFields(participantId: string, updatedFields: Partial<SequenceAssignment>) {
@@ -656,6 +575,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
           ...data.data,
           rejected: true,
           timestamp: new Date().getTime(),
+          withServerTimestamp: false,
           ...(reusableSequenceIndex === undefined ? {} : { reusableSequenceIndex }),
         },
       })

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -45,6 +45,13 @@ export type SequenceAssignment = {
   isDynamic: boolean; // Whether the study contains dynamic blocks
   stage: string; // The stage of the participant in the study
   conditions?: string[]; // The study condition(s) assigned to this participant.
+  sequenceIndex?: number; // Stable zero-based Latin-square slot for bounded assignment lookup.
+  creationIndex?: number; // Stable zero-based participant creation order.
+};
+
+export type SequenceAssignmentAllocation = {
+  sequenceIndex: number;
+  creationIndex: number;
 };
 
 export type REVISIT_MODE = 'dataCollectionEnabled' | 'developmentModeEnabled' | 'dataSharingEnabled';
@@ -70,7 +77,7 @@ export interface StageInfo {
   color: string;
 }
 
-interface StageData {
+export interface StageData {
   currentStage: StageInfo;
   allStages: StageInfo[];
 }
@@ -78,6 +85,11 @@ interface StageData {
 type ModesAndStageData = {
   modes: Record<REVISIT_MODE, boolean>;
   stageData: StageData;
+};
+
+export type ParticipantSessionBootstrapData = {
+  modesDocument: Record<REVISIT_MODE, boolean> & { stage?: StageData };
+  sequenceArray: Sequence[];
 };
 
 export interface ConditionData {
@@ -243,6 +255,13 @@ export abstract class StorageEngine {
   // Creates a sequence assignment for the given participantId and sequenceAssignment. Cloud storage engines should use the realtime database to create the sequence assignment and should use the server to prevent race conditions (i.e. using server timestamps).
   protected abstract _createSequenceAssignment(participantId: string, sequenceAssignment: SequenceAssignment, withServerTimestamp: boolean): Promise<void>;
 
+  // Atomically reserves a stable sequence slot and creation index and persists the assignment.
+  // Implementations must use a transaction, compare-and-swap counter, or equivalent bounded operation.
+  protected abstract _allocateSequenceAssignment(
+    participantId: string,
+    sequenceAssignment: SequenceAssignment,
+  ): Promise<SequenceAssignmentAllocation>;
+
   // Updates specific top-level fields in an existing sequence assignment without modifying timestamp fields.
   // This operation is a shallow patch (no deep merge for nested objects).
   protected abstract _updateSequenceAssignmentFields(
@@ -403,8 +422,11 @@ export abstract class StorageEngine {
     }
   }
 
-  private async getModesAndStageData(studyId: string): Promise<ModesAndStageData> {
-    const modesDoc = await this.getModes(studyId);
+  private async getModesAndStageData(
+    studyId: string,
+    existingModesDocument?: Record<REVISIT_MODE, boolean> & { stage?: StageData },
+  ): Promise<ModesAndStageData> {
+    const modesDoc = existingModesDocument ?? await this.getModes(studyId);
     const { stage, ...modeValues } = modesDoc;
 
     if (stage) {
@@ -715,10 +737,7 @@ export abstract class StorageEngine {
 
     // Skip saving config if the active config is already saved in storage
     if (currentConfigHash === configHash) {
-      const storedConfig = await this._getFromStorage(`configs/${configHash}`, 'config');
-      if (storedConfig && Object.keys(storedConfig).length > 0) {
-        return;
-      }
+      return;
     }
 
     // Push the config to storage and cache it, since it won't change
@@ -810,97 +829,56 @@ export abstract class StorageEngine {
   // This function is one of the most critical functions in the storage engine.
   // It uses the notion of sequence intents and assignments to determine the current sequence for the participant.
   // It handles rejected participants and allows for reusing a rejected participant's sequence.
-  protected async _getSequence(conditions?: string[], bootstrapData?: ModesAndStageData) {
+  protected async _getSequence(
+    sequenceArray: Sequence[],
+    conditions?: string[],
+    bootstrapData?: ModesAndStageData,
+  ) {
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
     if (this.studyId === undefined) {
       throw new Error('Study ID is not set');
     }
-    let sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
-
     const { modes, stageData } = bootstrapData ?? await this.getModesAndStageData(this.studyId);
     const currentStage = stageData.currentStage.stageName;
 
-    // Find all rejected documents
-    const rejectedDocs = sequenceAssignments
-      .filter((doc) => doc.rejected && !doc.claimed);
-    if (rejectedDocs.length > 0) {
-      const firstReject = rejectedDocs[0];
-      const firstRejectTime = firstReject.timestamp;
-      if (modes.dataCollectionEnabled) {
-        // Make the sequence assignment document for the participant
-        const participantSequenceAssignmentData: SequenceAssignment = {
-          participantId: this.currentParticipantId,
-          timestamp: firstRejectTime, // Use the timestamp of the first reject
-          rejected: false,
-          claimed: false,
-          claimedParticipantId: firstReject.participantId,
-          completed: null,
-          createdTime: new Date().getTime(), // Placeholder, will be set to server timestamp in cloud engines
-          total: 0,
-          answered: [],
-          isDynamic: false,
-          stage: currentStage,
-          ...(conditions ? { conditions } : {}),
-        };
-        // Mark the first reject as claimed
-        await this._claimSequenceAssignment(firstReject.participantId, firstReject);
-        // Set the participant's sequence assignment document
-        await this._createSequenceAssignment(this.currentParticipantId, participantSequenceAssignmentData, false);
-      }
-    } else if (modes.dataCollectionEnabled) {
-      const timestamp = new Date().getTime();
-      const participantSequenceAssignmentData: SequenceAssignment = {
-        participantId: this.currentParticipantId,
-        timestamp, // Placeholder, will be set to server timestamp in cloud engines
-        rejected: false,
-        claimed: false,
-        completed: null,
-        createdTime: timestamp, // Placeholder, will be set to server timestamp in cloud engines
-        total: 0,
-        answered: [],
-        isDynamic: false,
-        stage: currentStage,
-        ...(conditions ? { conditions } : {}),
-      };
-      await this._createSequenceAssignment(this.currentParticipantId, participantSequenceAssignmentData, true);
-    }
-
-    // Query all the intents to get a sequence and find our position in the queue
-    sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
-
-    // Get the latin square
-    const sequenceArray = await this.getSequenceArray();
-    if (!sequenceArray) {
-      throw new Error('Latin square not initialized');
-    }
-
-    // Get the current row
-    const intentIndex = sequenceAssignments.filter((assignment) => !assignment.rejected).findIndex(
-      (assignment) => assignment.participantId === this.currentParticipantId,
-    ) % sequenceArray.length;
     if (sequenceArray.length === 0) {
       throw new Error('Something really bad happened with sequence assignment');
     }
-    // If index = -1, we probably have data collection disabled. Give a random assignment.
-    if (intentIndex === -1) {
+
+    if (!modes.dataCollectionEnabled) {
       return {
         currentRow: sequenceArray[Math.floor(Math.random() * sequenceArray.length)],
         creationIndex: 1,
       };
     }
-    const currentRow = sequenceArray[intentIndex];
+
+    const timestamp = Date.now();
+    const participantSequenceAssignmentData: SequenceAssignment = {
+      participantId: this.currentParticipantId,
+      timestamp,
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: timestamp,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: currentStage,
+      ...(conditions ? { conditions } : {}),
+    };
+    const allocation = await this._allocateSequenceAssignment(
+      this.currentParticipantId,
+      participantSequenceAssignmentData,
+    );
+    const currentRow = sequenceArray[allocation.sequenceIndex % sequenceArray.length];
 
     if (!currentRow) {
       throw new Error('Latin square is empty');
     }
 
-    const creationSorted = sequenceAssignments.sort((a, b) => a.createdTime - b.createdTime);
-
-    const creationIndex = creationSorted.findIndex((assignment) => assignment.participantId === this.currentParticipantId) + 1;
-
-    return { currentRow, creationIndex };
+    return { currentRow, creationIndex: allocation.creationIndex + 1 };
   }
 
   // Initializes or resumes a participant session for the given studyId. This will create a new participant data object if it does not exist, or update the existing one.
@@ -909,6 +887,7 @@ export abstract class StorageEngine {
     config: StudyConfig,
     metadata: ParticipantMetadata,
     urlParticipantId?: string,
+    bootstrapData?: ParticipantSessionBootstrapData,
   ) {
     await this.verifyStudyDatabase();
 
@@ -934,7 +913,10 @@ export abstract class StorageEngine {
       throw new Error('Study ID is not set');
     }
 
-    const { modes, stageData } = await this.getModesAndStageData(this.studyId);
+    const { modes, stageData } = await this.getModesAndStageData(
+      this.studyId,
+      bootstrapData?.modesDocument,
+    );
     const currentStage = stageData.currentStage.stageName;
 
     if (isParticipantData(participant)) {
@@ -947,7 +929,15 @@ export abstract class StorageEngine {
     const participantConfigHash = await hash(JSON.stringify(config));
     const parsedConditions = parseConditionParam(searchParams.condition);
     const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
-    const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData });
+    const sequenceArray = bootstrapData?.sequenceArray ?? await this.getSequenceArray();
+    if (!sequenceArray) {
+      throw new Error('Latin square not initialized');
+    }
+    const { currentRow, creationIndex } = await this._getSequence(
+      sequenceArray,
+      conditions,
+      { modes, stageData },
+    );
     this.participantData = {
       participantId: this.currentParticipantId,
       participantConfigHash,
@@ -1425,10 +1415,10 @@ export abstract class StorageEngine {
       throw new Error('Participant not initialized');
     }
 
-    const sequenceAssignments = await this.getAllSequenceAssignments(studyIdToUse);
-    const sequenceAssignment = sequenceAssignments.find(
-      (assignment) => assignment.participantId === participantIdToUse,
-    );
+    if (studyIdToUse !== this.studyId) {
+      await this.initializeStudyDb(studyIdToUse);
+    }
+    const sequenceAssignment = await this._getSequenceAssignment(participantIdToUse);
 
     return sequenceAssignment ? sequenceAssignment.completed !== null : false;
   }

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -46,6 +46,7 @@ export type SequenceAssignment = {
   stage: string; // The stage of the participant in the study
   conditions?: string[]; // The study condition(s) assigned to this participant.
   sequenceIndex?: number; // Stable zero-based Latin-square slot for bounded assignment lookup.
+  reusableSequenceIndex?: number; // New vacancy created when a participant rejects a previously reused slot.
   creationIndex?: number; // Stable zero-based participant creation order.
 };
 

--- a/src/storage/tests/allocatorContracts.spec.ts
+++ b/src/storage/tests/allocatorContracts.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const firestoreIndexesPath = resolve(process.cwd(), 'firestore.indexes.json');
+const allocatorMigrationPath = resolve(
+  process.cwd(),
+  'supabase/migrations/20260730000000_allocate_sequence_assignment.sql',
+);
+
+describe('sequence allocator deployment contracts', () => {
+  test('declares both current and legacy rejected assignment indexes', () => {
+    const indexes = JSON.parse(readFileSync(firestoreIndexesPath, 'utf8')) as {
+      indexes: Array<{ fields: Array<{ fieldPath: string }> }>;
+    };
+    const fieldPaths = indexes.indexes.map(
+      (index) => index.fields.map((field) => field.fieldPath).join(','),
+    );
+
+    expect(fieldPaths).toContain('rejected,claimed,timestamp');
+    expect(fieldPaths).toContain('rejected,timestamp');
+  });
+
+  test('preserves arbitrary participant IDs when recording a reused assignment', () => {
+    const migration = readFileSync(allocatorMigrationPath, 'utf8');
+
+    expect(migration).toContain(
+      "substr(reusable_doc_id, length('sequenceAssignment_') + 1)",
+    );
+    expect(migration).not.toContain(
+      "replace(reusable_doc_id, 'sequenceAssignment_', '')",
+    );
+  });
+});

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -10,7 +10,9 @@ import { generateSequenceArray } from '../../utils/handleRandomSequences';
 import { hash } from '../engines/utils/storageEngineHelpers';
 import { Sequence, StoredAnswer, TrrackedProvenance } from '../../store/types';
 import { LocalStorageEngine } from '../engines/LocalStorageEngine';
-import { StorageEngine, StorageObject, StorageObjectType } from '../engines/types';
+import {
+  SequenceAssignment, StorageEngine, StorageObject, StorageObjectType,
+} from '../engines/types';
 import { filterSequenceByCondition } from '../../utils/handleConditionLogic';
 
 const studyId = 'test-study';
@@ -304,23 +306,16 @@ describe.each([
     expect(setHashSpy).not.toHaveBeenCalled();
   });
 
-  test('saveConfig restores missing config storage when the hash pointer is unchanged', async () => {
-    const configHash = await hash(JSON.stringify(configSimple));
+  test('saveConfig skips storage reads when the hash pointer is unchanged', async () => {
     await storageEngine.saveConfig(configSimple);
-
-    await (
-      storageEngine as unknown as {
-        _deleteFromStorage: StorageEngine['_deleteFromStorage'];
-      }
-    )._deleteFromStorage(`configs/${configHash}`, 'config');
-
-    let storedHashes = await storageEngine.getAllConfigsFromHash([configHash], studyId);
-    expect(storedHashes[configHash]).toBeNull();
+    const getFromStorageSpy = vi.spyOn(
+      storageEngine as unknown as { _getFromStorage: (...args: unknown[]) => Promise<unknown> },
+      '_getFromStorage',
+    );
 
     await storageEngine.saveConfig(configSimple);
 
-    storedHashes = await storageEngine.getAllConfigsFromHash([configHash], studyId);
-    expect(storedHashes[configHash]).toEqual(configSimple);
+    expect(getFromStorageSpy).not.toHaveBeenCalled();
   });
 
   test('getCurrentParticipantId returns the current participant ID', async () => {
@@ -369,6 +364,39 @@ describe.each([
     expect(participantData!.metadata).toEqual(participantMetadata);
     expect(participantData!.rejected).toBe(false);
     expect(participantData!.participantTags).toEqual([]);
+  });
+
+  test('fresh participant startup does not scan all sequence assignments', async () => {
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    await storageEngine.getParticipantCompletionStatus(participant.participantId);
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  test('participant bootstrap reuses prefetched modes and sequence array', async () => {
+    const modesSpy = vi.spyOn(storageEngine, 'getModes');
+    const sequenceSpy = vi.spyOn(storageEngine, 'getSequenceArray');
+    const modesDocument = await storageEngine.getModes(studyId);
+    const prefetchedSequenceArray = await storageEngine.getSequenceArray();
+    modesSpy.mockClear();
+    sequenceSpy.mockClear();
+
+    await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      undefined,
+      {
+        modesDocument,
+        sequenceArray: prefetchedSequenceArray!,
+      },
+    );
+
+    expect(modesSpy).not.toHaveBeenCalled();
+    expect(sequenceSpy).not.toHaveBeenCalled();
   });
 
   test('initializeParticipantSession reads modes only once for a new participant', async () => {
@@ -482,15 +510,76 @@ describe.each([
     }
   });
 
-  test('initializeParticipantSession omits conditions field in sequence assignment when empty', async () => {
-    const createSequenceAssignmentSpy = vi.spyOn(
-      storageEngine as unknown as { _createSequenceAssignment: (...args: unknown[]) => Promise<void> },
-      '_createSequenceAssignment',
+  test('concurrent participant starts reserve unique sequence and creation indexes', async () => {
+    const engines = Array.from({ length: 12 }, () => new TestEngine(true));
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+
+    const sessions = await Promise.all(engines.map((engine, index) => (
+      engine.initializeParticipantSession(
+        {},
+        configSimple,
+        participantMetadata,
+        `concurrent-${index}`,
+      )
+    )));
+    const assignments = (await storageEngine.getAllSequenceAssignments(studyId))
+      .filter((assignment) => assignment.participantId.startsWith('concurrent-'));
+
+    expect(new Set(assignments.map((assignment) => assignment.sequenceIndex)).size).toBe(12);
+    expect(assignments.map((assignment) => assignment.sequenceIndex).sort((a, b) => a! - b!))
+      .toEqual(Array.from({ length: 12 }, (_, index) => index));
+    expect(new Set(sessions.map((session) => session.participantIndex)).size).toBe(12);
+  });
+
+  test('allocator bootstraps legacy assignments without duplicating a sequence slot', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    for (let index = 0; index < 5; index += 1) {
+      // Sequential writes intentionally build a deterministic legacy assignment history.
+      // eslint-disable-next-line no-await-in-loop
+      await createAssignment(`legacy-${index}`, {
+        participantId: `legacy-${index}`,
+        timestamp: index,
+        rejected: index === 1,
+        claimed: false,
+        completed: null,
+        createdTime: index,
+        total: 0,
+        answered: [],
+        isDynamic: false,
+        stage: 'DEFAULT',
+      }, false);
+    }
+
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'legacy-replacement');
+    await storageEngine.clearCurrentParticipantId();
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'post-legacy-participant');
+
+    const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const replacement = assignments.find(
+      (assignment) => assignment.participantId === 'legacy-replacement',
     );
+    const appended = assignments.find(
+      (assignment) => assignment.participantId === 'post-legacy-participant',
+    );
+    expect(replacement?.sequenceIndex).toBe(1);
+    expect(appended?.sequenceIndex).toBe(5);
+  });
 
-    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
-
-    const sequenceAssignmentPayload = createSequenceAssignmentSpy.mock.calls[0][1] as Record<string, unknown>;
+  test('initializeParticipantSession omits conditions field in sequence assignment when empty', async () => {
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const sequenceAssignmentPayload = (await storageEngine.getAllSequenceAssignments(studyId))
+      .find((assignment) => assignment.participantId === participant.participantId)!;
     expect(Object.hasOwn(sequenceAssignmentPayload, 'conditions')).toBe(false);
   });
 

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -906,6 +906,10 @@ describe.each([
     expect(sequenceAssignment4!.createdTime).toBeDefined();
     expect(sequenceAssignment4!.createdTime).toBeGreaterThanOrEqual(sequenceAssignment3!.createdTime);
     expect(sequenceAssignment4!.completed).toBeNull();
+    expect(new Set([
+      sequenceAssignment3!.sequenceIndex,
+      sequenceAssignment4!.sequenceIndex,
+    ]).size).toBe(2);
 
     // Check the length of sequence assignments
     sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -594,6 +594,50 @@ describe.each([
     expect(new Set(sessions.map((session) => session.participantIndex)).size).toBe(12);
   });
 
+  test('uses a study-scoped Web Lock across storage engine contexts', async () => {
+    const requestedKeys: string[] = [];
+    const queues = new Map<string, Promise<void>>();
+    vi.stubGlobal('navigator', {
+      locks: {
+        request: async <T>(key: string, operation: () => Promise<T>) => {
+          requestedKeys.push(key);
+          const previous = queues.get(key) ?? Promise.resolve();
+          let release: () => void = () => undefined;
+          const current = new Promise<void>((resolve) => { release = resolve; });
+          queues.set(key, previous.then(() => current));
+          await previous;
+          try {
+            return await operation();
+          } finally {
+            release();
+          }
+        },
+      },
+    });
+    const engines = [new TestEngine(true), new TestEngine(true)];
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+
+    try {
+      const sessions = await Promise.all(engines.map((engine, index) => (
+        engine.initializeParticipantSession(
+          {},
+          configSimple,
+          participantMetadata,
+          `web-lock-context-${index}`,
+        )
+      )));
+
+      expect(requestedKeys).toHaveLength(2);
+      expect(new Set(requestedKeys).size).toBe(1);
+      expect(new Set(sessions.map((session) => session.participantIndex)).size).toBe(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   test('allocator bootstraps legacy assignments without duplicating a sequence slot', async () => {
     const createAssignment = (
       storageEngine as unknown as {

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -2,7 +2,9 @@ import {
   beforeAll, beforeEach, afterAll, afterEach, describe, expect, test, vi,
 } from 'vitest';
 import { signInAnonymously, signOut } from '@firebase/auth';
-import { enableNetwork, Timestamp } from 'firebase/firestore';
+import {
+  enableNetwork, getCountFromServer, getDoc, getDocs, runTransaction, Timestamp,
+} from 'firebase/firestore';
 import { type ParticipantMetadata, type StudyConfig } from '../../parser/types';
 import testConfigSimple from './testConfigSimple.json';
 import testConfigSimple2 from './testConfigSimple2.json';
@@ -187,6 +189,19 @@ vi.mock('firebase/firestore', () => {
         docs = docs.filter((document) => {
           const fieldValue = document.data()[constraint.field!];
           if (constraint.operator === '==') return fieldValue === constraint.value;
+          if (constraint.operator === '<') {
+            const toComparableNumber = (value: unknown) => (
+              value
+              && typeof value === 'object'
+              && 'toMillis' in value
+              && typeof value.toMillis === 'function'
+                ? value.toMillis()
+                : Number(value)
+            );
+            const constraintValue = toComparableNumber(constraint.value);
+            const comparableFieldValue = toComparableNumber(fieldValue);
+            return comparableFieldValue < constraintValue;
+          }
           if (constraint.operator === '>') {
             return fieldValue !== undefined
               && fieldValue !== null
@@ -468,12 +483,138 @@ describe.each([
 
   test('fresh participant startup does not scan all sequence assignments', async () => {
     const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    const countMock = vi.mocked(getCountFromServer);
+    const getDocsMock = vi.mocked(getDocs);
+    const transactionMock = vi.mocked(runTransaction);
+    countMock.mockClear();
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
 
     const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
     expect(scanSpy).not.toHaveBeenCalled();
+    expect(countMock).toHaveBeenCalledTimes(2);
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
 
+    const getDocMock = vi.mocked(getDoc);
+    getDocMock.mockClear();
+    countMock.mockClear();
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
     await storageEngine.getParticipantCompletionStatus(participant.participantId);
     expect(scanSpy).not.toHaveBeenCalled();
+    expect(getDocMock).toHaveBeenCalledTimes(1);
+    expect(countMock).not.toHaveBeenCalled();
+    expect(getDocsMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  test('fresh participant startup with an initialized allocator skips legacy counts', async () => {
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'allocator-seed');
+    await storageEngine.clearCurrentParticipantId();
+
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    const countMock = vi.mocked(getCountFromServer);
+    const getDocsMock = vi.mocked(getDocs);
+    const transactionMock = vi.mocked(runTransaction);
+    countMock.mockClear();
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
+
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'post-seed');
+
+    expect(scanSpy).not.toHaveBeenCalled();
+    expect(countMock).not.toHaveBeenCalled();
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('returning legacy assignment derives its indexes without an assignment scan', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    await createAssignment('legacy-returning', {
+      participantId: 'legacy-returning',
+      timestamp: 1,
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: 1,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+    }, false);
+
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    const countMock = vi.mocked(getCountFromServer);
+    const getDocsMock = vi.mocked(getDocs);
+    const transactionMock = vi.mocked(runTransaction);
+    countMock.mockClear();
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
+
+    const participant = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'legacy-returning',
+    );
+
+    expect(participant.participantIndex).toBe(1);
+    expect(scanSpy).not.toHaveBeenCalled();
+    expect(countMock).toHaveBeenCalledTimes(2);
+    expect(getDocsMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  test('legacy rejected-slot reuse uses bounded counts instead of an assignment scan', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    for (let index = 0; index < 5; index += 1) {
+      // Sequential writes intentionally build a deterministic legacy assignment history.
+      // eslint-disable-next-line no-await-in-loop
+      await createAssignment(`legacy-${index}`, {
+        participantId: `legacy-${index}`,
+        timestamp: index,
+        rejected: index === 1,
+        claimed: false,
+        completed: null,
+        createdTime: index,
+        total: 0,
+        answered: [],
+        isDynamic: false,
+        stage: 'DEFAULT',
+      }, false);
+    }
+
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    const countMock = vi.mocked(getCountFromServer);
+    countMock.mockClear();
+
+    const participant = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'legacy-replacement',
+    );
+
+    expect(participant.sequence).toEqual(sequenceArray[1]);
+    expect(scanSpy).not.toHaveBeenCalled();
+    expect(countMock).toHaveBeenCalledTimes(3);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -113,6 +113,14 @@ vi.mock('localforage', () => ({
 
 // Complete in-memory Firestore mock — no emulator needed.
 vi.mock('firebase/firestore', () => {
+  type QueryConstraint = {
+    type: 'where' | 'limit';
+    field?: string;
+    operator?: string;
+    value?: unknown;
+    count?: number;
+  };
+
   function resolveSentinels(data: DocData): DocData {
     const now = Date.now();
     const result: DocData = {};
@@ -172,12 +180,47 @@ vi.mock('firebase/firestore', () => {
     return docs;
   }
 
-  function mockGetDocs(collRef: { _path: string }) {
-    const docs = getDocsInCollection(collRef._path);
+  function mockGetDocs(collRef: { _path: string; _constraints?: QueryConstraint[] }) {
+    let docs = getDocsInCollection(collRef._path);
+    (collRef._constraints ?? []).forEach((constraint) => {
+      if (constraint.type === 'where') {
+        docs = docs.filter((document) => {
+          const fieldValue = document.data()[constraint.field!];
+          if (constraint.operator === '==') return fieldValue === constraint.value;
+          if (constraint.operator === '>') {
+            return fieldValue !== undefined
+              && fieldValue !== null
+              && String(fieldValue) > String(constraint.value);
+          }
+          return true;
+        });
+      } else if (constraint.type === 'limit') {
+        docs = docs.slice(0, constraint.count);
+      }
+    });
     return Promise.resolve({
       docs,
       forEach: (cb: (d: { id: string; data: () => DocData }) => void) => docs.forEach(cb),
     });
+  }
+
+  function mockQuery(collRef: { _path: string }, ...constraints: QueryConstraint[]) {
+    return { ...collRef, _constraints: constraints };
+  }
+
+  function mockWhere(field: string, operator: string, value: unknown): QueryConstraint {
+    return {
+      type: 'where', field, operator, value,
+    };
+  }
+
+  function mockLimit(count: number): QueryConstraint {
+    return { type: 'limit', count };
+  }
+
+  async function mockGetCountFromServer(collRef: { _path: string; _constraints?: QueryConstraint[] }) {
+    const snapshot = await mockGetDocs(collRef);
+    return { data: () => ({ count: snapshot.docs.length }) };
   }
 
   function mockUpdateDoc(docRef: { _path: string }, data: DocData) {
@@ -215,6 +258,24 @@ vi.mock('firebase/firestore', () => {
     };
   }
 
+  let transactionChain = Promise.resolve<unknown>(undefined);
+  function mockRunTransaction<T>(
+    _firestore: object,
+    operation: (transaction: {
+      get: typeof mockGetDoc;
+      set: typeof mockSetDoc;
+      update: typeof mockUpdateDoc;
+    }) => Promise<T>,
+  ) {
+    const result = transactionChain.then(() => operation({
+      get: mockGetDoc,
+      set: mockSetDoc,
+      update: mockUpdateDoc,
+    }));
+    transactionChain = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
   class MockTimestamp {
     constructor(public seconds: number, public nanoseconds: number) { }
 
@@ -227,6 +288,11 @@ vi.mock('firebase/firestore', () => {
     setDoc: vi.fn(mockSetDoc),
     getDoc: vi.fn(mockGetDoc),
     getDocs: vi.fn(mockGetDocs),
+    getCountFromServer: vi.fn(mockGetCountFromServer),
+    query: vi.fn(mockQuery),
+    where: vi.fn(mockWhere),
+    limit: vi.fn(mockLimit),
+    runTransaction: vi.fn(mockRunTransaction),
     updateDoc: vi.fn(mockUpdateDoc),
     onSnapshot: vi.fn(mockOnSnapshot),
     writeBatch: vi.fn(mockWriteBatch),
@@ -400,6 +466,16 @@ describe.each([
     expect(participantData!.participantTags).toEqual([]);
   });
 
+  test('fresh participant startup does not scan all sequence assignments', async () => {
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    await storageEngine.getParticipantCompletionStatus(participant.participantId);
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {
     const participantSession = await storageEngine.initializeParticipantSession({ condition: 'color' }, configSimple, participantMetadata);
 
@@ -473,13 +549,36 @@ describe.each([
     }
   });
 
+  test('concurrent participant starts reserve unique sequence and creation indexes', async () => {
+    const engines = Array.from({ length: 12 }, () => new TestEngine(true));
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+
+    const sessions = await Promise.all(engines.map((engine, index) => (
+      engine.initializeParticipantSession(
+        {},
+        configSimple,
+        participantMetadata,
+        `concurrent-${index}`,
+      )
+    )));
+    const assignments = (await storageEngine.getAllSequenceAssignments(studyId))
+      .filter((assignment) => assignment.participantId.startsWith('concurrent-'));
+
+    expect(new Set(assignments.map((assignment) => assignment.sequenceIndex)).size).toBe(12);
+    expect(assignments.map((assignment) => assignment.sequenceIndex).sort((a, b) => a! - b!))
+      .toEqual(Array.from({ length: 12 }, (_, index) => index));
+    expect(new Set(sessions.map((session) => session.participantIndex)).size).toBe(12);
+    expect(sessions.map((session) => session.participantIndex).sort((a, b) => a - b))
+      .toEqual(Array.from({ length: 12 }, (_, index) => index + 1));
+  });
+
   test('initializeParticipantSession omits conditions field in sequence assignment when empty', async () => {
-    // @ts-expect-error accessing protected method for spying
-    const createSequenceAssignmentSpy = vi.spyOn(storageEngine, '_createSequenceAssignment');
-
-    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
-
-    const sequenceAssignmentPayload = (createSequenceAssignmentSpy.mock.calls[0] as DocData[])[1];
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const sequenceAssignmentPayload = (await storageEngine.getAllSequenceAssignments(studyId))
+      .find((assignment) => assignment.participantId === participant.participantId)!;
     expect(Object.hasOwn(sequenceAssignmentPayload, 'conditions')).toBe(false);
   });
 

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -116,11 +116,12 @@ vi.mock('localforage', () => ({
 // Complete in-memory Firestore mock — no emulator needed.
 vi.mock('firebase/firestore', () => {
   type QueryConstraint = {
-    type: 'where' | 'limit';
+    type: 'where' | 'limit' | 'orderBy';
     field?: string;
     operator?: string;
     value?: unknown;
     count?: number;
+    direction?: 'asc' | 'desc';
   };
 
   function resolveSentinels(data: DocData): DocData {
@@ -209,6 +210,21 @@ vi.mock('firebase/firestore', () => {
           }
           return true;
         });
+      } else if (constraint.type === 'orderBy') {
+        docs = [...docs].sort((a, b) => {
+          const aValue = a.data()[constraint.field!];
+          const bValue = b.data()[constraint.field!];
+          const toComparableNumber = (value: unknown) => (
+            value
+            && typeof value === 'object'
+            && 'toMillis' in value
+            && typeof value.toMillis === 'function'
+              ? value.toMillis()
+              : Number(value)
+          );
+          return (toComparableNumber(aValue) - toComparableNumber(bValue))
+            * (constraint.direction === 'desc' ? -1 : 1);
+        });
       } else if (constraint.type === 'limit') {
         docs = docs.slice(0, constraint.count);
       }
@@ -231,6 +247,10 @@ vi.mock('firebase/firestore', () => {
 
   function mockLimit(count: number): QueryConstraint {
     return { type: 'limit', count };
+  }
+
+  function mockOrderBy(field: string, direction: 'asc' | 'desc' = 'asc'): QueryConstraint {
+    return { type: 'orderBy', field, direction };
   }
 
   async function mockGetCountFromServer(collRef: { _path: string; _constraints?: QueryConstraint[] }) {
@@ -306,6 +326,7 @@ vi.mock('firebase/firestore', () => {
     getCountFromServer: vi.fn(mockGetCountFromServer),
     query: vi.fn(mockQuery),
     where: vi.fn(mockWhere),
+    orderBy: vi.fn(mockOrderBy),
     limit: vi.fn(mockLimit),
     runTransaction: vi.fn(mockRunTransaction),
     updateDoc: vi.fn(mockUpdateDoc),
@@ -615,6 +636,50 @@ describe.each([
     expect(participant.sequence).toEqual(sequenceArray[1]);
     expect(scanSpy).not.toHaveBeenCalled();
     expect(countMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('rejected-slot reuse selects the earliest assignment timestamp', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    const rejectedAssignment = (
+      participantId: string,
+      timestamp: number,
+      sequenceIndex: number,
+    ): SequenceAssignment => ({
+      participantId,
+      timestamp,
+      rejected: true,
+      claimed: false,
+      completed: null,
+      createdTime: timestamp,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+      sequenceIndex,
+      creationIndex: sequenceIndex,
+    });
+    await createAssignment('newer-rejected', rejectedAssignment('newer-rejected', 20, 1), false);
+    await createAssignment('older-rejected', rejectedAssignment('older-rejected', 10, 0), false);
+
+    const participant = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'ordered-replacement',
+    );
+    const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+
+    expect(participant.sequence).toEqual(sequenceArray[0]);
+    expect(assignments.find(({ participantId }) => participantId === 'older-rejected')?.claimed).toBe(true);
+    expect(assignments.find(({ participantId }) => participantId === 'newer-rejected')?.claimed).toBe(false);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -931,6 +931,10 @@ describe.each([
     expect(sequenceAssignment4!.createdTime).toBeDefined();
     expect(sequenceAssignment4!.createdTime).toBeGreaterThanOrEqual(sequenceAssignment3!.createdTime);
     expect(sequenceAssignment4!.completed).toBeNull();
+    expect(new Set([
+      sequenceAssignment3!.sequenceIndex,
+      sequenceAssignment4!.sequenceIndex,
+    ]).size).toBe(2);
 
     sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);
     expect(sequenceAssignments.find((assignment) => assignment.participantId === participantId1)).toBeDefined();

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -170,13 +170,17 @@ vi.mock('firebase/firestore', () => {
 
   function getDocsInCollection(collPath: string) {
     const prefix = `${collPath}/`;
-    const docs: Array<{ id: string; data: () => DocData }> = [];
+    const docs: Array<{ id: string; data: () => DocData; ref: { _path: string; id: string } }> = [];
     for (const [path, data] of Object.entries(firestoreData)) {
       if (path.startsWith(prefix)) {
         const remainder = path.slice(prefix.length);
         if (!remainder.includes('/')) {
           const copy = { ...data };
-          docs.push({ id: remainder, data: () => copy });
+          docs.push({
+            id: remainder,
+            data: () => copy,
+            ref: { _path: path, id: remainder },
+          });
         }
       }
     }
@@ -515,7 +519,7 @@ describe.each([
     expect(scanSpy).not.toHaveBeenCalled();
     expect(countMock).toHaveBeenCalledTimes(2);
     expect(getDocsMock).toHaveBeenCalledTimes(1);
-    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(2);
 
     const getDocMock = vi.mocked(getDoc);
     getDocMock.mockClear();
@@ -591,8 +595,146 @@ describe.each([
     expect(participant.participantIndex).toBe(1);
     expect(scanSpy).not.toHaveBeenCalled();
     expect(countMock).toHaveBeenCalledTimes(2);
-    expect(getDocsMock).not.toHaveBeenCalled();
-    expect(transactionMock).not.toHaveBeenCalled();
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('allocator bounds provider operations for existing, rejected, and conflict paths', async () => {
+    await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'operation-existing',
+    );
+
+    const allocate = (
+      storageEngine as unknown as {
+        _allocateSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+        ) => Promise<{ sequenceIndex: number; creationIndex: number }>;
+      }
+    )._allocateSequenceAssignment.bind(storageEngine);
+    const assignment: SequenceAssignment = {
+      participantId: 'operation-existing',
+      timestamp: Date.now(),
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: Date.now(),
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+    };
+    const getDocsMock = vi.mocked(getDocs);
+    const transactionMock = vi.mocked(runTransaction);
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
+
+    await allocate('operation-existing', assignment);
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+
+    await storageEngine.rejectParticipant('operation-existing', 'operation-count rejection');
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
+    await allocate('operation-rejected', {
+      ...assignment,
+      participantId: 'operation-rejected',
+    });
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+
+    getDocsMock.mockClear();
+    transactionMock.mockClear();
+    transactionMock.mockRejectedValueOnce(new Error('transaction contention exhausted'));
+    await expect(allocate('operation-conflict', {
+      ...assignment,
+      participantId: 'operation-conflict',
+    })).rejects.toThrow('transaction contention exhausted');
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('concurrent starts claim one rejected slot at most once', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    await Promise.all([0, 1].map((index) => createAssignment(`rejected-source-${index}`, {
+      participantId: `rejected-source-${index}`,
+      timestamp: index,
+      rejected: true,
+      claimed: false,
+      completed: null,
+      createdTime: index,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+      sequenceIndex: index,
+      creationIndex: index,
+    }, false)));
+
+    const engines = [new TestEngine(true), new TestEngine(true)];
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+    await Promise.all(engines.map((engine, index) => engine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      `rejected-contender-${index}`,
+    )));
+
+    const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const contenders = assignments.filter(
+      (assignment) => assignment.participantId.startsWith('rejected-contender-'),
+    );
+    expect(contenders.map((assignment) => assignment.claimedParticipantId).sort()).toEqual([
+      'rejected-source-0',
+      'rejected-source-1',
+    ]);
+    expect(new Set(contenders.map((assignment) => assignment.sequenceIndex)).size).toBe(2);
+    expect(contenders.map((assignment) => assignment.sequenceIndex).sort()).toEqual([0, 1]);
+  });
+
+  test('startup retry recovers an assignment after participant persistence did not run', async () => {
+    const allocate = (
+      storageEngine as unknown as {
+        _allocateSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+        ) => Promise<{ sequenceIndex: number; creationIndex: number }>;
+      }
+    )._allocateSequenceAssignment.bind(storageEngine);
+    const assignment: SequenceAssignment = {
+      participantId: 'participant-write-retry',
+      timestamp: Date.now(),
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: Date.now(),
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+    };
+
+    const initialAllocation = await allocate('participant-write-retry', assignment);
+    const recoveredAllocation = await allocate('participant-write-retry', assignment);
+
+    expect(recoveredAllocation).toEqual(initialAllocation);
+    expect((await storageEngine.getAllSequenceAssignments(studyId)).filter(
+      (storedAssignment) => storedAssignment.participantId === 'participant-write-retry',
+    )).toHaveLength(1);
   });
 
   test('legacy rejected-slot reuse uses bounded counts instead of an assignment scan', async () => {

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -18,6 +18,12 @@ type RowData = Record<string, string | number | boolean | null | object>;
 const revisitRows: RowData[] = [];
 const storageFiles: Record<string, string> = {};
 const localStore: Record<string, string | number | object | null> = {};
+const supabaseOperations: Array<{
+  op: string | null;
+  filters: Array<{ col: string; type: string; val: string | number | boolean | null }>;
+  headOnly: boolean;
+  limit?: number;
+}> = [];
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
 vi.mock('@supabase/supabase-js', () => {
@@ -44,12 +50,13 @@ vi.mock('@supabase/supabase-js', () => {
 
   function applyFilters(
     rows: Array<RowData>,
-    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }>,
+    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' | 'lt' }>,
   ): Array<RowData> {
     return rows.filter((row) => filters.every(({ col, val, type }) => {
       const colVal = getFieldValue(row, col);
       if (type === 'eq') return colVal === val;
       if (type === 'not') return colVal !== null && colVal !== undefined;
+      if (type === 'lt') return colVal !== undefined && colVal !== null && colVal < val!;
       return typeof colVal === 'string' && matchLike(colVal, String(val));
     }));
   }
@@ -57,7 +64,7 @@ vi.mock('@supabase/supabase-js', () => {
   function makeQueryBuilder(getRows: () => Array<RowData>) {
     let op: 'select' | 'insert' | 'upsert' | 'update' | 'delete' | null = null;
     let payload: RowData | RowData[] | Partial<RowData> | null = null;
-    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }> = [];
+    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' | 'lt' }> = [];
     let isSingle = false;
     let allowMissingSingle = false;
     let requestedCount = false;
@@ -77,6 +84,7 @@ vi.mock('@supabase/supabase-js', () => {
       update(obj: Partial<RowData>) { op = 'update'; payload = obj; return qb; },
       delete() { op = 'delete'; return qb; },
       eq(col: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'eq' }); return qb; },
+      lt(col: string, val: string | number) { filters.push({ col, val, type: 'lt' }); return qb; },
       like(col: string, val: string) { filters.push({ col, val, type: 'like' }); return qb; },
       not(col: string, _operator: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'not' }); return qb; },
       order(col: string, options?: { ascending?: boolean }) {
@@ -91,6 +99,12 @@ vi.mock('@supabase/supabase-js', () => {
         reject?: (err: Error) => void,
       ) {
         Promise.resolve().then(() => {
+          supabaseOperations.push({
+            op,
+            filters: filters.map((filter) => ({ ...filter })),
+            headOnly,
+            limit: resultLimit,
+          });
           const rows = getRows();
           if (op === 'select') {
             let matched = applyFilters(rows, filters);
@@ -357,6 +371,7 @@ describe.each([
     await storageEngine.setSequenceArray(
       sequenceArray,
     );
+    supabaseOperations.length = 0;
   });
 
   afterEach(async () => {
@@ -428,9 +443,131 @@ describe.each([
 
     const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
     expect(scanSpy).not.toHaveBeenCalled();
+    const assignmentQueries = supabaseOperations.filter((operation) => operation.filters.some(
+      (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
+    ));
+    expect(assignmentQueries.filter((operation) => operation.headOnly)).toHaveLength(2);
+    expect(assignmentQueries.filter((operation) => !operation.headOnly)).toEqual([
+      expect.objectContaining({ limit: 1 }),
+    ]);
 
+    supabaseOperations.length = 0;
     await storageEngine.getParticipantCompletionStatus(participant.participantId);
     expect(scanSpy).not.toHaveBeenCalled();
+    expect(supabaseOperations.filter((operation) => operation.filters.some(
+      (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
+    ))).toHaveLength(0);
+  });
+
+  test('fresh participant startup with an initialized allocator skips legacy counts', async () => {
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'allocator-seed');
+    await storageEngine.clearCurrentParticipantId();
+    supabaseOperations.length = 0;
+
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'post-seed');
+
+    const assignmentQueries = supabaseOperations.filter((operation) => operation.filters.some(
+      (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
+    ));
+    expect(scanSpy).not.toHaveBeenCalled();
+    expect(assignmentQueries.filter((operation) => operation.headOnly)).toHaveLength(0);
+    expect(assignmentQueries.filter((operation) => !operation.headOnly)).toEqual([
+      expect.objectContaining({ limit: 1 }),
+    ]);
+  });
+
+  test('returning legacy assignment derives its indexes without an assignment scan', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    await createAssignment('legacy-returning', {
+      participantId: 'legacy-returning',
+      timestamp: 1,
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: 1,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+    }, false);
+    supabaseOperations.length = 0;
+
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    const participant = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'legacy-returning',
+    );
+
+    const unboundedReads = supabaseOperations.filter((operation) => (
+      !operation.headOnly
+      && operation.limit === undefined
+      && operation.filters.some(
+        (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
+      )
+    ));
+    expect(participant.participantIndex).toBe(1);
+    expect(scanSpy).not.toHaveBeenCalled();
+    expect(unboundedReads).toHaveLength(0);
+    expect(supabaseOperations.filter((operation) => operation.headOnly)).toHaveLength(3);
+  });
+
+  test('legacy rejected-slot reuse uses bounded counts instead of an assignment scan', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    for (let index = 0; index < 5; index += 1) {
+      // Sequential writes intentionally build a deterministic legacy assignment history.
+      // eslint-disable-next-line no-await-in-loop
+      await createAssignment(`legacy-${index}`, {
+        participantId: `legacy-${index}`,
+        timestamp: index,
+        rejected: index === 1,
+        claimed: false,
+        completed: null,
+        createdTime: index,
+        total: 0,
+        answered: [],
+        isDynamic: false,
+        stage: 'DEFAULT',
+      }, false);
+    }
+    supabaseOperations.length = 0;
+
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+    const participant = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'legacy-replacement',
+    );
+
+    const unboundedReads = supabaseOperations.filter((operation) => (
+      !operation.headOnly
+      && operation.limit === undefined
+      && operation.filters.some(
+        (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
+      )
+    ));
+    expect(participant.sequence).toEqual(sequenceArray[1]);
+    expect(scanSpy).not.toHaveBeenCalled();
+    expect(unboundedReads).toHaveLength(0);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -44,47 +44,97 @@ vi.mock('@supabase/supabase-js', () => {
 
   function applyFilters(
     rows: Array<RowData>,
-    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' }>,
+    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }>,
   ): Array<RowData> {
     return rows.filter((row) => filters.every(({ col, val, type }) => {
       const colVal = getFieldValue(row, col);
       if (type === 'eq') return colVal === val;
+      if (type === 'not') return colVal !== null && colVal !== undefined;
       return typeof colVal === 'string' && matchLike(colVal, String(val));
     }));
   }
 
   function makeQueryBuilder(getRows: () => Array<RowData>) {
-    let op: 'select' | 'upsert' | 'update' | 'delete' | null = null;
+    let op: 'select' | 'insert' | 'upsert' | 'update' | 'delete' | null = null;
     let payload: RowData | RowData[] | Partial<RowData> | null = null;
-    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' }> = [];
+    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }> = [];
     let isSingle = false;
+    let allowMissingSingle = false;
+    let requestedCount = false;
+    let headOnly = false;
+    let resultLimit: number | undefined;
+    let orderBy: { col: string; ascending: boolean } | undefined;
 
     const qb = {
-      select(_fields?: string) { op = 'select'; return qb; },
+      select(_fields?: string, options?: { count?: string; head?: boolean }) {
+        if (op === null) op = 'select';
+        requestedCount = options?.count === 'exact';
+        headOnly = options?.head === true;
+        return qb;
+      },
+      insert(row: RowData | RowData[]) { op = 'insert'; payload = row; return qb; },
       upsert(row: RowData | RowData[]) { op = 'upsert'; payload = row; return qb; },
       update(obj: Partial<RowData>) { op = 'update'; payload = obj; return qb; },
       delete() { op = 'delete'; return qb; },
       eq(col: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'eq' }); return qb; },
       like(col: string, val: string) { filters.push({ col, val, type: 'like' }); return qb; },
+      not(col: string, _operator: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'not' }); return qb; },
+      order(col: string, options?: { ascending?: boolean }) {
+        orderBy = { col, ascending: options?.ascending !== false };
+        return qb;
+      },
+      limit(count: number) { resultLimit = count; return qb; },
       single() { isSingle = true; return qb; },
+      maybeSingle() { isSingle = true; allowMissingSingle = true; return qb; },
       then(
-        resolve: (val: { data: RowData | RowData[] | null; error: { message: string; code?: string } | null }) => void,
+        resolve: (val: { data: RowData | RowData[] | null; error: { message: string; code?: string } | null; count?: number | null }) => void,
         reject?: (err: Error) => void,
       ) {
         Promise.resolve().then(() => {
           const rows = getRows();
           if (op === 'select') {
-            const matched = applyFilters(rows, filters);
+            let matched = applyFilters(rows, filters);
+            const count = requestedCount ? matched.length : null;
+            if (orderBy) {
+              matched = [...matched].sort((a, b) => {
+                const aValue = String(getFieldValue(a, orderBy!.col) ?? '');
+                const bValue = String(getFieldValue(b, orderBy!.col) ?? '');
+                return (aValue.localeCompare(bValue)) * (orderBy!.ascending ? 1 : -1);
+              });
+            }
+            if (resultLimit !== undefined) matched = matched.slice(0, resultLimit);
+            if (headOnly) {
+              resolve({ data: null, error: null, count });
+              return;
+            }
             // Return deep copies so later mutations to revisitRows don't alias into returned data
             if (isSingle) {
               if (matched.length === 0) {
-                resolve({ data: null, error: { message: 'No rows', code: 'PGRST116' } });
+                resolve({
+                  data: null,
+                  error: allowMissingSingle ? null : { message: 'No rows', code: 'PGRST116' },
+                  count,
+                });
               } else {
-                resolve({ data: JSON.parse(JSON.stringify(matched[0])), error: null });
+                resolve({ data: JSON.parse(JSON.stringify(matched[0])), error: null, count });
               }
             } else {
-              resolve({ data: JSON.parse(JSON.stringify(matched)), error: null });
+              resolve({ data: JSON.parse(JSON.stringify(matched)), error: null, count });
             }
+          } else if (op === 'insert') {
+            const toInsert = (Array.isArray(payload) ? payload : [payload]) as Array<RowData>;
+            const duplicate = toInsert.some((row) => rows.some(
+              (existing) => existing.studyId === row.studyId && existing.docId === row.docId,
+            ));
+            if (duplicate) {
+              resolve({ data: null, error: { message: 'duplicate key', code: '23505' } });
+              return;
+            }
+            toInsert.forEach((row) => rows.push({
+              ...row,
+              createdAt: (row.createdAt as string | undefined) ?? new Date().toISOString(),
+            }));
+            resolve({ data: toInsert, error: null });
           } else if (op === 'upsert') {
             const toUpsert = (Array.isArray(payload)
               ? payload
@@ -109,7 +159,7 @@ vi.mock('@supabase/supabase-js', () => {
           } else if (op === 'update') {
             const matched = applyFilters(rows, filters);
             matched.forEach((row) => Object.assign(row, payload as RowData));
-            resolve({ data: matched, error: null });
+            resolve({ data: JSON.parse(JSON.stringify(matched)), error: null });
           } else if (op === 'delete') {
             const matched = applyFilters(rows, filters);
             matched.forEach((row) => {
@@ -373,6 +423,16 @@ describe.each([
     expect(participantData!.participantTags).toEqual([]);
   });
 
+  test('fresh participant startup does not scan all sequence assignments', async () => {
+    const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
+
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    await storageEngine.getParticipantCompletionStatus(participant.participantId);
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {
     const participantSession = await storageEngine.initializeParticipantSession({ condition: 'color' }, configSimple, participantMetadata);
 
@@ -444,13 +504,36 @@ describe.each([
     }
   });
 
+  test('concurrent participant starts reserve unique sequence and creation indexes', async () => {
+    const engines = Array.from({ length: 12 }, () => new TestEngine(true));
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+
+    const sessions = await Promise.all(engines.map((engine, index) => (
+      engine.initializeParticipantSession(
+        {},
+        configSimple,
+        participantMetadata,
+        `concurrent-${index}`,
+      )
+    )));
+    const assignments = (await storageEngine.getAllSequenceAssignments(studyId))
+      .filter((assignment) => assignment.participantId.startsWith('concurrent-'));
+
+    expect(new Set(assignments.map((assignment) => assignment.sequenceIndex)).size).toBe(12);
+    expect(assignments.map((assignment) => assignment.sequenceIndex).sort((a, b) => a! - b!))
+      .toEqual(Array.from({ length: 12 }, (_, index) => index));
+    expect(new Set(sessions.map((session) => session.participantIndex)).size).toBe(12);
+    expect(sessions.map((session) => session.participantIndex).sort((a, b) => a - b))
+      .toEqual(Array.from({ length: 12 }, (_, index) => index + 1));
+  });
+
   test('initializeParticipantSession omits conditions field in sequence assignment when empty', async () => {
-    // @ts-expect-error accessing protected method for spying
-    const createSequenceAssignmentSpy = vi.spyOn(storageEngine, '_createSequenceAssignment');
-
-    await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
-
-    const sequenceAssignmentPayload = (createSequenceAssignmentSpy.mock.calls[0] as RowData[])[1];
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    const sequenceAssignmentPayload = (await storageEngine.getAllSequenceAssignments(studyId))
+      .find((assignment) => assignment.participantId === participant.participantId)!;
     expect(Object.hasOwn(sequenceAssignmentPayload, 'conditions')).toBe(false);
   });
 

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -18,6 +18,7 @@ type RowData = Record<string, string | number | boolean | null | object>;
 const revisitRows: RowData[] = [];
 const storageFiles: Record<string, string> = {};
 const localStore: Record<string, string | number | object | null> = {};
+let nextSupabaseSelectError: { message: string; code?: string } | null = null;
 const supabaseOperations: Array<{
   op: string | null;
   filters: Array<{ col: string; type: string; val: string | number | boolean | null }>;
@@ -105,6 +106,12 @@ vi.mock('@supabase/supabase-js', () => {
             headOnly,
             limit: resultLimit,
           });
+          if (op === 'select' && nextSupabaseSelectError) {
+            const error = nextSupabaseSelectError;
+            nextSupabaseSelectError = null;
+            resolve({ data: null, error });
+            return;
+          }
           const rows = getRows();
           if (op === 'select') {
             let matched = applyFilters(rows, filters);
@@ -371,6 +378,7 @@ describe.each([
     await storageEngine.setSequenceArray(
       sequenceArray,
     );
+    nextSupabaseSelectError = null;
     supabaseOperations.length = 0;
   });
 
@@ -457,6 +465,15 @@ describe.each([
     expect(supabaseOperations.filter((operation) => operation.filters.some(
       (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
     ))).toHaveLength(0);
+  });
+
+  test('participant completion lookup propagates provider failures', async () => {
+    const participant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+    nextSupabaseSelectError = { message: 'permission denied', code: '42501' };
+
+    await expect(
+      storageEngine.getParticipantCompletionStatus(participant.participantId),
+    ).rejects.toThrow('Failed to retrieve sequence assignment');
   });
 
   test('fresh participant startup with an initialized allocator skips legacy counts', async () => {
@@ -892,6 +909,10 @@ describe.each([
     expect(sequenceAssignment4!.createdTime).toBeDefined();
     expect(sequenceAssignment4!.createdTime).toBeGreaterThanOrEqual(sequenceAssignment3!.createdTime);
     expect(sequenceAssignment4!.completed).toBeNull();
+    expect(new Set([
+      sequenceAssignment3!.sequenceIndex,
+      sequenceAssignment4!.sequenceIndex,
+    ]).size).toBe(2);
 
     // Check the length of sequence assignments
     sequenceAssignments = await storageEngine.getAllSequenceAssignments(studyId);

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -118,9 +118,12 @@ vi.mock('@supabase/supabase-js', () => {
             const count = requestedCount ? matched.length : null;
             if (orderBy) {
               matched = [...matched].sort((a, b) => {
-                const aValue = String(getFieldValue(a, orderBy!.col) ?? '');
-                const bValue = String(getFieldValue(b, orderBy!.col) ?? '');
-                return (aValue.localeCompare(bValue)) * (orderBy!.ascending ? 1 : -1);
+                const aValue = getFieldValue(a, orderBy!.col);
+                const bValue = getFieldValue(b, orderBy!.col);
+                const comparison = typeof aValue === 'number' && typeof bValue === 'number'
+                  ? aValue - bValue
+                  : String(aValue ?? '').localeCompare(String(bValue ?? ''));
+                return comparison * (orderBy!.ascending ? 1 : -1);
               });
             }
             if (resultLimit !== undefined) matched = matched.slice(0, resultLimit);
@@ -476,6 +479,36 @@ describe.each([
     ).rejects.toThrow('Failed to retrieve sequence assignment');
   });
 
+  test('study verification rejects a missing connect row', async () => {
+    const connectRowIndex = revisitRows.findIndex(
+      (row) => row.docId === 'connect',
+    );
+    expect(connectRowIndex).toBeGreaterThanOrEqual(0);
+    revisitRows.splice(connectRowIndex, 1);
+
+    const verifyStudyDatabase = (
+      storageEngine as unknown as {
+        _verifyStudyDatabase: () => Promise<void>;
+      }
+    )._verifyStudyDatabase.bind(storageEngine);
+    await expect(verifyStudyDatabase())
+      .rejects.toThrow('Study database not initialized or does not exist');
+  });
+
+  test('allocator lookup propagates provider failures without attempting initialization', async () => {
+    nextSupabaseSelectError = { message: 'permission denied', code: '42501' };
+    const getOrCreateSequenceAllocator = (
+      storageEngine as unknown as {
+        getOrCreateSequenceAllocator: () => Promise<unknown>;
+      }
+    ).getOrCreateSequenceAllocator.bind(storageEngine);
+
+    await expect(getOrCreateSequenceAllocator())
+      .rejects.toThrow('Failed to retrieve sequence assignment allocator');
+    expect(supabaseOperations).toHaveLength(1);
+    expect(supabaseOperations[0]).toMatchObject({ op: 'select', headOnly: false });
+  });
+
   test('fresh participant startup with an initialized allocator skips legacy counts', async () => {
     await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'allocator-seed');
     await storageEngine.clearCurrentParticipantId();
@@ -585,6 +618,50 @@ describe.each([
     expect(participant.sequence).toEqual(sequenceArray[1]);
     expect(scanSpy).not.toHaveBeenCalled();
     expect(unboundedReads).toHaveLength(0);
+  });
+
+  test('rejected-slot reuse selects the earliest assignment timestamp', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    const rejectedAssignment = (
+      participantId: string,
+      timestamp: number,
+      sequenceIndex: number,
+    ): SequenceAssignment => ({
+      participantId,
+      timestamp,
+      rejected: true,
+      claimed: false,
+      completed: null,
+      createdTime: timestamp,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+      sequenceIndex,
+      creationIndex: sequenceIndex,
+    });
+    await createAssignment('newer-rejected', rejectedAssignment('newer-rejected', 20, 1), false);
+    await createAssignment('older-rejected', rejectedAssignment('older-rejected', 10, 0), false);
+
+    const participant = await storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'ordered-replacement',
+    );
+    const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+
+    expect(participant.sequence).toEqual(sequenceArray[0]);
+    expect(assignments.find(({ participantId }) => participantId === 'older-rejected')?.claimed).toBe(true);
+    expect(assignments.find(({ participantId }) => participantId === 'newer-rejected')?.claimed).toBe(false);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -25,9 +25,133 @@ const supabaseOperations: Array<{
   headOnly: boolean;
   limit?: number;
 }> = [];
+const supabaseRpcOperations: Array<{ name: string; participantId: string }> = [];
+let nextSupabaseRpcError: { message: string; code: string } | null = null;
+let supabaseRpcChain = Promise.resolve<unknown>(undefined);
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
 vi.mock('@supabase/supabase-js', () => {
+  async function allocateSequenceAssignmentRpc(args: {
+    p_study_id: string;
+    p_participant_id: string;
+    p_assignment: SequenceAssignment;
+  }) {
+    const assignmentDocId = `sequenceAssignment_${args.p_participant_id}`;
+    const existingRow = revisitRows.find(
+      (row) => row.studyId === args.p_study_id && row.docId === assignmentDocId,
+    );
+    if (existingRow) {
+      const existing = existingRow.data as SequenceAssignment;
+      if (existing.sequenceIndex !== undefined && existing.creationIndex !== undefined) {
+        return {
+          sequenceIndex: existing.sequenceIndex,
+          creationIndex: existing.creationIndex,
+        };
+      }
+      const assignments = revisitRows.filter(
+        (row) => row.studyId === args.p_study_id
+          && String(row.docId).startsWith('sequenceAssignment_'),
+      );
+      return {
+        sequenceIndex: assignments.filter((row) => {
+          const assignment = row.data as SequenceAssignment & { withServerTimestamp?: boolean };
+          const timestamp = assignment.withServerTimestamp
+            ? new Date(String(row.createdAt)).getTime()
+            : assignment.timestamp;
+          return !assignment.rejected && timestamp < existing.timestamp;
+        }).length,
+        creationIndex: assignments.filter(
+          (row) => new Date(String(row.createdAt)).getTime()
+            < new Date(String(existingRow.createdAt)).getTime(),
+        ).length,
+      };
+    }
+
+    const assignmentRows = revisitRows.filter(
+      (row) => row.studyId === args.p_study_id
+        && String(row.docId).startsWith('sequenceAssignment_'),
+    );
+    let allocatorRow = revisitRows.find(
+      (row) => row.studyId === args.p_study_id && row.docId === 'sequenceAllocator',
+    );
+    const allocator = allocatorRow
+      ? allocatorRow.data as { nextSequenceIndex: number; nextCreationIndex: number; version: number }
+      : {
+        nextSequenceIndex: assignmentRows.filter(
+          (row) => !(row.data as SequenceAssignment).claimed,
+        ).length,
+        nextCreationIndex: assignmentRows.length,
+        version: 0,
+      };
+    const reusableRow = assignmentRows
+      .filter((row) => {
+        const assignment = row.data as SequenceAssignment;
+        return assignment.rejected && !assignment.claimed;
+      })
+      .sort((a, b) => {
+        const assignmentA = a.data as SequenceAssignment & { withServerTimestamp?: boolean };
+        const assignmentB = b.data as SequenceAssignment & { withServerTimestamp?: boolean };
+        const timestampA = assignmentA.withServerTimestamp
+          ? new Date(String(a.createdAt)).getTime()
+          : assignmentA.timestamp;
+        const timestampB = assignmentB.withServerTimestamp
+          ? new Date(String(b.createdAt)).getTime()
+          : assignmentB.timestamp;
+        return timestampA - timestampB;
+      })[0];
+    const reusable = reusableRow?.data as
+      (SequenceAssignment & { withServerTimestamp?: boolean }) | undefined;
+    const reusableTimestamp = reusable?.withServerTimestamp
+      ? new Date(String(reusableRow!.createdAt)).getTime()
+      : reusable?.timestamp;
+    const sequenceIndex = reusable
+      ? reusable.reusableSequenceIndex
+        ?? reusable.sequenceIndex
+        ?? assignmentRows.filter((row) => {
+          const assignment = row.data as SequenceAssignment & { withServerTimestamp?: boolean };
+          const timestamp = assignment.withServerTimestamp
+            ? new Date(String(row.createdAt)).getTime()
+            : assignment.timestamp;
+          return !assignment.rejected && timestamp < reusableTimestamp!;
+        }).length
+      : allocator.nextSequenceIndex;
+    const creationIndex = allocator.nextCreationIndex;
+
+    if (reusableRow && reusable) {
+      reusableRow.data = { ...reusable, claimed: true, sequenceIndex };
+    }
+    revisitRows.push({
+      studyId: args.p_study_id,
+      docId: assignmentDocId,
+      data: {
+        ...args.p_assignment,
+        ...(reusable ? {
+          timestamp: reusableTimestamp,
+          claimedParticipantId: reusable.participantId,
+          withServerTimestamp: false,
+        } : { withServerTimestamp: true }),
+        sequenceIndex,
+        creationIndex,
+      },
+      createdAt: new Date().toISOString(),
+    });
+    allocatorRow ??= {
+      studyId: args.p_study_id,
+      docId: 'sequenceAllocator',
+      data: {},
+      createdAt: new Date().toISOString(),
+    };
+    allocatorRow.data = {
+      nextSequenceIndex: reusable ? allocator.nextSequenceIndex : allocator.nextSequenceIndex + 1,
+      nextCreationIndex: allocator.nextCreationIndex + 1,
+      version: allocator.version + 1,
+    };
+    if (!revisitRows.includes(allocatorRow)) {
+      revisitRows.push(allocatorRow);
+    }
+    return { sequenceIndex, creationIndex };
+  }
+
   function matchLike(value: string, pattern: string): boolean {
     const regexStr = `^${pattern
       .replace(/[.+^${}()|[\]\\]/g, '\\$&')
@@ -204,6 +328,21 @@ vi.mock('@supabase/supabase-js', () => {
     AuthError: class AuthError extends Error { },
     createClient: () => ({
       from: (_table: string) => makeQueryBuilder(() => revisitRows),
+      rpc: (name: string, args: {
+        p_study_id: string;
+        p_participant_id: string;
+        p_assignment: SequenceAssignment;
+      }) => {
+        supabaseRpcOperations.push({ name, participantId: args.p_participant_id });
+        if (nextSupabaseRpcError) {
+          const error = nextSupabaseRpcError;
+          nextSupabaseRpcError = null;
+          return Promise.resolve({ data: null, error });
+        }
+        const result = supabaseRpcChain.then(() => allocateSequenceAssignmentRpc(args));
+        supabaseRpcChain = result.then(() => undefined, () => undefined);
+        return result.then((data) => ({ data, error: null }));
+      },
       schema: (schemaName: string) => ({
         from: (_table: string) => makeQueryBuilder(() => {
           if (schemaName === 'storage') {
@@ -382,7 +521,10 @@ describe.each([
       sequenceArray,
     );
     nextSupabaseSelectError = null;
+    nextSupabaseRpcError = null;
     supabaseOperations.length = 0;
+    supabaseRpcOperations.length = 0;
+    supabaseRpcChain = Promise.resolve();
   });
 
   afterEach(async () => {
@@ -457,10 +599,11 @@ describe.each([
     const assignmentQueries = supabaseOperations.filter((operation) => operation.filters.some(
       (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
     ));
-    expect(assignmentQueries.filter((operation) => operation.headOnly)).toHaveLength(2);
-    expect(assignmentQueries.filter((operation) => !operation.headOnly)).toEqual([
-      expect.objectContaining({ limit: 1 }),
-    ]);
+    expect(assignmentQueries).toHaveLength(0);
+    expect(supabaseRpcOperations).toEqual([{
+      name: 'allocate_sequence_assignment',
+      participantId: participant.participantId,
+    }]);
 
     supabaseOperations.length = 0;
     await storageEngine.getParticipantCompletionStatus(participant.participantId);
@@ -513,6 +656,7 @@ describe.each([
     await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'allocator-seed');
     await storageEngine.clearCurrentParticipantId();
     supabaseOperations.length = 0;
+    supabaseRpcOperations.length = 0;
 
     const scanSpy = vi.spyOn(storageEngine, 'getAllSequenceAssignments');
     await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata, 'post-seed');
@@ -521,10 +665,11 @@ describe.each([
       (filter) => filter.col === 'docId' && filter.type === 'like' && filter.val === 'sequenceAssignment_%',
     ));
     expect(scanSpy).not.toHaveBeenCalled();
-    expect(assignmentQueries.filter((operation) => operation.headOnly)).toHaveLength(0);
-    expect(assignmentQueries.filter((operation) => !operation.headOnly)).toEqual([
-      expect.objectContaining({ limit: 1 }),
-    ]);
+    expect(assignmentQueries).toHaveLength(0);
+    expect(supabaseRpcOperations).toEqual([{
+      name: 'allocate_sequence_assignment',
+      participantId: 'post-seed',
+    }]);
   });
 
   test('returning legacy assignment derives its indexes without an assignment scan', async () => {
@@ -569,7 +714,119 @@ describe.each([
     expect(participant.participantIndex).toBe(1);
     expect(scanSpy).not.toHaveBeenCalled();
     expect(unboundedReads).toHaveLength(0);
-    expect(supabaseOperations.filter((operation) => operation.headOnly)).toHaveLength(3);
+    expect(supabaseOperations.filter((operation) => operation.headOnly)).toHaveLength(0);
+    expect(supabaseRpcOperations).toEqual([{
+      name: 'allocate_sequence_assignment',
+      participantId: 'legacy-returning',
+    }]);
+  });
+
+  test('allocator uses one RPC for existing, rejected, and conflict paths', async () => {
+    const allocate = (
+      storageEngine as unknown as {
+        _allocateSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+        ) => Promise<{ sequenceIndex: number; creationIndex: number }>;
+      }
+    )._allocateSequenceAssignment.bind(storageEngine);
+    const assignment: SequenceAssignment = {
+      participantId: 'operation-existing',
+      timestamp: Date.now(),
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: Date.now(),
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+    };
+
+    const initialAllocation = await allocate('operation-existing', assignment);
+    supabaseRpcOperations.length = 0;
+    const recoveredAllocation = await allocate('operation-existing', assignment);
+    // No participant-data record exists between these calls. A startup retry must recover
+    // the committed assignment rather than consume another allocator position.
+    expect(recoveredAllocation).toEqual(initialAllocation);
+    expect((await storageEngine.getAllSequenceAssignments(studyId)).filter(
+      (storedAssignment) => storedAssignment.participantId === 'operation-existing',
+    )).toHaveLength(1);
+    expect(supabaseRpcOperations).toEqual([{
+      name: 'allocate_sequence_assignment',
+      participantId: 'operation-existing',
+    }]);
+
+    await storageEngine.rejectParticipant('operation-existing', 'operation-count rejection');
+    supabaseRpcOperations.length = 0;
+    await allocate('operation-rejected', {
+      ...assignment,
+      participantId: 'operation-rejected',
+    });
+    expect(supabaseRpcOperations).toEqual([{
+      name: 'allocate_sequence_assignment',
+      participantId: 'operation-rejected',
+    }]);
+
+    supabaseRpcOperations.length = 0;
+    nextSupabaseRpcError = { message: 'lock timeout', code: '55P03' };
+    await expect(allocate('operation-conflict', {
+      ...assignment,
+      participantId: 'operation-conflict',
+    })).rejects.toThrow('lock timeout');
+    expect(supabaseRpcOperations).toEqual([{
+      name: 'allocate_sequence_assignment',
+      participantId: 'operation-conflict',
+    }]);
+  });
+
+  test('concurrent starts claim one rejected slot at most once', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    await Promise.all([0, 1].map((index) => createAssignment(`rejected-source-${index}`, {
+      participantId: `rejected-source-${index}`,
+      timestamp: index,
+      rejected: true,
+      claimed: false,
+      completed: null,
+      createdTime: index,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+      sequenceIndex: index,
+      creationIndex: index,
+    }, false)));
+
+    const engines = [new TestEngine(true), new TestEngine(true)];
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+    await Promise.all(engines.map((engine, index) => engine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      `rejected-contender-${index}`,
+    )));
+
+    const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+    const contenders = assignments.filter(
+      (assignment) => assignment.participantId.startsWith('rejected-contender-'),
+    );
+    expect(contenders.map((assignment) => assignment.claimedParticipantId).sort()).toEqual([
+      'rejected-source-0',
+      'rejected-source-1',
+    ]);
+    expect(new Set(contenders.map((assignment) => assignment.sequenceIndex)).size).toBe(2);
+    expect(contenders.map((assignment) => assignment.sequenceIndex).sort()).toEqual([0, 1]);
   });
 
   test('legacy rejected-slot reuse uses bounded counts instead of an assignment scan', async () => {

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -27,6 +27,7 @@ const supabaseOperations: Array<{
 }> = [];
 const supabaseRpcOperations: Array<{ name: string; participantId: string }> = [];
 let nextSupabaseRpcError: { message: string; code: string } | null = null;
+let nextSupabaseMutationError: { message: string; code: string } | null = null;
 let supabaseRpcChain = Promise.resolve<unknown>(undefined);
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
@@ -284,6 +285,12 @@ vi.mock('@supabase/supabase-js', () => {
             }));
             resolve({ data: toInsert, error: null });
           } else if (op === 'upsert') {
+            if (nextSupabaseMutationError) {
+              const error = nextSupabaseMutationError;
+              nextSupabaseMutationError = null;
+              resolve({ data: null, error });
+              return;
+            }
             const toUpsert = (Array.isArray(payload)
               ? payload
               : [payload]) as Array<RowData>;
@@ -522,6 +529,7 @@ describe.each([
     );
     nextSupabaseSelectError = null;
     nextSupabaseRpcError = null;
+    nextSupabaseMutationError = null;
     supabaseOperations.length = 0;
     supabaseRpcOperations.length = 0;
     supabaseRpcChain = Promise.resolve();
@@ -780,6 +788,60 @@ describe.each([
     }]);
   });
 
+  test('concurrent starts for the same participant recover one allocation', async () => {
+    const engines = [new TestEngine(true), new TestEngine(true)];
+    await Promise.all(engines.map(async (engine) => {
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+    }));
+
+    const sessions = await Promise.all(engines.map((engine) => (
+      engine.initializeParticipantSession({}, configSimple, participantMetadata, 'same-participant')
+    )));
+
+    expect(sessions[0].sequence).toEqual(sessions[1].sequence);
+    expect((await storageEngine.getAllSequenceAssignments(studyId)).filter(
+      (assignment) => assignment.participantId === 'same-participant',
+    )).toHaveLength(1);
+  });
+
+  test('fails closed when the allocation RPC migration is unavailable', async () => {
+    nextSupabaseRpcError = { message: 'function not found', code: 'PGRST202' };
+
+    await expect(storageEngine.initializeParticipantSession(
+      {},
+      configSimple,
+      participantMetadata,
+      'migration-required',
+    )).rejects.toThrow('Apply the allocate_sequence_assignment migration');
+  });
+
+  test('propagates assignment upsert failures', async () => {
+    const createAssignment = (
+      storageEngine as unknown as {
+        _createSequenceAssignment: (
+          participantId: string,
+          assignment: SequenceAssignment,
+          withServerTimestamp: boolean,
+        ) => Promise<void>;
+      }
+    )._createSequenceAssignment.bind(storageEngine);
+    nextSupabaseMutationError = { message: 'permission denied', code: '42501' };
+
+    await expect(createAssignment('write-failure', {
+      participantId: 'write-failure',
+      timestamp: 1,
+      rejected: false,
+      claimed: false,
+      completed: null,
+      createdTime: 1,
+      total: 0,
+      answered: [],
+      isDynamic: false,
+      stage: 'DEFAULT',
+    }, false)).rejects.toThrow('Failed to create sequence assignment');
+  });
+
   test('concurrent starts claim one rejected slot at most once', async () => {
     const createAssignment = (
       storageEngine as unknown as {
@@ -919,6 +981,40 @@ describe.each([
     expect(participant.sequence).toEqual(sequenceArray[0]);
     expect(assignments.find(({ participantId }) => participantId === 'older-rejected')?.claimed).toBe(true);
     expect(assignments.find(({ participantId }) => participantId === 'newer-rejected')?.claimed).toBe(false);
+  });
+
+  test('production rejection timestamps preserve FIFO reuse order', async () => {
+    const startParticipant = async (participantId: string) => {
+      const engine = new TestEngine(true);
+      await engine.connect();
+      await engine.initializeStudyDb(studyId);
+      const session = await engine.initializeParticipantSession(
+        {},
+        configSimple,
+        participantMetadata,
+        participantId,
+      );
+      return { engine, session };
+    };
+    const first = await startParticipant('fifo-first');
+    const second = await startParticipant('fifo-second');
+    vi.useFakeTimers();
+    vi.setSystemTime(100);
+    await second.engine.rejectParticipant(second.session.participantId, 'rejected first');
+    vi.setSystemTime(200);
+    await first.engine.rejectParticipant(first.session.participantId, 'rejected second');
+    vi.useRealTimers();
+
+    const replacementOne = (await startParticipant('fifo-replacement-one')).session;
+    const replacementTwo = (await startParticipant('fifo-replacement-two')).session;
+    const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+
+    expect(assignments.find(
+      ({ participantId }) => participantId === replacementOne.participantId,
+    )?.claimedParticipantId).toBe(second.session.participantId);
+    expect(assignments.find(
+      ({ participantId }) => participantId === replacementTwo.participantId,
+    )?.claimedParticipantId).toBe(first.session.participantId);
   });
 
   test('initializeParticipantSession sets conditions from searchParams condition', async () => {

--- a/src/storage/tests/primitivesFirebase.spec.ts
+++ b/src/storage/tests/primitivesFirebase.spec.ts
@@ -220,6 +220,26 @@ vi.mock('firebase/firestore', () => {
     };
   }
 
+  function mockQuery(collRef: { _path: string }) {
+    return collRef;
+  }
+
+  async function mockGetCountFromServer(collRef: { _path: string }) {
+    const snapshot = await mockGetDocs(collRef);
+    return { data: () => ({ count: snapshot.docs.length }) };
+  }
+
+  function mockRunTransaction<T>(
+    _firestore: object,
+    operation: (transaction: {
+      get: typeof mockGetDoc;
+      set: typeof mockSetDoc;
+      update: typeof mockUpdateDoc;
+    }) => Promise<T>,
+  ) {
+    return operation({ get: mockGetDoc, set: mockSetDoc, update: mockUpdateDoc });
+  }
+
   class MockTimestamp {
     constructor(public seconds: number, public nanoseconds: number) { }
 
@@ -232,6 +252,11 @@ vi.mock('firebase/firestore', () => {
     setDoc: vi.fn(mockSetDoc),
     getDoc: vi.fn(mockGetDoc),
     getDocs: vi.fn(mockGetDocs),
+    getCountFromServer: vi.fn(mockGetCountFromServer),
+    query: vi.fn(mockQuery),
+    where: vi.fn(() => ({})),
+    limit: vi.fn(() => ({})),
+    runTransaction: vi.fn(mockRunTransaction),
     updateDoc: vi.fn(mockUpdateDoc),
     onSnapshot: vi.fn(mockOnSnapshot),
     writeBatch: vi.fn(mockWriteBatch),

--- a/src/storage/tests/primitivesFirebase.spec.ts
+++ b/src/storage/tests/primitivesFirebase.spec.ts
@@ -255,6 +255,7 @@ vi.mock('firebase/firestore', () => {
     getCountFromServer: vi.fn(mockGetCountFromServer),
     query: vi.fn(mockQuery),
     where: vi.fn(() => ({})),
+    orderBy: vi.fn(() => ({})),
     limit: vi.fn(() => ({})),
     runTransaction: vi.fn(mockRunTransaction),
     updateDoc: vi.fn(mockUpdateDoc),

--- a/src/storage/tests/primitivesFirebase.spec.ts
+++ b/src/storage/tests/primitivesFirebase.spec.ts
@@ -118,6 +118,15 @@ vi.mock('localforage', () => ({
 }));
 
 vi.mock('firebase/firestore', () => {
+  type QueryConstraint = {
+    type: 'where' | 'limit' | 'orderBy';
+    field?: string;
+    operator?: string;
+    value?: unknown;
+    count?: number;
+    direction?: 'asc' | 'desc';
+  };
+
   function resolveSentinels(data: DocData): DocData {
     const now = Date.now();
     const result: DocData = {};
@@ -164,21 +173,42 @@ vi.mock('firebase/firestore', () => {
 
   function getDocsInCollection(collPath: string) {
     const prefix = `${collPath}/`;
-    const docs: Array<{ id: string; data: () => DocData }> = [];
+    const docs: Array<{ id: string; data: () => DocData; ref: { _path: string; id: string } }> = [];
     for (const [path, data] of Object.entries(firestoreData)) {
       if (path.startsWith(prefix)) {
         const remainder = path.slice(prefix.length);
         if (!remainder.includes('/')) {
           const copy = { ...data };
-          docs.push({ id: remainder, data: () => copy });
+          docs.push({
+            id: remainder,
+            data: () => copy,
+            ref: { _path: path, id: remainder },
+          });
         }
       }
     }
     return docs;
   }
 
-  function mockGetDocs(collRef: { _path: string }) {
-    const docs = getDocsInCollection(collRef._path);
+  function mockGetDocs(collRef: { _path: string; _constraints?: QueryConstraint[] }) {
+    let docs = getDocsInCollection(collRef._path);
+    (collRef._constraints ?? []).forEach((constraint) => {
+      if (constraint.type === 'where') {
+        docs = docs.filter((document) => {
+          const fieldValue = document.data()[constraint.field!];
+          if (constraint.operator === '==') return fieldValue === constraint.value;
+          if (constraint.operator === '<') return Number(fieldValue) < Number(constraint.value);
+          return true;
+        });
+      } else if (constraint.type === 'orderBy') {
+        docs = [...docs].sort((a, b) => {
+          const comparison = Number(a.data()[constraint.field!]) - Number(b.data()[constraint.field!]);
+          return constraint.direction === 'desc' ? -comparison : comparison;
+        });
+      } else {
+        docs = docs.slice(0, constraint.count);
+      }
+    });
     return Promise.resolve({
       docs,
       forEach: (cb: (d: { id: string; data: () => DocData }) => void) => docs.forEach(cb),
@@ -220,8 +250,8 @@ vi.mock('firebase/firestore', () => {
     };
   }
 
-  function mockQuery(collRef: { _path: string }) {
-    return collRef;
+  function mockQuery(collRef: { _path: string }, ...constraints: QueryConstraint[]) {
+    return { ...collRef, _constraints: constraints };
   }
 
   async function mockGetCountFromServer(collRef: { _path: string }) {
@@ -254,9 +284,13 @@ vi.mock('firebase/firestore', () => {
     getDocs: vi.fn(mockGetDocs),
     getCountFromServer: vi.fn(mockGetCountFromServer),
     query: vi.fn(mockQuery),
-    where: vi.fn(() => ({})),
-    orderBy: vi.fn(() => ({})),
-    limit: vi.fn(() => ({})),
+    where: vi.fn((field: string, operator: string, value: unknown) => ({
+      type: 'where', field, operator, value,
+    })),
+    limit: vi.fn((count: number) => ({ type: 'limit', count })),
+    orderBy: vi.fn((field: string, direction: 'asc' | 'desc' = 'asc') => ({
+      type: 'orderBy', field, direction,
+    })),
     runTransaction: vi.fn(mockRunTransaction),
     updateDoc: vi.fn(mockUpdateDoc),
     onSnapshot: vi.fn(mockOnSnapshot),

--- a/src/storage/tests/primitivesSupabase.spec.ts
+++ b/src/storage/tests/primitivesSupabase.spec.ts
@@ -39,48 +39,73 @@ vi.mock('@supabase/supabase-js', () => {
 
   function applyFilters(
     rows: Array<RowData>,
-    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' }>,
+    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }>,
   ): Array<RowData> {
     return rows.filter((row) => filters.every(({ col, val, type }) => {
       const colVal = getFieldValue(row, col);
       if (type === 'eq') return colVal === val;
+      if (type === 'not') return colVal !== null && colVal !== undefined;
       return typeof colVal === 'string' && matchLike(colVal, String(val));
     }));
   }
 
   function makeQueryBuilder(getRows: () => Array<RowData>) {
-    let op: 'select' | 'upsert' | 'update' | 'delete' | null = null;
+    let op: 'select' | 'insert' | 'upsert' | 'update' | 'delete' | null = null;
     let payload: RowData | RowData[] | Partial<RowData> | null = null;
-    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' }> = [];
+    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }> = [];
     let isSingle = false;
+    let allowMissingSingle = false;
+    let requestedCount = false;
+    let headOnly = false;
+    let resultLimit: number | undefined;
 
     const qb = {
-      select(_fields?: string) { op = 'select'; return qb; },
+      select(_fields?: string, options?: { count?: string; head?: boolean }) {
+        if (op === null) op = 'select';
+        requestedCount = options?.count === 'exact';
+        headOnly = options?.head === true;
+        return qb;
+      },
+      insert(row: RowData | RowData[]) { op = 'insert'; payload = row; return qb; },
       upsert(row: RowData | RowData[]) { op = 'upsert'; payload = row; return qb; },
       update(obj: Partial<RowData>) { op = 'update'; payload = obj; return qb; },
       delete() { op = 'delete'; return qb; },
       eq(col: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'eq' }); return qb; },
       like(col: string, val: string) { filters.push({ col, val, type: 'like' }); return qb; },
+      not(col: string, _operator: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'not' }); return qb; },
+      order(_col: string, _options?: { ascending?: boolean }) { return qb; },
+      limit(count: number) { resultLimit = count; return qb; },
       single() { isSingle = true; return qb; },
+      maybeSingle() { isSingle = true; allowMissingSingle = true; return qb; },
       then(
-        resolve: (val: { data: RowData | RowData[] | null; error: { message: string; code?: string } | null }) => void,
+        resolve: (val: { data: RowData | RowData[] | null; error: { message: string; code?: string } | null; count?: number | null }) => void,
         reject?: (err: Error) => void,
       ) {
         Promise.resolve().then(() => {
           const rows = getRows();
           if (op === 'select') {
-            const matched = applyFilters(rows, filters);
+            let matched = applyFilters(rows, filters);
+            const count = requestedCount ? matched.length : null;
+            if (resultLimit !== undefined) matched = matched.slice(0, resultLimit);
+            if (headOnly) {
+              resolve({ data: null, error: null, count });
+              return;
+            }
             // Return deep copies so later mutations to revisitRows don't alias into returned data
             if (isSingle) {
               if (matched.length === 0) {
-                resolve({ data: null, error: { message: 'No rows', code: 'PGRST116' } });
+                resolve({
+                  data: null,
+                  error: allowMissingSingle ? null : { message: 'No rows', code: 'PGRST116' },
+                  count,
+                });
               } else {
-                resolve({ data: JSON.parse(JSON.stringify(matched[0])), error: null });
+                resolve({ data: JSON.parse(JSON.stringify(matched[0])), error: null, count });
               }
             } else {
-              resolve({ data: JSON.parse(JSON.stringify(matched)), error: null });
+              resolve({ data: JSON.parse(JSON.stringify(matched)), error: null, count });
             }
-          } else if (op === 'upsert') {
+          } else if (op === 'insert' || op === 'upsert') {
             const toUpsert = (Array.isArray(payload)
               ? payload
               : [payload]) as Array<RowData>;

--- a/src/storage/tests/primitivesSupabase.spec.ts
+++ b/src/storage/tests/primitivesSupabase.spec.ts
@@ -39,12 +39,13 @@ vi.mock('@supabase/supabase-js', () => {
 
   function applyFilters(
     rows: Array<RowData>,
-    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }>,
+    filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' | 'lt' }>,
   ): Array<RowData> {
     return rows.filter((row) => filters.every(({ col, val, type }) => {
       const colVal = getFieldValue(row, col);
       if (type === 'eq') return colVal === val;
       if (type === 'not') return colVal !== null && colVal !== undefined;
+      if (type === 'lt') return colVal !== undefined && colVal !== null && colVal < val!;
       return typeof colVal === 'string' && matchLike(colVal, String(val));
     }));
   }
@@ -52,7 +53,7 @@ vi.mock('@supabase/supabase-js', () => {
   function makeQueryBuilder(getRows: () => Array<RowData>) {
     let op: 'select' | 'insert' | 'upsert' | 'update' | 'delete' | null = null;
     let payload: RowData | RowData[] | Partial<RowData> | null = null;
-    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' }> = [];
+    const filters: Array<{ col: string; val: string | number | boolean | null; type: 'eq' | 'like' | 'not' | 'lt' }> = [];
     let isSingle = false;
     let allowMissingSingle = false;
     let requestedCount = false;
@@ -71,6 +72,7 @@ vi.mock('@supabase/supabase-js', () => {
       update(obj: Partial<RowData>) { op = 'update'; payload = obj; return qb; },
       delete() { op = 'delete'; return qb; },
       eq(col: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'eq' }); return qb; },
+      lt(col: string, val: string | number) { filters.push({ col, val, type: 'lt' }); return qb; },
       like(col: string, val: string) { filters.push({ col, val, type: 'like' }); return qb; },
       not(col: string, _operator: string, val: string | number | boolean | null) { filters.push({ col, val, type: 'not' }); return qb; },
       order(_col: string, _options?: { ascending?: boolean }) { return qb; },

--- a/src/storage/tests/primitivesSupabase.spec.ts
+++ b/src/storage/tests/primitivesSupabase.spec.ts
@@ -5,7 +5,7 @@ import { ParticipantMetadata, StudyConfig } from '../../parser/types';
 import testConfigSimple from './testConfigSimple.json';
 import { generateSequenceArray } from '../../utils/handleRandomSequences';
 import { SupabaseStorageEngine } from '../engines/SupabaseStorageEngine';
-import { StorageEngine, cleanupModes } from '../engines/types';
+import { SequenceAssignment, StorageEngine, cleanupModes } from '../engines/types';
 import { hash } from '../engines/utils/storageEngineHelpers';
 
 type RowData = Record<string, string | number | boolean | null | object>;
@@ -152,6 +152,48 @@ vi.mock('@supabase/supabase-js', () => {
     AuthError: class AuthError extends Error { },
     createClient: () => ({
       from: (_table: string) => makeQueryBuilder(() => revisitRows),
+      rpc: async (_name: string, args: {
+        p_study_id: string;
+        p_participant_id: string;
+        p_assignment: SequenceAssignment;
+      }) => {
+        const docId = `sequenceAssignment_${args.p_participant_id}`;
+        const existing = revisitRows.find(
+          (row) => row.studyId === args.p_study_id && row.docId === docId,
+        );
+        if (existing) {
+          const assignment = existing.data as SequenceAssignment;
+          return {
+            data: {
+              sequenceIndex: assignment.sequenceIndex,
+              creationIndex: assignment.creationIndex,
+            },
+            error: null,
+          };
+        }
+        const assignmentCount = revisitRows.filter(
+          (row) => row.studyId === args.p_study_id
+            && String(row.docId).startsWith('sequenceAssignment_'),
+        ).length;
+        revisitRows.push({
+          studyId: args.p_study_id,
+          docId,
+          data: {
+            ...args.p_assignment,
+            withServerTimestamp: true,
+            sequenceIndex: assignmentCount,
+            creationIndex: assignmentCount,
+          },
+          createdAt: new Date().toISOString(),
+        });
+        return {
+          data: {
+            sequenceIndex: assignmentCount,
+            creationIndex: assignmentCount,
+          },
+          error: null,
+        };
+      },
       schema: (schemaName: string) => ({
         from: (_table: string) => makeQueryBuilder(() => {
           if (schemaName === 'storage') {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -63,6 +63,11 @@ class TestStorageEngine extends StorageEngine {
 
   protected _createSequenceAssignment = vi.fn(async () => { });
 
+  protected _allocateSequenceAssignment = vi.fn(async () => ({
+    sequenceIndex: 0,
+    creationIndex: 0,
+  }));
+
   protected _getSequenceAssignment = vi.fn(async () => null);
 
   protected _updateSequenceAssignmentFields = vi.fn(async () => { });

--- a/supabase/migrations/20260730000000_allocate_sequence_assignment.sql
+++ b/supabase/migrations/20260730000000_allocate_sequence_assignment.sql
@@ -1,0 +1,204 @@
+-- Atomically reserve a participant's sequence and creation indexes in one provider call.
+-- Existing deployments can apply this migration without rewriting allocator or assignment rows;
+-- the client retains its bounded compare-and-swap fallback until the function is installed.
+create or replace function public.allocate_sequence_assignment(
+  p_study_id text,
+  p_participant_id text,
+  p_assignment jsonb
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  assignment_doc_id text := 'sequenceAssignment_' || p_participant_id;
+  allocator_data jsonb;
+  existing_assignment jsonb;
+  existing_created_at timestamptz;
+  reusable_doc_id text;
+  reusable_assignment jsonb;
+  reusable_created_at timestamptz;
+  sequence_index bigint;
+  creation_index bigint;
+  next_sequence_index bigint;
+  next_creation_index bigint;
+  total_assignments bigint;
+  claimed_assignments bigint;
+  reusable_timestamp_ms double precision;
+begin
+  -- Bound lock contention instead of allowing participant startup to wait indefinitely.
+  set local lock_timeout = '5s';
+  perform pg_advisory_xact_lock(hashtextextended(p_study_id, 0));
+
+  select data, "createdAt"
+    into existing_assignment, existing_created_at
+    from public.revisit
+   where "studyId" = p_study_id
+     and "docId" = assignment_doc_id;
+
+  if found then
+    if existing_assignment ? 'sequenceIndex'
+       and existing_assignment ? 'creationIndex' then
+      return jsonb_build_object(
+        'sequenceIndex', (existing_assignment->>'sequenceIndex')::bigint,
+        'creationIndex', (existing_assignment->>'creationIndex')::bigint
+      );
+    end if;
+
+    -- Lazy compatibility for assignments written before allocator metadata existed.
+    select count(*)
+      into sequence_index
+      from public.revisit
+     where "studyId" = p_study_id
+       and "docId" like 'sequenceAssignment\_%' escape '\'
+       and (data->>'rejected')::boolean = false
+       and (
+         case
+           when coalesce((data->>'withServerTimestamp')::boolean, false)
+             then extract(epoch from "createdAt") * 1000
+           else (data->>'timestamp')::double precision
+         end
+       ) < (
+         case
+           when coalesce((existing_assignment->>'withServerTimestamp')::boolean, false)
+             then extract(epoch from existing_created_at) * 1000
+           else (existing_assignment->>'timestamp')::double precision
+         end
+       );
+
+    select count(*)
+      into creation_index
+      from public.revisit
+     where "studyId" = p_study_id
+       and "docId" like 'sequenceAssignment\_%' escape '\'
+       and "createdAt" < existing_created_at;
+
+    return jsonb_build_object(
+      'sequenceIndex', sequence_index,
+      'creationIndex', creation_index
+    );
+  end if;
+
+  select data
+    into allocator_data
+    from public.revisit
+   where "studyId" = p_study_id
+     and "docId" = 'sequenceAllocator'
+   for update;
+
+  if not found then
+    -- Lazy allocator initialization is aggregate-only and runs under the same study lock.
+    select count(*),
+           count(*) filter (where (data->>'claimed')::boolean = true)
+      into total_assignments, claimed_assignments
+      from public.revisit
+     where "studyId" = p_study_id
+       and "docId" like 'sequenceAssignment\_%' escape '\';
+
+    allocator_data := jsonb_build_object(
+      'nextSequenceIndex', total_assignments - claimed_assignments,
+      'nextCreationIndex', total_assignments,
+      'version', 0
+    );
+  end if;
+
+  select "docId", data, "createdAt"
+    into reusable_doc_id, reusable_assignment, reusable_created_at
+    from public.revisit
+   where "studyId" = p_study_id
+     and "docId" like 'sequenceAssignment\_%' escape '\'
+     and (data->>'rejected')::boolean = true
+     and (data->>'claimed')::boolean = false
+   order by (
+     case
+       when coalesce((data->>'withServerTimestamp')::boolean, false)
+         then extract(epoch from "createdAt") * 1000
+       else (data->>'timestamp')::double precision
+     end
+   ), "createdAt"
+   limit 1
+   for update;
+
+  next_sequence_index := (allocator_data->>'nextSequenceIndex')::bigint;
+  next_creation_index := (allocator_data->>'nextCreationIndex')::bigint;
+  creation_index := next_creation_index;
+
+  if reusable_doc_id is not null then
+    reusable_timestamp_ms := case
+      when coalesce((reusable_assignment->>'withServerTimestamp')::boolean, false)
+        then extract(epoch from reusable_created_at) * 1000
+      else (reusable_assignment->>'timestamp')::double precision
+    end;
+    sequence_index := coalesce(
+      (reusable_assignment->>'reusableSequenceIndex')::bigint,
+      (reusable_assignment->>'sequenceIndex')::bigint
+    );
+    if sequence_index is null then
+      -- Lazy compatibility for rejected assignments written before stable indexes.
+      select count(*)
+        into sequence_index
+        from public.revisit
+       where "studyId" = p_study_id
+         and "docId" like 'sequenceAssignment\_%' escape '\'
+         and (data->>'rejected')::boolean = false
+         and (
+           case
+             when coalesce((data->>'withServerTimestamp')::boolean, false)
+               then extract(epoch from "createdAt") * 1000
+             else (data->>'timestamp')::double precision
+           end
+         ) < reusable_timestamp_ms;
+    end if;
+
+    update public.revisit
+       set data = reusable_assignment || jsonb_build_object(
+         'claimed', true,
+         'sequenceIndex', sequence_index
+       )
+     where "studyId" = p_study_id
+       and "docId" = reusable_doc_id;
+  else
+    sequence_index := next_sequence_index;
+    next_sequence_index := next_sequence_index + 1;
+  end if;
+
+  insert into public.revisit ("studyId", "docId", data)
+  values (
+    p_study_id,
+    assignment_doc_id,
+    jsonb_strip_nulls(p_assignment || jsonb_build_object(
+      'timestamp', case
+        when reusable_doc_id is null then p_assignment->'timestamp'
+        else to_jsonb(reusable_timestamp_ms)
+      end,
+      'withServerTimestamp', reusable_doc_id is null,
+      'claimedParticipantId', case
+        when reusable_doc_id is null then null
+        else to_jsonb(replace(reusable_doc_id, 'sequenceAssignment_', ''))
+      end,
+      'sequenceIndex', sequence_index,
+      'creationIndex', creation_index
+    ))
+  );
+
+  allocator_data := jsonb_build_object(
+    'nextSequenceIndex', next_sequence_index,
+    'nextCreationIndex', next_creation_index + 1,
+    'version', coalesce((allocator_data->>'version')::bigint, 0) + 1
+  );
+  insert into public.revisit ("studyId", "docId", data)
+  values (p_study_id, 'sequenceAllocator', allocator_data)
+  on conflict ("studyId", "docId")
+  do update set data = excluded.data;
+
+  return jsonb_build_object(
+    'sequenceIndex', sequence_index,
+    'creationIndex', creation_index
+  );
+end;
+$$;
+
+revoke all on function public.allocate_sequence_assignment(text, text, jsonb) from public;
+grant execute on function public.allocate_sequence_assignment(text, text, jsonb)
+  to anon, authenticated, service_role;

--- a/supabase/migrations/20260730000000_allocate_sequence_assignment.sql
+++ b/supabase/migrations/20260730000000_allocate_sequence_assignment.sql
@@ -175,7 +175,7 @@ begin
       'withServerTimestamp', reusable_doc_id is null,
       'claimedParticipantId', case
         when reusable_doc_id is null then null
-        else to_jsonb(replace(reusable_doc_id, 'sequenceAssignment_', ''))
+        else to_jsonb(substr(reusable_doc_id, length('sequenceAssignment_') + 1))
       end,
       'sequenceIndex', sequence_index,
       'creationIndex', creation_index


### PR DESCRIPTION
## Summary

- reserve Firebase assignments with one bounded rejected-slot query followed by one transaction, without the duplicated participant/allocator pre-reads
- retry a bounded candidate conflict so concurrent starts preserve rejected-slot reuse order without double claims
- add a single atomic Supabase `allocate_sequence_assignment` RPC that commits allocator state, reusable-slot claims, and the participant assignment together
- retain lazy legacy assignment/allocator handling and the bounded Supabase compare-and-swap fallback for deployments that have not installed the RPC yet
- document provider operation bounds, deployment requirements, and live-trace limitations

## Why

The bounded allocator from #1311 still serialized provider reads before its atomic reservation step. Firebase read participant and allocator state before reading them again in the transaction, while Supabase separately selected, claimed, reserved, and created rows. Those extra request/response cycles remained on fresh participant startup.

This change moves Supabase allocation into one database transaction and removes Firebase's duplicated document pre-read phase while preserving atomic assignment, FIFO rejected-slot reuse, legacy compatibility, bounded contention failure, and startup recovery when participant-data persistence fails after assignment.

## Stack dependency

This PR targets `dev` but is stacked on #1311 because `dev` does not yet contain the bounded allocator that #1322 optimizes. The #1322 implementation is isolated in commit `086a1c5b`; merge #1311 first so this PR's review diff collapses to the allocator round-trip changes.

## Deployment

- Apply `supabase/migrations/20260730000000_allocate_sequence_assignment.sql` before enabling the one-RPC Supabase path.
- Deploy `firestore.indexes.json` to each Firebase project so rejected candidates can be selected deterministically by assignment timestamp.

## Validation

- `yarn unittest --run` — 2,054 passed, 1 skipped
- focused storage/provider suite — 218 passed
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`
- PostgreSQL 15 migration smoke for fresh allocation, rejected reuse, returning assignment recovery, and legacy index lookup

Live before/after HAR capture was unavailable because the development environment does not have authenticated Firebase and Supabase study credentials. `SEQUENCE_ASSIGNMENT_ALLOCATION.md` records the expected provider-operation traces and the production verification still needed after deploying the migration and index.

Closes #1322.
