### PR TITLE
Add permanent Firebase and Supabase deployments

### DIFF
--- a/.github/scripts/publish-pages-snapshot.sh
+++ b/.github/scripts/publish-pages-snapshot.sh
@@ -22,7 +22,11 @@ if [[ ! -d "$pages_checkout/.git" ]]; then
   exit 2
 fi
 
-if [[ -n "$destination_dir" && "$destination_dir" != "dev" && ! "$destination_dir" =~ ^PR[0-9]+$ ]]; then
+if [[ -n "$destination_dir"
+  && "$destination_dir" != "dev"
+  && "$destination_dir" != "supabase"
+  && "$destination_dir" != "dev-supabase"
+  && ! "$destination_dir" =~ ^PR[0-9]+$ ]]; then
   echo "Unsupported Pages destination: $destination_dir" >&2
   exit 2
 fi
@@ -32,7 +36,8 @@ pages_checkout="$(cd "$pages_checkout" && pwd -P)"
 
 git -C "$pages_checkout" config user.name "github-actions[bot]"
 git -C "$pages_checkout" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git -C "$pages_checkout" checkout --orphan pages-snapshot
+snapshot_branch="pages-snapshot-${destination_dir:-root}"
+git -C "$pages_checkout" checkout --orphan "$snapshot_branch"
 
 if [[ -z "$destination_dir" ]]; then
   rsync -a --delete \
@@ -40,6 +45,8 @@ if [[ -z "$destination_dir" ]]; then
     --exclude='/.nojekyll' \
     --exclude='/CNAME' \
     --exclude='/dev/' \
+    --exclude='/supabase/' \
+    --exclude='/dev-supabase/' \
     --exclude='/PR[0-9]*/' \
     "$publish_dir/" "$pages_checkout/"
 else

--- a/.github/scripts/publish-pages-snapshot.sh
+++ b/.github/scripts/publish-pages-snapshot.sh
@@ -39,6 +39,10 @@ git -C "$pages_checkout" config user.email "41898282+github-actions[bot]@users.n
 snapshot_branch="pages-snapshot-${destination_dir:-root}"
 git -C "$pages_checkout" checkout --orphan "$snapshot_branch"
 
+if [[ -n "$destination_dir" && ! "$destination_dir" =~ ^PR[0-9]+$ ]]; then
+  cp "$publish_dir/404.html" "$pages_checkout/404.html"
+fi
+
 if [[ -z "$destination_dir" ]]; then
   rsync -a --delete \
     --exclude='/.git/' \

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: false
   queue: max
 
-# Keep the existing publisher until a maintainer approves the initial force-push cutover.
 jobs:
   deploy-main:
     runs-on: ubuntu-latest
@@ -38,23 +37,13 @@ jobs:
           VITE_STORAGE_ENGINE: firebase
 
       - uses: actions/checkout@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         with:
           ref: gh-pages
           path: .pages
           fetch-depth: 1
 
       - name: Deploy current-only main Firebase snapshot
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist '' ./.pages
-
-      - uses: peaceiris/actions-gh-pages@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        name: Deploy main Firebase snapshot
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          keep_files: true
-          publish_dir: ./dist
 
       - name: Build main Supabase deployment
         run: yarn build
@@ -63,16 +52,7 @@ jobs:
           VITE_STORAGE_ENGINE: supabase
 
       - name: Deploy current-only main Supabase snapshot
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist supabase ./.pages
-
-      - uses: peaceiris/actions-gh-pages@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        name: Deploy main Supabase snapshot
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: "supabase"
 
   deploy-dev:
     runs-on: ubuntu-latest
@@ -96,23 +76,13 @@ jobs:
           VITE_STORAGE_ENGINE: firebase
 
       - uses: actions/checkout@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         with:
           ref: gh-pages
           path: .pages
           fetch-depth: 1
 
       - name: Deploy current-only dev Firebase snapshot
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist dev ./.pages
-
-      - uses: peaceiris/actions-gh-pages@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        name: Deploy dev Firebase snapshot
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: "dev"
 
       - name: Build dev Supabase deployment
         run: yarn build
@@ -121,16 +91,7 @@ jobs:
           VITE_STORAGE_ENGINE: supabase
 
       - name: Deploy current-only dev Supabase snapshot
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist dev-supabase ./.pages
-
-      - uses: peaceiris/actions-gh-pages@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        name: Deploy dev Supabase snapshot
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: "dev-supabase"
 
   pr-deploy:
     runs-on: ubuntu-latest
@@ -167,23 +128,13 @@ jobs:
           VITE_BASE_PATH: "/study/PR${{ github.event.number }}/"
 
       - uses: actions/checkout@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         with:
           ref: gh-pages
           path: .pages
           fetch-depth: 1
 
       - name: Push current-only PR deploy preview
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist "PR${{ github.event.number }}" ./.pages
-
-      - name: Push PR deploy preview
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: "PR${{ github.event.number }}"
 
       - name: Update comment
         uses: hasura/comment-progress@v2.2.0

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
   workflow_dispatch:
   pull_request:
 
@@ -30,17 +31,11 @@ jobs:
 
       - run: yarn install --immutable
 
-      # If on main without env vars, build with .env file
-      - name: Build with .env file
-        if: ${{ vars.VITE_STORAGE_ENGINE == '' }}
+      - name: Build main Firebase deployment
         run: yarn build
-
-      # If on main with env vars, build with github environment variables
-      - name: Build with github environment variables
-        if: ${{ vars.VITE_STORAGE_ENGINE != '' }}
-        run: VITE_STORAGE_ENGINE=$VITE_STORAGE_ENGINE yarn build
         env:
-          VITE_STORAGE_ENGINE: ${{ vars.VITE_STORAGE_ENGINE }}
+          VITE_BASE_PATH: "/study/"
+          VITE_STORAGE_ENGINE: firebase
 
       - uses: actions/checkout@v3
         if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
@@ -49,20 +44,39 @@ jobs:
           path: .pages
           fetch-depth: 1
 
-      - name: Deploy current-only snapshot
+      - name: Deploy current-only main Firebase snapshot
         if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist '' ./.pages
 
       - uses: peaceiris/actions-gh-pages@v3
         if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        name: Deploy
+        name: Deploy main Firebase snapshot
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_dir: ./dist
+
+      - name: Build main Supabase deployment
+        run: yarn build
+        env:
+          VITE_BASE_PATH: "/study/supabase/"
+          VITE_STORAGE_ENGINE: supabase
+
+      - name: Deploy current-only main Supabase snapshot
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: .github/scripts/publish-pages-snapshot.sh ./dist supabase ./.pages
+
+      - uses: peaceiris/actions-gh-pages@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
+        name: Deploy main Supabase snapshot
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          destination_dir: "supabase"
 
   deploy-dev:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/dev'}}
+    if: ${{ github.ref == 'refs/heads/dev' }}
     permissions:
       contents: write
     steps:
@@ -75,10 +89,11 @@ jobs:
 
       - run: yarn install --immutable
 
-      - name: Build dev branch
-        run: VITE_BASE_PATH=/dev yarn build
+      - name: Build dev Firebase deployment
+        run: yarn build
         env:
-          VITE_BASE_PATH: "/dev/"
+          VITE_BASE_PATH: "/study/dev/"
+          VITE_STORAGE_ENGINE: firebase
 
       - uses: actions/checkout@v3
         if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
@@ -87,17 +102,35 @@ jobs:
           path: .pages
           fetch-depth: 1
 
-      - name: Deploy current-only dev snapshot
+      - name: Deploy current-only dev Firebase snapshot
         if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./dist dev ./.pages
 
       - uses: peaceiris/actions-gh-pages@v3
         if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        name: Deploy dev branch
+        name: Deploy dev Firebase snapshot
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           destination_dir: "dev"
+
+      - name: Build dev Supabase deployment
+        run: yarn build
+        env:
+          VITE_BASE_PATH: "/study/dev-supabase/"
+          VITE_STORAGE_ENGINE: supabase
+
+      - name: Deploy current-only dev Supabase snapshot
+        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
+        run: .github/scripts/publish-pages-snapshot.sh ./dist dev-supabase ./.pages
+
+      - uses: peaceiris/actions-gh-pages@v3
+        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
+        name: Deploy dev Supabase snapshot
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: "dev-supabase"
 
   pr-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_close.yaml
+++ b/.github/workflows/pr_close.yaml
@@ -8,7 +8,6 @@ concurrency:
   cancel-in-progress: false
   queue: max
 
-# Keep the existing publisher until a maintainer approves the initial force-push cutover.
 jobs:
   delete_preview:
     runs-on: ubuntu-latest
@@ -17,34 +16,18 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
 
       - uses: actions/checkout@v3
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         with:
           ref: gh-pages
           path: .pages
           fetch-depth: 1
 
       - name: make empty snapshot directory
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: mkdir empty-pages
 
       - name: delete preview from current-only snapshot
-        if: ${{ vars.PAGES_SINGLE_COMMIT == 'true' }}
         run: .github/scripts/publish-pages-snapshot.sh ./empty-pages "PR${{ github.event.number }}" ./.pages
-
-      - name: make empty dir
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        run: mkdir public
-
-      - name: delete folder
-        if: ${{ vars.PAGES_SINGLE_COMMIT != 'true' }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          destination_dir: "PR${{ github.event.number }}"
 
       - name: Comment on PR
         uses: hasura/comment-progress@v2.2.0

--- a/public/404.html
+++ b/public/404.html
@@ -23,9 +23,10 @@
     // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
     // Otherwise, leave pathSegmentsToKeep as 0.
 
-    // Grep for PR***, if we find that we want 2 segments
-    var PRFound = !!window.location.pathname.match(/\/PR\d+\//);
-    var pathSegmentsToKeep = PRFound ? 2 : 1;
+    // Keep the deployment directory for nested permanent and PR deployments.
+    var deploymentSegment = window.location.pathname.split('/')[2];
+    var nestedDeploymentFound = /^(?:dev|supabase|dev-supabase|PR\d+)$/.test(deploymentSegment);
+    var pathSegmentsToKeep = nestedDeploymentFound ? 2 : 1;
 
     var l = window.location;
     l.replace(


### PR DESCRIPTION
## Summary

- deploy production Firebase and Supabase builds from both `main` and `dev`
- publish the four permanent paths at `/study/`, `/study/dev/`, `/study/supabase/`, and `/study/dev-supabase/`
- use the established one-commit snapshot publisher for main, dev, PR publishing, and PR cleanup
- preserve permanent deployments and PR previews when replacing the `gh-pages` snapshot
- let trusted permanent publishes refresh the shared root `404.html` while preventing PR publishes from changing it
- preserve nested deployment roots when GitHub Pages redirects direct SPA deep links
- build every permanent deployment in Vite production mode so study data uses the existing `prod-` prefix

## Validation

- built all four storage-engine/base-path combinations with `corepack yarn build`
- rebuilt the dev Firebase variant after the single-publisher change and verified its base path, copied `404.html`, and compiled `prod-` prefix
- parsed both workflow YAML files, ran `bash -n` on the publisher, and ran `git diff --check`
- exercised dev, dev-Supabase, PR publish, PR close, main, and main-Supabase transitions against a temporary Git remote
- verified shared `404.html` ownership, stale root deletion, target replacement, sibling preservation, and the final remote snapshot after every transition
- validated root, permanent nested, PR, query/hash, and non-deployment 404 redirect cases

## Deployment note

The Supabase builds assume `https://supabase.revisit.dev` will be repaired. Its current TLS/upstream outage is infrastructure work outside this PR.

Closes #1231
