### PR TITLE
Make WindowEvents optional in tidy CSV export

### DIFF
--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -55,6 +55,7 @@ const OPTIONAL_COMMON_PROPS = [
   'metaData',
   'participantTags',
   'taskTags',
+  'windowEvents',
 ] as const;
 
 const REQUIRED_PROPS = [
@@ -234,29 +235,31 @@ function participantDataToRows(
         return tidyRow;
       }).flat();
 
-      const windowEventsCount = {
-        focus: trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length,
-        input: trialAnswer.windowEvents.filter((event) => event[1] === 'input').length,
-        keydown: trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length,
-        keyup: trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length,
-        mousemove: trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length,
-        mousedown: trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length,
-        mouseup: trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length,
-        resize: trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length,
-        scroll: trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length,
-        visibility: trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length,
-      };
+      if (properties.includes('windowEvents')) {
+        const windowEventsCount = {
+          focus: trialAnswer.windowEvents.filter((event) => event[1] === 'focus').length,
+          input: trialAnswer.windowEvents.filter((event) => event[1] === 'input').length,
+          keydown: trialAnswer.windowEvents.filter((event) => event[1] === 'keydown').length,
+          keyup: trialAnswer.windowEvents.filter((event) => event[1] === 'keyup').length,
+          mousemove: trialAnswer.windowEvents.filter((event) => event[1] === 'mousemove').length,
+          mousedown: trialAnswer.windowEvents.filter((event) => event[1] === 'mousedown').length,
+          mouseup: trialAnswer.windowEvents.filter((event) => event[1] === 'mouseup').length,
+          resize: trialAnswer.windowEvents.filter((event) => event[1] === 'resize').length,
+          scroll: trialAnswer.windowEvents.filter((event) => event[1] === 'scroll').length,
+          visibility: trialAnswer.windowEvents.filter((event) => event[1] === 'visibility').length,
+        };
 
-      // Add a window events count row for each component
-      rows.push({
-        participantId: participant.participantId,
-        trialId,
-        trialOrder,
-        responseId: 'windowEvents',
-        answer: JSON.stringify(windowEventsCount),
-        ...(properties.includes('condition') ? { condition: conditionValue } : {}),
-        ...(properties.includes('stage') ? { stage: participant.stage } : {}),
-      } as TidyRow);
+        // Add a window events count row for each component
+        rows.push({
+          participantId: participant.participantId,
+          trialId,
+          trialOrder,
+          responseId: 'windowEvents',
+          answer: JSON.stringify(windowEventsCount),
+          ...(properties.includes('condition') ? { condition: conditionValue } : {}),
+          ...(properties.includes('stage') ? { stage: participant.stage } : {}),
+        } as TidyRow);
+      }
 
       return rows;
     }).flat()], Array.from(newHeaders)];
@@ -313,7 +316,8 @@ export async function getTableData(
   const header = combinedProperties
     .filter((p) => p !== 'condition' || hasCondition)
     .filter((p) => p !== 'metaData')
-    .filter((p) => p !== 'participantTags');
+    .filter((p) => p !== 'participantTags')
+    .filter((p) => p !== 'windowEvents');
   const allData = await Promise.all(data.map(async (participant) => {
     const participantConfig = allConfigs[participant.participantConfigHash];
     const qualitativeCodes = selectedProperties.includes('participantTags') || selectedProperties.includes('taskTags')

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -1,5 +1,5 @@
 import {
-  cleanup, render, waitFor,
+  cleanup, fireEvent, render, screen, waitFor, within,
 } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import {
@@ -359,7 +359,22 @@ describe('getTableData', () => {
     }));
   });
 
-  test('exports empty answer rows and window event counts', async () => {
+  test('omits window event rows by default', async () => {
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+
+    const tableData = await getTableData(
+      ['answer'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+    );
+
+    expect(tableData.rows.find((row) => row.responseId === 'windowEvents')).toBeUndefined();
+  });
+
+  test('exports empty answer rows and selected window event counts', async () => {
     const participant = makeParticipant({
       answers: {
         testComponent_0: {
@@ -386,7 +401,7 @@ describe('getTableData', () => {
     });
 
     const tableData = await getTableData(
-      ['answer'],
+      ['answer', 'windowEvents'],
       [participant],
       storageEngine,
       'test-study',
@@ -401,6 +416,7 @@ describe('getTableData', () => {
       responseId: '',
     }));
     expect(emptyAnswerRow?.answer).toBeUndefined();
+    expect(tableData.header).not.toContain('windowEvents');
     expect(windowEventsRow).toEqual(expect.objectContaining({
       participantId: 'p1',
       trialId: 'testComponent',
@@ -416,6 +432,37 @@ describe('getTableData', () => {
         resize: 1,
         scroll: 1,
         visibility: 1,
+      }),
+    }));
+  });
+
+  test('exports zero window event counts when selected', async () => {
+    const storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+
+    const tableData = await getTableData(
+      ['windowEvents'],
+      [makeParticipant()],
+      storageEngine,
+      'test-study',
+    );
+
+    expect(tableData.rows.find((row) => row.responseId === 'windowEvents')).toEqual(expect.objectContaining({
+      participantId: 'p1',
+      trialId: 'testComponent',
+      responseId: 'windowEvents',
+      answer: JSON.stringify({
+        focus: 0,
+        input: 0,
+        keydown: 0,
+        keyup: 0,
+        mousemove: 0,
+        mousedown: 0,
+        mouseup: 0,
+        resize: 0,
+        scroll: 0,
+        visibility: 0,
       }),
     }));
   });
@@ -535,6 +582,42 @@ describe('DownloadTidy', () => {
     cleanup();
     storageEngineHookMock.storageEngine = undefined;
     vi.clearAllMocks();
+  });
+
+  test('exposes window events as an unselected optional property', async () => {
+    storageEngineHookMock.storageEngine = makeStorageEngine({
+      'hash-1': configSimple,
+    });
+
+    render(
+      <MantineProvider>
+        <DownloadTidy
+          opened
+          close={vi.fn()}
+          filename="test-study_tidy.csv"
+          data={[makeParticipant()]}
+          studyId="test-study"
+        />
+      </MantineProvider>,
+    );
+
+    const windowEventsButton = screen.getByRole('button', { name: 'windowEvents' });
+    await waitFor(() => {
+      expect(within(document.body.querySelector('tbody')!).getByText('response')).not.toBeNull();
+    });
+    expect(within(document.body.querySelector('tbody')!).queryByText('windowEvents')).toBeNull();
+
+    fireEvent.click(windowEventsButton);
+
+    await waitFor(() => {
+      expect(within(document.body.querySelector('tbody')!).getByText('windowEvents')).not.toBeNull();
+    });
+
+    fireEvent.click(windowEventsButton);
+
+    await waitFor(() => {
+      expect(within(document.body.querySelector('tbody')!).queryByText('windowEvents')).toBeNull();
+    });
   });
 
   test('shows an informational warning when selected participants reference missing configs', async () => {


### PR DESCRIPTION
Closes #1413

## Summary
- Make the Tidy CSV WindowEvents summary an optional export item, disabled by default.
- Preserve the existing per-trial event-count rows when enabled.
- Add coverage for default omission, opt-in/opt-out behavior, preserved counts, and zero-event summaries.

## Verification
- `corepack yarn unittest --run src/components/downloader/tests/DownloadTidy.spec.tsx`
- `corepack yarn typecheck`
- `corepack yarn lint`
- `corepack yarn build`
- `git diff --check`

An independent adversarial review found no correctness or YAGNI issues; its UI toggle-off coverage gap was added before this PR.