### PR TITLE
Add repository agent skills

### DIFF
--- a/.agents/skills/adversarial-review/SKILL.md
+++ b/.agents/skills/adversarial-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: adversarial-review
+description: Launch an independent adversarial review subagent on gpt-5.6-sol with high reasoning effort to challenge work for correctness, regressions, edge cases, test adequacy, and YAGNI minimality. Use when the user invokes $adversarial-review or asks to launch, spawn, or run an adversarial reviewer or review subagent to check correctness, conciseness, simplicity, speculative complexity, unnecessary churn, or overlooked issues.
+---
+
+# Adversarial Review
+
+Launch exactly one independent, read-only reviewer. Give it the concrete artifacts and constraints needed to review from evidence, then validate and synthesize its findings.
+
+## Prepare the handoff
+
+Identify the review target from the request and current task. Gather enough concrete state to make the handoff self-contained:
+
+- Objective and acceptance criteria
+- Repository and relevant paths, or artifact locations
+- Exact comparison scope such as base, head, merge base, diff, plan, or document
+- Important constraints and domain invariants
+- Validation already performed and any known failures
+- Questions the reviewer must answer
+
+Do not include the parent's conclusions as facts. Ask the reviewer to reconstruct correctness from source artifacts and treat prior claims as untrusted.
+
+Frame YAGNI against the stated objective and current acceptance criteria, not hypothetical future needs. Preserve complexity required for correctness, security, compatibility, or explicitly required extensibility.
+
+## Launch the reviewer
+
+Call `collaboration.spawn_agent` directly with:
+
+- `task_name`: `adversarial_review`, adding a short numeric suffix only if that name is already in use
+- `model`: `gpt-5.6-sol`
+- `reasoning_effort`: `high`
+- `fork_turns`: `none`
+- `message`: the self-contained handoff plus the review contract below
+
+Use this review contract:
+
+> Act as an independent adversarial reviewer. Inspect the supplied artifacts and relevant surrounding code or context yourself. Challenge correctness first, then apply YAGNI: every abstraction, dependency, configuration surface, compatibility path, test, and documentation change must serve the stated objective or current acceptance criteria. Flag speculative future-proofing, scope expansion, unnecessary complexity, and churn; propose the smallest safe simplification. Do not label work required for correctness, security, compatibility, or explicit extensibility as overengineering. Also look for behavioral regressions, broken contracts or invariants, edge cases, unsafe assumptions, and missing or misleading tests. Verify suspected issues before reporting them. Do not edit files, push changes, post comments, or mutate external state. Return only evidence-backed findings ordered by severity, with precise file and line references when available and a suggested resolution for each. If there are no findings, say so and identify residual risks or verification gaps.
+
+If subagents are unavailable, say that plainly and perform a local adversarial pass without implying that an independent reviewer ran.
+
+## Integrate the result
+
+Continue useful local work while the reviewer runs when the tasks do not conflict. Wait for the reviewer before presenting a final correctness judgment.
+
+Independently confirm each reported issue against the current artifacts. Reject false positives and stale-scope findings. Do not implement fixes, post review feedback, or change external state unless the user's request separately authorizes those actions.
+
+Report:
+
+- Confirmed findings, ordered by severity, with suggested resolutions
+- Any reviewer claims rejected after local verification
+- Whether the work is correct and the smallest sufficient solution within the reviewed scope
+- Residual risks and checks not performed

--- a/.agents/skills/adversarial-review/agents/openai.yaml
+++ b/.agents/skills/adversarial-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Adversarial Review"
+  short_description: "Challenge correctness and conciseness independently"
+  default_prompt: "Use $adversarial-review to independently challenge this work for correctness and conciseness."

--- a/.agents/skills/specify-github-issues/SKILL.md
+++ b/.agents/skills/specify-github-issues/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: specify-github-issues
+description: Structured workflow for turning a specific underspecified GitHub issue into a detailed, reviewed specification. Use only when the user provides one or more explicit issue numbers or URLs and asks to specify, clarify, or prepare those issues; draft clarifying questions with recommended defaults, incorporate user edits, update issue bodies while preserving original intent, and apply the `specified` label.
+---
+
+# Specify GitHub Issues
+
+## Overview
+
+Use this skill to run a two-phase issue-specification workflow for explicitly named issue numbers: first draft clarifying questions with recommended defaults, then apply the user's reviewed answers back to those issues and label them `specified`.
+
+## Workflow
+
+### 1. Establish Scope
+
+- Determine the repository and issue source from the user request, active workspace, GitHub URL, or available GitHub tools.
+- If the repository cannot be determined safely, ask for it before querying issues.
+- Require the user to provide at least one issue number or issue URL. If none is provided, ask for the issue number and stop.
+- Do not scan or process every open issue. If the user asks for all open issues, explain that this skill requires specific issue numbers and ask them to choose the first issue or a small explicit list.
+- Respect higher-priority repo or user instructions about GitHub access. If direct GitHub writes are prohibited, draft the updates instead of mutating issues.
+- Treat `specified` as the default label name unless the user names a different label.
+
+### 2. Fetch The Named Issues
+
+- Fetch only the issue numbers or issue URLs explicitly provided by the user.
+- Confirm each item is an open issue, not a pull request.
+- If an issue already has the `specified` label, tell the user and ask whether to revise the existing specification or skip it.
+- Capture each issue's number, title, URL, labels, author-provided body, comments if relevant, and any linked project context available without excessive digging.
+- If the user provides many issue numbers, process them in clear batches and preserve the per-issue mapping throughout.
+
+### 3. Analyze What Is Underspecified
+
+For each issue, separate:
+
+- Confirmed intent from the existing issue.
+- Missing decisions needed before implementation.
+- Assumptions implied by the codebase, product conventions, labels, or related issues.
+- Risks if the issue is implemented as written.
+- Possible acceptance criteria and test expectations.
+
+Look for gaps in scope, users/personas, UX, data model, API contracts, validation, error states, permissions, migration/backfill, analytics, performance, accessibility, compatibility, rollout, dependencies, non-goals, edge cases, and tests.
+
+### 4. Ask Clarifying Questions With Defaults
+
+Produce a review packet, not issue mutations. Ask a thorough but useful set of questions for each issue. Every question must include a recommended default.
+
+Use defaults that are conservative, testable, aligned with existing project behavior, and likely to preserve the issue's original intent. Mark defaults clearly as recommendations, not accepted decisions.
+
+Recommended format:
+
+```markdown
+## #123 Issue title
+
+Current intent:
+...
+
+Needs specification:
+- ...
+
+Clarifying questions and recommended defaults:
+1. Question: ...
+   Recommended default: ...
+   Why this default: ...
+
+Proposed acceptance criteria:
+- ...
+
+Suggested non-goals:
+- ...
+```
+
+After presenting the review packet, stop and wait for the user's edited answers or approval before updating issues.
+
+### 5. Apply Reviewed Specifications
+
+When the user returns edited answers:
+
+- Map answers back to issue numbers. If a mapping is ambiguous, ask before writing.
+- Preserve the original issue body and intent. Prefer appending a structured `Specification` section unless the issue already has a clear specification section that should be updated in place.
+- Do not close issues, change priority, assign owners, edit milestones, or remove existing content unless explicitly requested.
+- Add the `specified` label only after the issue body update succeeds.
+- If the label does not exist and the available tool cannot create it, report that clearly and provide the exact next action needed.
+
+Suggested issue-body structure:
+
+```markdown
+<existing issue body>
+
+---
+
+## Specification
+
+_Added after specification review._
+
+### Summary
+...
+
+### Decisions
+- ...
+
+### Acceptance Criteria
+- [ ] ...
+
+### Out of Scope
+- ...
+
+### Implementation Notes
+- ...
+
+### Testing Notes
+- ...
+
+### Open Questions
+- ...
+```
+
+Omit empty sections. Keep wording faithful to the user's reviewed answers. If there are unresolved questions, include them under `Open Questions` and do not apply the `specified` label unless the user explicitly says the issue is sufficiently specified despite them.
+
+### 6. Verify And Report
+
+After each update:
+
+- Verify the issue body contains the new specification.
+- Verify the `specified` label is present.
+- Report the issue number, title, URL, whether the body update succeeded, and whether labeling succeeded.
+- Call out any issues skipped because they still need decisions.

--- a/.agents/skills/specify-github-issues/SKILL.md
+++ b/.agents/skills/specify-github-issues/SKILL.md
@@ -1,126 +1,165 @@
 ---
 name: specify-github-issues
-description: Structured workflow for turning a specific underspecified GitHub issue into a detailed, reviewed specification. Use only when the user provides one or more explicit issue numbers or URLs and asks to specify, clarify, or prepare those issues; draft clarifying questions with recommended defaults, incorporate user edits, update issue bodies while preserving original intent, and apply the `specified` label.
+description: Turn explicitly named GitHub issues into implementation-ready specifications through evidence gathering, targeted clarification, and an adversarial YAGNI review. Use when the user asks to specify, clarify, or prepare one or more issue numbers or URLs; do not use for an unspecified backlog or for silently mutating issues before review.
 ---
 
 # Specify GitHub Issues
 
-## Overview
+Create a specification that another engineer can implement without rediscovering the product intent, affected surface, edge cases, or acceptance criteria. Treat the issue and the user's proposed solution as inputs to investigate, not as proof that the proposed scope or design is correct.
 
-Use this skill to run a two-phase issue-specification workflow for explicitly named issue numbers: first draft clarifying questions with recommended defaults, then apply the user's reviewed answers back to those issues and label them `specified`.
+Use a staged workflow. Do not draft a final specification, update an issue, or apply the `specified` label until material unknowns have been resolved or the user explicitly accepts documented assumptions.
 
-## Workflow
+## 1. Establish the exact scope
 
-### 1. Establish Scope
+- Require at least one explicit issue number or issue URL. Do not scan or process an entire backlog.
+- Determine the canonical repository and confirm that each item is an open issue, not a pull request.
+- Fetch the issue title, body, labels, relevant comments, linked issues, and available project context.
+- Inspect the relevant code, configuration, current UI, routes, API/storage contracts, and tests before deciding what is underspecified. If the repository or required evidence is unavailable, say so and ask for it.
+- Separate the confirmed problem from the user's suggested implementation. Do not treat a requested component, endpoint, database field, or refactor as necessary until its purpose is established.
 
-- Determine the repository and issue source from the user request, active workspace, GitHub URL, or available GitHub tools.
-- If the repository cannot be determined safely, ask for it before querying issues.
-- Require the user to provide at least one issue number or issue URL. If none is provided, ask for the issue number and stop.
-- Do not scan or process every open issue. If the user asks for all open issues, explain that this skill requires specific issue numbers and ask them to choose the first issue or a small explicit list.
-- Respect higher-priority repo or user instructions about GitHub access. If direct GitHub writes are prohibited, draft the updates instead of mutating issues.
-- Treat `specified` as the default label name unless the user names a different label.
+Build an initial scope map for each issue:
 
-### 2. Fetch The Named Issues
+- Who is affected and what user or system action starts the behavior?
+- What exact URL, route, page, entry point, API endpoint, deep link, or external resource is affected?
+- Which exact UI elements, controls, content regions, states, and responsive layouts are affected?
+- Which files, components, data sources, providers, storage records, or external systems are involved?
+- What is the current behavior, what is wrong, and what should remain unchanged?
+- What are the reproduction steps, expected result, and observable failure or success signal?
 
-- Fetch only the issue numbers or issue URLs explicitly provided by the user.
-- Confirm each item is an open issue, not a pull request.
-- If an issue already has the `specified` label, tell the user and ask whether to revise the existing specification or skip it.
-- Capture each issue's number, title, URL, labels, author-provided body, comments if relevant, and any linked project context available without excessive digging.
-- If the user provides many issue numbers, process them in clear batches and preserve the per-issue mapping throughout.
+If any of these are unknown, they belong in the clarification round rather than in a guessed specification.
 
-### 3. Analyze What Is Underspecified
+## 2. Ask a first clarification round
 
-For each issue, separate:
+Produce a review packet, not issue mutations. Ask only questions that resolve a material implementation decision, but ask enough that the final spec cannot be mistaken for a different feature.
 
-- Confirmed intent from the existing issue.
-- Missing decisions needed before implementation.
-- Assumptions implied by the codebase, product conventions, labels, or related issues.
-- Risks if the issue is implemented as written.
-- Possible acceptance criteria and test expectations.
+Every question must include:
 
-Look for gaps in scope, users/personas, UX, data model, API contracts, validation, error states, permissions, migration/backfill, analytics, performance, accessibility, compatibility, rollout, dependencies, non-goals, edge cases, and tests.
+- The decision being requested
+- A recommended default grounded in the issue, current code, or existing product behavior
+- Why the default is the smallest safe and maintainable choice
+- What would change if the user selects another option
 
-### 4. Ask Clarifying Questions With Defaults
+Cover the applicable dimensions below. Explicitly ask about URLs/routes and UI elements whenever the issue has a user-facing surface.
 
-Produce a review packet, not issue mutations. Ask a thorough but useful set of questions for each issue. Every question must include a recommended default.
+- **Problem and users:** affected persona, trigger, current behavior, desired outcome, reproduction, frequency, severity, and non-affected users
+- **Surface:** exact URL(s), route(s), entry point(s), screen/page, component(s), API endpoint(s), storage record(s), and external integration(s)
+- **UI behavior:** exact elements and copy, placement, visibility, enabled/disabled rules, loading/empty/error/success states, navigation, focus, keyboard behavior, responsiveness, and accessibility
+- **Data and contracts:** inputs, outputs, persistence, validation, defaults, serialization, backward compatibility, permissions, privacy, and failure handling
+- **Boundaries:** supported and unsupported cases, non-goals, compatibility constraints, rollout or migration needs, and what must not change
+- **Verification:** observable acceptance criteria, regression cases, unit/integration/E2E coverage, and how a reviewer can reproduce the result
 
-Use defaults that are conservative, testable, aligned with existing project behavior, and likely to preserve the issue's original intent. Mark defaults clearly as recommendations, not accepted decisions.
-
-Recommended format:
+Use a format like:
 
 ```markdown
 ## #123 Issue title
 
-Current intent:
-...
-
-Needs specification:
+### Evidence and confirmed intent
 - ...
 
-Clarifying questions and recommended defaults:
-1. Question: ...
-   Recommended default: ...
-   Why this default: ...
-
-Proposed acceptance criteria:
+### Unknowns that block a reliable specification
 - ...
 
-Suggested non-goals:
+### Clarifying questions and recommended defaults
+1. **Affected URL and entry point:** Which exact URL or route should change?
+   **Recommended default:** `/the-existing-route`, because the current code and issue reproduction point there.
+   **Why:** This keeps the fix within the reported surface and avoids expanding navigation.
+   **If different:** The acceptance criteria, affected files, and E2E coverage must change.
+
+2. **UI surface:** Which controls or content regions should be changed, and what should happen in loading, empty, error, and disabled states?
+   **Recommended default:** ...
+   **Why:** ...
+   **If different:** ...
+
+### Proposed non-goals
 - ...
 ```
 
-After presenting the review packet, stop and wait for the user's edited answers or approval before updating issues.
+After presenting the packet, stop and wait for the user's answers or approval. Do not append a specification or label the issue yet.
 
-### 5. Apply Reviewed Specifications
+## 3. Re-check and challenge the proposed scope
 
-When the user returns edited answers:
+After the user answers, map every answer to the issue and re-inspect the affected code and contracts. Ask focused follow-up questions for any remaining material ambiguity; multiple clarification rounds are expected when the issue spans UI, persistence, or integrations.
 
-- Map answers back to issue numbers. If a mapping is ambiguous, ask before writing.
-- Preserve the original issue body and intent. Prefer appending a structured `Specification` section unless the issue already has a clear specification section that should be updated in place.
-- Do not close issues, change priority, assign owners, edit milestones, or remove existing content unless explicitly requested.
-- Add the `specified` label only after the issue body update succeeds.
-- If the label does not exist and the available tool cannot create it, report that clearly and provide the exact next action needed.
+Before drafting the specification, conduct an explicit adversarial scope review:
 
-Suggested issue-body structure:
+- Is this solving the confirmed problem, or only implementing the user's preferred mechanism?
+- Is the requested behavior already available through a smaller change, existing component, route, configuration option, or shared utility?
+- Does each new abstraction, dependency, state field, endpoint, migration, compatibility path, and UI state have a demonstrated need?
+- Can any proposed behavior, option, generalized API, or future-proofing be removed without failing the stated outcome?
+- Does the scope introduce duplicated sources of truth, new persistence, migration risk, security/privacy exposure, accessibility regressions, or unnecessary operational burden?
+- Are the acceptance criteria precise enough to distinguish the fix from a plausible but incorrect implementation?
+
+Push back clearly but respectfully when the evidence does not support the requested scope. Offer the smallest sufficient alternative and ask the user to confirm whether the broader request is still intentional. Do not reject complexity required for correctness, security, compatibility, accessibility, or an explicitly accepted requirement.
+
+If the user does not resolve a material challenge, leave it as an open decision and do not claim the issue is fully specified.
+
+## 4. Draft the implementation-ready specification
+
+Draft only after the affected surface, behavior, boundaries, and verification approach are sufficiently determined. The specification should let another engineer implement the work without another product-discovery round.
+
+Prefer appending this structure to the existing issue body:
 
 ```markdown
-<existing issue body>
-
 ---
 
 ## Specification
 
-_Added after specification review._
+_Added after clarification and scope review._
 
 ### Summary
-...
+One concise statement of the confirmed problem and smallest sufficient outcome.
 
-### Decisions
-- ...
+### Users and affected surface
+- Users/personas:
+- Trigger/reproduction:
+- Exact URL(s), route(s), entry point(s), or API endpoint(s):
+- Affected UI elements and states:
+- Relevant code, data, storage, or external contracts:
 
-### Acceptance Criteria
+### Required behavior
+Describe the behavior as observable cases, including success, loading, empty, error, disabled, navigation, and accessibility behavior where applicable.
+
+### Data and contract changes
+Describe inputs, outputs, persistence, validation, defaults, compatibility, permissions, privacy, and migration/backfill requirements. State explicitly when no data or contract change is required.
+
+### Acceptance criteria
 - [ ] ...
 
-### Out of Scope
+### Tests and verification
+- Unit/integration coverage:
+- E2E or manual reproduction:
+- Regression and edge cases:
+
+### Non-goals and rejected scope
 - ...
 
-### Implementation Notes
-- ...
+### Implementation notes
+Only include constraints supported by the codebase or confirmed decisions. Do not prescribe an implementation when multiple simple implementations satisfy the contract.
 
-### Testing Notes
-- ...
-
-### Open Questions
-- ...
+### Open questions and assumptions
+Include only unresolved items that the user explicitly accepted as assumptions. Otherwise, stop clarification before labeling.
 ```
 
-Omit empty sections. Keep wording faithful to the user's reviewed answers. If there are unresolved questions, include them under `Open Questions` and do not apply the `specified` label unless the user explicitly says the issue is sufficiently specified despite them.
+Acceptance criteria must be testable and specific about the affected surface. Include negative cases and preservation requirements, not only the happy path. Keep the specification concise: remove background, options, and implementation detail that do not affect implementation or verification.
 
-### 6. Verify And Report
+## 5. Apply only an approved, complete specification
+
+When the user approves the specification or returns final answers:
+
+- Map each decision to the correct issue number. If mapping is ambiguous, ask before writing.
+- Preserve the original issue body and intent. Append or update a structured `Specification` section rather than replacing useful author context.
+- Do not close issues, change priority, assign owners, edit milestones, or remove existing content unless explicitly requested.
+- Do not apply `specified` while material questions, unsupported assumptions, or unresolved scope challenges remain.
+- Add the `specified` label only after the issue body update succeeds. Use `specified` unless the user names another label.
+- If the label does not exist or the available GitHub capability cannot create it, report that clearly and provide the exact next action.
+
+## 6. Verify and report
 
 After each update:
 
-- Verify the issue body contains the new specification.
-- Verify the `specified` label is present.
-- Report the issue number, title, URL, whether the body update succeeded, and whether labeling succeeded.
-- Call out any issues skipped because they still need decisions.
+- Re-fetch the issue and verify the specification is present and readable.
+- Verify the expected label is present.
+- Report the issue number, title, URL, body-update result, label result, and any remaining assumptions.
+- Distinguish confirmed facts, user-approved decisions, agent recommendations, and unresolved risks.
+
+If the issue is not ready, report the blocking questions and the smallest next decision needed instead of presenting an implementation-ready conclusion.

--- a/.agents/skills/specify-github-issues/SKILL.md
+++ b/.agents/skills/specify-github-issues/SKILL.md
@@ -1,165 +1,88 @@
 ---
 name: specify-github-issues
-description: Turn explicitly named GitHub issues into implementation-ready specifications through evidence gathering, targeted clarification, and an adversarial YAGNI review. Use when the user asks to specify, clarify, or prepare one or more issue numbers or URLs; do not use for an unspecified backlog or for silently mutating issues before review.
+description: Turn explicitly named GitHub issues into concise, implementation-ready specifications through evidence gathering, targeted clarification, and an adversarial YAGNI review. Use when the user asks to specify, clarify, or prepare issue numbers or URLs; do not process an unspecified backlog or mutate issues before review.
 ---
 
 # Specify GitHub Issues
 
-Create a specification that another engineer can implement without rediscovering the product intent, affected surface, edge cases, or acceptance criteria. Treat the issue and the user's proposed solution as inputs to investigate, not as proof that the proposed scope or design is correct.
+Produce a specification another engineer can implement without rediscovering the problem, affected surface, edge cases, or acceptance criteria. Treat the issue and any proposed solution as inputs to investigate, not as proof that the requested scope or mechanism is correct.
 
-Use a staged workflow. Do not draft a final specification, update an issue, or apply the `specified` label until material unknowns have been resolved or the user explicitly accepts documented assumptions.
+## 1. Establish scope from evidence
 
-## 1. Establish the exact scope
+- Require at least one explicit issue number or URL. Do not scan a backlog.
+- Resolve the canonical repository and confirm each item is an open issue, not a pull request.
+- Fetch the issue body, labels, relevant comments, and linked context.
+- Inspect the relevant code, routes, UI, data/storage/API contracts, and tests before deciding what is underspecified. If required evidence is unavailable, ask for it.
+- If the issue already has a `Specification` section or `specified` label, show it and ask whether to revise or skip it.
 
-- Require at least one explicit issue number or issue URL. Do not scan or process an entire backlog.
-- Determine the canonical repository and confirm that each item is an open issue, not a pull request.
-- Fetch the issue title, body, labels, relevant comments, linked issues, and available project context.
-- Inspect the relevant code, configuration, current UI, routes, API/storage contracts, and tests before deciding what is underspecified. If the repository or required evidence is unavailable, say so and ask for it.
-- Separate the confirmed problem from the user's suggested implementation. Do not treat a requested component, endpoint, database field, or refactor as necessary until its purpose is established.
+For each issue, record the evidence and identify unknowns across this single checklist:
 
-Build an initial scope map for each issue:
+- affected users, trigger, current behavior, desired outcome, and reproduction;
+- exact URL, route, page, entry point, API endpoint, or external resource;
+- exact UI elements and relevant loading, empty, error, disabled, navigation, responsive, and accessibility states;
+- involved files/components, data sources, persistence, permissions, and external contracts;
+- what must remain unchanged, non-goals, edge cases, and how success will be verified.
 
-- Who is affected and what user or system action starts the behavior?
-- What exact URL, route, page, entry point, API endpoint, deep link, or external resource is affected?
-- Which exact UI elements, controls, content regions, states, and responsive layouts are affected?
-- Which files, components, data sources, providers, storage records, or external systems are involved?
-- What is the current behavior, what is wrong, and what should remain unchanged?
-- What are the reproduction steps, expected result, and observable failure or success signal?
+Ask the user only about decisions the evidence cannot settle. Never fill a material gap with an unmarked assumption.
 
-If any of these are unknown, they belong in the clarification round rather than in a guessed specification.
+## 2. Clarify before drafting
 
-## 2. Ask a first clarification round
+Create a review packet; do not mutate GitHub. Ask a targeted question for each material decision. Every question gets a recommended default and a brief rationale grounded in the issue, codebase, or existing product behavior. Mention alternatives only when they materially change scope or risk.
 
-Produce a review packet, not issue mutations. Ask only questions that resolve a material implementation decision, but ask enough that the final spec cannot be mistaken for a different feature.
+Cover only the applicable parts of the checklist above, especially the exact URL/route and UI surface for user-facing work. Include data/permission behavior, boundaries, non-goals, and tests when they affect implementation. Keep the packet concise and distinguish confirmed facts, user decisions, recommendations, and unresolved risks.
 
-Every question must include:
+After the packet, stop and wait for answers. If a material ambiguity remains, ask a focused follow-up rather than drafting around it. If the evidence already resolves the scope, present a draft for review instead of inventing questions.
 
-- The decision being requested
-- A recommended default grounded in the issue, current code, or existing product behavior
-- Why the default is the smallest safe and maintainable choice
-- What would change if the user selects another option
+## 3. Challenge the scope, then draft
 
-Cover the applicable dimensions below. Explicitly ask about URLs/routes and UI elements whenever the issue has a user-facing surface.
+After answers arrive, re-check the affected code and contracts and challenge the request:
 
-- **Problem and users:** affected persona, trigger, current behavior, desired outcome, reproduction, frequency, severity, and non-affected users
-- **Surface:** exact URL(s), route(s), entry point(s), screen/page, component(s), API endpoint(s), storage record(s), and external integration(s)
-- **UI behavior:** exact elements and copy, placement, visibility, enabled/disabled rules, loading/empty/error/success states, navigation, focus, keyboard behavior, responsiveness, and accessibility
-- **Data and contracts:** inputs, outputs, persistence, validation, defaults, serialization, backward compatibility, permissions, privacy, and failure handling
-- **Boundaries:** supported and unsupported cases, non-goals, compatibility constraints, rollout or migration needs, and what must not change
-- **Verification:** observable acceptance criteria, regression cases, unit/integration/E2E coverage, and how a reviewer can reproduce the result
+- Does it solve the confirmed problem, or only implement the user's preferred mechanism?
+- Can an existing component, route, configuration option, or utility solve it with less code and state?
+- Is every new abstraction, dependency, state field, endpoint, migration, compatibility path, and UI state necessary for the stated outcome?
+- Does the proposal create duplicated sources of truth, unnecessary persistence, security/privacy risk, accessibility regressions, or operational burden?
 
-Use a format like:
+Push back respectfully when the evidence does not support the requested scope. Offer the smallest sufficient alternative. Preserve complexity required for correctness, security, compatibility, accessibility, or an explicitly accepted requirement. Do not proceed while a material scope challenge is unresolved.
+
+Present the exact draft Markdown and stop. Do not update GitHub until the user explicitly approves that draft and authorizes the write.
+
+Use this structure, omitting sections that do not apply:
 
 ```markdown
-## #123 Issue title
-
-### Evidence and confirmed intent
-- ...
-
-### Unknowns that block a reliable specification
-- ...
-
-### Clarifying questions and recommended defaults
-1. **Affected URL and entry point:** Which exact URL or route should change?
-   **Recommended default:** `/the-existing-route`, because the current code and issue reproduction point there.
-   **Why:** This keeps the fix within the reported surface and avoids expanding navigation.
-   **If different:** The acceptance criteria, affected files, and E2E coverage must change.
-
-2. **UI surface:** Which controls or content regions should be changed, and what should happen in loading, empty, error, and disabled states?
-   **Recommended default:** ...
-   **Why:** ...
-   **If different:** ...
-
-### Proposed non-goals
-- ...
-```
-
-After presenting the packet, stop and wait for the user's answers or approval. Do not append a specification or label the issue yet.
-
-## 3. Re-check and challenge the proposed scope
-
-After the user answers, map every answer to the issue and re-inspect the affected code and contracts. Ask focused follow-up questions for any remaining material ambiguity; multiple clarification rounds are expected when the issue spans UI, persistence, or integrations.
-
-Before drafting the specification, conduct an explicit adversarial scope review:
-
-- Is this solving the confirmed problem, or only implementing the user's preferred mechanism?
-- Is the requested behavior already available through a smaller change, existing component, route, configuration option, or shared utility?
-- Does each new abstraction, dependency, state field, endpoint, migration, compatibility path, and UI state have a demonstrated need?
-- Can any proposed behavior, option, generalized API, or future-proofing be removed without failing the stated outcome?
-- Does the scope introduce duplicated sources of truth, new persistence, migration risk, security/privacy exposure, accessibility regressions, or unnecessary operational burden?
-- Are the acceptance criteria precise enough to distinguish the fix from a plausible but incorrect implementation?
-
-Push back clearly but respectfully when the evidence does not support the requested scope. Offer the smallest sufficient alternative and ask the user to confirm whether the broader request is still intentional. Do not reject complexity required for correctness, security, compatibility, accessibility, or an explicitly accepted requirement.
-
-If the user does not resolve a material challenge, leave it as an open decision and do not claim the issue is fully specified.
-
-## 4. Draft the implementation-ready specification
-
-Draft only after the affected surface, behavior, boundaries, and verification approach are sufficiently determined. The specification should let another engineer implement the work without another product-discovery round.
-
-Prefer appending this structure to the existing issue body:
-
-```markdown
----
-
 ## Specification
 
-_Added after clarification and scope review._
-
 ### Summary
-One concise statement of the confirmed problem and smallest sufficient outcome.
+The confirmed problem and smallest sufficient outcome.
 
-### Users and affected surface
-- Users/personas:
-- Trigger/reproduction:
-- Exact URL(s), route(s), entry point(s), or API endpoint(s):
-- Affected UI elements and states:
+### Affected surface
+- Users and trigger/reproduction:
+- Exact URL(s), route(s), entry point(s), or endpoint(s):
+- UI elements and states:
 - Relevant code, data, storage, or external contracts:
 
 ### Required behavior
-Describe the behavior as observable cases, including success, loading, empty, error, disabled, navigation, and accessibility behavior where applicable.
-
-### Data and contract changes
-Describe inputs, outputs, persistence, validation, defaults, compatibility, permissions, privacy, and migration/backfill requirements. State explicitly when no data or contract change is required.
+Observable success, failure, empty/loading/disabled, navigation, and accessibility behavior where applicable.
 
 ### Acceptance criteria
-- [ ] ...
+- [ ] Testable behavior, including negative cases and preservation requirements.
 
 ### Tests and verification
-- Unit/integration coverage:
-- E2E or manual reproduction:
-- Regression and edge cases:
+- Unit/integration/E2E or manual reproduction:
 
-### Non-goals and rejected scope
-- ...
-
-### Implementation notes
-Only include constraints supported by the codebase or confirmed decisions. Do not prescribe an implementation when multiple simple implementations satisfy the contract.
-
-### Open questions and assumptions
-Include only unresolved items that the user explicitly accepted as assumptions. Otherwise, stop clarification before labeling.
+### Non-goals and assumptions
+- Only confirmed boundaries and explicitly accepted assumptions.
 ```
 
-Acceptance criteria must be testable and specific about the affected surface. Include negative cases and preservation requirements, not only the happy path. Keep the specification concise: remove background, options, and implementation detail that do not affect implementation or verification.
+Keep the specification concise. Do not prescribe an implementation when multiple simple implementations satisfy the contract.
 
-## 5. Apply only an approved, complete specification
+## 4. Apply and verify an approved specification
 
-When the user approves the specification or returns final answers:
+After explicit approval of the exact draft and authorization to write:
 
-- Map each decision to the correct issue number. If mapping is ambiguous, ask before writing.
-- Preserve the original issue body and intent. Append or update a structured `Specification` section rather than replacing useful author context.
+- Re-fetch the issue body, labels, and relevant comments immediately before writing. If they changed materially, reconcile and obtain renewed approval.
+- Preserve the original body and intent; append or update only the structured `Specification` section.
 - Do not close issues, change priority, assign owners, edit milestones, or remove existing content unless explicitly requested.
-- Do not apply `specified` while material questions, unsupported assumptions, or unresolved scope challenges remain.
-- Add the `specified` label only after the issue body update succeeds. Use `specified` unless the user names another label.
-- If the label does not exist or the available GitHub capability cannot create it, report that clearly and provide the exact next action.
+- Update the body first, then add the `specified` label (or the user-named label). If the label cannot be created, report that clearly.
+- Re-fetch after the update and verify the specification and label.
 
-## 6. Verify and report
-
-After each update:
-
-- Re-fetch the issue and verify the specification is present and readable.
-- Verify the expected label is present.
-- Report the issue number, title, URL, body-update result, label result, and any remaining assumptions.
-- Distinguish confirmed facts, user-approved decisions, agent recommendations, and unresolved risks.
-
-If the issue is not ready, report the blocking questions and the smallest next decision needed instead of presenting an implementation-ready conclusion.
+Report the issue number, title, URL, body-update result, label result, confirmed decisions, assumptions, and any remaining risks. If the issue is not ready, report the blocking question instead of claiming it is specified.

--- a/.agents/skills/specify-github-issues/agents/openai.yaml
+++ b/.agents/skills/specify-github-issues/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Specify GitHub Issues"
+  short_description: "Clarify issues, then label specified."
+  default_prompt: "Use $specify-github-issues on issue #123 to draft clarifying questions with recommended defaults, then update the issue after I review the answers."

--- a/.agents/skills/specify-github-issues/agents/openai.yaml
+++ b/.agents/skills/specify-github-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Specify GitHub Issues"
-  short_description: "Clarify, challenge, and specify issues."
-  default_prompt: "Use $specify-github-issues on issue #123 to inspect the affected surface, ask clarifying questions, challenge unnecessary scope, and produce an implementation-ready specification."
+  short_description: "Clarify and challenge issue scope."
+  default_prompt: "Use $specify-github-issues on issue #123 to inspect scope, ask material questions, challenge unnecessary complexity, and draft an implementation-ready specification."

--- a/.agents/skills/specify-github-issues/agents/openai.yaml
+++ b/.agents/skills/specify-github-issues/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Specify GitHub Issues"
-  short_description: "Clarify issues, then label specified."
-  default_prompt: "Use $specify-github-issues on issue #123 to draft clarifying questions with recommended defaults, then update the issue after I review the answers."
+  short_description: "Clarify, challenge, and specify issues."
+  default_prompt: "Use $specify-github-issues on issue #123 to inspect the affected surface, ask clarifying questions, challenge unnecessary scope, and produce an implementation-ready specification."


### PR DESCRIPTION
## Summary

- Add the `specify-github-issues` workflow under `.agents/skills/`.
- Add the `adversarial-review` workflow under `.agents/skills/`.
- Include Codex UI metadata for both skills.
- Strengthen issue specification with evidence-first scope mapping, exact URLs/routes and UI elements, follow-up clarification rounds, adversarial YAGNI/correctness review, and an implementation-readiness gate.

## Validation

- Confirmed each repository skill matches its intended Agent Skills structure.
- `git diff --check origin/dev...HEAD` passed.
- Commit hooks passed via a temporary Corepack Yarn shim.
- The skill-creator validator remains unavailable because Python `yaml` is not installed.