### PR TITLE
Allow styling required asterisks with CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,15 @@
       .no-last-child-bottom-padding {
         font-weight: 500;
       }
+
+      .required-asterisk {
+        color: #fa5252;
+        margin-left: 4px;
+      }
     </style>
 
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-
 

--- a/src/components/ReactMarkdownWrapper.tsx
+++ b/src/components/ReactMarkdownWrapper.tsx
@@ -77,7 +77,7 @@ export function ReactMarkdownWrapper({ text, required, inline }: { text: string;
       const asteriskNode: Element = {
         type: 'element',
         tagName: 'span',
-        properties: { style: 'color: #fa5252; margin-left: 4px' },
+        properties: { className: 'required-asterisk' },
         children: [
           {
             type: 'text',

--- a/src/components/tests/ReactMarkdownWrapper.spec.tsx
+++ b/src/components/tests/ReactMarkdownWrapper.spec.tsx
@@ -63,6 +63,7 @@ describe('ReactMarkdownWrapper', () => {
   test('appends asterisk to required text', () => {
     const { container } = render(<ReactMarkdownWrapper text="Required field" required />);
     expect(container.textContent).toContain('*');
+    expect(container.querySelector('.required-asterisk')).not.toBeNull();
   });
 
   test('renders markdown with multiple headings', () => {


### PR DESCRIPTION
### What this PR addresses and why it's needed

Allows class-based targeting and CSS styling of the required asterisk in prompts. For example, a Study Designer can make the mark less distracting or hide it when every question is mandatory.

This follows up on the accidentally closed #1395.

### Are there any additional TODOs before this PR is ready to go?

None.