### PR TITLE
Compress discontinuous participant timeline gaps

### DIFF
--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -9,7 +9,7 @@ import { useResizeObserver } from '@mantine/hooks';
 import { ParticipantData } from '../../../storage/types';
 import { SingleTaskLabelLines } from './SingleTaskLabelLines';
 import { SingleTask } from './SingleTask';
-import { StudyConfig } from '../../../parser/types';
+import { StoredAnswer, StudyConfig } from '../../../parser/types';
 import { getComponentAnswerStatus } from '../../../utils/correctAnswer';
 import { parseConditionParam } from '../../../utils/handleConditionLogic';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
@@ -19,9 +19,12 @@ import {
   ReplayTaskOrder,
 } from './taskOrdering';
 import {
+  getGapAwareTimelineLayout,
   getUniformTimelineMetrics,
+  isValidTimelineInterval,
   TimelineMode,
 } from './timelineLayout';
+import { youtubeReadableDuration } from '../../../utils/humanReadableDuration';
 
 const LABEL_GAP = 25;
 const CHARACTER_SIZE = 8;
@@ -29,6 +32,16 @@ const CHARACTER_SIZE = 8;
 const margin = {
   left: 20, top: 20, right: 20, bottom: 20,
 };
+
+function invalidTimelineAnchor(answer: Pick<StoredAnswer, 'startTime' | 'endTime'>, xScale: d3.ScaleLinear<number, number>) {
+  if (Number.isFinite(answer.startTime) && answer.startTime > 0) {
+    return answer.startTime;
+  }
+  if (Number.isFinite(answer.endTime) && answer.endTime > 0) {
+    return answer.endTime;
+  }
+  return xScale.domain()[0];
+}
 
 export function AllTasksTimeline({
   participantData, width, studyId, studyConfig, maxLength, taskOrder = 'sequence', timelineMode = 'time',
@@ -59,25 +72,38 @@ export function AllTasksTimeline({
     }).timelineWidth;
   }, [availableWidth, participantData.answers, timelineMode]);
 
-  const xScale = useMemo(() => {
+  const { xScale, collapsedGaps, completedTimelineEnd } = useMemo(() => {
     if (timelineMode === 'uniform') {
-      return d3.scaleLinear([margin.left, timelineWidth - margin.right]).domain([0, Math.max(Object.entries(participantData.answers || {}).length, 1)]).clamp(true);
+      return {
+        xScale: d3.scaleLinear([margin.left, timelineWidth - margin.right]).domain([0, Math.max(Object.entries(participantData.answers || {}).length, 1)]).clamp(true),
+        collapsedGaps: [],
+        completedTimelineEnd: timelineWidth - margin.right,
+      };
     }
 
-    const allStartTimes = Object.values(participantData.answers || {}).filter((answer) => answer.startTime).map((answer) => [answer.startTime, answer.endTime]).flat();
-
-    const extent = d3.extent(allStartTimes) as [number, number];
-
-    const scale = d3.scaleLinear([margin.left, (timelineWidth * percentComplete - (percentComplete !== 1 ? 0 : margin.right))]).domain([extent[0], maxLength ? extent[0] + maxLength : extent[1]]).clamp(true);
-
-    return scale;
+    const layout = getGapAwareTimelineLayout({
+      answers: participantData.answers || {},
+      rangeStart: margin.left,
+      rangeEnd: timelineWidth * percentComplete - (percentComplete !== 1 ? 0 : margin.right),
+      maxLength,
+    });
+    return { xScale: layout.scale, collapsedGaps: layout.collapsedGaps, completedTimelineEnd: layout.rangeEnd };
   }, [maxLength, participantData.answers, percentComplete, timelineMode, timelineWidth]);
 
+  const renderedTimelineWidth = useMemo(() => {
+    if (timelineMode === 'uniform') {
+      return timelineWidth;
+    }
+    const originalCompletedEnd = timelineWidth * percentComplete - (percentComplete !== 1 ? 0 : margin.right);
+    const incompleteWidth = Math.max(0, timelineWidth - margin.right - originalCompletedEnd);
+    return Math.max(timelineWidth, completedTimelineEnd + incompleteWidth + margin.right);
+  }, [completedTimelineEnd, percentComplete, timelineMode, timelineWidth]);
+
   const incompleteXScale = useMemo(() => {
-    const scale = d3.scaleLinear([timelineWidth * percentComplete, timelineWidth - margin.right]).domain([0, Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).length]).clamp(true);
+    const scale = d3.scaleLinear([completedTimelineEnd, renderedTimelineWidth - margin.right]).domain([0, Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).length]).clamp(true);
 
     return scale;
-  }, [participantData.answers, percentComplete, timelineWidth]);
+  }, [completedTimelineEnd, participantData.answers, renderedTimelineWidth]);
 
   const maxHeight = useMemo(() => {
     const incompleteEntries = Object.entries(participantData.answers || {}).filter((e) => e[1].startTime === 0).sort(compareReplayAnswerEntries);
@@ -93,10 +119,18 @@ export function AllTasksTimeline({
 
       // Check if the previous entry overlaps with the current entry
       const prev = i > 0 ? sortedEntries[i - currentHeight - 1] : null;
-      const prevScale = timelineMode === 'uniform' || (prev && prev[1].startTime) ? xScale : incompleteXScale;
-      const prevStart = prev ? timelineMode === 'uniform' ? entryIndexes.get(prev[0]) ?? 0 : prev[1].startTime ? prev[1].startTime : incompleteEntryIndexes.get(prev[0]) ?? 0 : 0;
+      const prevScale = timelineMode === 'uniform' || (prev && prev[1].startTime !== 0) ? xScale : incompleteXScale;
+      const prevStart = prev ? timelineMode === 'uniform'
+        ? entryIndexes.get(prev[0]) ?? 0
+        : prev[1].startTime === 0
+          ? incompleteEntryIndexes.get(prev[0]) ?? 0
+          : isValidTimelineInterval(prev[1]) ? prev[1].startTime : invalidTimelineAnchor(prev[1], xScale) : 0;
       const scale = timelineMode === 'uniform' || answer.startTime !== 0 ? xScale : incompleteXScale;
-      const scaleStart = timelineMode === 'uniform' ? entryIndexes.get(identifier) ?? 0 : answer.startTime ? answer.startTime : incompleteEntryIndexes.get(identifier) ?? 0;
+      const scaleStart = timelineMode === 'uniform'
+        ? entryIndexes.get(identifier) ?? 0
+        : answer.startTime === 0
+          ? incompleteEntryIndexes.get(identifier) ?? 0
+          : isValidTimelineInterval(answer) ? answer.startTime : invalidTimelineAnchor(answer, xScale);
 
       // If the previous entry overlaps with the current entry , increase the height
       if (prev && prev[0].length * (CHARACTER_SIZE + 1) + prevScale(prevStart) > scale(scaleStart)) {
@@ -134,12 +168,21 @@ export function AllTasksTimeline({
 
       const prev = i > 0 ? combined[i - currentHeight - 1] : null;
 
-      const prevScale = timelineMode === 'uniform' || (prev && prev[1].startTime) ? xScale : incompleteXScale;
-      const prevStart = prev ? timelineMode === 'uniform' ? entryIndexes.get(prev[0]) ?? 0 : prev[1].startTime ? prev[1].startTime : incompleteEntryIndexes.get(prev[0]) ?? 0 : 0;
+      const prevScale = timelineMode === 'uniform' || (prev && prev[1].startTime !== 0) ? xScale : incompleteXScale;
+      const prevStart = prev ? timelineMode === 'uniform'
+        ? entryIndexes.get(prev[0]) ?? 0
+        : prev[1].startTime === 0
+          ? incompleteEntryIndexes.get(prev[0]) ?? 0
+          : isValidTimelineInterval(prev[1]) ? prev[1].startTime : invalidTimelineAnchor(prev[1], xScale) : 0;
       const incompleteEntryIndex = incompleteEntryIndexes.get(identifier) ?? 0;
       const uniformEntryIndex = entryIndexes.get(identifier) ?? 0;
-      const scaleStart = timelineMode === 'uniform' ? uniformEntryIndex : answer.startTime ? answer.startTime : incompleteEntryIndex;
-      const scaleEnd = timelineMode === 'uniform' ? uniformEntryIndex + 1 : answer.endTime > 0 ? answer.endTime : incompleteEntryIndex + 1;
+      const hasValidTiming = isValidTimelineInterval(answer);
+      const scaleStart = timelineMode === 'uniform'
+        ? uniformEntryIndex
+        : answer.startTime === 0 ? incompleteEntryIndex : hasValidTiming ? answer.startTime : invalidTimelineAnchor(answer, xScale);
+      const scaleEnd = timelineMode === 'uniform'
+        ? uniformEntryIndex + 1
+        : answer.startTime === 0 ? incompleteEntryIndex + 1 : hasValidTiming ? answer.endTime : scaleStart;
 
       if (prev && prev[0].length * (CHARACTER_SIZE + 1) + prevScale(prevStart) > scale(scaleStart)) {
         currentHeight += 1;
@@ -240,7 +283,7 @@ export function AllTasksTimeline({
         width: '100%',
         maxWidth: '100%',
         minWidth: 0,
-        overflowX: timelineMode === 'uniform' ? 'auto' : 'visible',
+        overflowX: timelineMode === 'uniform' || renderedTimelineWidth > availableWidth ? 'auto' : 'visible',
         overflowY: 'visible',
       }}
     >
@@ -249,7 +292,7 @@ export function AllTasksTimeline({
         onPointerLeave={() => setHoveredTaskIdentifier(null)}
         onPointerCancel={() => setHoveredTaskIdentifier(null)}
         style={{
-          width: timelineWidth,
+          width: renderedTimelineWidth,
           height: maxHeight,
           display: 'block',
           overflow: 'visible',
@@ -258,6 +301,18 @@ export function AllTasksTimeline({
         {tasks.map((t) => t.line)}
         {tasks.filter((t) => t.identifier !== hoveredTaskIdentifier).map((t) => t.label)}
         {browsedAway}
+        {collapsedGaps.map((gap) => {
+          const label = `${youtubeReadableDuration(gap.duration)} gap — no component timing recorded`;
+          return (
+            <Tooltip withinPortal key={`${gap.startTime}-${gap.endTime}`} label={label}>
+              <g data-testid="timeline-gap-break" aria-label={label}>
+                <rect x={gap.startX} width={gap.endX - gap.startX} y={maxHeight - 25} height={25} fill="whitesmoke" />
+                <line x1={gap.startX + 3} x2={gap.startX + 7} y1={maxHeight - 7} y2={maxHeight - 18} stroke="gray" strokeWidth={2} />
+                <line x1={gap.startX + 9} x2={gap.startX + 13} y1={maxHeight - 7} y2={maxHeight - 18} stroke="gray" strokeWidth={2} />
+              </g>
+            </Tooltip>
+          );
+        })}
         {hoveredTask?.label}
       </svg>
     </Box>

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -24,7 +24,6 @@ import {
   isValidTimelineInterval,
   TimelineMode,
 } from './timelineLayout';
-import { youtubeReadableDuration } from '../../../utils/humanReadableDuration';
 
 const LABEL_GAP = 25;
 const CHARACTER_SIZE = 8;
@@ -41,6 +40,24 @@ function invalidTimelineAnchor(answer: Pick<StoredAnswer, 'startTime' | 'endTime
     return answer.endTime;
   }
   return xScale.domain()[0];
+}
+
+function readableGapDuration(msDuration: number) {
+  let secondsRemaining = Math.floor(msDuration / 1000);
+  const units = [
+    ['d', 86_400],
+    ['h', 3_600],
+    ['m', 60],
+    ['s', 1],
+  ] as const;
+
+  const parts = units.flatMap(([label, seconds]) => {
+    const value = Math.floor(secondsRemaining / seconds);
+    secondsRemaining %= seconds;
+    return value > 0 ? [`${value}${label}`] : [];
+  });
+
+  return parts.join(' ') || '0s';
 }
 
 export function AllTasksTimeline({
@@ -302,7 +319,7 @@ export function AllTasksTimeline({
         {tasks.filter((t) => t.identifier !== hoveredTaskIdentifier).map((t) => t.label)}
         {browsedAway}
         {collapsedGaps.map((gap) => {
-          const label = `${youtubeReadableDuration(gap.duration)} gap — no component timing recorded`;
+          const label = `${readableGapDuration(gap.duration)} gap — no component timing recorded`;
           return (
             <Tooltip withinPortal key={`${gap.startTime}-${gap.endTime}`} label={label}>
               <g data-testid="timeline-gap-break" aria-label={label}>

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -321,10 +321,10 @@ export function AllTasksTimeline({
           return (
             <Tooltip withinPortal key={`${gap.startTime}-${gap.endTime}`} label={label}>
               <g data-testid="timeline-gap-break" aria-label={label}>
-                <rect x={gap.startX} width={gap.endX - gap.startX} y={0} height={maxHeight} fill="var(--mantine-color-orange-1)" />
-                <line x1={gap.startX} x2={gap.startX} y1={0} y2={maxHeight} stroke="var(--mantine-color-orange-7)" strokeDasharray="3 2" />
-                <line x1={gap.endX} x2={gap.endX} y1={0} y2={maxHeight} stroke="var(--mantine-color-orange-7)" strokeDasharray="3 2" />
-                <text x={midpoint} y={maxHeight / 2} textAnchor="middle" dominantBaseline="middle" fontSize={12} fontWeight={700} fill="var(--mantine-color-orange-9)">&#47;&#47;</text>
+                <rect x={gap.startX} width={gap.endX - gap.startX} y={maxHeight - 25} height={25} fill="var(--mantine-color-orange-1)" />
+                <line x1={gap.startX} x2={gap.startX} y1={maxHeight - 25} y2={maxHeight} stroke="var(--mantine-color-orange-7)" strokeDasharray="3 2" />
+                <line x1={gap.endX} x2={gap.endX} y1={maxHeight - 25} y2={maxHeight} stroke="var(--mantine-color-orange-7)" strokeDasharray="3 2" />
+                <text x={midpoint} y={maxHeight - 12.5} textAnchor="middle" dominantBaseline="middle" fontSize={12} fontWeight={700} fill="var(--mantine-color-orange-9)">&#47;&#47;</text>
               </g>
             </Tooltip>
           );

--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -315,21 +315,23 @@ export function AllTasksTimeline({
           overflow: 'visible',
         }}
       >
-        {tasks.map((t) => t.line)}
-        {tasks.filter((t) => t.identifier !== hoveredTaskIdentifier).map((t) => t.label)}
-        {browsedAway}
         {collapsedGaps.map((gap) => {
           const label = `${readableGapDuration(gap.duration)} gap — no component timing recorded`;
+          const midpoint = (gap.startX + gap.endX) / 2;
           return (
             <Tooltip withinPortal key={`${gap.startTime}-${gap.endTime}`} label={label}>
               <g data-testid="timeline-gap-break" aria-label={label}>
-                <rect x={gap.startX} width={gap.endX - gap.startX} y={maxHeight - 25} height={25} fill="whitesmoke" />
-                <line x1={gap.startX + 3} x2={gap.startX + 7} y1={maxHeight - 7} y2={maxHeight - 18} stroke="gray" strokeWidth={2} />
-                <line x1={gap.startX + 9} x2={gap.startX + 13} y1={maxHeight - 7} y2={maxHeight - 18} stroke="gray" strokeWidth={2} />
+                <rect x={gap.startX} width={gap.endX - gap.startX} y={0} height={maxHeight} fill="var(--mantine-color-orange-1)" />
+                <line x1={gap.startX} x2={gap.startX} y1={0} y2={maxHeight} stroke="var(--mantine-color-orange-7)" strokeDasharray="3 2" />
+                <line x1={gap.endX} x2={gap.endX} y1={0} y2={maxHeight} stroke="var(--mantine-color-orange-7)" strokeDasharray="3 2" />
+                <text x={midpoint} y={maxHeight / 2} textAnchor="middle" dominantBaseline="middle" fontSize={12} fontWeight={700} fill="var(--mantine-color-orange-9)">&#47;&#47;</text>
               </g>
             </Tooltip>
           );
         })}
+        {tasks.map((t) => t.line)}
+        {tasks.filter((t) => t.identifier !== hoveredTaskIdentifier).map((t) => t.label)}
+        {browsedAway}
         {hoveredTask?.label}
       </svg>
     </Box>

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -315,11 +315,12 @@ describe('AllTasksTimeline', () => {
   });
 
   test('marks a large time gap but omits the marker in uniform mode', () => {
+    const gapDuration = ((3 * 24 + 5) * 60 * 60 + 2 * 60 + 4) * 1_000;
     const participant = makeParticipant({
       answers: {
         trial1_0: makeAnswer({ endTime: t0 + 5_000 }),
         trial2_1: makeAnswer({
-          componentName: 'trial2', trialOrder: '1_0', startTime: t0 + 3_605_000, endTime: t0 + 3_610_000,
+          componentName: 'trial2', trialOrder: '1_0', startTime: t0 + 5_000 + gapDuration, endTime: t0 + 10_000 + gapDuration,
         }),
       },
     });
@@ -335,7 +336,7 @@ describe('AllTasksTimeline', () => {
     const uniformHtml = renderToStaticMarkup(<AllTasksTimeline {...props} timelineMode="uniform" />);
 
     expect(timeHtml).toContain('data-testid="timeline-gap-break"');
-    expect(timeHtml).toContain('gap — no component timing recorded');
+    expect(timeHtml).toContain('3d 5h 2m 4s gap — no component timing recorded');
     expect(uniformHtml).not.toContain('timeline-gap-break');
   });
 

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -337,6 +337,9 @@ describe('AllTasksTimeline', () => {
 
     expect(timeHtml).toContain('data-testid="timeline-gap-break"');
     expect(timeHtml).toContain('3d 5h 2m 4s gap — no component timing recorded');
+    expect(timeHtml).toContain('fill="var(--mantine-color-orange-1)"');
+    expect(timeHtml).toContain('stroke-dasharray="3 2"');
+    expect(timeHtml).toContain('font-weight="700"');
     expect(uniformHtml).not.toContain('timeline-gap-break');
   });
 

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -314,6 +314,50 @@ describe('AllTasksTimeline', () => {
     expect(html).not.toContain('Browsed away');
   });
 
+  test('marks a large time gap but omits the marker in uniform mode', () => {
+    const participant = makeParticipant({
+      answers: {
+        trial1_0: makeAnswer({ endTime: t0 + 5_000 }),
+        trial2_1: makeAnswer({
+          componentName: 'trial2', trialOrder: '1_0', startTime: t0 + 3_605_000, endTime: t0 + 3_610_000,
+        }),
+      },
+    });
+    const props = {
+      participantData: participant,
+      width: 600,
+      studyId: 'test-study',
+      studyConfig: emptyConfig,
+      maxLength: undefined,
+    };
+
+    const timeHtml = renderToStaticMarkup(<AllTasksTimeline {...props} />);
+    const uniformHtml = renderToStaticMarkup(<AllTasksTimeline {...props} timelineMode="uniform" />);
+
+    expect(timeHtml).toContain('data-testid="timeline-gap-break"');
+    expect(timeHtml).toContain('gap — no component timing recorded');
+    expect(uniformHtml).not.toContain('timeline-gap-break');
+  });
+
+  test('keeps invalid completed timing selectable without drawing a timed bar', () => {
+    const html = renderToStaticMarkup(
+      <AllTasksTimeline
+        participantData={makeParticipant({
+          answers: {
+            invalid_0: makeAnswer({ componentName: 'invalid', startTime: -1, endTime: t0 + 5_000 }),
+          },
+        })}
+        width={600}
+        studyId="test-study"
+        studyConfig={emptyConfig}
+        maxLength={undefined}
+      />,
+    );
+
+    expect(html).toContain('invalid_0');
+    expect(html).toMatch(/fill="lightgray"[^>]*width="0"/);
+  });
+
   test('handles all tracked window event types without error', () => {
     const participant = makeParticipant({
       answers: {

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -337,7 +337,7 @@ describe('AllTasksTimeline', () => {
 
     expect(timeHtml).toContain('data-testid="timeline-gap-break"');
     expect(timeHtml).toContain('3d 5h 2m 4s gap — no component timing recorded');
-    expect(timeHtml).toContain('fill="var(--mantine-color-orange-1)"');
+    expect(timeHtml).toContain('height="25" fill="var(--mantine-color-orange-1)"');
     expect(timeHtml).toContain('stroke-dasharray="3 2"');
     expect(timeHtml).toContain('font-weight="700"');
     expect(uniformHtml).not.toContain('timeline-gap-break');

--- a/src/analysis/individualStudy/replay/tests/timelineLayout.spec.ts
+++ b/src/analysis/individualStudy/replay/tests/timelineLayout.spec.ts
@@ -3,7 +3,75 @@ import {
   expect,
   test,
 } from 'vitest';
-import { getUniformTimelineMetrics } from '../timelineLayout';
+import {
+  getGapAwareTimelineLayout,
+  getUniformTimelineMetrics,
+  TIMELINE_GAP_BREAK_WIDTH,
+} from '../timelineLayout';
+
+const t0 = 1_700_000_000_000;
+
+describe('getGapAwareTimelineLayout', () => {
+  test('compresses a large uncovered interval while preserving task duration proportions', () => {
+    const layout = getGapAwareTimelineLayout({
+      answers: {
+        first: { startTime: t0, endTime: t0 + 10_000 },
+        second: { startTime: t0 + 3_610_000, endTime: t0 + 3_630_000 },
+      },
+      rangeStart: 20,
+      rangeEnd: 620,
+    });
+
+    expect(layout.collapsedGaps).toHaveLength(1);
+    expect(layout.collapsedGaps[0].endX - layout.collapsedGaps[0].startX).toBe(TIMELINE_GAP_BREAK_WIDTH);
+    const firstWidth = layout.scale(t0 + 10_000) - layout.scale(t0);
+    const secondWidth = layout.scale(t0 + 3_630_000) - layout.scale(t0 + 3_610_000);
+    expect(secondWidth / firstWidth).toBeCloseTo(2);
+  });
+
+  test('does not create breaks for small gaps or overlapping intervals', () => {
+    const layout = getGapAwareTimelineLayout({
+      answers: {
+        first: { startTime: t0, endTime: t0 + 10_000 },
+        overlap: { startTime: t0 + 5_000, endTime: t0 + 15_000 },
+        next: { startTime: t0 + 16_000, endTime: t0 + 30_000 },
+        invalid: { startTime: t0 + 40_000, endTime: t0 + 35_000 },
+      },
+      rangeStart: 20,
+      rangeEnd: 620,
+    });
+
+    expect(layout.collapsedGaps).toEqual([]);
+  });
+
+  test('uses the break width for gaps between zero-duration intervals', () => {
+    const layout = getGapAwareTimelineLayout({
+      answers: {
+        first: { startTime: t0, endTime: t0 },
+        second: { startTime: t0 + 10_000, endTime: t0 + 10_000 },
+      },
+      rangeStart: 20,
+      rangeEnd: 620,
+    });
+
+    expect(layout.scale(t0)).toBe(layout.collapsedGaps[0].startX);
+    expect(layout.scale(t0 + 10_000)).toBe(layout.collapsedGaps[0].endX);
+  });
+
+  test('keeps multiple breaks monotonic when their fixed widths exceed the range', () => {
+    const times = [0, 1_000, 2_000, 3_000, 4_000].map((offset) => t0 + offset);
+    const layout = getGapAwareTimelineLayout({
+      answers: Object.fromEntries(times.map((time, index) => [`task${index}`, { startTime: time, endTime: time }])),
+      rangeStart: 20,
+      rangeEnd: 40,
+    });
+    const positions = times.map(layout.scale);
+
+    expect(layout.collapsedGaps).toHaveLength(4);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    expect(layout.collapsedGaps.at(-1)?.endX).toBeLessThanOrEqual(layout.rangeEnd);
+  });
+});
 
 describe('getUniformTimelineMetrics', () => {
   test('fills available width when tasks can be wider than the minimum', () => {

--- a/src/analysis/individualStudy/replay/tests/timelineLayout.spec.ts
+++ b/src/analysis/individualStudy/replay/tests/timelineLayout.spec.ts
@@ -44,6 +44,28 @@ describe('getGapAwareTimelineLayout', () => {
     expect(layout.collapsedGaps).toEqual([]);
   });
 
+  test('compresses gaps over 5% of the timeline or over 30 seconds', () => {
+    const percentageLayout = getGapAwareTimelineLayout({
+      answers: {
+        first: { startTime: t0, endTime: t0 + 1_000 },
+        second: { startTime: t0 + 7_000, endTime: t0 + 100_000 },
+      },
+      rangeStart: 20,
+      rangeEnd: 620,
+    });
+    const durationLayout = getGapAwareTimelineLayout({
+      answers: {
+        first: { startTime: t0, endTime: t0 + 1_000 },
+        second: { startTime: t0 + 32_000, endTime: t0 + 1_000_000 },
+      },
+      rangeStart: 20,
+      rangeEnd: 620,
+    });
+
+    expect(percentageLayout.collapsedGaps).toHaveLength(1);
+    expect(durationLayout.collapsedGaps).toHaveLength(1);
+  });
+
   test('uses the break width for gaps between zero-duration intervals', () => {
     const layout = getGapAwareTimelineLayout({
       answers: {

--- a/src/analysis/individualStudy/replay/timelineLayout.ts
+++ b/src/analysis/individualStudy/replay/timelineLayout.ts
@@ -1,11 +1,130 @@
+import * as d3 from 'd3';
+import type { StoredAnswer } from '../../../parser/types';
+
 export type TimelineMode = 'time' | 'uniform';
 
 export const UNIFORM_TASK_MIN_WIDTH = 48;
+export const TIMELINE_GAP_BREAK_WIDTH = 16;
+
+export function isValidTimelineInterval(answer: Pick<StoredAnswer, 'startTime' | 'endTime'>) {
+  return Number.isFinite(answer.startTime)
+    && Number.isFinite(answer.endTime)
+    && answer.startTime > 0
+    && answer.endTime > 0
+    && answer.endTime >= answer.startTime;
+}
+
+export type CollapsedTimelineGap = {
+  startTime: number;
+  endTime: number;
+  duration: number;
+  startX: number;
+  endX: number;
+};
 
 type TimelineMargin = {
   left: number;
   right: number;
 };
+
+export function getGapAwareTimelineLayout({
+  answers,
+  rangeStart,
+  rangeEnd,
+  maxLength,
+}: {
+  answers: Record<string, Pick<StoredAnswer, 'startTime' | 'endTime'>>;
+  rangeStart: number;
+  rangeEnd: number;
+  maxLength?: number;
+}) {
+  const intervals = Object.values(answers)
+    .filter(isValidTimelineInterval)
+    .map((answer) => ({ startTime: answer.startTime, endTime: answer.endTime }))
+    .sort((a, b) => a.startTime - b.startTime);
+  const safeRangeEnd = Math.max(rangeStart, rangeEnd);
+
+  if (intervals.length === 0) {
+    return {
+      scale: d3.scaleLinear([rangeStart, safeRangeEnd]).domain([0, 1]).clamp(true),
+      collapsedGaps: [] as CollapsedTimelineGap[],
+      rangeEnd: safeRangeEnd,
+    };
+  }
+
+  const domainStart = intervals[0].startTime;
+  const domainEnd = maxLength === undefined
+    ? Math.max(...intervals.map((interval) => interval.endTime))
+    : domainStart + Math.max(0, maxLength);
+  const merged = intervals
+    .filter((interval) => interval.startTime <= domainEnd)
+    .map((interval) => ({
+      startTime: interval.startTime,
+      endTime: Math.min(interval.endTime, domainEnd),
+    }))
+    .reduce<{ startTime: number; endTime: number }[]>((result, interval) => {
+      const previous = result.at(-1);
+      if (previous && interval.startTime <= previous.endTime) {
+        previous.endTime = Math.max(previous.endTime, interval.endTime);
+      } else {
+        result.push(interval);
+      }
+      return result;
+    }, []);
+  const domainSpan = Math.max(0, domainEnd - domainStart);
+  if (domainSpan === 0) {
+    return {
+      scale: d3.scaleLinear([rangeStart, rangeStart]).domain([domainStart, domainStart + 1]).clamp(true),
+      collapsedGaps: [] as CollapsedTimelineGap[],
+      rangeEnd: rangeStart,
+    };
+  }
+
+  const gaps = merged.slice(1).map((interval, index) => ({
+    startTime: merged[index].endTime,
+    endTime: interval.startTime,
+    duration: interval.startTime - merged[index].endTime,
+  })).filter((gap) => domainSpan > 0 && gap.duration / domainSpan > 0.1);
+  const collapsedDuration = gaps.reduce((total, gap) => total + gap.duration, 0);
+  const retainedDuration = Math.max(0, domainSpan - collapsedDuration);
+  const effectiveRangeEnd = Math.max(safeRangeEnd, rangeStart + gaps.length * TIMELINE_GAP_BREAK_WIDTH);
+  const availableWidth = effectiveRangeEnd - rangeStart;
+  const linearWidth = Math.max(0, availableWidth - gaps.length * TIMELINE_GAP_BREAK_WIDTH);
+  const pixelsPerMillisecond = retainedDuration > 0 ? linearWidth / retainedDuration : 0;
+  const domain = [domainStart];
+  const range = [rangeStart];
+  const collapsedGaps: CollapsedTimelineGap[] = [];
+  let currentTime = domainStart;
+  let currentX = rangeStart;
+
+  gaps.forEach((gap) => {
+    currentX += (gap.startTime - currentTime) * pixelsPerMillisecond;
+    if (gap.startTime > currentTime) {
+      domain.push(gap.startTime);
+      range.push(currentX);
+    }
+    domain.push(gap.endTime);
+    range.push(currentX + TIMELINE_GAP_BREAK_WIDTH);
+    collapsedGaps.push({
+      ...gap,
+      startX: currentX,
+      endX: currentX + TIMELINE_GAP_BREAK_WIDTH,
+    });
+    currentX += TIMELINE_GAP_BREAK_WIDTH;
+    currentTime = gap.endTime;
+  });
+
+  if (domainEnd > currentTime) {
+    domain.push(domainEnd);
+    range.push(effectiveRangeEnd);
+  }
+
+  return {
+    scale: d3.scaleLinear(range).domain(domain).clamp(true),
+    collapsedGaps,
+    rangeEnd: effectiveRangeEnd,
+  };
+}
 
 export function getUniformTimelineMetrics({
   availableWidth,

--- a/src/analysis/individualStudy/replay/timelineLayout.ts
+++ b/src/analysis/individualStudy/replay/timelineLayout.ts
@@ -5,6 +5,8 @@ export type TimelineMode = 'time' | 'uniform';
 
 export const UNIFORM_TASK_MIN_WIDTH = 48;
 export const TIMELINE_GAP_BREAK_WIDTH = 16;
+const TIMELINE_GAP_PERCENT_THRESHOLD = 0.05;
+const TIMELINE_GAP_DURATION_THRESHOLD = 30_000;
 
 export function isValidTimelineInterval(answer: Pick<StoredAnswer, 'startTime' | 'endTime'>) {
   return Number.isFinite(answer.startTime)
@@ -84,7 +86,9 @@ export function getGapAwareTimelineLayout({
     startTime: merged[index].endTime,
     endTime: interval.startTime,
     duration: interval.startTime - merged[index].endTime,
-  })).filter((gap) => domainSpan > 0 && gap.duration / domainSpan > 0.1);
+  })).filter((gap) => domainSpan > 0
+    && (gap.duration / domainSpan > TIMELINE_GAP_PERCENT_THRESHOLD
+      || gap.duration > TIMELINE_GAP_DURATION_THRESHOLD));
   const collapsedDuration = gaps.reduce((total, gap) => total + gap.duration, 0);
   const retainedDuration = Math.max(0, domainSpan - collapsedDuration);
   const effectiveRangeEnd = Math.max(safeRangeEnd, rangeStart + gaps.length * TIMELINE_GAP_BREAK_WIDTH);

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -322,6 +322,7 @@ export function TableView({
             { value: 'uniform', label: 'Uniform' },
           ]}
         />
+        <Text size="xs" c="dimmed">Long gaps in Time mode are marked //</Text>
         <ParticipantRejectModal selectedParticipants={selectedParticipants} refresh={handleRefresh} />
       </Flex>
     ),

--- a/src/analysis/individualStudy/table/tests/TableView.spec.tsx
+++ b/src/analysis/individualStudy/table/tests/TableView.spec.tsx
@@ -146,6 +146,7 @@ describe('TableView', () => {
     expect(html).toContain('Answer time');
     expect(html).toContain('Time');
     expect(html).toContain('Uniform');
+    expect(html).toContain('Long gaps in Time mode are marked //');
   });
 
   test('uses sequence ordering and time sizing by default for participant timelines', () => {


### PR DESCRIPTION
## Summary
- compress large uncovered gaps in Participant View Time timelines into labeled 16px break markers
- preserve recorded task durations, Uniform mode, and raw table Duration values
- keep invalid completed intervals selectable without letting them distort timing geometry

## Adversarial review
- fixed invalid intervals that could render positive or non-finite widths
- fixed duplicate scale knots for zero-duration intervals
- kept multi-break scales monotonic on narrow timelines

## Validation
- corepack yarn unittest --run src/analysis/individualStudy/replay/tests/timelineLayout.spec.ts src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx src/analysis/individualStudy/table/tests/TableView.spec.tsx (48 passed)
- corepack yarn typecheck
- corepack yarn lint
- corepack yarn build
- git diff --check

A prior full unit-suite attempt stalled without a final summary; the directly affected suites pass.

Closes #1362