### PR TITLE
Upgrade Mantine to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
-        "@mantine/core": "^7.10.1",
-        "@mantine/dates": "^7.10.1",
-        "@mantine/form": "^7.10.1",
-        "@mantine/hooks": "^7.10.1",
-        "@mantine/modals": "^7.10.1",
-        "@mantine/notifications": "^7.12.0",
+        "@mantine/core": "^9.5.1",
+        "@mantine/dates": "^9.5.1",
+        "@mantine/form": "^9.5.1",
+        "@mantine/hooks": "^9.5.1",
+        "@mantine/modals": "^9.5.1",
+        "@mantine/notifications": "^9.5.1",
         "@mui/icons-material": "^7.0.0",
         "@mui/material": "^7.0.0",
         "@mui/system": "^7.0.0",
@@ -49,7 +49,7 @@
         "lodash.isequal": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.throttle": "^4.1.1",
-        "mantine-react-table": "^2.0.0-beta.9",
+        "mantine-react-table": "2.0.0-beta.9",
         "plyr": "^3.8.4",
         "plyr-react": "^6.0.0",
         "react": "^19.2.8",
@@ -1679,46 +1679,46 @@
       "license": "Apache-2.0"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.8.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1726,9 +1726,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@fontsource/roboto": {
@@ -1880,97 +1880,97 @@
       }
     },
     "node_modules/@mantine/core": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz",
-      "integrity": "sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.5.1.tgz",
+      "integrity": "sha512-3olDOYJBfW4kR37Aqdy/+FnYG7iNb5SPzOGeCp9dDxnt65K94sEqETDnXGJptOMO2xLm4KLJ/eBt3IIhJA7Z4Q==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react": "^0.26.28",
+        "@floating-ui/react": "^0.27.19",
         "clsx": "^2.1.1",
-        "react-number-format": "^5.4.3",
-        "react-remove-scroll": "^2.6.2",
-        "react-textarea-autosize": "8.5.9",
-        "type-fest": "^4.27.0"
+        "react-number-format": "^5.4.5",
+        "react-remove-scroll": "^2.7.2",
+        "type-fest": "^5.8.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "7.17.8",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "@mantine/hooks": "9.5.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/dates": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-7.17.8.tgz",
-      "integrity": "sha512-KYog/YL83PnsMef7EZagpOFq9I2gfnK0eYSzC8YvV9Mb6t/x9InqRssGWVb0GIr+TNILpEkhKoGaSKZNy10Q1g==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.5.1.tgz",
+      "integrity": "sha512-1FTIgF8L6AKEb+Ql53zVyCCp4JxvQp/AUDts5T/JEI7U0CZGpzg+FHGtmNShLR4ONuOfzOV1gkgU8INbxVJjag==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "@mantine/core": "7.17.8",
-        "@mantine/hooks": "7.17.8",
+        "@mantine/core": "9.5.1",
+        "@mantine/hooks": "9.5.1",
         "dayjs": ">=1.0.0",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/form": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-7.17.8.tgz",
-      "integrity": "sha512-cRLAMYOsZT17jyV9Myl29xacgaswGVAz3Ku6bvphBFad7Nzorra809uKFJxm2yKW5NknZ4ENHSXjyru7k0GTGA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-9.5.1.tgz",
+      "integrity": "sha512-WsMZGBTsoG2Y/K+6QK0+GmsJxq5KzWHIzo65lRpkq/SwdenV9G+3m0LstlhI9i2/wQF83GfwP7mCbKMfzf00Eg==",
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "fast-deep-equal": "^3.1.3",
         "klona": "^2.0.6"
       },
       "peerDependencies": {
-        "react": "^18.x || ^19.x"
+        "react": "^19.2.0"
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz",
-      "integrity": "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.5.1.tgz",
+      "integrity": "sha512-2sK9OdWvrzKBOuWxLfQA5qcAJzxpzqNlKumaP7Uq0i7LDBQeY/sYgNiBWLwtW+iZw6fFXwPf0nI7q5VVpvqnNQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^18.x || ^19.x"
+        "react": "^19.2.0"
       }
     },
     "node_modules/@mantine/modals": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-7.17.8.tgz",
-      "integrity": "sha512-7Eylnopjh8b0xIrtXnle8DsNsLghq82uUYMalm54nMaCSD9N/qAuCPGfAE0k2tsWj5cGDC2/uMbU0RSBjGanbA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.5.1.tgz",
+      "integrity": "sha512-hvfNqwgiIxe/3sWPX5pIHzYnwV28U5w9UrA0Y+Dh3HDkmIu2PZ3nwcUhqS+Za6gFZCx53XuNLZs2OMW2hrvdzg==",
       "license": "MIT",
       "peerDependencies": {
-        "@mantine/core": "7.17.8",
-        "@mantine/hooks": "7.17.8",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "@mantine/core": "9.5.1",
+        "@mantine/hooks": "9.5.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/notifications": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-7.17.8.tgz",
-      "integrity": "sha512-/YK16IZ198W6ru/IVecCtHcVveL08u2c8TbQTu/2p26LSIM9AbJhUkrU6H+AO0dgVVvmdmNdvPxcJnfq3S9TMg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.5.1.tgz",
+      "integrity": "sha512-/MIGWag8U20HTM4gOGSNVhmQ0n6YM2gdSR1NbtBffSh77nuzwPjr68UmpMc2WHFMi8OBlrSIcw9Xpe3YPfgnvQ==",
       "license": "MIT",
       "dependencies": {
-        "@mantine/store": "7.17.8",
+        "@mantine/store": "9.5.1",
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@mantine/core": "7.17.8",
-        "@mantine/hooks": "7.17.8",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
+        "@mantine/core": "9.5.1",
+        "@mantine/hooks": "9.5.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/store": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-7.17.8.tgz",
-      "integrity": "sha512-/FrB6PAVH4NEjQ1dsc9qOB+VvVlSuyjf4oOOlM9gscPuapDP/79Ryq7JkhHYfS55VWQ/YUlY24hDI2VV+VptXg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.5.1.tgz",
+      "integrity": "sha512-nDmA9S+qnQQ61KYgph06Wt2cx1tj3Z6eeyK3HvFeuLb5FcGycbITsVy/+3LltH2qdqkpNeAA9wQ926NFjn5hvA==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^18.x || ^19.x"
+        "react": "^19.2.0"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -12592,9 +12592,9 @@
       }
     },
     "node_modules/react-number-format": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
-      "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
+      "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -12625,9 +12625,9 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -12731,23 +12731,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -13662,9 +13645,9 @@
       "license": "MIT"
     },
     "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/table-layout": {
@@ -13687,6 +13670,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -13914,12 +13909,15 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14338,20 +14336,6 @@
         }
       }
     },
-    "node_modules/use-composed-ref": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/use-deep-compare-effect": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
@@ -14367,37 +14351,6 @@
       },
       "peerDependencies": {
         "react": ">=16.13"
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "unittest": "vitest",
     "unittest-coverage": "vitest run --coverage --coverage.reporter=text",
     "find-revisit-users": "bash scripts/find-revisit-users.sh",
-    "postinstall": "husky"
+    "postinstall": "husky && node scripts/patch-mantine-react-table.cjs"
   },
   "lint-staged": {
     "*.{tsx,jsx,ts,js}": "yarn lint"
@@ -30,12 +30,12 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "@mantine/core": "^7.10.1",
-    "@mantine/dates": "^7.10.1",
-    "@mantine/form": "^7.10.1",
-    "@mantine/hooks": "^7.10.1",
-    "@mantine/modals": "^7.10.1",
-    "@mantine/notifications": "^7.12.0",
+    "@mantine/core": "^9.5.1",
+    "@mantine/dates": "^9.5.1",
+    "@mantine/form": "^9.5.1",
+    "@mantine/hooks": "^9.5.1",
+    "@mantine/modals": "^9.5.1",
+    "@mantine/notifications": "^9.5.1",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
     "@mui/system": "^7.0.0",
@@ -65,7 +65,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "lodash.throttle": "^4.1.1",
-    "mantine-react-table": "^2.0.0-beta.9",
+    "mantine-react-table": "2.0.0-beta.9",
     "plyr": "^3.8.4",
     "plyr-react": "^6.0.0",
     "react": "^19.2.8",

--- a/scripts/patch-mantine-react-table.cjs
+++ b/scripts/patch-mantine-react-table.cjs
@@ -1,0 +1,32 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const packageDirectory = path.resolve(__dirname, '../node_modules/mantine-react-table');
+const packageJson = JSON.parse(fs.readFileSync(path.join(packageDirectory, 'package.json'), 'utf8'));
+
+if (packageJson.version !== '2.0.0-beta.9') {
+  throw new Error(`Expected mantine-react-table 2.0.0-beta.9, found ${packageJson.version}. Remove this shim when upgrading MRT.`);
+}
+
+[
+  ['dist/index.esm.mjs'],
+  ['dist/index.cjs'],
+].forEach(([relativePath]) => {
+  const filePath = path.join(packageDirectory, relativePath);
+  const source = fs.readFileSync(filePath, 'utf8');
+  const newTextValue = 'expanded:';
+  const occurrences = source.match(/\bin:/g)?.length ?? 0;
+
+  if (occurrences === 0) {
+    if (!source.includes(newTextValue)) {
+      throw new Error(`Could not find Mantine Collapse calls in ${relativePath}.`);
+    }
+    return;
+  }
+
+  if (occurrences !== 5) {
+    throw new Error(`Expected five Mantine Collapse calls in ${relativePath}, found ${occurrences}.`);
+  }
+
+  fs.writeFileSync(filePath, source.replace(/\bin:/g, newTextValue));
+});

--- a/src/analysis/individualStudy/LiveMonitor/ParticipantSection.tsx
+++ b/src/analysis/individualStudy/LiveMonitor/ParticipantSection.tsx
@@ -52,7 +52,7 @@ export function ParticipantSection({
           )
         </Title>
       </Group>
-      <Collapse in={isOpen}>
+      <Collapse expanded={isOpen}>
         {participants.length > 0 && (
           <Grid mt="xs">
             {participants.map(({ assignment, progress }, index) => (

--- a/src/analysis/individualStudy/LiveMonitor/tests/LiveMonitorView.spec.tsx
+++ b/src/analysis/individualStudy/LiveMonitor/tests/LiveMonitorView.spec.tsx
@@ -38,7 +38,7 @@ vi.mock('@mantine/core', () => ({
     { Col: ({ children }: { children: ReactNode }) => <div>{children}</div> },
   ),
   RingProgress: ({ label }: { label?: ReactNode }) => <div>{label}</div>,
-  Collapse: ({ children, in: open }: { children: ReactNode; in?: boolean }) => (
+  Collapse: ({ children, expanded: open }: { children: ReactNode; expanded?: boolean }) => (
     open ? <div>{children}</div> : null
   ),
 }));

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -403,7 +403,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyConfigs={studyConfig && displayStudyId ? { [displayStudyId]: studyConfig } : undefined} />
       <AppShell.Main style={{ height: '100dvh' }}>
         <Stack ref={ref} style={{ height: '100%', maxHeight: '100dvh', overflow: 'hidden' }} justify="space-between">
-          <Flex direction="row" align="center" justify="space-between" p="sm" gap="md">
+          <Flex direction="row" align="center" justify="space-between" py="sm" gap="md">
             <Flex direction="row" align="center" gap="md">
               <Title order={5}>{displayStudyId}</Title>
               {studyConfig && canonicalStudyId && (

--- a/src/analysis/individualStudy/stats/ResponseVisualization.tsx
+++ b/src/analysis/individualStudy/stats/ResponseVisualization.tsx
@@ -245,7 +245,7 @@ export function ResponseVisualization({
         <IconChevronDown style={{ rotate: opened ? '180deg' : 'none', transition: 'rotate 200ms' }} />
       </Flex>
 
-      <Collapse in={opened} mah={400}>
+      <Collapse expanded={opened} mah={400}>
         <Box
           style={{
             position: 'sticky', backgroundColor: 'white', zIndex: 2,

--- a/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
+++ b/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
@@ -36,7 +36,7 @@ vi.mock('@mantine/core', () => ({
   }),
   Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
   Title: ({ children }: { children: ReactNode }) => <h5>{children}</h5>,
-  Collapse: ({ children, in: open }: { children: ReactNode; in?: boolean }) => (
+  Collapse: ({ children, expanded: open }: { children: ReactNode; expanded?: boolean }) => (
     open ? <div>{children}</div> : null
   ),
   Code: ({ children }: { children: ReactNode }) => <code>{children}</code>,

--- a/src/analysis/individualStudy/thinkAloud/tags/tests/EditTagPopover.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/tests/EditTagPopover.spec.tsx
@@ -47,7 +47,7 @@ describe('EditTagPopover', () => {
       resolveSave = resolve;
     }));
     render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <EditTagPopover tag={tag} currentNames={[tag.name]} editTagCallback={editTagCallback} />
       </MantineProvider>,
     );
@@ -73,7 +73,7 @@ describe('EditTagPopover', () => {
   test('keeps the edit popover open when persistence fails', async () => {
     const editTagCallback = vi.fn().mockRejectedValue(new Error('save failed'));
     render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <EditTagPopover tag={tag} currentNames={[tag.name]} editTagCallback={editTagCallback} />
       </MantineProvider>,
     );

--- a/src/analysis/individualStudy/thinkAloud/tags/tests/TagEditor.spec.tsx
+++ b/src/analysis/individualStudy/thinkAloud/tags/tests/TagEditor.spec.tsx
@@ -43,7 +43,7 @@ describe('TagEditor', () => {
     const createTagCallback = vi.fn(() => new Promise<void>((resolve) => {
       resolveSave = resolve;
     }));
-    render(<MantineProvider><TagEditor createTagCallback={createTagCallback} tags={[]} /></MantineProvider>);
+    render(<MantineProvider env="test"><TagEditor createTagCallback={createTagCallback} tags={[]} /></MantineProvider>);
 
     fireEvent.click(screen.getByRole('button', { name: 'Create new tag' }));
     const nameInput = await screen.findByPlaceholderText('Enter tag name');
@@ -61,7 +61,7 @@ describe('TagEditor', () => {
 
   test('keeps the creation popover open when persistence fails', async () => {
     const createTagCallback = vi.fn().mockRejectedValue(new Error('save failed'));
-    render(<MantineProvider><TagEditor createTagCallback={createTagCallback} tags={[]} /></MantineProvider>);
+    render(<MantineProvider env="test"><TagEditor createTagCallback={createTagCallback} tags={[]} /></MantineProvider>);
 
     fireEvent.click(screen.getByRole('button', { name: 'Create new tag' }));
     fireEvent.change(await screen.findByPlaceholderText('Enter tag name'), { target: { value: 'New Tag' } });

--- a/src/analysis/interface/AppHeader.tsx
+++ b/src/analysis/interface/AppHeader.tsx
@@ -34,7 +34,7 @@ export function AppHeader({
 
   return (
     <AppShell.Header p="md">
-      <Grid mt={-7} align="center">
+      <Grid align="center">
         <Grid.Col span={6}>
           <Flex align="center" onClick={() => navigate('/')} style={{ cursor: 'pointer' }}>
             <Image w={40} src={`${PREFIX}revisitAssets/revisitLogoSquare.svg`} alt="Revisit Logo" />

--- a/src/components/ErrorLoadingConfig.tsx
+++ b/src/components/ErrorLoadingConfig.tsx
@@ -240,7 +240,7 @@ export function ErrorLoadingConfig({
       <Text size="sm" c="dimmed">
         {headerText}
       </Text>
-      <Collapse in={isOpen}>
+      <Collapse expanded={isOpen}>
         <Stack gap="md" mt="xs">
           {groupIssuesByCategory().map(({ category, entries }, idx, arr) => {
             const categoryCount = entries.reduce((sum, e) => sum + e.issues.length, 0);

--- a/src/components/ReactMarkdownWrapper.tsx
+++ b/src/components/ReactMarkdownWrapper.tsx
@@ -27,8 +27,10 @@ const markdownComponents = (inline?: boolean): Partial<Components> => ({
   h6({ node: _, ...props }) { return <Title {...props} order={6} pb={inline ? undefined : 12} />; },
   a({ node: _, ...props }) { return <Anchor {...props} ref={undefined} />; },
   code({ node: _, ...props }) { return <Code {...props} />; },
-  ul({ node: _, ...props }) { return <List withPadding {...props} pb={inline ? undefined : 8} />; },
-  ol({ node: _, type: _type, ...props }) { return <List {...props} type="ordered" withPadding pb={inline ? undefined : 8} />; },
+  ul({ node: _, ref: _ref, ...props }) { return <List withPadding {...props} pb={inline ? undefined : 8} />; },
+  ol({
+    node: _, type: _type, ref: _ref, ...props
+  }) { return <List {...props} type="ordered" withPadding pb={inline ? undefined : 8} />; },
   table({ node: _, ...props }) { return <Table {...props} mb={12} borderColor="grey" />; },
   thead({ node: _, ...props }) { return <Table.Thead {...props} />; },
   tbody({ node: _, ...props }) { return <Table.Tbody {...props} />; },

--- a/src/components/interface/AppHeader.tsx
+++ b/src/components/interface/AppHeader.tsx
@@ -202,7 +202,7 @@ export function AppHeader({ developmentModeEnabled, dataCollectionEnabled }: { d
 
   return (
     <AppShell.Header className="header" p="md">
-      <Grid mt={-7} align="center">
+      <Grid align="center">
         <Grid.Col span={4}>
           <Flex align="center">
             <Image w={40} src={`${PREFIX}${logoPath}`} alt="Study Logo" className="logoImage" />

--- a/src/components/response/CheckBoxInput.tsx
+++ b/src/components/response/CheckBoxInput.tsx
@@ -3,7 +3,7 @@ import {
 } from '@mantine/core';
 import { useEffect, useMemo, useState } from 'react';
 import { CheckboxResponse, ParsedStringOption } from '../../parser/types';
-import { DONT_KNOW_DEFAULT_VALUE, normalizeCheckboxDontKnowValue } from './utils';
+import { DONT_KNOW_DEFAULT_VALUE, normalizeCheckboxDontKnowValue, normalizeCheckboxValue } from './utils';
 import { HorizontalHandler } from './HorizontalHandler';
 import classes from './css/Checkbox.module.css';
 import inputClasses from './css/Input.module.css';
@@ -50,7 +50,7 @@ export function CheckBoxInput({
   );
 
   const [otherSelected, setOtherSelected] = useState(false);
-  const selectedValues = useMemo(() => (Array.isArray(answer.value) ? answer.value : []), [answer.value]);
+  const selectedValues = useMemo(() => normalizeCheckboxValue(answer.value), [answer.value]);
 
   useEffect(() => {
     if (!response.withDontKnow || selectedValues.length === 0) {
@@ -77,6 +77,7 @@ export function CheckBoxInput({
       label={prompt.length > 0 && <InputLabel prompt={prompt} required={required} index={index} enumerateQuestions={enumerateQuestions} infoText={infoText} />}
       description={secondaryText}
       {...answer}
+      value={selectedValues}
       error={error}
       errorProps={{ c: required ? 'red' : 'orange', fz: 'sm', mt: 'xs' }}
       style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -28,7 +28,7 @@ import { TextOnlyInput } from './TextOnlyInput';
 import { useFetchStylesheet } from '../../utils/fetchStylesheet';
 import { parseStringOptionValue, parseStringOptions } from '../../utils/stringOptions';
 import {
-  getDefaultFieldValue,
+  getDefaultFieldValue, normalizeCheckboxValue,
 } from './utils';
 import {
   generateErrorMessage,
@@ -131,7 +131,8 @@ export function ResponseSwitcher({
 
   const fieldInitialValue = useMemo(() => {
     if (response.paramCapture) {
-      return searchParams.get(response.paramCapture) || '';
+      const capturedValue = searchParams.get(response.paramCapture);
+      return response.type === 'checkbox' ? normalizeCheckboxValue(capturedValue) : capturedValue || '';
     }
 
     const defaultFieldValue = getDefaultFieldValue(response);

--- a/src/components/response/tests/ResponseInput.spec.tsx
+++ b/src/components/response/tests/ResponseInput.spec.tsx
@@ -185,7 +185,7 @@ vi.mock('../../ReactMarkdownWrapper', () => ({
 }));
 
 vi.mock('@mantine/hooks', () => ({
-  useMove: vi.fn(() => ({ ref: { current: null } })),
+  useMove: vi.fn(() => ({ ref: () => undefined, active: false })),
 }));
 
 vi.mock('../sliderBreaks', () => ({
@@ -808,7 +808,7 @@ describe('SliderInput', () => {
     let capturedCallback: ((pos: { x: number; y: number }) => void) | null = null;
     vi.mocked(useMove).mockImplementationOnce((fn: (pos: { x: number; y: number }) => void) => {
       capturedCallback = fn;
-      return { ref: { current: null }, active: false };
+      return { ref: () => undefined, active: false };
     });
     const mockOnChange = vi.fn();
     await act(async () => render(
@@ -882,7 +882,7 @@ describe('SliderInput', () => {
     let capturedCallback: ((pos: { x: number; y: number }) => void) | null = null;
     vi.mocked(useMove).mockImplementationOnce((fn: (pos: { x: number; y: number }) => void) => {
       capturedCallback = fn;
-      return { ref: { current: null }, active: false };
+      return { ref: () => undefined, active: false };
     });
     const mockOnChange = vi.fn();
     render(

--- a/src/components/response/tests/ResponseInput.spec.tsx
+++ b/src/components/response/tests/ResponseInput.spec.tsx
@@ -90,8 +90,15 @@ vi.mock('@mantine/core', () => {
       <div data-value={value} data-checked={checked}>{label}</div>
     ),
     {
-      Group: ({ children, label, description }: { children?: ReactNode; label?: ReactNode; description?: ReactNode }) => (
-        <div>
+      Group: ({
+        children, label, description, value,
+      }: {
+        children?: ReactNode;
+        label?: ReactNode;
+        description?: ReactNode;
+        value?: string[];
+      }) => (
+        <div data-group-value={JSON.stringify(value)}>
           {label}
           {description}
           {children}
@@ -251,6 +258,7 @@ vi.mock('../utils', () => ({
   generateErrorMessage: vi.fn(() => null),
   DONT_KNOW_DEFAULT_VALUE: "I don't know",
   normalizeCheckboxDontKnowValue: vi.fn((v: string[]) => v),
+  normalizeCheckboxValue: vi.fn((v: unknown) => (typeof v === 'string' && v.length > 0 ? [v] : [])),
   usesStandaloneDontKnowField: vi.fn(() => false),
   getDefaultFieldValue: vi.fn(() => null),
 }));
@@ -570,6 +578,19 @@ describe('CheckBoxInput', () => {
     expect(html).toContain('A');
     expect(html).toContain('B');
     expect(html).toContain('C');
+  });
+
+  test('renders a malformed scalar answer as a selected checkbox', () => {
+    const html = renderToStaticMarkup(
+      <CheckBoxInput
+        response={base}
+        disabled={false}
+        answer={{ value: 'A' } as unknown as { value: string[] }}
+        index={1}
+        enumerateQuestions={false}
+      />,
+    );
+    expect(html).toContain('data-group-value="[&quot;A&quot;]"');
   });
 
   test('renders "Other" checkbox label when withOther=true and horizontal=true', () => {

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -1202,6 +1202,13 @@ describe('generateInitFields additional branches', () => {
     expect(generateInitFields([response], {})).toMatchObject({ q1: [] });
   });
 
+  test('initializes checkbox response to empty array', () => {
+    const response: Response = {
+      id: 'q1', prompt: '', type: 'checkbox', options: ['A', 'B'],
+    };
+    expect(generateInitFields([response], {})).toMatchObject({ q1: [] });
+  });
+
   test('initializes ranking-categorical to empty array', () => {
     const response: Response = {
       id: 'q1', prompt: '', type: 'ranking-categorical', options: [],

--- a/src/components/response/tests/utils.spec.ts
+++ b/src/components/response/tests/utils.spec.ts
@@ -11,6 +11,7 @@ import {
   getDefaultFieldValue,
   generateValidation,
   mergeReactiveAnswers,
+  normalizeCheckboxValue,
   normalizeCheckboxDontKnowValue,
   useAnswerField,
 } from '../utils';
@@ -1207,6 +1208,16 @@ describe('generateInitFields additional branches', () => {
       id: 'q1', prompt: '', type: 'checkbox', options: ['A', 'B'],
     };
     expect(generateInitFields([response], {})).toMatchObject({ q1: [] });
+  });
+
+  test('normalizes stored and captured checkbox values to arrays', () => {
+    const response: Response = {
+      id: 'q1', prompt: '', type: 'checkbox', options: ['A', 'B'], paramCapture: 'color',
+    };
+
+    expect(generateInitFields([response], { q1: 'A' })).toMatchObject({ q1: ['A'] });
+    expect(generateInitFields([response], {})).toMatchObject({ q1: ['blue'] });
+    expect(normalizeCheckboxValue('')).toEqual([]);
   });
 
   test('initializes ranking-categorical to empty array', () => {

--- a/src/components/response/utils.ts
+++ b/src/components/response/utils.ts
@@ -15,6 +15,14 @@ type ResponseWithDefault = Response & { default?: ResponseDefault };
 
 export const DONT_KNOW_DEFAULT_VALUE = "I don't know";
 
+export function normalizeCheckboxValue(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+
+  return typeof value === 'string' && value.length > 0 ? [value] : [];
+}
+
 export function normalizeCheckboxDontKnowValue(value: string[]) {
   return value.includes(DONT_KNOW_DEFAULT_VALUE) ? [] : value;
 }
@@ -45,7 +53,7 @@ export const getDefaultFieldValue = (response: Response) => {
   }
 
   if (response.type === 'checkbox') {
-    return Array.isArray(responseDefault) ? responseDefault : (responseDefault === null ? [] : [responseDefault.toString()]);
+    return normalizeCheckboxValue(responseDefault);
   }
 
   if (response.type === 'likert') {
@@ -94,7 +102,7 @@ export const generateInitFields = (responses: Response[], storedAnswer: StoredAn
     if (hasStoredAnswer) {
       initObj = {
         ...initObj,
-        [response.id]: answer,
+        [response.id]: response.type === 'checkbox' ? normalizeCheckboxValue(answer) : answer,
         ...dontKnowObj,
         ...otherObj,
       };
@@ -102,7 +110,8 @@ export const generateInitFields = (responses: Response[], storedAnswer: StoredAn
       let initField: StoredAnswer['answer'][string] = '';
       const defaultFieldValue = getDefaultFieldValue(response);
       if (response.paramCapture) {
-        initField = queryParameters.get(response.paramCapture);
+        const capturedValue = queryParameters.get(response.paramCapture);
+        initField = response.type === 'checkbox' ? normalizeCheckboxValue(capturedValue) : capturedValue;
       } else if (defaultFieldValue !== null) {
         initField = defaultFieldValue;
       } else if (response.type === 'checkbox' || response.type === 'reactive' || response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {

--- a/src/components/response/utils.ts
+++ b/src/components/response/utils.ts
@@ -105,7 +105,7 @@ export const generateInitFields = (responses: Response[], storedAnswer: StoredAn
         initField = queryParameters.get(response.paramCapture);
       } else if (defaultFieldValue !== null) {
         initField = defaultFieldValue;
-      } else if (response.type === 'reactive' || response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {
+      } else if (response.type === 'checkbox' || response.type === 'reactive' || response.type === 'ranking-sublist' || response.type === 'ranking-categorical' || response.type === 'ranking-pairwise') {
         initField = [];
       } else if (response.type === 'matrix-radio' || response.type === 'matrix-checkbox') {
         initField = Object.fromEntries(

--- a/src/public/example-brush-interactions/assets/Scatter.tsx
+++ b/src/public/example-brush-interactions/assets/Scatter.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useResizeObserver } from '@mantine/hooks';
-import { useEffect, useMemo, useState } from 'react';
+import {
+  useCallback, useEffect, useMemo, useRef, useState,
+} from 'react';
 import ColumnTable from 'arquero/dist/types/table/column-table';
 import * as d3 from 'd3';
 import {
@@ -37,10 +39,15 @@ export function Scatter({
         setBrushedSpace: (brush: [[number | null, number | null], [number | null, number | null]], xScale: any, yScale: any, selType: 'drag' | 'handle' | 'clear' | null, ids?: string[]) => void,
         brushType: BrushNames
     }) {
-  const [ref, { height: originalHeight, width: originalWidth }] = useResizeObserver();
+  const [resizeRef, { height: originalHeight, width: originalWidth }] = useResizeObserver();
+  const scatterRef = useRef<SVGSVGElement | null>(null);
+  const ref = useCallback((element: SVGSVGElement | null) => {
+    resizeRef(element);
+    scatterRef.current = element;
+  }, [resizeRef]);
 
-  const [brushXRef] = useResizeObserver();
-  const [brushYRef] = useResizeObserver();
+  const brushXRef = useRef<SVGGElement | null>(null);
+  const brushYRef = useRef<SVGGElement | null>(null);
 
   const [isPaintbrushSelect, setIsPaintbrushSelect] = useState<boolean>(true);
 
@@ -113,19 +120,19 @@ export function Scatter({
       });
 
       if (brushXRef.current && brushYRef.current) {
-        d3.select(brushYRef.current).call(brushY);
-        d3.select(brushXRef.current).call(brushX);
+        d3.select(brushYRef.current!).call(brushY);
+        d3.select(brushXRef.current!).call(brushX);
 
         if (!brushState.hasBrush) {
-          d3.select(brushYRef.current).call(brushY.move, [yScale(yMax), yScale(yMin)]);
-          d3.select(brushXRef.current).call(brushX.move, [xScale(new Date('2015-01-02')), xScale(new Date('2015-12-31'))]);
+          d3.select(brushYRef.current!).call(brushY.move, [yScale(yMax), yScale(yMin)]);
+          d3.select(brushXRef.current!).call(brushX.move, [xScale(new Date('2015-01-02')), xScale(new Date('2015-12-31'))]);
           setBrushedSpace([[xScale(new Date('2015-01-02')), yScale(yMax)], [xScale(new Date('2015-12-31')), yScale(yMin)]], xScale, yScale, 'drag');
         }
       }
 
       return () => {
-        d3.select(brushYRef.current).call(brushY.move, [yScale(yMax), yScale(yMin)]);
-        d3.select(brushXRef.current).call(brushX.move, [xScale(new Date('2015-01-02')), xScale(new Date('2015-12-31'))]);
+        d3.select(brushYRef.current!).call(brushY.move, [yScale(yMax), yScale(yMin)]);
+        d3.select(brushXRef.current!).call(brushX.move, [xScale(new Date('2015-01-02')), xScale(new Date('2015-12-31'))]);
         setBrushedSpace([[xScale(new Date('2015-01-02')), yScale(yMax)], [xScale(new Date('2015-12-31')), yScale(yMin)]], xScale, yScale, 'clear');
       };
     }
@@ -136,15 +143,15 @@ export function Scatter({
         }
       }).on('end', (currData) => {
         if (currData.selection === null && currData.sourceEvent !== undefined) {
-          d3.select(ref.current).call(brush.move, null);
+          d3.select(scatterRef.current! as unknown as SVGGElement).call(brush.move, null);
           setFilteredTable(null);
         }
       });
 
-      d3.select(ref.current).call(brush);
+      d3.select(scatterRef.current! as unknown as SVGGElement).call(brush);
 
       return () => {
-        d3.select(ref.current).call(brush.move, null);
+        d3.select(scatterRef.current! as unknown as SVGGElement).call(brush.move, null);
         setBrushedSpace([[null, null], [null, null]], xScale, yScale, 'clear');
       };
     }

--- a/src/public/example-llm-chatbot/assets/ChatInterface.tsx
+++ b/src/public/example-llm-chatbot/assets/ChatInterface.tsx
@@ -535,7 +535,7 @@ Rules:
           <Flex direction="column" align="center" justify="center" py="xl" style={{ color: '#6B7280' }}>
             <IconMessage size={48} style={{ opacity: 0.5, marginBottom: rem(12) }} />
             <Text size="lg" fw={500} mb={4}>Start a conversation</Text>
-            <Text size="sm" color="dimmed">
+            <Text size="sm" c="dimmed">
               Ask me anything about the clustered heatmap on the left!
             </Text>
           </Flex>
@@ -567,7 +567,7 @@ Rules:
                   ) : (
                     <Text size="sm">{message.content}</Text>
                   )}
-                  <Text size="xs" mt={4} color={message.role === 'user' ? 'blue.1' : 'gray.6'}>
+                  <Text size="xs" mt={4} c={message.role === 'user' ? 'blue.1' : 'gray.6'}>
                     {new Date(message.timestamp).toLocaleTimeString()}
                   </Text>
                 </Paper>
@@ -590,7 +590,7 @@ Rules:
       {/* Error Display */}
       {error && (
         <Paper mb="md" p="sm" radius="md" withBorder style={{ backgroundColor: '#fff0f0', borderColor: '#ffe3e3' }}>
-          <Text color="red" size="sm">{error}</Text>
+          <Text c="red" size="sm">{error}</Text>
         </Paper>
       )}
       {/* Input Form */}
@@ -620,7 +620,7 @@ Rules:
           <IconSend size={18} />
         </Button>
       </form>
-      <Text mt="md" size="xs" color="dimmed">
+      <Text mt="md" size="xs" c="dimmed">
         Press Enter to send, Shift+Enter for new line. All conversations are recorded for research purposes.
       </Text>
     </Card>

--- a/src/public/example-llm-chatbot/assets/LLMInterface.tsx
+++ b/src/public/example-llm-chatbot/assets/LLMInterface.tsx
@@ -54,7 +54,7 @@ export default function LLMInterface({
   }, [setAnswer]);
 
   return (
-    <Grid gutter="md">
+    <Grid gap="md">
       <Grid.Col span={6}>
         <ImageDisplay />
       </Grid.Col>

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,7 +132,7 @@
   dependencies:
     "@babel/types" "^7.29.7"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.13", "@babel/runtime@^7.28.4", "@babel/runtime@^7.28.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.28.4", "@babel/runtime@^7.28.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
@@ -828,41 +828,41 @@
   resolved "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz"
   integrity sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==
 
-"@floating-ui/core@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz"
-  integrity sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==
+"@floating-ui/core@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz"
+  integrity sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==
   dependencies:
-    "@floating-ui/utils" "^0.2.10"
+    "@floating-ui/utils" "^0.2.12"
 
-"@floating-ui/dom@^1.7.4":
-  version "1.7.4"
-  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz"
-  integrity sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==
+"@floating-ui/dom@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz"
+  integrity sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==
   dependencies:
-    "@floating-ui/core" "^1.7.3"
-    "@floating-ui/utils" "^0.2.10"
+    "@floating-ui/core" "^1.8.0"
+    "@floating-ui/utils" "^0.2.12"
 
-"@floating-ui/react-dom@^2.1.2":
-  version "2.1.6"
-  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz"
-  integrity sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==
+"@floating-ui/react-dom@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz"
+  integrity sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==
   dependencies:
-    "@floating-ui/dom" "^1.7.4"
+    "@floating-ui/dom" "^1.8.0"
 
-"@floating-ui/react@^0.26.28":
-  version "0.26.28"
-  resolved "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz"
-  integrity sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==
+"@floating-ui/react@^0.27.19":
+  version "0.27.20"
+  resolved "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz"
+  integrity sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==
   dependencies:
-    "@floating-ui/react-dom" "^2.1.2"
-    "@floating-ui/utils" "^0.2.8"
+    "@floating-ui/react-dom" "^2.1.9"
+    "@floating-ui/utils" "^0.2.12"
     tabbable "^6.0.0"
 
-"@floating-ui/utils@^0.2.10", "@floating-ui/utils@^0.2.8":
-  version "0.2.10"
-  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz"
-  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+"@floating-ui/utils@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz"
+  integrity sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==
 
 "@fontsource/roboto@^4.5.1":
   version "4.5.8"
@@ -955,55 +955,55 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@mantine/core@^7.10.1":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/core/-/core-7.17.8.tgz"
-  integrity sha512-42sfdLZSCpsCYmLCjSuntuPcDg3PLbakSmmYfz5Auea8gZYLr+8SS5k647doVu0BRAecqYOytkX2QC5/u/8VHw==
+"@mantine/core@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/core/-/core-9.5.1.tgz"
+  integrity sha512-3olDOYJBfW4kR37Aqdy/+FnYG7iNb5SPzOGeCp9dDxnt65K94sEqETDnXGJptOMO2xLm4KLJ/eBt3IIhJA7Z4Q==
   dependencies:
-    "@floating-ui/react" "^0.26.28"
+    "@floating-ui/react" "^0.27.19"
     clsx "^2.1.1"
-    react-number-format "^5.4.3"
-    react-remove-scroll "^2.6.2"
-    react-textarea-autosize "8.5.9"
-    type-fest "^4.27.0"
+    react-number-format "^5.4.5"
+    react-remove-scroll "^2.7.2"
+    type-fest "^5.8.0"
 
-"@mantine/dates@^7.10.1":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/dates/-/dates-7.17.8.tgz"
-  integrity sha512-KYog/YL83PnsMef7EZagpOFq9I2gfnK0eYSzC8YvV9Mb6t/x9InqRssGWVb0GIr+TNILpEkhKoGaSKZNy10Q1g==
+"@mantine/dates@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/dates/-/dates-9.5.1.tgz"
+  integrity sha512-1FTIgF8L6AKEb+Ql53zVyCCp4JxvQp/AUDts5T/JEI7U0CZGpzg+FHGtmNShLR4ONuOfzOV1gkgU8INbxVJjag==
   dependencies:
     clsx "^2.1.1"
 
-"@mantine/form@^7.10.1":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/form/-/form-7.17.8.tgz"
-  integrity sha512-cRLAMYOsZT17jyV9Myl29xacgaswGVAz3Ku6bvphBFad7Nzorra809uKFJxm2yKW5NknZ4ENHSXjyru7k0GTGA==
+"@mantine/form@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/form/-/form-9.5.1.tgz"
+  integrity sha512-WsMZGBTsoG2Y/K+6QK0+GmsJxq5KzWHIzo65lRpkq/SwdenV9G+3m0LstlhI9i2/wQF83GfwP7mCbKMfzf00Eg==
   dependencies:
+    "@standard-schema/spec" "^1.1.0"
     fast-deep-equal "^3.1.3"
     klona "^2.0.6"
 
-"@mantine/hooks@^7.10.1":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz"
-  integrity sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==
+"@mantine/hooks@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.5.1.tgz"
+  integrity sha512-2sK9OdWvrzKBOuWxLfQA5qcAJzxpzqNlKumaP7Uq0i7LDBQeY/sYgNiBWLwtW+iZw6fFXwPf0nI7q5VVpvqnNQ==
 
-"@mantine/modals@^7.10.1":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/modals/-/modals-7.17.8.tgz"
-  integrity sha512-7Eylnopjh8b0xIrtXnle8DsNsLghq82uUYMalm54nMaCSD9N/qAuCPGfAE0k2tsWj5cGDC2/uMbU0RSBjGanbA==
+"@mantine/modals@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/modals/-/modals-9.5.1.tgz"
+  integrity sha512-hvfNqwgiIxe/3sWPX5pIHzYnwV28U5w9UrA0Y+Dh3HDkmIu2PZ3nwcUhqS+Za6gFZCx53XuNLZs2OMW2hrvdzg==
 
-"@mantine/notifications@^7.12.0":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/notifications/-/notifications-7.17.8.tgz"
-  integrity sha512-/YK16IZ198W6ru/IVecCtHcVveL08u2c8TbQTu/2p26LSIM9AbJhUkrU6H+AO0dgVVvmdmNdvPxcJnfq3S9TMg==
+"@mantine/notifications@^9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.5.1.tgz"
+  integrity sha512-/MIGWag8U20HTM4gOGSNVhmQ0n6YM2gdSR1NbtBffSh77nuzwPjr68UmpMc2WHFMi8OBlrSIcw9Xpe3YPfgnvQ==
   dependencies:
-    "@mantine/store" "7.17.8"
+    "@mantine/store" "9.5.1"
     react-transition-group "4.4.5"
 
-"@mantine/store@7.17.8":
-  version "7.17.8"
-  resolved "https://registry.npmjs.org/@mantine/store/-/store-7.17.8.tgz"
-  integrity sha512-/FrB6PAVH4NEjQ1dsc9qOB+VvVlSuyjf4oOOlM9gscPuapDP/79Ryq7JkhHYfS55VWQ/YUlY24hDI2VV+VptXg==
+"@mantine/store@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.npmjs.org/@mantine/store/-/store-9.5.1.tgz"
+  integrity sha512-nDmA9S+qnQQ61KYgph06Wt2cx1tj3Z6eeyK3HvFeuLb5FcGycbITsVy/+3LltH2qdqkpNeAA9wQ926NFjn5hvA==
 
 "@mui/core-downloads-tracker@^7.3.8":
   version "7.3.8"
@@ -4748,7 +4748,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-mantine-react-table@^2.0.0-beta.9:
+mantine-react-table@2.0.0-beta.9:
   version "2.0.0-beta.9"
   resolved "https://registry.npmjs.org/mantine-react-table/-/mantine-react-table-2.0.0-beta.9.tgz"
   integrity sha512-ZdfcwebWaPERoDvAuk43VYcBCzamohARVclnbuepT0PHZ0wRcDPMBR+zgaocL+pFy8EXUGwvWTOKNh25ITpjNQ==
@@ -5954,10 +5954,10 @@ react-markdown@^9.0.3:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
-react-number-format@^5.4.3:
-  version "5.4.4"
-  resolved "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz"
-  integrity sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==
+react-number-format@^5.4.5:
+  version "5.4.5"
+  resolved "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz"
+  integrity sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==
 
 react-redux@^9.2.0:
   version "9.2.0"
@@ -5975,10 +5975,10 @@ react-remove-scroll-bar@^2.3.7:
     react-style-singleton "^2.2.2"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.6.2:
-  version "2.7.1"
-  resolved "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz"
-  integrity sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==
+react-remove-scroll@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
   dependencies:
     react-remove-scroll-bar "^2.3.7"
     react-style-singleton "^2.2.3"
@@ -6013,15 +6013,6 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
   dependencies:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
-
-react-textarea-autosize@8.5.9:
-  version "8.5.9"
-  resolved "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz"
-  integrity sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==
-  dependencies:
-    "@babel/runtime" "^7.20.13"
-    use-composed-ref "^1.3.0"
-    use-latest "^1.2.1"
 
 react-transition-group@^4.4.5, react-transition-group@4.4.5:
   version "4.4.5"
@@ -6653,9 +6644,9 @@ symbol-tree@^3.2.4:
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 tabbable@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz"
-  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz"
+  integrity sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==
 
 table-layout@^4.1.0:
   version "4.1.1"
@@ -6664,6 +6655,11 @@ table-layout@^4.1.0:
   dependencies:
     array-back "^6.2.2"
     wordwrapjs "^5.1.0"
+
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
 
 tinybench@^2.9.0:
   version "2.9.0"
@@ -6777,10 +6773,12 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-fest@^4.27.0:
-  version "4.41.0"
-  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
-  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+type-fest@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz"
+  integrity sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -7056,11 +7054,6 @@ use-callback-ref@^1.3.3:
   dependencies:
     tslib "^2.0.0"
 
-use-composed-ref@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz"
-  integrity sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==
-
 use-deep-compare-effect@^1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz"
@@ -7068,18 +7061,6 @@ use-deep-compare-effect@^1.8.1:
   dependencies:
     "@babel/runtime" "^7.12.5"
     dequal "^2.0.2"
-
-use-isomorphic-layout-effect@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz"
-  integrity sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==
-
-use-latest@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz"
-  integrity sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==
-  dependencies:
-    use-isomorphic-layout-effect "^1.1.1"
 
 use-sidecar@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
## Summary

- Upgrade Mantine packages from v7 to v9 and apply the required API migrations.
- Update callback-ref usage and affected test mocks.
- Add a version-pinned, idempotent postinstall shim for Mantine React Table 2.0.0-beta.9 so its five stale Collapse props work with Mantine 9.

Follow-up replacement work is tracked separately in #1420.

Closes #1418.

## Validation

- `corepack yarn typecheck`
- `corepack yarn lint`
- `corepack yarn build`
- `corepack yarn unittest --run` — 150 files passed; 2074 tests passed, 1 skipped
- `node scripts/check-lockfile-drift.mjs`
- `git diff --check`
- `corepack yarn install --frozen-lockfile --non-interactive` — postinstall shim executed successfully
- Both MRT bundles: 0 stale `in:` props, 5 `expanded:` props; CJS import verified
