### PR TITLE
disable audio/screen recording if datacolleciton is disabled

### DIFF
--- a/src/components/interface/RecordingAudioWaveform.tsx
+++ b/src/components/interface/RecordingAudioWaveform.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@mantine/core';
 import { useRef, useEffect } from 'react';
+import { useStoreSelector } from '../../store/store';
 
 export function RecordingAudioWaveform({
   width = 60,
@@ -22,6 +23,8 @@ export function RecordingAudioWaveform({
   const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const animationFrameIdRef = useRef<number>(0);
   const mediaStreamRef = useRef<MediaStream | null>(null);
+  const modes = useStoreSelector((state) => state.modes);
+  const { dataCollectionEnabled } = modes;
 
   useEffect(() => {
     let lastTime = 0;
@@ -68,6 +71,10 @@ export function RecordingAudioWaveform({
     };
 
     const setupAudio = async () => {
+      if (!dataCollectionEnabled) {
+        return;
+      }
+
       const canvas = canvasRef.current;
 
       if (!canvas) {
@@ -128,7 +135,7 @@ export function RecordingAudioWaveform({
         audioContextRef.current.close();
       }
     };
-  }, [width, height, fps, fftSize, barColor, barWidth]);
+  }, [width, height, fps, fftSize, barColor, barWidth, dataCollectionEnabled]);
 
   return (
     <Flex>

--- a/src/components/interface/tests/RecordingAudioWaveform.spec.tsx
+++ b/src/components/interface/tests/RecordingAudioWaveform.spec.tsx
@@ -5,6 +5,7 @@ import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { RecordingAudioWaveform } from '../RecordingAudioWaveform';
+import type { StoreState } from '../../../store/types';
 
 // ── stubs for canvas / Web Audio API (not available in jsdom) ─────────────────
 
@@ -29,6 +30,7 @@ const mockSource = { connect: vi.fn(), disconnect: vi.fn() };
 
 const mockClose = vi.fn().mockResolvedValue(undefined);
 const mockGetUserMedia = vi.fn();
+let mockModes = { dataCollectionEnabled: true, developmentModeEnabled: false, dataSharingEnabled: false };
 
 class MockAudioContext {
   state: AudioContextState = 'running';
@@ -44,10 +46,17 @@ vi.mock('@mantine/core', () => ({
   Flex: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
+vi.mock('../../../store/store', () => ({
+  useStoreSelector: (selector: (s: StoreState) => unknown) => selector({
+    modes: mockModes,
+  } as StoreState),
+}));
+
 describe('RecordingAudioWaveform', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetUserMedia.mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] });
+    mockModes = { dataCollectionEnabled: true, developmentModeEnabled: false, dataSharingEnabled: false };
     vi.stubGlobal('AudioContext', vi.fn(MockAudioContext));
     vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
@@ -126,5 +135,13 @@ describe('RecordingAudioWaveform', () => {
     // Should render without crashing even when context is unavailable
     const { container } = await act(async () => render(<RecordingAudioWaveform />));
     expect(container.querySelector('canvas')).not.toBeNull();
+  });
+
+  test('does not call getUserMedia when data collection is disabled', async () => {
+    mockModes = { ...mockModes, dataCollectionEnabled: false };
+    await act(async () => {
+      render(<RecordingAudioWaveform width={60} height={36} fps={30} />);
+    });
+    expect(mockGetUserMedia).not.toHaveBeenCalled();
   });
 });

--- a/src/public/libraries/mic-check/assets/AudioTest.tsx
+++ b/src/public/libraries/mic-check/assets/AudioTest.tsx
@@ -5,10 +5,24 @@ import {
   useEffect,
 } from 'react';
 import { StimulusParams } from '../../../../store/types';
+import { useStoreSelector } from '../../../../store/store';
 import { RecordingAudioWaveform } from '../../../../components/interface/RecordingAudioWaveform';
 
 export function AudioTest({ setAnswer }: StimulusParams<undefined>) {
+  const { dataCollectionEnabled } = useStoreSelector((state) => state.modes);
   useEffect(() => {
+    if (!dataCollectionEnabled) {
+      setAnswer({
+        status: true,
+        answers: {
+          audioTest: true,
+        },
+      });
+      return;
+    }
+
+    setAnswer({ status: false, answers: {} });
+
     const _stream = navigator.mediaDevices.getUserMedia({
       audio: true,
     });
@@ -45,6 +59,7 @@ export function AudioTest({ setAnswer }: StimulusParams<undefined>) {
                 audioTest: true,
               },
             });
+            break;
           }
         }
 

--- a/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
+++ b/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { useRecordingContext } from '../../../../store/hooks/useRecording';
 import { StimulusParams } from '../../../../store/types';
 import { RecordingAudioWaveform } from '../../../../components/interface/RecordingAudioWaveform';
+import { useStoreSelector } from "../../../../store/store";
 
 function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
   const {
@@ -19,8 +20,18 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
 
   // audioCapturingSuccess is set to true when we detect sound.
   const [audioCapturingSuccess, setAudioCapturingSuccess] = useState(false);
+  const { dataCollectionEnabled } = useStoreSelector((state) => state.modes);
 
   useEffect(() => {
+    if (!dataCollectionEnabled) {
+      setAnswer({
+        status: true,
+        answers: {
+          audioTest: true,
+        },
+      });
+      return;
+    }
     setAnswer({
       status: screenCapturing && (studyHasAudioRecording ? audioCapturingSuccess : true),
       answers: {
@@ -102,7 +113,10 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
               <strong>Click the button below</strong>
               {' '}
               to enable screen and audio recording.
-              <Button type="button" onClick={screenCapturing ? stopCapture : startCapture} display="block" mt="sm">
+              <Button type="button"
+                      onClick={screenCapturing ? stopCapture : startCapture}
+                      disabled={!dataCollectionEnabled}
+                      display="block" mt="sm">
                 {screenCapturing ? 'Stop Recording' : 'Start Recording'}
               </Button>
               <video
@@ -146,7 +160,10 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
           <strong>Click the button below</strong>
           {' '}
           to enable screen recording.
-          <Button type="button" onClick={screenCapturing ? stopCapture : startCapture} display="block" mt="sm">
+          <Button type="button"
+                  onClick={screenCapturing ? stopCapture : startCapture}
+                  disabled={!dataCollectionEnabled}
+                  display="block" mt="sm">
             {screenCapturing ? 'Stop Recording' : 'Start Recording'}
           </Button>
           <video

--- a/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
+++ b/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
@@ -38,7 +38,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
         screenRecordingPermission: screenCapturing,
       },
     });
-  }, [screenCapturing, audioCapturingSuccess, setAnswer, studyHasAudioRecording]);
+  }, [screenCapturing, audioCapturingSuccess, setAnswer, studyHasAudioRecording, dataCollectionEnabled]);
 
   useEffect(() => {
     if (!screenCapturing) {
@@ -113,7 +113,13 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
               <strong>Click the button below</strong>
               {' '}
               to enable screen and audio recording.
-              <Button type="button" onClick={screenCapturing ? stopCapture : startCapture} display="block" mt="sm">
+              <Button
+                type="button"
+                onClick={screenCapturing ? stopCapture : startCapture}
+                disabled={!dataCollectionEnabled}
+                display="block"
+                mt="sm"
+              >
                 {screenCapturing ? 'Stop Recording' : 'Start Recording'}
               </Button>
               <video

--- a/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
+++ b/src/public/libraries/screen-recording/assets/ScreenRecording.tsx
@@ -27,7 +27,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
       setAnswer({
         status: true,
         answers: {
-          audioTest: true,
+          screenRecordingPermission: true,
         },
       });
       return;
@@ -113,10 +113,7 @@ function ScreenRecordingPermission({ setAnswer }: StimulusParams<undefined>) {
               <strong>Click the button below</strong>
               {' '}
               to enable screen and audio recording.
-              <Button type="button"
-                      onClick={screenCapturing ? stopCapture : startCapture}
-                      disabled={!dataCollectionEnabled}
-                      display="block" mt="sm">
+              <Button type="button" onClick={screenCapturing ? stopCapture : startCapture} display="block" mt="sm">
                 {screenCapturing ? 'Stop Recording' : 'Start Recording'}
               </Button>
               <video

--- a/src/store/hooks/tests/useRecording.spec.ts
+++ b/src/store/hooks/tests/useRecording.spec.ts
@@ -5,6 +5,7 @@ import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { useRecording, useRecordingContext } from '../useRecording';
+import type { StoreState } from '../../types';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -18,6 +19,7 @@ let mockRecordingConfig = {
 let mockCurrentComponent = 'intro';
 let mockStorageEngine: Record<string, ReturnType<typeof vi.fn>> | null = null;
 let mockStoredAnswer: { endTime: number } | null = null;
+let mockModes = { dataCollectionEnabled: true, developmentModeEnabled: false, dataSharingEnabled: false };
 
 // ── media mocks ────────────────────────────────────────────────────────────────
 
@@ -99,6 +101,12 @@ vi.mock('../useIsAnalysis', () => ({
   useIsAnalysis: () => false,
 }));
 
+vi.mock('../../store', () => ({
+  useStoreSelector: (selector: (s: StoreState) => unknown) => selector({
+    modes: mockModes,
+  } as StoreState),
+}));
+
 // ── lifecycle ──────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -112,6 +120,7 @@ beforeEach(() => {
   mockCurrentComponent = 'intro';
   mockStorageEngine = null;
   mockStoredAnswer = null;
+  mockModes = { dataCollectionEnabled: true, developmentModeEnabled: false, dataSharingEnabled: false };
 
   vi.stubGlobal('MediaStream', MockMediaStream);
   vi.stubGlobal('MediaRecorder', MockMediaRecorder);
@@ -444,5 +453,52 @@ describe('useRecording isRejected effect', () => {
 describe('useRecordingContext', () => {
   test('throws when used outside RecordingProvider', () => {
     expect(() => { renderHook(() => useRecordingContext()); }).toThrow('useRecordingContext must be used within a RecordingProvider');
+  });
+});
+
+// ── DataCollection disabled tests ────────────────────────────────────────────────────────
+
+describe('useRecording with data collection disabled', () => {
+  test('does not call getUserMedia/recorder/storage via audio recording', async () => {
+    mockModes = { ...mockModes, dataCollectionEnabled: false };
+    mockRecordingConfig = {
+      ...mockRecordingConfig,
+      studyHasAudioRecording: true,
+      currentComponentHasAudioRecording: true,
+    };
+    mockStorageEngine = {
+      saveAudioRecording: vi.fn(async () => {}),
+      saveScreenRecording: vi.fn(async () => {}),
+    };
+
+    const { result } = renderHook(() => useRecording());
+    await act(async () => { /* let effects settle */ });
+
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(mockStorageEngine.saveAudioRecording).not.toHaveBeenCalled();
+    expect(result.current.isAudioRecording).toBe(false);
+  });
+
+  test('does not call getUserMedia/getDisplayMedia/recorder/storage via startScreenCapture', async () => {
+    mockModes = { ...mockModes, dataCollectionEnabled: false };
+    mockRecordingConfig = {
+      ...mockRecordingConfig,
+      studyHasScreenRecording: true,
+      studyHasAudioRecording: true,
+      currentComponentHasScreenRecording: true,
+      currentComponentHasAudioRecording: true,
+    };
+    mockStorageEngine = {
+      saveAudioRecording: vi.fn(async () => {}),
+      saveScreenRecording: vi.fn(async () => {}),
+    };
+
+    const { result } = renderHook(() => useRecording());
+    act(() => { result.current.startScreenCapture(); });
+    await act(async () => { /* let effects settle */ });
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(mockStorageEngine.saveAudioRecording).not.toHaveBeenCalled();
+    expect(mockStorageEngine.saveScreenRecording).not.toHaveBeenCalled();
+    expect(result.current.isAudioCapturing).toBe(false);
   });
 });

--- a/src/store/hooks/tests/useRecording.spec.ts
+++ b/src/store/hooks/tests/useRecording.spec.ts
@@ -5,6 +5,7 @@ import {
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
+import { MantineProvider } from '@mantine/core';
 import * as recordingHooks from '../useRecording';
 import { useRecording, useRecordingContext } from '../useRecording';
 import type { StoreState } from '../../types';
@@ -70,6 +71,26 @@ class MockMediaRecorder {
   triggerEvent(event: string, data?: Blob) {
     this._listeners[event]?.({ data });
   }
+}
+
+vi.hoisted(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+function renderWithMantine(ui: React.ReactElement) {
+  return render(React.createElement(MantineProvider, null, ui));
 }
 
 // ── module mocks ───────────────────────────────────────────────────────────────
@@ -572,12 +593,14 @@ describe('ScreenRecordingPermission component', () => {
       audioMediaStream: { current: null },
     } as unknown as ReturnType<typeof recordingHooks.useRecordingContext>);
 
-    render(React.createElement(ScreenRecordingPermission, {
-      setAnswer: vi.fn(),
-      parameters: undefined,
-      answers: {},
-      useTrrack: vi.fn(),
-    } as React.ComponentProps<typeof ScreenRecordingPermission>));
+    renderWithMantine(
+      React.createElement(ScreenRecordingPermission, {
+        setAnswer: vi.fn(),
+        parameters: undefined,
+        answers: {},
+        useTrrack: vi.fn(),
+      } as React.ComponentProps<typeof ScreenRecordingPermission>),
+    );
 
     const button = screen.getByRole('button', { name: 'Start Recording' });
     expect((button as HTMLButtonElement).disabled).toBe(true);
@@ -600,12 +623,14 @@ describe('ScreenRecordingPermission component', () => {
       audioMediaStream: { current: null },
     } as unknown as ReturnType<typeof recordingHooks.useRecordingContext>);
 
-    render(React.createElement(ScreenRecordingPermission, {
-      setAnswer: vi.fn(),
-      parameters: undefined,
-      answers: {},
-      useTrrack: vi.fn(),
-    } as React.ComponentProps<typeof ScreenRecordingPermission>));
+    renderWithMantine(
+      React.createElement(ScreenRecordingPermission, {
+        setAnswer: vi.fn(),
+        parameters: undefined,
+        answers: {},
+        useTrrack: vi.fn(),
+      } as React.ComponentProps<typeof ScreenRecordingPermission>),
+    );
 
     const button = screen.getByRole('button', { name: 'Start Recording' });
     expect((button as HTMLButtonElement).disabled).toBe(true);

--- a/src/store/hooks/tests/useRecording.spec.ts
+++ b/src/store/hooks/tests/useRecording.spec.ts
@@ -1,11 +1,14 @@
+import React from 'react';
 import {
-  renderHook, act, cleanup, waitFor,
+  renderHook, act, cleanup, waitFor, render, screen, fireEvent,
 } from '@testing-library/react';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
+import * as recordingHooks from '../useRecording';
 import { useRecording, useRecordingContext } from '../useRecording';
 import type { StoreState } from '../../types';
+import ScreenRecordingPermission from '../../../public/libraries/screen-recording/assets/ScreenRecording';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -493,12 +496,121 @@ describe('useRecording with data collection disabled', () => {
       saveScreenRecording: vi.fn(async () => {}),
     };
 
-    const { result } = renderHook(() => useRecording());
+    const MediaRecorderSpy = vi.spyOn(globalThis as never, 'MediaRecorder');
+    const originalTitle = document.title;
+    const { result, rerender } = renderHook(() => useRecording());
+
     act(() => { result.current.startScreenCapture(); });
-    await act(async () => { /* let effects settle */ });
+    await act(async () => { /* noop */ });
+
+    expect(navigator.mediaDevices.getDisplayMedia).not.toHaveBeenCalled();
     expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+
+    expect(MediaRecorderSpy).not.toHaveBeenCalled();
+
     expect(mockStorageEngine.saveAudioRecording).not.toHaveBeenCalled();
     expect(mockStorageEngine.saveScreenRecording).not.toHaveBeenCalled();
+
+    expect(result.current.isScreenCapturing).toBe(false);
     expect(result.current.isAudioCapturing).toBe(false);
+    expect(result.current.isMediaCapturing).toBe(false);
+
+    expect(document.title).toBe(originalTitle);
+
+    mockCurrentComponent = 'end';
+    rerender();
+    expect(result.current.isRejected).toBe(false);
+  });
+
+  test('startScreenCapture is a no-op when dataCollectionEnabled is false (does not change title, capturing flags, or set isRejected)', async () => {
+    mockModes = { ...mockModes, dataCollectionEnabled: false };
+    mockRecordingConfig = {
+      ...mockRecordingConfig,
+      studyHasScreenRecording: true,
+      studyHasAudioRecording: true,
+      currentComponentHasScreenRecording: true,
+      currentComponentHasAudioRecording: true,
+    };
+    mockStorageEngine = {
+      saveAudioRecording: vi.fn(async () => {}),
+      saveScreenRecording: vi.fn(async () => {}),
+    };
+
+    const originalTitle = document.title;
+    const { result, rerender } = renderHook(() => useRecording());
+
+    act(() => { result.current.startScreenCapture(); });
+    await act(async () => { /* noop */ });
+
+    expect(navigator.mediaDevices.getDisplayMedia).not.toHaveBeenCalled();
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+
+    expect(result.current.isScreenCapturing).toBe(false);
+    expect(result.current.isAudioCapturing).toBe(false);
+    expect(result.current.isMediaCapturing).toBe(false);
+
+    expect(document.title).toBe(originalTitle);
+
+    mockCurrentComponent = 'end';
+    rerender();
+    expect(result.current.isRejected).toBe(false);
+  });
+});
+
+describe('ScreenRecordingPermission component', () => {
+  test('screen-only button is disabled when data collection is off', () => {
+    mockModes = { ...mockModes, dataCollectionEnabled: false };
+    const startScreenCapture = vi.fn();
+    const stopScreenCapture = vi.fn();
+    vi.spyOn(recordingHooks, 'useRecordingContext').mockReturnValue({
+      studyHasAudioRecording: false,
+      recordVideoRef: { current: null },
+      startScreenCapture,
+      stopScreenCapture,
+      isScreenCapturing: false,
+      isAudioCapturing: false,
+      audioMediaStream: { current: null },
+    } as unknown as ReturnType<typeof recordingHooks.useRecordingContext>);
+
+    render(React.createElement(ScreenRecordingPermission, {
+      setAnswer: vi.fn(),
+      parameters: undefined,
+      answers: {},
+      useTrrack: vi.fn(),
+    } as React.ComponentProps<typeof ScreenRecordingPermission>));
+
+    const button = screen.getByRole('button', { name: 'Start Recording' });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(button);
+    expect(startScreenCapture).not.toHaveBeenCalled();
+    expect(stopScreenCapture).not.toHaveBeenCalled();
+  });
+
+  test('combined screen-and-audio button is disabled when data collection is off', () => {
+    mockModes = { ...mockModes, dataCollectionEnabled: false };
+    const startScreenCapture = vi.fn();
+    const stopScreenCapture = vi.fn();
+    vi.spyOn(recordingHooks, 'useRecordingContext').mockReturnValue({
+      studyHasAudioRecording: true,
+      recordVideoRef: { current: null },
+      startScreenCapture,
+      stopScreenCapture,
+      isScreenCapturing: false,
+      isAudioCapturing: false,
+      audioMediaStream: { current: null },
+    } as unknown as ReturnType<typeof recordingHooks.useRecordingContext>);
+
+    render(React.createElement(ScreenRecordingPermission, {
+      setAnswer: vi.fn(),
+      parameters: undefined,
+      answers: {},
+      useTrrack: vi.fn(),
+    } as React.ComponentProps<typeof ScreenRecordingPermission>));
+
+    const button = screen.getByRole('button', { name: 'Start Recording' });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(button);
+    expect(startScreenCapture).not.toHaveBeenCalled();
+    expect(stopScreenCapture).not.toHaveBeenCalled();
   });
 });

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -359,6 +359,8 @@ export function useRecording() {
 
   // Start screen capture. This does not begin recording.
   const startScreenCapture = useCallback(() => {
+    if (!dataCollectionEnabled) return;
+
     const captureFn = async () => {
       document.title = `RECORD THIS TAB: ${pageTitle}`;
 
@@ -366,7 +368,7 @@ export function useRecording() {
         setRecordingError(null);
         setAudioRecordingError(null);
 
-        const screenStream = (studyHasScreenRecording && dataCollectionEnabled) ? await navigator.mediaDevices.getDisplayMedia({
+        const screenStream = (studyHasScreenRecording) ? await navigator.mediaDevices.getDisplayMedia({
           video: { displaySurface: 'browser', ...(recordScreenFPS ? { frameRate: { ideal: recordScreenFPS } } : {}) },
           audio: false,
           // @ts-expect-error: experimental (selfBrowserSurface and preferCurrentTab are not yet standardized)

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -13,6 +13,7 @@ import {
   shouldMonitorMutedAudio,
   SPEECH_DETECTION_HOLD_MS,
 } from '../../utils/recordingWarnings';
+import { useStoreSelector } from '../store';
 
 /**
  * Captures and records the screen and audio.
@@ -40,6 +41,7 @@ export function useRecording() {
   const [isSpeakingWhileMuted, setIsSpeakingWhileMuted] = useState(false);
   const [analysisStreamReady, setAnalysisStreamReady] = useState(false);
   const [showMutedWarning, setShowMutedWarning] = useState(false);
+  const modes = useStoreSelector((state) => state.modes);
 
   // currentMediaStream and recorder can be just screen, just audio, or screen and audio combined.
   const currentMediaStream = useRef<MediaStream>(null);
@@ -54,6 +56,8 @@ export function useRecording() {
   const isAnalysis = useIsAnalysis();
 
   const { storageEngine } = useStorageEngine();
+
+  const { dataCollectionEnabled } = modes;
 
   const currentComponent = useCurrentComponent();
 
@@ -125,8 +129,11 @@ export function useRecording() {
 
   // Start screen recording
   const startScreenRecording = useCallback((trialName: string) => {
-    // check if the current stimulus needs combined or just screen
+    if (!dataCollectionEnabled) {
+      return;
+    }
 
+    // check if the current stimulus needs combined or just screen
     if (!(currentComponentHasAudioRecording || currentComponentHasScreenRecording)) {
       return;
     }
@@ -248,6 +255,10 @@ export function useRecording() {
   }, [currentComponent, isScreenCapturing, screenCaptureStarted]);
 
   const startAudioRecording = useCallback((trialName: string) => {
+    if (!dataCollectionEnabled) {
+      return;
+    }
+
     navigator.mediaDevices.getUserMedia({
       audio: true,
     }).then((s) => {
@@ -295,7 +306,7 @@ export function useRecording() {
       setAudioRecordingError('Microphone permission denied');
       setIsAudioRecording(false);
     });
-  }, [storageEngine, isMuted]);
+  }, [dataCollectionEnabled, isMuted, storageEngine]);
 
   // For study with just audio recording
   useEffect(() => {
@@ -355,7 +366,7 @@ export function useRecording() {
         setRecordingError(null);
         setAudioRecordingError(null);
 
-        const screenStream = studyHasScreenRecording ? await navigator.mediaDevices.getDisplayMedia({
+        const screenStream = (studyHasScreenRecording && dataCollectionEnabled) ? await navigator.mediaDevices.getDisplayMedia({
           video: { displaySurface: 'browser', ...(recordScreenFPS ? { frameRate: { ideal: recordScreenFPS } } : {}) },
           audio: false,
           // @ts-expect-error: experimental (selfBrowserSurface and preferCurrentTab are not yet standardized)
@@ -367,7 +378,7 @@ export function useRecording() {
         screenMediaStream.current = screenStream;
 
         let micStream: MediaStream | null = null;
-        if (studyHasAudioRecording) {
+        if (studyHasAudioRecording && dataCollectionEnabled) {
           try {
             micStream = await navigator.mediaDevices.getUserMedia({
               audio: true,
@@ -418,7 +429,7 @@ export function useRecording() {
       }
     };
     captureFn();
-  }, [pageTitle, recordAudio, recordScreenFPS, stopScreenCapture, studyHasAudioRecording, studyHasScreenRecording]);
+  }, [pageTitle, recordAudio, recordScreenFPS, stopScreenCapture, studyHasAudioRecording, studyHasScreenRecording, dataCollectionEnabled]);
 
   useEffect(() => {
     audioMediaStream.current?.getAudioTracks().forEach((track) => {

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -482,6 +482,11 @@ export function useAreResponsesValid(id: string) {
     if (id.includes('reviewer-')) {
       return true;
     }
+
+    if (!state.trialValidation[id]) {
+      return false;
+    }
+
     const valid = !(state.trialValidation[id]) ? true : Object.values(state.trialValidation[id]).every((x) => {
       if (typeof x === 'object' && 'valid' in x) {
         return x.valid;

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -482,11 +482,6 @@ export function useAreResponsesValid(id: string) {
     if (id.includes('reviewer-')) {
       return true;
     }
-
-    if (!state.trialValidation[id]) {
-      return false;
-    }
-
     const valid = !(state.trialValidation[id]) ? true : Object.values(state.trialValidation[id]).every((x) => {
       if (typeof x === 'object' && 'valid' in x) {
         return x.valid;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1183 .

### Give a longer description of what this PR addresses and why it's needed
When data collection is turned off the audio recording seemed to still be happening, now we escape before recording or any visual indication for it is triggered and we can proceed without needing to use the recording.  In the case of screen recording you couldn't proceed because of errors and recording had to be started, now the start recording button is disabled so no accidental data collection is started. If data collection is enabled the behavior should be the same as before.

Also there is a small hotfix: when the permissions for the audio is not given but instead the site is reloaded the user could bypass the required answer and continue without audio, now there will be an error if audio is required and no permission has been granted as it should be.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
<img width="1911" height="846" alt="image" src="https://github.com/user-attachments/assets/f1bd0de3-8093-4d1f-86a7-c7706d20417a" />
<img width="1911" height="846" alt="image" src="https://github.com/user-attachments/assets/e4e79098-bd26-4b1a-9e91-d2020e56dc95" />


Now:
<img width="1911" height="846" alt="image" src="https://github.com/user-attachments/assets/f1b1f90e-0037-49f9-8ab7-7c41d15c4e3e" />
<img width="1911" height="846" alt="image" src="https://github.com/user-attachments/assets/c1598cfd-dbd7-42fb-bcff-70c02c34a368" />

