### PR TITLE
Harden study config loading failures

### DIFF
--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -30,6 +30,7 @@ import { parseStudyConfig } from '../../parser/parser';
 import { useAsync } from '../../store/hooks/useAsync';
 import { StorageEngine } from '../../storage/engines/types';
 import { DownloadButtons } from '../../components/downloader/DownloadButtons';
+import { ErrorLoadingConfig } from '../../components/ErrorLoadingConfig';
 import { useStudyRecordings } from '../../utils/useStudyRecordings';
 import { getSequenceConditions, parseConditionParam } from '../../utils/handleConditionLogic';
 import 'mantine-react-table/styles.css';
@@ -122,7 +123,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     storageEngine && canonicalStudyId ? [storageEngine, canonicalStudyId] : null,
   );
   const studyUsesConditions = useMemo(
-    () => (studyConfig ? getSequenceConditions(studyConfig.sequence).length > 0 : false),
+    () => (studyConfig?.sequence ? getSequenceConditions(studyConfig.sequence).length > 0 : false),
     [studyConfig],
   );
 
@@ -383,6 +384,21 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
 
   if (startupError) {
     return <StartupErrorScreen error={startupError.error} />;
+  }
+
+  if (studyConfig?.errors?.length) {
+    return (
+      <>
+        <AppHeader
+          studyIds={globalConfig.configsList}
+          selectedStudyId={displayStudyId}
+          studyConfigs={displayStudyId ? { [displayStudyId]: studyConfig } : undefined}
+        />
+        <AppShell.Main>
+          <ErrorLoadingConfig issues={studyConfig.errors} type="error" />
+        </AppShell.Main>
+      </>
+    );
   }
 
   if (!routeStudyId) {

--- a/src/analysis/interface/AppHeader.tsx
+++ b/src/analysis/interface/AppHeader.tsx
@@ -18,7 +18,7 @@ export function AppHeader({
   studyIds: string[];
   selectedStudyId?: string;
   studyHref?: string;
-  studyConfigs?: Record<string, { $schema: string } | null>;
+  studyConfigs?: Record<string, { $schema?: unknown } | null>;
 }) {
   const navigate = useNavigate();
   const { studyId } = useParams();
@@ -26,7 +26,10 @@ export function AppHeader({
 
   const selectorData = studyIds.map((id) => ({ value: id, label: id })).sort((a, b) => a.label.localeCompare(b.label));
   const revisitVersion = studyIds
-    .map((id) => studyConfigs?.[id]?.$schema.match(STUDY_SCHEMA_VERSION_REGEX)?.[1])
+    .map((id) => {
+      const schema = studyConfigs?.[id]?.$schema;
+      return typeof schema === 'string' ? schema.match(STUDY_SCHEMA_VERSION_REGEX)?.[1] : undefined;
+    })
     .filter((version): version is string => version !== undefined)
     .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0];
 

--- a/src/analysis/tests/AppHeader.spec.tsx
+++ b/src/analysis/tests/AppHeader.spec.tsx
@@ -65,4 +65,11 @@ describe('AppHeader', () => {
     const html = renderToStaticMarkup(<AppHeader studyIds={['my-study']} selectedStudyId="my-study" />);
     expect(html).toContain('Go to Study');
   });
+
+  test('does not crash when a loaded config has no schema', () => {
+    const html = renderToStaticMarkup(
+      <AppHeader studyIds={['my-study']} studyConfigs={{ 'my-study': {} }} />,
+    );
+    expect(html).toContain('ReVISit Analytics Platform');
+  });
 });

--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -23,7 +23,7 @@ import { useStudyRecordings } from '../utils/useStudyRecordings';
 import { useDeviceRules } from '../utils/useDeviceRules';
 import { getUnmetDeviceRestrictionLines, getUnmetDeviceRestrictionTooltip } from './interface/DeviceRestrictionString';
 
-function StudyCard({
+function ValidStudyCard({
   configName,
   config,
   url,
@@ -135,91 +135,79 @@ function StudyCard({
 
   return (
     <Card key={configName} shadow="sm" radius="md" my="sm" withBorder>
-      {config.errors.length > 0
-        ? (
-          <>
-            <Text size="md" fw="bold">{configName}</Text>
-            <ErrorLoadingConfig issues={config.errors} type="error" />
-            {config.warnings.length > 0 && (
-              <ErrorLoadingConfig issues={config.warnings} type="warning" />
-            )}
-          </>
-        )
-        : (
-          <>
-            <Flex direction="row" justify="space-between">
-              <Text fw="bold">
-                {config.studyMetadata.title}
-              </Text>
-            </Flex>
-            <Text c="dimmed">
-              <Text span fw={500}>Authors: </Text>
-              {config.studyMetadata.authors.join(', ')}
-            </Text>
-            <Text c="dimmed">{config.studyMetadata.description}</Text>
-            <Text c="dimmed" ta="right" style={{ paddingRight: 5 }}>
-              <Anchor
-                target="_blank"
-                onClick={(e) => e.stopPropagation()}
-                href={`${import.meta.env.VITE_REPO_URL}${url}`}
-              >
-                View source:
-                {' '}
-                {url}
-                <IconExternalLink style={{
-                  width: rem(18), height: rem(18), marginLeft: rem(2), marginBottom: rem(-3),
-                }}
-                />
-              </Anchor>
-            </Text>
+      <Flex direction="row" justify="space-between">
+        <Text fw="bold">
+          {config.studyMetadata.title}
+        </Text>
+      </Flex>
+      <Text c="dimmed">
+        <Text span fw={500}>Authors: </Text>
+        {config.studyMetadata.authors.join(', ')}
+      </Text>
+      <Text c="dimmed">{config.studyMetadata.description}</Text>
+      <Text c="dimmed" ta="right" style={{ paddingRight: 5 }}>
+        <Anchor
+          target="_blank"
+          onClick={(e) => e.stopPropagation()}
+          href={`${import.meta.env.VITE_REPO_URL}${url}`}
+        >
+          View source:
+          {' '}
+          {url}
+          <IconExternalLink style={{
+            width: rem(18), height: rem(18), marginLeft: rem(2), marginBottom: rem(-3),
+          }}
+          />
+        </Anchor>
+      </Text>
 
-            {config.warnings.length > 0 && (
-              <ErrorLoadingConfig issues={config.warnings} type="warning" />
-            )}
+      {config.warnings.length > 0 && (
+      <ErrorLoadingConfig issues={config.warnings} type="warning" />
+      )}
 
-            <Divider my="md" />
+      <Divider my="md" />
 
-            <Flex direction="row" gap="sm">
-              <Text fw="bold" size="sm" opacity={0.7}>
-                Study Status:
-                {' '}
-                {currentMode}
-              </Text>
-              {studyStatusAndTiming
+      <Flex direction="row" gap="sm">
+        <Text fw="bold" size="sm" opacity={0.7}>
+          Study Status:
+          {' '}
+          {currentMode}
+        </Text>
+        {studyStatusAndTiming
                 && <ParticipantStatusBadges completed={studyStatusAndTiming.completed} inProgress={studyStatusAndTiming.inProgress} rejected={studyStatusAndTiming.rejected} />}
-              <Flex ml="auto" gap="sm" opacity={0.7}>
-                {hasAudioRecording && (
-                  <Tooltip label="Audio recording enabled" withinPortal position="bottom">
-                    <IconMicrophone size={16} color="orange" />
-                  </Tooltip>
-                )}
-                {hasScreenRecording && (
-                  <Tooltip label="Screen recording enabled" withinPortal position="bottom">
-                    <IconDeviceDesktop size={16} color="orange" />
-                  </Tooltip>
-                )}
-                {modes?.developmentModeEnabled
-                  ? <Tooltip label="Development mode enabled" withinPortal position="bottom"><IconSchema size={16} color="green" /></Tooltip>
-                  : <Tooltip label="Development mode disabled" withinPortal position="bottom"><IconSchemaOff size={16} color="red" /></Tooltip>}
-                {modes?.dataSharingEnabled
-                  ? <Tooltip label="Data sharing enabled" withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip>
-                  : <Tooltip label="Data sharing disabled" withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
-                {storageEngine?.getEngine() === 'localStorage'
-                  ? <Tooltip label="Local storage enabled" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip>
-                  : storageEngine?.getEngine() === 'firebase'
-                    ? <Tooltip label="Firebase enabled" withinPortal position="bottom"><IconBrandFirebase size={16} color="green" /></Tooltip>
-                    : storageEngine?.getEngine() === 'supabase'
-                      ? <Tooltip label="Supabase enabled" withinPortal position="bottom"><IconBrandSupabase size={16} color="green" /></Tooltip>
-                      : <Tooltip label="Unknown storage engine enabled" withinPortal position="bottom"><IconDatabase size={16} color="red" /></Tooltip>}
-                {unmetRestrictions.length > 0 && (
-                <Tooltip label={restrictionsTooltip} multiline style={{ whiteSpace: 'pre-line' }} withinPortal position="bottom">
-                  <IconBan size={16} color="red" />
-                </Tooltip>
-                )}
-              </Flex>
-            </Flex>
+        <Flex ml="auto" gap="sm" opacity={0.7}>
+          {hasAudioRecording && (
+          <Tooltip label="Audio recording enabled" withinPortal position="bottom">
+            <IconMicrophone size={16} color="orange" />
+          </Tooltip>
+          )}
+          {hasScreenRecording && (
+          <Tooltip label="Screen recording enabled" withinPortal position="bottom">
+            <IconDeviceDesktop size={16} color="orange" />
+          </Tooltip>
+          )}
+          {modes?.developmentModeEnabled
+            ? <Tooltip label="Development mode enabled" withinPortal position="bottom"><IconSchema size={16} color="green" /></Tooltip>
+            : <Tooltip label="Development mode disabled" withinPortal position="bottom"><IconSchemaOff size={16} color="red" /></Tooltip>}
+          {modes?.dataSharingEnabled
+            ? <Tooltip label="Data sharing enabled" withinPortal position="bottom"><IconGraph size={16} color="green" /></Tooltip>
+            : <Tooltip label="Data sharing disabled" withinPortal position="bottom"><IconGraphOff size={16} color="red" /></Tooltip>}
+          {storageEngine?.getEngine() === 'localStorage'
+            ? <Tooltip label="Local storage enabled" withinPortal position="bottom"><IconDatabase size={16} color="green" /></Tooltip>
+            : storageEngine?.getEngine() === 'firebase'
+              ? <Tooltip label="Firebase enabled" withinPortal position="bottom"><IconBrandFirebase size={16} color="green" /></Tooltip>
+              : storageEngine?.getEngine() === 'supabase'
+                ? <Tooltip label="Supabase enabled" withinPortal position="bottom"><IconBrandSupabase size={16} color="green" /></Tooltip>
+                : <Tooltip label="Unknown storage engine enabled" withinPortal position="bottom"><IconDatabase size={16} color="red" /></Tooltip>}
+          {unmetRestrictions.length > 0 && (
+          <Tooltip label={restrictionsTooltip} multiline style={{ whiteSpace: 'pre-line' }} withinPortal position="bottom">
+            <IconBan size={16} color="red" />
+          </Tooltip>
+          )}
+        </Flex>
+      </Flex>
 
-            {minTime && maxTime
+      {minTime && maxTime
               && (
                 <Text c="dimmed" mt={4}>
                   Activity:
@@ -232,78 +220,102 @@ function StudyCard({
                 </Text>
               )}
 
-            {conditions.length > 0 && (
-              <Flex direction="row" align="center" gap="xs" mt="sm" wrap="wrap">
-                {conditions.map((condition) => {
-                  const conditionUrl = new URL(`${PREFIX}${url}`, window.location.origin);
-                  conditionUrl.searchParams.set('condition', condition);
-                  const conditionUrlString = conditionUrl.toString();
+      {conditions.length > 0 && (
+      <Flex direction="row" align="center" gap="xs" mt="sm" wrap="wrap">
+        {conditions.map((condition) => {
+          const conditionUrl = new URL(`${PREFIX}${url}`, window.location.origin);
+          conditionUrl.searchParams.set('condition', condition);
+          const conditionUrlString = conditionUrl.toString();
 
-                  return (
-                    <CopyButton key={condition} value={conditionUrlString}>
-                      {({ copied, copy }) => (
-                        <Tooltip label={copied ? 'Copied!' : 'Copy URL'}>
-                          <Badge
-                            size="sm"
-                            variant="light"
-                            rightSection={
+          return (
+            <CopyButton key={condition} value={conditionUrlString}>
+              {({ copied, copy }) => (
+                <Tooltip label={copied ? 'Copied!' : 'Copy URL'}>
+                  <Badge
+                    size="sm"
+                    variant="light"
+                    rightSection={
                               copied ? <IconCheck size={12} /> : <IconCopy size={12} />
                             }
-                            onClick={copy}
-                            style={{ cursor: 'pointer' }}
-                          >
-                            {condition}
-                          </Badge>
-                        </Tooltip>
-                      )}
-                    </CopyButton>
-                  );
-                })}
-              </Flex>
-            )}
-
-            <Flex direction="row" align="end" gap="sm" mt="md" wrap="wrap">
-              {conditions.length > 0 && (
-                <MultiSelect
-                  value={selectedConditions}
-                  data={conditionOptions}
-                  w={260}
-                  onChange={(value) => {
-                    if (value.length === 0) {
-                      setSelectedConditions(['default']);
-                      return;
-                    }
-
-                    if (value.includes('default') && value.length > 1) {
-                      setSelectedConditions(value.filter((condition) => condition !== 'default'));
-                      return;
-                    }
-
-                    setSelectedConditions(value);
-                  }}
-                />
+                    onClick={copy}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {condition}
+                  </Badge>
+                </Tooltip>
               )}
-              <Button
-                leftSection={<IconChartHistogram />}
-                style={{ marginLeft: 'auto' }}
-                variant="default"
-                component="a"
-                href={`${PREFIX}analysis/stats/${url}`}
-              >
-                Analyze & Manage Study
-              </Button>
-              <Button
-                leftSection={<IconListCheck />}
-                component="a"
-                href={studyUrl}
-              >
-                Go to Study
-              </Button>
-            </Flex>
-          </>
+            </CopyButton>
+          );
+        })}
+      </Flex>
+      )}
+
+      <Flex direction="row" align="end" gap="sm" mt="md" wrap="wrap">
+        {conditions.length > 0 && (
+        <MultiSelect
+          value={selectedConditions}
+          data={conditionOptions}
+          w={260}
+          onChange={(value) => {
+            if (value.length === 0) {
+              setSelectedConditions(['default']);
+              return;
+            }
+
+            if (value.includes('default') && value.length > 1) {
+              setSelectedConditions(value.filter((condition) => condition !== 'default'));
+              return;
+            }
+
+            setSelectedConditions(value);
+          }}
+        />
         )}
+        <Button
+          leftSection={<IconChartHistogram />}
+          style={{ marginLeft: 'auto' }}
+          variant="default"
+          component="a"
+          href={`${PREFIX}analysis/stats/${url}`}
+        >
+          Analyze & Manage Study
+        </Button>
+        <Button
+          leftSection={<IconListCheck />}
+          component="a"
+          href={studyUrl}
+        >
+          Go to Study
+        </Button>
+      </Flex>
     </Card>
   );
+}
+
+function StudyCard({
+  configName,
+  config,
+  url,
+  modes,
+}: {
+  configName: string;
+  config: ParsedConfig<StudyConfig>;
+  url: string;
+  modes: Record<REVISIT_MODE, boolean> | null;
+}) {
+  if (config.errors.length > 0) {
+    return (
+      <Card key={configName} shadow="sm" radius="md" my="sm" withBorder>
+        <Text size="md" fw="bold">{configName}</Text>
+        <ErrorLoadingConfig issues={config.errors} type="error" />
+        {config.warnings.length > 0 && (
+          <ErrorLoadingConfig issues={config.warnings} type="warning" />
+        )}
+      </Card>
+    );
+  }
+
+  return <ValidStudyCard configName={configName} config={config} url={url} modes={modes} />;
 }
 
 function StudyCards({

--- a/src/components/tests/ConfigSwitcher.spec.tsx
+++ b/src/components/tests/ConfigSwitcher.spec.tsx
@@ -3,7 +3,7 @@ import {
   render, act, cleanup,
 } from '@testing-library/react';
 import {
-  afterEach, describe, expect, test, vi,
+  afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import type {
   ParsedConfig, ParserErrorWarning, StudyConfig,
@@ -107,8 +107,10 @@ vi.mock('../../utils/handleConditionLogic', () => ({
   getSequenceConditions: vi.fn(() => []),
 }));
 
+const useStudyRecordingsMock = vi.hoisted(() => vi.fn(() => ({ hasAudio: false, hasScreenRecording: false })));
+
 vi.mock('../../utils/useStudyRecordings', () => ({
-  useStudyRecordings: () => ({ hasAudio: false, hasScreenRecording: false }),
+  useStudyRecordings: useStudyRecordingsMock,
 }));
 
 vi.mock('../../utils/useDeviceRules', () => ({
@@ -143,6 +145,7 @@ const studyConfigs: Record<string, ParsedConfig<StudyConfig> | null> = {
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
+beforeEach(() => { vi.clearAllMocks(); });
 afterEach(() => { cleanup(); });
 
 describe('ConfigSwitcher', () => {
@@ -174,15 +177,17 @@ describe('ConfigSwitcher', () => {
     };
     const studyConfigsWithErrors: Record<string, ParsedConfig<StudyConfig> | null> = {
       'test-study': {
-        ...minimalStudyConfig,
         errors: [mockError],
-        warnings: [{ ...mockError, message: 'A warning', category: 'unused-component' }],
-      },
+        warnings: [],
+      } as unknown as ParsedConfig<StudyConfig>,
     };
     const { container } = await act(async () => render(
       <ConfigSwitcher globalConfig={globalConfig} studyConfigs={studyConfigsWithErrors} />,
     ));
-    expect(container).toBeDefined();
+    expect(container.textContent).toContain('test-study');
+    expect(container.querySelector('[data-testid="error-loading-config"]')).not.toBeNull();
+    expect(vi.mocked(getSequenceConditions)).not.toHaveBeenCalled();
+    expect(useStudyRecordingsMock).not.toHaveBeenCalled();
   });
 
   test('renders config with warnings but no errors', async () => {

--- a/src/utils/fetchConfig.ts
+++ b/src/utils/fetchConfig.ts
@@ -3,9 +3,36 @@ import { GlobalConfig, ParsedConfig, StudyConfig } from '../parser/types';
 import { parseStudyConfig } from '../parser/parser';
 import { PREFIX } from './Prefix';
 
-async function fetchStudyConfig(configLocation: string) {
-  const config = await (await fetch(`${PREFIX}${configLocation}`)).text();
-  return await parseStudyConfig(config);
+function createConfigLoadError(message: string): ParsedConfig<StudyConfig> {
+  return {
+    errors: [{
+      message,
+      instancePath: 'root',
+      params: { action: 'Check that the config path exists and the deployment is serving it' },
+      category: 'invalid-config',
+    }],
+    warnings: [],
+  } as unknown as ParsedConfig<StudyConfig>;
+}
+
+async function fetchStudyConfig(configLocation: string): Promise<ParsedConfig<StudyConfig>> {
+  let configText: string;
+
+  try {
+    const response = await fetch(`${PREFIX}${configLocation}`);
+    if (!response.ok) {
+      return createConfigLoadError(
+        `Unable to load study config \`${configLocation}\`: ${response.status} ${response.statusText || 'Request failed'}`,
+      );
+    }
+
+    configText = await response.text();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return createConfigLoadError(`Unable to load study config \`${configLocation}\`: ${detail}`);
+  }
+
+  return await parseStudyConfig(configText);
 }
 
 function sanitizeStringForUrlLegacy(fileName: string) {

--- a/src/utils/tests/fetchConfig.spec.ts
+++ b/src/utils/tests/fetchConfig.spec.ts
@@ -21,6 +21,7 @@ describe('fetchConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
       text: async () => JSON.stringify({ test: true }),
     });
     const parsedConfig = {
@@ -75,5 +76,57 @@ describe('fetchConfig', () => {
     expect(results['test-config-1.2']).not.toBeNull();
     expect(results['plain-study']).not.toBeNull();
     expect(parseStudyConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a config error when the config request fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => '<!doctype html>',
+    });
+
+    const result = await getStudyConfig('test-config-1.2', globalConfig);
+
+    expect(result?.errors).toEqual([expect.objectContaining({
+      message: 'Unable to load study config `test-config-1.2/config.json`: 404 Not Found',
+      category: 'invalid-config',
+    })]);
+    expect(parseStudyConfig).not.toHaveBeenCalled();
+  });
+
+  it('keeps successful configs when another config request fails', async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('test-config-1.2')) {
+        return {
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          text: async () => '',
+        };
+      }
+
+      return {
+        ok: true,
+        text: async () => JSON.stringify({ test: true }),
+      };
+    });
+
+    const results = await fetchStudyConfigs(globalConfig);
+
+    expect(results['test-config-1.2']?.errors).toHaveLength(1);
+    expect(results['plain-study']).toEqual(expect.objectContaining({ errors: [], warnings: [] }));
+    expect(parseStudyConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a config error when fetching the config rejects', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network unavailable'));
+
+    const result = await getStudyConfig('test-config-1.2', globalConfig);
+
+    expect(result?.errors).toEqual([expect.objectContaining({
+      message: 'Unable to load study config `test-config-1.2/config.json`: network unavailable',
+      category: 'invalid-config',
+    })]);
   });
 });

--- a/src/utils/tests/useStudyRecordings.spec.ts
+++ b/src/utils/tests/useStudyRecordings.spec.ts
@@ -21,6 +21,15 @@ describe('useStudyRecordings', () => {
     });
   });
 
+  test('both flags are false when the loaded config is incomplete', async () => {
+    const config = { errors: [], warnings: [] } as unknown as Parameters<typeof useStudyRecordings>[0];
+    const { result } = renderHook(() => useStudyRecordings(config));
+    await waitFor(() => {
+      expect(result.current.hasAudioRecording).toBe(false);
+      expect(result.current.hasScreenRecording).toBe(false);
+    });
+  });
+
   test('hasScreenRecording is true when uiConfig.recordScreen is true', async () => {
     const config = makeStudyConfig({ uiConfig: { recordScreen: true } });
     const { result } = renderHook(() => useStudyRecordings(config));

--- a/src/utils/useStudyRecordings.ts
+++ b/src/utils/useStudyRecordings.ts
@@ -10,7 +10,7 @@ export function useStudyRecordings(studyConfig: StudyConfig | undefined) {
   const [hasScreenRecording, setHasScreenRecording] = useState(false);
 
   useEffect(() => {
-    if (!studyConfig) {
+    if (!studyConfig?.uiConfig || !studyConfig.components) {
       setHasAudioRecording(false);
       setHasScreenRecording(false);
       return;


### PR DESCRIPTION
## Summary

- Treat non-2xx and network failures while loading study configs as per-config errors.
- Prevent missing or malformed `$schema` values from crashing the shared header.
- Keep invalid configs out of valid study-card and analysis rendering paths.
- Add regressions for 404/503/network failures, mixed bulk loads, malformed cards, incomplete recording configs, and missing schemas.

## Validation

- `corepack yarn unittest --run src/utils/tests/fetchConfig.spec.ts src/analysis/tests/AppHeader.spec.tsx src/components/tests/ConfigSwitcher.spec.tsx src/utils/tests/useStudyRecordings.spec.ts`
- `corepack yarn typecheck`
- `corepack yarn lint`
- `corepack yarn build`
- `git diff --check`

Build passes with existing Vite/Rolldown warnings only.