### PR TITLE
Add download action for Markdown stimuli

### DIFF
--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine/core';
 import {
   IconChartHistogram,
+  IconDownload,
   IconDotsVertical,
   IconMail,
   IconMicrophone,
@@ -275,6 +276,22 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
               >
                 Help
               </Button>
+            )}
+
+            {componentConfig.type === 'markdown' && componentConfig.allowDownload !== false && (
+              <Tooltip label="Download stimulus">
+                <ActionIcon
+                  component="a"
+                  href={`${PREFIX}${componentConfig.path}`}
+                  download
+                  aria-label="Download stimulus"
+                  size="lg"
+                  variant="subtle"
+                  color="gray"
+                >
+                  <IconDownload />
+                </ActionIcon>
+              </Tooltip>
             )}
 
             <Menu

--- a/src/components/interface/tests/AppHeader.spec.tsx
+++ b/src/components/interface/tests/AppHeader.spec.tsx
@@ -14,6 +14,17 @@ import { getNewParticipant } from '../../../utils/nextParticipant';
 let mockStorageEngineFailedToConnect = false;
 let mockedCurrentComponent = 'componentA';
 let mockIsAnalysis = false;
+let mockedComponentConfig: {
+  withProgressBar: boolean;
+  showTitle: boolean;
+  type: 'markdown' | 'questionnaire';
+  path?: string;
+  allowDownload?: boolean;
+} = {
+  withProgressBar: false,
+  showTitle: true,
+  type: 'questionnaire',
+};
 
 let mockedRecordingContext = {
   isScreenRecording: false,
@@ -45,9 +56,21 @@ const mockStudyConfig = {
 };
 
 vi.mock('@mantine/core', () => ({
-  ActionIcon: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
-    <button type="button" onClick={onClick}>{children}</button>
-  ),
+  ActionIcon: ({
+    children, component, href, download, onClick, 'aria-label': ariaLabel,
+  }: {
+    children: ReactNode;
+    component?: string;
+    href?: string;
+    download?: boolean;
+    onClick?: () => void;
+    'aria-label'?: string;
+  }) => {
+    if (component === 'a') {
+      return <a href={href} download={download} aria-label={ariaLabel}>{children}</a>;
+    }
+    return <button type="button" onClick={onClick} aria-label={ariaLabel}>{children}</button>;
+  },
   AppShell: Object.assign(
     ({ children }: { children: ReactNode }) => <div>{children}</div>,
     { Header: ({ children }: { children: ReactNode }) => <header>{children}</header> },
@@ -87,6 +110,7 @@ vi.mock('@mantine/core', () => ({
 
 vi.mock('@tabler/icons-react', () => ({
   IconChartHistogram: () => null,
+  IconDownload: () => null,
   IconDotsVertical: () => null,
   IconMail: () => null,
   IconMicrophone: () => null,
@@ -140,10 +164,7 @@ vi.mock('../RecordingAudioWaveform', () => ({
 }));
 
 vi.mock('../../../utils/handleComponentInheritance', () => ({
-  studyComponentToIndividualComponent: vi.fn(() => ({
-    withProgressBar: false,
-    showTitle: true,
-  })),
+  studyComponentToIndividualComponent: vi.fn(() => mockedComponentConfig),
 }));
 
 vi.mock('../../../store/hooks/useRecording', () => ({
@@ -207,6 +228,11 @@ describe('AppHeader', () => {
     mockStorageEngineFailedToConnect = false;
     mockIsAnalysis = false;
     mockedCurrentComponent = 'componentA';
+    mockedComponentConfig = {
+      withProgressBar: false,
+      showTitle: true,
+      type: 'questionnaire',
+    };
     mockedRecordingContext = {
       isScreenRecording: false,
       isAudioRecording: false,
@@ -259,6 +285,41 @@ describe('AppHeader', () => {
     expect(html).toContain('Demo Mode');
     // Dev mode controls should not appear
     expect(html).not.toContain('Study Browser');
+  });
+
+  test.each([undefined, true])('shows the Markdown download when allowDownload is %s', (allowDownload) => {
+    mockedComponentConfig = {
+      withProgressBar: false,
+      showTitle: true,
+      type: 'markdown',
+      path: 'test-study/assets/stimulus.md',
+      allowDownload,
+    };
+
+    const { container } = render(
+      <AppHeader developmentModeEnabled={false} dataCollectionEnabled />,
+    );
+
+    const downloadLink = container.querySelector('a[aria-label="Download stimulus"]');
+    expect(downloadLink).not.toBeNull();
+    expect(downloadLink?.getAttribute('href')).toBe('/test-study/assets/stimulus.md');
+    expect(downloadLink?.hasAttribute('download')).toBe(true);
+  });
+
+  test('hides the Markdown download when allowDownload is false', () => {
+    mockedComponentConfig = {
+      withProgressBar: false,
+      showTitle: true,
+      type: 'markdown',
+      path: 'test-study/assets/stimulus.md',
+      allowDownload: false,
+    };
+
+    const { container } = render(
+      <AppHeader developmentModeEnabled={false} dataCollectionEnabled />,
+    );
+
+    expect(container.querySelector('a[aria-label="Download stimulus"]')).toBeNull();
   });
 
   // --- Audio/recording state tests from original file ---

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -32,6 +32,10 @@
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
+          "allowDownload": {
+            "description": "Controls whether the participant can download the Markdown stimulus. Defaults to true.",
+            "type": "boolean"
+          },
           "allowFailedTraining": {
             "description": "Controls whether the component should allow failed training. If present, will override the allow failed training setting in the uiConfig.",
             "type": "boolean"
@@ -1188,6 +1192,10 @@
       "additionalProperties": false,
       "description": "An InheritedComponent is a component that inherits properties from a baseComponent. This is used to avoid repeating properties in components. This also means that components in the baseComponents object can be partially defined, while components in the components object can inherit from them and must be fully defined and include all properties (after potentially merging with a base component).",
       "properties": {
+        "allowDownload": {
+          "description": "Controls whether the participant can download the Markdown stimulus. Defaults to true.",
+          "type": "boolean"
+        },
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If present, will override the allow failed training setting in the uiConfig.",
           "type": "boolean"
@@ -1733,6 +1741,10 @@
       "additionalProperties": false,
       "description": "The MarkdownComponent interface is used to define the properties of a markdown component. The components can be used to render many different things, such as consent forms, instructions, and debriefs. Additionally, you can use the markdown component to render images, videos, and other media, with supporting text. Markdown components can have responses (e.g. in a consent form), or no responses (e.g. in a help text file). Here's an example with no responses for a simple help text file:\n\n```json {   \"type\": \"markdown\",   \"path\": \"<study-name>/assets/help.md\",   \"response\": [] } ```",
       "properties": {
+        "allowDownload": {
+          "description": "Controls whether the participant can download the Markdown stimulus. Defaults to true.",
+          "type": "boolean"
+        },
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If present, will override the allow failed training setting in the uiConfig.",
           "type": "boolean"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -32,6 +32,10 @@
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
+          "allowDownload": {
+            "description": "Controls whether the participant can download the Markdown stimulus. Defaults to true.",
+            "type": "boolean"
+          },
           "allowFailedTraining": {
             "description": "Controls whether the component should allow failed training. If present, will override the allow failed training setting in the uiConfig.",
             "type": "boolean"
@@ -1261,6 +1265,10 @@
       "additionalProperties": false,
       "description": "An InheritedComponent is a component that inherits properties from a baseComponent. This is used to avoid repeating properties in components. This also means that components in the baseComponents object can be partially defined, while components in the components object can inherit from them and must be fully defined and include all properties (after potentially merging with a base component).",
       "properties": {
+        "allowDownload": {
+          "description": "Controls whether the participant can download the Markdown stimulus. Defaults to true.",
+          "type": "boolean"
+        },
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If present, will override the allow failed training setting in the uiConfig.",
           "type": "boolean"
@@ -1757,6 +1765,10 @@
       "additionalProperties": false,
       "description": "The MarkdownComponent interface is used to define the properties of a markdown component. The components can be used to render many different things, such as consent forms, instructions, and debriefs. Additionally, you can use the markdown component to render images, videos, and other media, with supporting text. Markdown components can have responses (e.g. in a consent form), or no responses (e.g. in a help text file). Here's an example with no responses for a simple help text file:\n\n```json {   \"type\": \"markdown\",   \"path\": \"<study-name>/assets/help.md\",   \"response\": [] } ```",
       "properties": {
+        "allowDownload": {
+          "description": "Controls whether the participant can download the Markdown stimulus. Defaults to true.",
+          "type": "boolean"
+        },
         "allowFailedTraining": {
           "description": "Controls whether the component should allow failed training. If present, will override the allow failed training setting in the uiConfig.",
           "type": "boolean"

--- a/src/parser/tests/parser.spec.ts
+++ b/src/parser/tests/parser.spec.ts
@@ -15,6 +15,72 @@ function mockFetchText(body: string) {
   return { text: () => Promise.resolve(body) } as Response;
 }
 
+describe('Markdown download config parsing', () => {
+  function makeStudyConfig(allowDownload?: boolean | string) {
+    return {
+      $schema: '',
+      studyMetadata: {
+        title: 'Markdown Download Test',
+        version: '1.0',
+        authors: ['Test'],
+        date: '2026-08-20',
+        description: 'Ensures Markdown downloads can be configured.',
+        organizations: ['Test Org'],
+      },
+      uiConfig: {
+        contactEmail: 'test@test.com',
+        logoPath: '',
+        withProgressBar: true,
+        withSidebar: true,
+      },
+      components: {
+        instructions: {
+          type: 'markdown',
+          path: 'test-study/assets/instructions.md',
+          response: [],
+          ...(allowDownload === undefined ? {} : { allowDownload }),
+        },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['instructions'],
+      },
+    };
+  }
+
+  test.each([undefined, true, false])('accepts allowDownload set to %s', async (allowDownload) => {
+    const result = await parseStudyConfig(JSON.stringify(makeStudyConfig(allowDownload)));
+
+    expect(result.errors).toEqual([]);
+  });
+
+  test.each([undefined, true])('accepts inherited allowDownload override set to %s', async (allowDownload) => {
+    const directConfig = makeStudyConfig(false);
+    const studyConfig = {
+      ...directConfig,
+      baseComponents: {
+        markdownInstructions: directConfig.components.instructions,
+      },
+      components: {
+        instructions: {
+          baseComponent: 'markdownInstructions',
+          ...(allowDownload === undefined ? {} : { allowDownload }),
+        },
+      },
+    };
+
+    const result = await parseStudyConfig(JSON.stringify(studyConfig));
+
+    expect(result.errors).toEqual([]);
+  });
+
+  test('rejects a non-boolean allowDownload value', async () => {
+    const result = await parseStudyConfig(JSON.stringify(makeStudyConfig('yes')));
+
+    expect(result.errors.some((error) => error.instancePath?.includes('allowDownload'))).toBe(true);
+  });
+});
+
 describe('Component auto-advance config parsing', () => {
   test('accepts component-level auto-advance timeout options on a base component', async () => {
     const studyConfig = {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1109,6 +1109,8 @@ export interface MarkdownComponent extends BaseIndividualComponent {
   type: 'markdown';
   /** The path to the markdown file. This should be a relative path from the public folder. */
   path: string;
+  /** Controls whether the participant can download the Markdown stimulus. Defaults to true. */
+  allowDownload?: boolean;
 }
 
 /**

--- a/src/utils/tests/handleComponentInheritance.spec.ts
+++ b/src/utils/tests/handleComponentInheritance.spec.ts
@@ -17,7 +17,9 @@ describe('studyComponentToIndividualComponent', () => {
   });
 
   test('merges the base component with the inherited component', () => {
-    const base: IndividualComponent = { type: 'markdown', path: '/base.md', response: [] };
+    const base: IndividualComponent = {
+      type: 'markdown', path: '/base.md', response: [], allowDownload: false,
+    };
     const inherited: InheritedComponent = { baseComponent: 'base', path: '/override.md' };
     const config = makeStudyConfig({ baseComponents: { base } });
 
@@ -25,6 +27,17 @@ describe('studyComponentToIndividualComponent', () => {
 
     expect(result).toHaveProperty('path', '/override.md');
     expect(result).toHaveProperty('type', 'markdown');
+    expect(result).toHaveProperty('allowDownload', false);
+  });
+
+  test('allows an inherited component to override the Markdown download setting', () => {
+    const base: IndividualComponent = {
+      type: 'markdown', path: '/base.md', response: [], allowDownload: false,
+    };
+    const inherited: InheritedComponent = { baseComponent: 'base', allowDownload: true };
+    const config = makeStudyConfig({ baseComponents: { base } });
+
+    expect(studyComponentToIndividualComponent(inherited, config)).toHaveProperty('allowDownload', true);
   });
 
   test('falls back to the component itself when studyConfig has no baseComponents', () => {

--- a/tests/demo-html.spec.ts
+++ b/tests/demo-html.spec.ts
@@ -17,9 +17,13 @@ test('Test website component with previous button', async ({ page }) => {
   await openStudyFromLanding(page, 'Demo Studies', 'HTML as a Stimulus');
 
   await expect(page.getByText(/example study.*embed html elements/i)).toBeVisible();
+  const downloadLink = page.getByRole('link', { name: 'Download stimulus' });
+  await expect(downloadLink).toHaveAttribute('href', '/demo-html/assets/introduction.md');
+  await expect(downloadLink).toHaveAttribute('download', '');
 
   // Click on the next button
   await nextClick(page);
+  await expect(downloadLink).toHaveCount(0);
 
   // Check the page contains the question
   const questionText = await page.getByText('How many bars have a value greater than 1?');


### PR DESCRIPTION
## Summary

- show an accessible Markdown download action in the study header by default
- allow study designers to disable it per Markdown component with `allowDownload: false`
- support inherited component configuration and regenerate the Study and Library schemas

## Testing

- `corepack yarn unittest --run` (2,074 passed, 1 skipped)
- `corepack yarn typecheck`
- `corepack yarn lint`
- `corepack yarn build`
- `corepack yarn playwright test tests/demo-html.spec.ts --project=chromium`
- `git diff --check`

## Review

An independent adversarial review identified missing inherited-config coverage. Added parser and merge-utility tests for inherited `false` and child `true` overrides before publication.