### PR TITLE
Harden Supabase MinIO startup and health checks

### DIFF
--- a/supabase/docker-compose.yml
+++ b/supabase/docker-compose.yml
@@ -255,6 +255,7 @@ services:
 
   minio:
     image: minio/minio
+    restart: unless-stopped
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -278,7 +279,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc alias set supa-minio http://minio:9000 supa-storage secret1234;
-      /usr/bin/mc mb supa-minio/stub;
+      /usr/bin/mc mb --ignore-existing supa-minio/stub;
       exit 0;
       "
   storage:
@@ -299,7 +300,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:5000/status"
+          "http://127.0.0.1:5000/status"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## Summary
- restart MinIO automatically with the rest of the Supabase stack
- make physical bucket creation idempotent when `stub` already exists
- use IPv4 for the Storage API healthcheck because the service listens on IPv4 while `localhost` resolves to `::1` in the container

## Validation
- `docker compose config --quiet`
- `git diff --check`

## Live evidence
- the existing healthcheck failed against `[::1]:5000`, while `127.0.0.1:5000/status` succeeded
- Storage returned 500 while MinIO was stopped and recovered after MinIO restarted

Follow-up to #1406.