### PR TITLE
Add stage participant controls and startup preview

### DIFF
--- a/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
+++ b/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
@@ -73,6 +73,7 @@ export function ParticipantTimeoutModal({
   const { user } = useAuth();
   const [uncontrolledOpened, setUncontrolledOpened] = useState(false);
   const [timingOutParticipantIds, setTimingOutParticipantIds] = useState<string[]>([]);
+  const [timeoutError, setTimeoutError] = useState<string | null>(null);
   const opened = controlledOpened ?? uncontrolledOpened;
 
   const inProgressParticipants = useMemo(
@@ -86,11 +87,13 @@ export function ParticipantTimeoutModal({
     }
 
     setTimingOutParticipantIds((ids) => [...ids, participantId]);
+    setTimeoutError(null);
     try {
       await storageEngine.rejectParticipant(participantId, 'Timed out by admin');
       await refresh();
     } catch (error) {
       console.error('Failed to time out participant:', error);
+      setTimeoutError('The participant could not be timed out. Please try again.');
     } finally {
       setTimingOutParticipantIds((ids) => ids.filter((id) => id !== participantId));
     }
@@ -133,6 +136,7 @@ export function ParticipantTimeoutModal({
           <Alert icon={<IconClockOff size={16} />} color="orange" title="Time out a participant">
             Timing out a participant rejects them and returns their sequence assignment for reuse.
           </Alert>
+          {timeoutError && <Alert color="red" title="Unable to time out participant">{timeoutError}</Alert>}
           {description && <Text size="sm" c="dimmed">{description}</Text>}
           {inProgressParticipants.length === 0 ? (
             <Text c="dimmed">There are no in-progress participants.</Text>

--- a/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
+++ b/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
@@ -57,14 +57,21 @@ export function getInProgressParticipantsByElapsedTime(
 export function ParticipantTimeoutModal({
   participants,
   refresh,
+  opened: controlledOpened,
+  onClose,
+  hideReviewButton = false,
 }: {
   participants: ParticipantDataWithStatus[];
   refresh: () => Promise<unknown>;
+  opened?: boolean;
+  onClose?: () => void;
+  hideReviewButton?: boolean;
 }) {
   const { storageEngine } = useStorageEngine();
   const { user } = useAuth();
-  const [opened, setOpened] = useState(false);
+  const [uncontrolledOpened, setUncontrolledOpened] = useState(false);
   const [timingOutParticipantIds, setTimingOutParticipantIds] = useState<string[]>([]);
+  const opened = controlledOpened ?? uncontrolledOpened;
 
   const inProgressParticipants = useMemo(
     () => getInProgressParticipantsByElapsedTime(participants),
@@ -89,26 +96,34 @@ export function ParticipantTimeoutModal({
 
   const reviewLabel = `Review (${inProgressParticipants.length})`;
   const reviewAriaLabel = `Review In-Progress Participants (${inProgressParticipants.length})`;
+  const handleClose = () => {
+    if (controlledOpened === undefined) {
+      setUncontrolledOpened(false);
+    }
+    onClose?.();
+  };
 
   return (
     <>
-      <Tooltip label={user.isAdmin ? reviewAriaLabel : 'Only admins can time out participants'}>
-        <span>
-          <Button
-            aria-label={reviewAriaLabel}
-            leftSection={<IconClockOff size={16} />}
-            disabled={!user.isAdmin || inProgressParticipants.length === 0}
-            onClick={() => setOpened(true)}
-            size="xs"
-            variant="light"
-          >
-            {reviewLabel}
-          </Button>
-        </span>
-      </Tooltip>
+      {!hideReviewButton && (
+        <Tooltip label={user.isAdmin ? reviewAriaLabel : 'Only admins can time out participants'}>
+          <span>
+            <Button
+              aria-label={reviewAriaLabel}
+              leftSection={<IconClockOff size={16} />}
+              disabled={!user.isAdmin || inProgressParticipants.length === 0}
+              onClick={() => setUncontrolledOpened(true)}
+              size="xs"
+              variant="light"
+            >
+              {reviewLabel}
+            </Button>
+          </span>
+        </Tooltip>
+      )}
       <Modal
         opened={opened}
-        onClose={() => setOpened(false)}
+        onClose={handleClose}
         title="In-Progress Participants"
         size="lg"
       >

--- a/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
+++ b/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
@@ -87,16 +87,19 @@ export function ParticipantTimeoutModal({
     }
   }, [refresh, storageEngine, timingOutParticipantIds]);
 
-  const reviewLabel = `Review In-Progress Participants (${inProgressParticipants.length})`;
+  const reviewLabel = `Review (${inProgressParticipants.length})`;
+  const reviewAriaLabel = `Review In-Progress Participants (${inProgressParticipants.length})`;
 
   return (
     <>
-      <Tooltip label="Only admins can time out participants" disabled={user.isAdmin}>
+      <Tooltip label={user.isAdmin ? reviewAriaLabel : 'Only admins can time out participants'}>
         <span>
           <Button
+            aria-label={reviewAriaLabel}
             leftSection={<IconClockOff size={16} />}
             disabled={!user.isAdmin || inProgressParticipants.length === 0}
             onClick={() => setOpened(true)}
+            size="xs"
             variant="light"
           >
             {reviewLabel}

--- a/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
+++ b/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
@@ -1,0 +1,150 @@
+import {
+  Alert, Button, Group, Modal, Stack, Text, Tooltip,
+} from '@mantine/core';
+import { IconClockOff } from '@tabler/icons-react';
+import { useCallback, useMemo, useState } from 'react';
+import { useStorageEngine } from '../../storage/storageEngineHooks';
+import { ParticipantDataWithStatus } from '../../storage/types';
+import { useAuth } from '../../store/hooks/useAuth';
+
+export type TimedOutParticipant = ParticipantDataWithStatus & {
+  elapsedTime: number | null;
+};
+
+export function formatElapsedTime(elapsedTime: number) {
+  const totalMinutes = Math.floor(Math.max(elapsedTime, 0) / 60_000);
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return `${days}d ${hours}h ${minutes}m`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+function getParticipantStartTime(participant: ParticipantDataWithStatus) {
+  if (participant.createdTime) {
+    return participant.createdTime;
+  }
+
+  const answerStartTimes = Object.values(participant.answers)
+    .map((answer) => answer.startTime)
+    .filter((startTime) => startTime > 0);
+
+  return answerStartTimes.length > 0 ? Math.min(...answerStartTimes) : null;
+}
+
+export function getInProgressParticipantsByElapsedTime(
+  participants: ParticipantDataWithStatus[],
+  now: number = Date.now(),
+): TimedOutParticipant[] {
+  return participants
+    .filter((participant) => !participant.completed && !participant.rejected)
+    .map((participant) => {
+      const startTime = getParticipantStartTime(participant);
+      return {
+        ...participant,
+        elapsedTime: startTime === null ? null : Math.max(now - startTime, 0),
+      };
+    })
+    .sort((a, b) => (b.elapsedTime ?? -1) - (a.elapsedTime ?? -1));
+}
+
+export function ParticipantTimeoutModal({
+  participants,
+  refresh,
+}: {
+  participants: ParticipantDataWithStatus[];
+  refresh: () => Promise<unknown>;
+}) {
+  const { storageEngine } = useStorageEngine();
+  const { user } = useAuth();
+  const [opened, setOpened] = useState(false);
+  const [timingOutParticipantIds, setTimingOutParticipantIds] = useState<string[]>([]);
+
+  const inProgressParticipants = useMemo(
+    () => getInProgressParticipantsByElapsedTime(participants),
+    [participants],
+  );
+
+  const handleTimeOutParticipant = useCallback(async (participantId: string) => {
+    if (!storageEngine || timingOutParticipantIds.includes(participantId)) {
+      return;
+    }
+
+    setTimingOutParticipantIds((ids) => [...ids, participantId]);
+    try {
+      await storageEngine.rejectParticipant(participantId, 'Timed out by admin');
+      await refresh();
+    } catch (error) {
+      console.error('Failed to time out participant:', error);
+    } finally {
+      setTimingOutParticipantIds((ids) => ids.filter((id) => id !== participantId));
+    }
+  }, [refresh, storageEngine, timingOutParticipantIds]);
+
+  const reviewLabel = `Review In-Progress Participants (${inProgressParticipants.length})`;
+
+  return (
+    <>
+      <Tooltip label="Only admins can time out participants" disabled={user.isAdmin}>
+        <span>
+          <Button
+            leftSection={<IconClockOff size={16} />}
+            disabled={!user.isAdmin || inProgressParticipants.length === 0}
+            onClick={() => setOpened(true)}
+            variant="light"
+          >
+            {reviewLabel}
+          </Button>
+        </span>
+      </Tooltip>
+      <Modal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        title="In-Progress Participants"
+        size="lg"
+      >
+        <Stack gap="sm">
+          <Alert icon={<IconClockOff size={16} />} color="orange" title="Time out a participant">
+            Timing out a participant rejects them and returns their sequence assignment for reuse.
+          </Alert>
+          {inProgressParticipants.length === 0 ? (
+            <Text c="dimmed">There are no in-progress participants.</Text>
+          ) : (
+            inProgressParticipants.map((participant) => (
+              <Group key={participant.participantId} justify="space-between" wrap="nowrap">
+                <Stack gap={0} style={{ minWidth: 0 }}>
+                  <Text fw={500}>
+                    Participant
+                    {' '}
+                    {participant.participantIndex + 1}
+                  </Text>
+                  <Text size="sm" c="dimmed" truncate="end">{participant.participantId}</Text>
+                </Stack>
+                <Group gap="md" wrap="nowrap">
+                  <Text size="sm" fw={500} style={{ whiteSpace: 'nowrap' }}>
+                    {participant.elapsedTime === null
+                      ? 'Length unavailable'
+                      : formatElapsedTime(participant.elapsedTime)}
+                  </Text>
+                  <Button
+                    color="red"
+                    loading={timingOutParticipantIds.includes(participant.participantId)}
+                    onClick={() => handleTimeOutParticipant(participant.participantId)}
+                  >
+                    Time Out
+                  </Button>
+                </Group>
+              </Group>
+            ))
+          )}
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
+++ b/src/analysis/individualStudy/ParticipantTimeoutModal.tsx
@@ -60,12 +60,14 @@ export function ParticipantTimeoutModal({
   opened: controlledOpened,
   onClose,
   hideReviewButton = false,
+  description,
 }: {
   participants: ParticipantDataWithStatus[];
   refresh: () => Promise<unknown>;
   opened?: boolean;
   onClose?: () => void;
   hideReviewButton?: boolean;
+  description?: string;
 }) {
   const { storageEngine } = useStorageEngine();
   const { user } = useAuth();
@@ -131,6 +133,7 @@ export function ParticipantTimeoutModal({
           <Alert icon={<IconClockOff size={16} />} color="orange" title="Time out a participant">
             Timing out a participant rejects them and returns their sequence assignment for reuse.
           </Alert>
+          {description && <Text size="sm" c="dimmed">{description}</Text>}
           {inProgressParticipants.length === 0 ? (
             <Text c="dimmed">There are no in-progress participants.</Text>
           ) : (

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -1,5 +1,5 @@
 import {
-  Alert, AppShell, Badge, Center, Checkbox, Container, Flex, Group, LoadingOverlay, Stack, Tabs, Text, Title, MultiSelect, Tooltip,
+  Alert, AppShell, Badge, Center, Checkbox, Container, Divider, Flex, Group, LoadingOverlay, Stack, Tabs, Text, Title, MultiSelect, Tooltip,
 } from '@mantine/core';
 import { useNavigate, useParams } from 'react-router';
 import {
@@ -580,6 +580,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
               </Flex>
             </Flex>
           </Flex>
+          <Divider style={{ marginBlock: -4 }} />
           <LoadingOverlay visible={status === 'pending'} />
 
           {status === 'success' ? (

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -37,6 +37,7 @@ import { ThinkAloudAnalysis } from './thinkAloud/ThinkAloudAnalysis';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 import { ConfigView } from './config/ConfigView';
 import { StartupErrorScreen } from '../../components/StartupErrorScreen';
+import { ParticipantTimeoutModal } from './ParticipantTimeoutModal';
 
 const TABLE_HEADER_HEIGHT = 37; // Height of the tabs header
 
@@ -407,13 +408,19 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
             <Flex direction="row" align="center" gap="md">
               <Title order={5}>{displayStudyId}</Title>
               {studyConfig && canonicalStudyId && (
-                <DownloadButtons
-                  visibleParticipants={selectedParticipants.length > 0 ? selectedParticipants : visibleParticipants}
-                  studyId={canonicalStudyId}
-                  gap="10px"
-                  hasAudio={hasAudioRecording}
-                  hasScreenRecording={hasScreenRecording}
-                />
+                <Group gap="sm">
+                  <DownloadButtons
+                    visibleParticipants={selectedParticipants.length > 0 ? selectedParticipants : visibleParticipants}
+                    studyId={canonicalStudyId}
+                    gap="10px"
+                    hasAudio={hasAudioRecording}
+                    hasScreenRecording={hasScreenRecording}
+                  />
+                  <ParticipantTimeoutModal
+                    participants={expData ?? []}
+                    refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)}
+                  />
+                </Group>
               )}
             </Flex>
             <Flex direction="row" align="center" gap="md">
@@ -642,7 +649,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} currentConfigHash={currentConfigHash} />}
               </Tabs.Panel>
               <Tabs.Panel style={{ overflow: 'auto' }} value="manage" pt="xs">
-                {canonicalStudyId && user.isAdmin ? <ManageView studyId={canonicalStudyId} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
+                {canonicalStudyId && user.isAdmin ? <ManageView studyId={canonicalStudyId} studyConfig={studyConfig} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
               </Tabs.Panel>
             </Tabs>
           ) : null}

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -25,6 +25,7 @@ import { TableView } from './table/TableView';
 import { StatsView } from './stats/StatsView';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { ManageView } from './management/ManageView';
+import { StageManagementItem } from './management/StageManagementItem';
 import { useAuth } from '../../store/hooks/useAuth';
 import { parseStudyConfig } from '../../parser/parser';
 import { useAsync } from '../../store/hooks/useAsync';
@@ -37,9 +38,6 @@ import { ThinkAloudAnalysis } from './thinkAloud/ThinkAloudAnalysis';
 import { FirebaseStorageEngine } from '../../storage/engines/FirebaseStorageEngine';
 import { ConfigView } from './config/ConfigView';
 import { StartupErrorScreen } from '../../components/StartupErrorScreen';
-import { ParticipantTimeoutModal } from './ParticipantTimeoutModal';
-
-const TABLE_HEADER_HEIGHT = 37; // Height of the tabs header
 
 function sortByStartTime(a: ParticipantDataWithStatus, b: ParticipantDataWithStatus) {
   const aStartTimes = Object.values(a.answers).map((answer) => answer.startTime).filter((startTime) => startTime !== undefined).sort();
@@ -404,11 +402,24 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       <AppHeader studyIds={globalConfig.configsList} selectedStudyId={displayStudyId} studyConfigs={studyConfig && displayStudyId ? { [displayStudyId]: studyConfig } : undefined} />
       <AppShell.Main style={{ height: '100dvh' }}>
         <Stack ref={ref} style={{ height: '100%', maxHeight: '100dvh', overflow: 'hidden' }} justify="space-between">
-          <Flex direction="row" align="center" justify="space-between" p="sm" gap="md">
-            <Flex direction="row" align="center" gap="md">
-              <Title order={5}>{displayStudyId}</Title>
+          <Flex direction="row" align="center" justify="space-between" p="sm" gap="md" wrap="wrap" style={{ minWidth: 0 }}>
+            <Flex direction="row" align="center" gap="md" wrap="nowrap" style={{ minWidth: 0 }}>
+              <Title
+                order={5}
+                title={displayStudyId}
+                style={{
+                  flexShrink: 1,
+                  minWidth: 0,
+                  maxWidth: 'min(30vw, 360px)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {displayStudyId}
+              </Title>
               {studyConfig && canonicalStudyId && (
-                <Group gap="sm">
+                <Group gap="sm" wrap="nowrap">
                   <DownloadButtons
                     visibleParticipants={selectedParticipants.length > 0 ? selectedParticipants : visibleParticipants}
                     studyId={canonicalStudyId}
@@ -416,16 +427,12 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     hasAudio={hasAudioRecording}
                     hasScreenRecording={hasScreenRecording}
                   />
-                  <ParticipantTimeoutModal
-                    participants={expData ?? []}
-                    refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)}
-                  />
                 </Group>
               )}
             </Flex>
-            <Flex direction="row" align="center" gap="md">
-              <Flex direction="row" align="center" gap="xs">
-                <Text size="sm" fw={500}>Stage:</Text>
+            <Flex direction="row" align="center" gap="md" wrap="nowrap">
+              <Flex direction="row" align="center" gap="xs" wrap="nowrap">
+                <Text size="sm" fw={500} style={{ whiteSpace: 'nowrap' }}>Stage:</Text>
                 <MultiSelect
                   data={availableStages}
                   value={selectedStages}
@@ -452,8 +459,8 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 />
               </Flex>
 
-              <Flex direction="row" align="center" gap="xs">
-                <Text size="sm" fw={500}>Config:</Text>
+              <Flex direction="row" align="center" gap="xs" wrap="nowrap">
+                <Text size="sm" fw={500} style={{ whiteSpace: 'nowrap' }}>Config:</Text>
                 <MultiSelect
                   data={configSelectData}
                   value={selectedConfigs}
@@ -508,8 +515,8 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
               </Flex>
 
               {availableConditions.length > 0 && (
-                <Flex direction="row" align="center" gap="xs">
-                  <Text size="sm" fw={500}>Condition:</Text>
+                <Flex direction="row" align="center" gap="xs" wrap="nowrap">
+                  <Text size="sm" fw={500} style={{ whiteSpace: 'nowrap' }}>Condition:</Text>
                   <MultiSelect
                     data={availableConditions}
                     value={selectedConditions}
@@ -537,33 +544,36 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                 </Flex>
               )}
 
-              <Flex direction="row" align="center" gap="xs">
-                <Text size="sm" fw={500}>Participants:</Text>
+              <Flex direction="row" align="center" gap="xs" wrap="nowrap">
+                <Text size="sm" fw={500} style={{ whiteSpace: 'nowrap' }}>Participants:</Text>
                 <Checkbox.Group
                   value={includedParticipants}
                   onChange={(e) => setIncludedParticipants(e)}
                 >
-                  <Group gap="xs">
+                  <Group gap={6} wrap="nowrap">
                     <Checkbox
                       value="completed"
                       label={selectedParticipants.length > 0
                         ? `Completed (${selectedParticipantCounts.completed} of ${participantCounts.completed})`
                         : `Completed (${participantCounts.completed})`}
-                      size="sm"
+                      size="xs"
+                      styles={{ label: { whiteSpace: 'nowrap' } }}
                     />
                     <Checkbox
                       value="inProgress"
                       label={selectedParticipants.length > 0
                         ? `In Progress (${selectedParticipantCounts.inProgress} of ${participantCounts.inProgress})`
                         : `In Progress (${participantCounts.inProgress})`}
-                      size="sm"
+                      size="xs"
+                      styles={{ label: { whiteSpace: 'nowrap' } }}
                     />
                     <Checkbox
                       value="rejected"
                       label={selectedParticipants.length > 0
                         ? `Rejected (${selectedParticipantCounts.rejected} of ${participantCounts.rejected})`
                         : `Rejected (${participantCounts.rejected})`}
-                      size="sm"
+                      size="xs"
+                      styles={{ label: { whiteSpace: 'nowrap' } }}
                     />
                   </Group>
                 </Checkbox.Group>
@@ -575,17 +585,19 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
           {status === 'success' ? (
             <Tabs
               style={{
-                flexGrow: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden',
+                flexGrow: 1, display: 'flex', minHeight: 0, overflow: 'hidden',
               }}
               keepMounted={false}
+              orientation="vertical"
+              styles={{ tab: { paddingLeft: 6 } }}
               variant="outline"
               value={analysisTab}
               onChange={(value) => navigate(`/analysis/stats/${routeStudyId}/${value}`)}
             >
-              <Tabs.List>
-                <Tabs.Tab value="summary" leftSection={<IconChartPie size={16} />}>Study Summary</Tabs.Tab>
-                <Tabs.Tab value="table" leftSection={<IconTable size={16} />}>Participant View</Tabs.Tab>
-                <Tabs.Tab value="stats" leftSection={<IconChartDonut2 size={16} />}>Trial Stats</Tabs.Tab>
+              <Tabs.List style={{ flex: '0 0 190px', overflowY: 'auto' }}>
+                <Tabs.Tab value="summary" leftSection={<IconChartPie size={16} />} style={{ justifyContent: 'flex-start' }}>Study Summary</Tabs.Tab>
+                <Tabs.Tab value="table" leftSection={<IconTable size={16} />} style={{ justifyContent: 'flex-start' }}>Participant View</Tabs.Tab>
+                <Tabs.Tab value="stats" leftSection={<IconChartDonut2 size={16} />} style={{ justifyContent: 'flex-start' }}>Trial Stats</Tabs.Tab>
                 <Tooltip
                   label={!isFirebaseEngine
                     ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config'
@@ -593,7 +605,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                   disabled={codingEnabled}
                 >
                   <span>
-                    <Tabs.Tab value="tagging" leftSection={<IconTags size={16} />} disabled={!codingEnabled}>Coding</Tabs.Tab>
+                    <Tabs.Tab value="tagging" leftSection={<IconTags size={16} />} disabled={!codingEnabled} style={{ justifyContent: 'flex-start' }}>Coding</Tabs.Tab>
                   </span>
                 </Tooltip>
                 <Tooltip
@@ -601,56 +613,62 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                   disabled={liveMonitorEnabled}
                 >
                   <span>
-                    <Tabs.Tab value="live-monitor" leftSection={<IconDashboard size={16} />} disabled={!liveMonitorEnabled}>Live Monitor</Tabs.Tab>
+                    <Tabs.Tab value="live-monitor" leftSection={<IconDashboard size={16} />} disabled={!liveMonitorEnabled} style={{ justifyContent: 'flex-start' }}>Live Monitor</Tabs.Tab>
                   </span>
                 </Tooltip>
-                <Tabs.Tab value="config" leftSection={<IconFileCode size={16} />}>Config</Tabs.Tab>
-                <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin}>Manage</Tabs.Tab>
+                <Tabs.Tab value="config" leftSection={<IconFileCode size={16} />} style={{ justifyContent: 'flex-start' }}>Config</Tabs.Tab>
+                <Tabs.Tab value="stages" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin} style={{ justifyContent: 'flex-start' }}>Stage Management</Tabs.Tab>
+                <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin} style={{ justifyContent: 'flex-start' }}>Manage</Tabs.Tab>
               </Tabs.List>
-              <Tabs.Panel style={{ overflow: 'auto' }} value="summary" pt="xs">
-                {studyConfig && (
-                  <SummaryView
-                    studyConfig={studyConfig}
-                    visibleParticipants={visibleParticipants}
-                    allConfigs={allConfigs}
-                    currentConfigLabel={currentConfigLabel}
-                  />
-                )}
-              </Tabs.Panel>
-              <Tabs.Panel style={{ height: `calc(100% - ${TABLE_HEADER_HEIGHT}px)` }} value="table" pt="xs">
-                {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} studyConfig={studyConfig} allConfigs={allConfigs} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
-              </Tabs.Panel>
-              <Tabs.Panel style={{ overflow: 'auto' }} value="stats" pt="xs">
-                {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} />}
-              </Tabs.Panel>
-              <Tabs.Panel value="tagging" pt="xs">
-                {studyConfig && codingEnabled
-                  ? <ThinkAloudAnalysis visibleParticipants={visibleParticipants} storageEngine={storageEngine as FirebaseStorageEngine} />
-                  : (
-                    <Center>
-                      <Text c="dimmed">
-                        {!isFirebaseEngine
-                          ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config'
-                          : 'Think aloud coding is only available for studies with audio recording enabled in your study config'}
-                      </Text>
-                    </Center>
+              <Stack gap={0} pl="xs" pr="sm" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="summary" pt="xs">
+                  {studyConfig && (
+                    <SummaryView
+                      studyConfig={studyConfig}
+                      visibleParticipants={visibleParticipants}
+                      allConfigs={allConfigs}
+                      currentConfigLabel={currentConfigLabel}
+                    />
                   )}
-              </Tabs.Panel>
-              <Tabs.Panel style={{ overflow: 'auto' }} value="live-monitor" pt="xs">
-                {studyConfig && liveMonitorEnabled
-                  ? <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />
-                  : (
-                    <Center>
-                      <Text c="dimmed">Live Monitor is only available when using Firebase</Text>
-                    </Center>
-                  )}
-              </Tabs.Panel>
-              <Tabs.Panel style={{ overflow: 'auto' }} value="config" pt="xs">
-                {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} currentConfigHash={currentConfigHash} />}
-              </Tabs.Panel>
-              <Tabs.Panel style={{ overflow: 'auto' }} value="manage" pt="xs">
-                {canonicalStudyId && user.isAdmin ? <ManageView studyId={canonicalStudyId} studyConfig={studyConfig} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
-              </Tabs.Panel>
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="table" pt="xs">
+                  {studyConfig && <TableView width={width} stageColors={stageColors} visibleParticipants={visibleParticipants} participantsForTimeout={expData ?? []} studyConfig={studyConfig} allConfigs={allConfigs} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId ?? undefined)} selectedParticipants={selectedParticipants} onSelectionChange={setSelectedParticipants} />}
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="stats" pt="xs">
+                  {studyConfig && <StatsView studyConfig={studyConfig} visibleParticipants={visibleParticipants} allConfigs={allConfigs} />}
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="tagging" pt="xs">
+                  {studyConfig && codingEnabled
+                    ? <ThinkAloudAnalysis visibleParticipants={visibleParticipants} storageEngine={storageEngine as FirebaseStorageEngine} />
+                    : (
+                      <Center>
+                        <Text c="dimmed">
+                          {!isFirebaseEngine
+                            ? 'Think aloud coding is only available when using Firebase and when audio recording is enabled in your study config'
+                            : 'Think aloud coding is only available for studies with audio recording enabled in your study config'}
+                        </Text>
+                      </Center>
+                    )}
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="live-monitor" pt="xs">
+                  {studyConfig && liveMonitorEnabled
+                    ? <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />
+                    : (
+                      <Center>
+                        <Text c="dimmed">Live Monitor is only available when using Firebase</Text>
+                      </Center>
+                    )}
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="config" pt="xs">
+                  {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} currentConfigHash={currentConfigHash} />}
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="stages" pt="xs">
+                  {canonicalStudyId && user.isAdmin ? <StageManagementItem studyId={canonicalStudyId} studyConfig={studyConfig} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
+                </Tabs.Panel>
+                <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="manage" pt="xs">
+                  {canonicalStudyId && user.isAdmin ? <ManageView studyId={canonicalStudyId} refresh={() => execute(studyConfig, storageEngine, canonicalStudyId)} /> : <Container mt={20}><Alert title="Unauthorized Access" variant="light" color="red" icon={<IconInfoCircle />}>You are not authorized to manage the data for this study.</Alert></Container>}
+                </Tabs.Panel>
+              </Stack>
             </Tabs>
           ) : null}
         </Stack>

--- a/src/analysis/individualStudy/management/ManageView.tsx
+++ b/src/analysis/individualStudy/management/ManageView.tsx
@@ -3,18 +3,13 @@ import {
 } from '@mantine/core';
 import { DataManagementItem } from './DataManagementItem';
 import { RevisitModesItem } from './RevisitModesItem';
-import { StageManagementItem } from './StageManagementItem';
 import { ParticipantDataWithStatus } from '../../../storage/types';
-import { StudyConfig } from '../../../parser/types';
 
-export function ManageView({ studyId, refresh, studyConfig }: { studyId: string, refresh: () => Promise<ParticipantDataWithStatus[]>, studyConfig?: StudyConfig }) {
+export function ManageView({ studyId, refresh }: { studyId: string, refresh: () => Promise<ParticipantDataWithStatus[]> }) {
   return (
     <Stack gap="lg" w="60%" mx="auto">
       <Paper shadow="sm" p="lg" radius="md" withBorder>
         <RevisitModesItem studyId={studyId} />
-      </Paper>
-      <Paper shadow="sm" p="lg" radius="md" withBorder>
-        <StageManagementItem studyId={studyId} studyConfig={studyConfig} />
       </Paper>
       <Paper shadow="sm" p="lg" radius="md" withBorder>
         <DataManagementItem studyId={studyId} refresh={refresh} />

--- a/src/analysis/individualStudy/management/ManageView.tsx
+++ b/src/analysis/individualStudy/management/ManageView.tsx
@@ -5,15 +5,16 @@ import { DataManagementItem } from './DataManagementItem';
 import { RevisitModesItem } from './RevisitModesItem';
 import { StageManagementItem } from './StageManagementItem';
 import { ParticipantDataWithStatus } from '../../../storage/types';
+import { StudyConfig } from '../../../parser/types';
 
-export function ManageView({ studyId, refresh }: { studyId: string, refresh: () => Promise<ParticipantDataWithStatus[]> }) {
+export function ManageView({ studyId, refresh, studyConfig }: { studyId: string, refresh: () => Promise<ParticipantDataWithStatus[]>, studyConfig?: StudyConfig }) {
   return (
     <Stack gap="lg" w="60%" mx="auto">
       <Paper shadow="sm" p="lg" radius="md" withBorder>
         <RevisitModesItem studyId={studyId} />
       </Paper>
       <Paper shadow="sm" p="lg" radius="md" withBorder>
-        <StageManagementItem studyId={studyId} />
+        <StageManagementItem studyId={studyId} studyConfig={studyConfig} />
       </Paper>
       <Paper shadow="sm" p="lg" radius="md" withBorder>
         <DataManagementItem studyId={studyId} refresh={refresh} />

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -1,13 +1,145 @@
 import {
-  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio,
+  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch,
   Title,
 } from '@mantine/core';
-import { useEffect, useState } from 'react';
 import {
-  IconEdit, IconCheck, IconX,
+  Fragment, useCallback, useEffect, useMemo, useState,
+} from 'react';
+import isEqual from 'lodash.isequal';
+import {
+  IconEdit, IconCheck, IconX, IconChevronDown, IconChevronUp, IconToggleLeft, IconToggleRight,
 } from '@tabler/icons-react';
+import {
+  MantineReactTable,
+  useMantineReactTable,
+  type MRT_ColumnDef as MrtColumnDef,
+} from 'mantine-react-table';
 import { useStorageEngine } from '../../../storage/storageEngineHooks';
-import { StageInfo } from '../../../storage/engines/types';
+import { FactorObject, FactorPrimitive, StudyConfig } from '../../../parser/types';
+import { ParticipantDataWithStatus } from '../../../storage/types';
+import { getBetweenSubjectsCombinationKey, StageInfo } from '../../../storage/engines/types';
+import { DISTINCT_COLOR_PALETTE, getDistinctColorShade } from '../../../utils/colors';
+
+type BetweenSubjectsLevel = FactorPrimitive | FactorObject;
+
+type BetweenSubjectsFactor = {
+  factorName: string;
+  levels: BetweenSubjectsLevel[];
+};
+
+type BetweenSubjectsCombination = {
+  key: string;
+  parameters: Record<string, BetweenSubjectsLevel>;
+};
+
+type BetweenSubjectsCombinationRow = {
+  combinationKey: string;
+  participantCount: number;
+  desiredParticipants: number | '';
+  enabled: boolean;
+  [factorName: string]: string | number | boolean;
+};
+
+const DEFAULT_STAGE_COLOR = DISTINCT_COLOR_PALETTE[0];
+
+export function getBetweenSubjectsFactors(studyConfig?: StudyConfig): BetweenSubjectsFactor[] {
+  return studyConfig?.betweenSubjects?.flatMap((factorName) => {
+    const factor = studyConfig.factors?.[factorName];
+    if (!Array.isArray(factor) || factor.length === 0 || !factor.every((level) => (
+      typeof level !== 'object' || (level !== null && !Array.isArray(level))
+    ))) {
+      return [];
+    }
+
+    return [{ factorName, levels: factor as BetweenSubjectsLevel[] }];
+  }) || [];
+}
+
+export function getStageParticipantCounts(participants: ParticipantDataWithStatus[]) {
+  return participants.reduce<Record<string, number>>((counts, participant) => {
+    if (!participant.rejected) {
+      counts[participant.stage] = (counts[participant.stage] || 0) + 1;
+    }
+    return counts;
+  }, {});
+}
+
+export function getBetweenSubjectsCombinations(
+  betweenSubjectsFactors: BetweenSubjectsFactor[],
+): BetweenSubjectsCombination[] {
+  if (betweenSubjectsFactors.length === 0) {
+    return [];
+  }
+
+  const factorNames = betweenSubjectsFactors.map((factor) => factor.factorName);
+  return betweenSubjectsFactors.reduce<Record<string, BetweenSubjectsLevel>[]>(
+    (combinations, factor) => combinations.flatMap((parameters) => factor.levels.map((level) => ({
+      ...parameters,
+      [factor.factorName]: level,
+    }))),
+    [{}],
+  ).map((parameters) => ({
+    key: getBetweenSubjectsCombinationKey(parameters, factorNames),
+    parameters,
+  }));
+}
+
+export function getBetweenSubjectsCombinationCount(
+  participants: ParticipantDataWithStatus[],
+  stageName: string,
+  combination: BetweenSubjectsCombination,
+  betweenSubjectsFactors: BetweenSubjectsFactor[],
+) {
+  return participants.filter((participant) => (
+    !participant.rejected
+    && participant.stage === stageName
+    && betweenSubjectsFactors.every((factor) => (
+      isEqual(participant.sequence.parameters?.[factor.factorName], combination.parameters[factor.factorName])
+    ))
+  )).length;
+}
+
+export function getDefaultDesiredParticipantCounts(
+  maxParticipants: number | undefined,
+  combinations: BetweenSubjectsCombination[],
+) {
+  if (maxParticipants === undefined || combinations.length === 0) {
+    return {};
+  }
+
+  const countPerCombination = Math.floor(maxParticipants / combinations.length);
+  const remainder = maxParticipants % combinations.length;
+
+  return Object.fromEntries(combinations.map((combination, index) => [
+    combination.key,
+    countPerCombination + (index < remainder ? 1 : 0),
+  ]));
+}
+
+export function getDesiredParticipantCounts(
+  maxParticipants: number | undefined,
+  combinations: BetweenSubjectsCombination[],
+  desiredParticipantsByCombination: Record<string, number> | undefined,
+): Record<string, number | ''> {
+  const manualCount = combinations.reduce((count, combination) => (
+    count + (desiredParticipantsByCombination?.[combination.key] ?? 0)
+  ), 0);
+  const automaticallyAllocatedCounts = getDefaultDesiredParticipantCounts(
+    maxParticipants === undefined ? undefined : Math.max(maxParticipants - manualCount, 0),
+    combinations.filter((combination) => !Object.hasOwn(desiredParticipantsByCombination || {}, combination.key)),
+  );
+
+  return Object.fromEntries(combinations.map((combination) => [
+    combination.key,
+    desiredParticipantsByCombination?.[combination.key]
+      ?? automaticallyAllocatedCounts[combination.key]
+      ?? '',
+  ]));
+}
+
+function formatBetweenSubjectsLevel(level: BetweenSubjectsLevel) {
+  return typeof level === 'object' ? JSON.stringify(level) : String(level);
+}
 
 export function validateStageName(stageName: string, allStages: StageInfo[]): string | null {
   const normalizedStageName = stageName.trim();
@@ -37,40 +169,221 @@ export function validateStageName(stageName: string, allStages: StageInfo[]): st
   return null;
 }
 
-export function StageManagementItem({ studyId }: { studyId: string }) {
+export function getNextStageColor(allStages: StageInfo[]): string {
+  const usedColors = new Set(allStages.map((stage) => stage.color.toLowerCase()));
+
+  return DISTINCT_COLOR_PALETTE.find((color) => !usedColors.has(color.toLowerCase()))
+    ?? DISTINCT_COLOR_PALETTE[allStages.length % DISTINCT_COLOR_PALETTE.length];
+}
+
+function renderCombinationEnabledCell(
+  row: BetweenSubjectsCombinationRow,
+  stage: StageInfo,
+  betweenSubjectsFactors: BetweenSubjectsFactor[],
+  onToggle: (stage: StageInfo, combinationKey: string, enabled: boolean) => Promise<void>,
+) {
+  const combinationLabel = betweenSubjectsFactors
+    .map((factor) => String(row[factor.factorName]))
+    .join(' / ');
+
+  return (
+    <Switch
+      aria-label={`Enable ${combinationLabel} for ${stage.stageName}`}
+      checked={row.enabled}
+      onChange={(event) => onToggle(
+        stage,
+        row.combinationKey,
+        event.currentTarget.checked,
+      )}
+    />
+  );
+}
+
+function renderDesiredParticipantsCell(
+  row: BetweenSubjectsCombinationRow,
+  stage: StageInfo,
+  onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>,
+) {
+  return (
+    <NumberInput
+      aria-label={`Desired participants for ${row.combinationKey} in ${stage.stageName}`}
+      min={0}
+      allowDecimal={false}
+      value={row.desiredParticipants}
+      onChange={(value) => onSetDesiredParticipants(
+        stage,
+        row.combinationKey,
+        typeof value === 'number' ? value : '',
+      )}
+    />
+  );
+}
+
+function BetweenSubjectsCombinationTable({
+  stage,
+  participants,
+  betweenSubjectsFactors,
+  combinations,
+  onToggle,
+  onSetDesiredParticipants,
+}: {
+  stage: StageInfo;
+  participants: ParticipantDataWithStatus[];
+  betweenSubjectsFactors: BetweenSubjectsFactor[];
+  combinations: BetweenSubjectsCombination[];
+  onToggle: (stage: StageInfo, combinationKey: string, enabled: boolean) => Promise<void>;
+  onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>;
+}) {
+  const data = useMemo<BetweenSubjectsCombinationRow[]>(() => {
+    const desiredParticipantCounts = getDesiredParticipantCounts(
+      stage.maxParticipants,
+      combinations,
+      stage.desiredParticipantsByCombination,
+    );
+
+    return combinations.map((combination) => ({
+      combinationKey: combination.key,
+      participantCount: getBetweenSubjectsCombinationCount(
+        participants,
+        stage.stageName,
+        combination,
+        betweenSubjectsFactors,
+      ),
+      desiredParticipants: desiredParticipantCounts[combination.key],
+      enabled: !stage.disabledBetweenSubjectsCombinations?.includes(combination.key),
+      ...Object.fromEntries(betweenSubjectsFactors.map((factor) => [
+        factor.factorName,
+        formatBetweenSubjectsLevel(combination.parameters[factor.factorName]),
+      ])),
+    }));
+  }, [betweenSubjectsFactors, combinations, participants, stage]);
+
+  const columns = useMemo<MrtColumnDef<BetweenSubjectsCombinationRow>[]>(() => [
+    ...betweenSubjectsFactors.map((factor) => ({
+      accessorKey: factor.factorName,
+      header: factor.factorName,
+    } satisfies MrtColumnDef<BetweenSubjectsCombinationRow>)),
+    {
+      accessorKey: 'participantCount',
+      header: 'Participants',
+    },
+    {
+      accessorKey: 'desiredParticipants',
+      header: 'Desired Participants',
+      Cell: ({ row }) => renderDesiredParticipantsCell(
+        row.original,
+        stage,
+        onSetDesiredParticipants,
+      ),
+    },
+    {
+      accessorKey: 'enabled',
+      header: 'Enabled',
+      Cell: ({ row }) => renderCombinationEnabledCell(
+        row.original,
+        stage,
+        betweenSubjectsFactors,
+        onToggle,
+      ),
+    },
+  ], [betweenSubjectsFactors, onSetDesiredParticipants, onToggle, stage]);
+
+  const table = useMantineReactTable({
+    columns,
+    data,
+    enableBottomToolbar: false,
+    enableColumnDragging: true,
+    enableColumnOrdering: true,
+    enableDensityToggle: false,
+    enablePagination: false,
+    enableSorting: true,
+    enableTopToolbar: false,
+    getRowId: (row) => row.combinationKey,
+    mantinePaperProps: {
+      style: {
+        background: 'transparent', boxShadow: 'none', maxWidth: '100%', minWidth: 0,
+      },
+    },
+    mantineTableContainerProps: { style: { maxWidth: '100%', overflowX: 'auto' } },
+    mantineTableProps: { style: { minWidth: 'max-content' } },
+    mantineTableBodyCellProps: ({ column, row }) => {
+      const factorIndex = betweenSubjectsFactors.findIndex((factor) => factor.factorName === column.id);
+      if (factorIndex === -1) {
+        return {};
+      }
+
+      const factor = betweenSubjectsFactors[factorIndex];
+      const levelIndex = factor.levels.findIndex((level) => (
+        formatBetweenSubjectsLevel(level) === row.original[factor.factorName]
+      ));
+
+      return {
+        style: {
+          backgroundColor: getDistinctColorShade(factorIndex, levelIndex, factor.levels.length),
+        },
+      };
+    },
+  });
+
+  return <MantineReactTable table={table} />;
+}
+
+export function StageManagementItem({ studyId, studyConfig }: { studyId: string; studyConfig?: StudyConfig }) {
   const { storageEngine } = useStorageEngine();
 
   const [asyncStatus, setAsyncStatus] = useState(false);
-  const [currentStage, setCurrentStage] = useState<StageInfo>({ stageName: 'DEFAULT', color: '#F05A30' });
-  const [allStages, setAllStages] = useState<StageInfo[]>([{ stageName: 'DEFAULT', color: '#F05A30' }]);
+  const [currentStage, setCurrentStage] = useState<StageInfo>({ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR });
+  const [allStages, setAllStages] = useState<StageInfo[]>([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]);
+  const [stageParticipantCounts, setStageParticipantCounts] = useState<Record<string, number>>({});
+  const [participants, setParticipants] = useState<ParticipantDataWithStatus[]>([]);
+  const [expandedStageNames, setExpandedStageNames] = useState<string[]>([]);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editingStageName, setEditingStageName] = useState('');
-  const [editingStageColor, setEditingStageColor] = useState('#F05A30');
+  const [editingStageColor, setEditingStageColor] = useState(DEFAULT_STAGE_COLOR);
+  const [editingStageMaxParticipants, setEditingStageMaxParticipants] = useState<number | ''>('');
+  const [editingStageLimitEnabled, setEditingStageLimitEnabled] = useState(false);
   const [editError, setEditError] = useState('');
   const [addingNewStage, setAddingNewStage] = useState(false);
   const [newStageName, setNewStageName] = useState('');
-  const [newStageColor, setNewStageColor] = useState('#F05A30');
+  const [newStageColor, setNewStageColor] = useState(DEFAULT_STAGE_COLOR);
+  const [newStageMaxParticipants, setNewStageMaxParticipants] = useState<number | ''>('');
+  const [newStageLimitEnabled, setNewStageLimitEnabled] = useState(false);
   const [newStageError, setNewStageError] = useState('');
+  const betweenSubjectsFactors = getBetweenSubjectsFactors(studyConfig);
+  const betweenSubjectsCombinations = getBetweenSubjectsCombinations(betweenSubjectsFactors);
+
+  const refreshStageData = useCallback(async () => {
+    if (!storageEngine) {
+      return;
+    }
+
+    const [stageData, allParticipants] = await Promise.all([
+      storageEngine.getStageData(studyId),
+      storageEngine.getAllParticipantsData(studyId),
+    ]);
+    setCurrentStage(stageData.currentStage);
+    setAllStages(stageData.allStages);
+    setParticipants(allParticipants);
+    setStageParticipantCounts(getStageParticipantCounts(allParticipants));
+  }, [storageEngine, studyId]);
 
   useEffect(() => {
     const fetchData = async () => {
-      if (storageEngine) {
-        try {
-          const stageData = await storageEngine.getStageData(studyId);
-          setCurrentStage(stageData.currentStage);
-          setAllStages(stageData.allStages);
-          setAsyncStatus(true);
-        } catch (error) {
-          console.error('Failed to load stage data:', error);
-          // Set defaults on error
-          setCurrentStage({ stageName: 'DEFAULT', color: '#F05A30' });
-          setAllStages([{ stageName: 'DEFAULT', color: '#F05A30' }]);
-          setAsyncStatus(true);
-        }
+      try {
+        await refreshStageData();
+      } catch (error) {
+        console.error('Failed to load stage data:', error);
+        // Set defaults on error
+        setCurrentStage({ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR });
+        setAllStages([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]);
+        setStageParticipantCounts({});
+        setParticipants([]);
+      } finally {
+        setAsyncStatus(true);
       }
     };
     fetchData();
-  }, [storageEngine, studyId]);
+  }, [refreshStageData]);
 
   const handleSetCurrentStage = async (stageName: string, color: string) => {
     if (storageEngine) {
@@ -83,18 +396,24 @@ export function StageManagementItem({ studyId }: { studyId: string }) {
     setEditingIndex(index);
     setEditingStageName(allStages[index].stageName);
     setEditingStageColor(allStages[index].color);
+    setEditingStageMaxParticipants(allStages[index].maxParticipants ?? '');
+    setEditingStageLimitEnabled(allStages[index].maxParticipants !== undefined);
     setEditError('');
   };
 
   const handleSaveEdit = async (originalName: string) => {
     if (storageEngine) {
-      // Update the stage color
-      await storageEngine.updateStageColor(studyId, originalName, editingStageColor);
+      const hasParticipantLimit = editingStageLimitEnabled && editingStageMaxParticipants !== '';
+      await storageEngine.updateStage(studyId, originalName, {
+        color: editingStageColor,
+        maxParticipants: hasParticipantLimit
+          ? editingStageMaxParticipants
+          : null,
+        ...(hasParticipantLimit ? {} : { desiredParticipantsByCombination: null }),
+      });
 
       // Refresh data
-      const stageData = await storageEngine.getStageData(studyId);
-      setCurrentStage(stageData.currentStage);
-      setAllStages(stageData.allStages);
+      await refreshStageData();
       setEditingIndex(null);
       setEditError('');
     }
@@ -103,14 +422,18 @@ export function StageManagementItem({ studyId }: { studyId: string }) {
   const handleCancelEdit = () => {
     setEditingIndex(null);
     setEditingStageName('');
-    setEditingStageColor('#F05A30');
+    setEditingStageColor(DEFAULT_STAGE_COLOR);
+    setEditingStageMaxParticipants('');
+    setEditingStageLimitEnabled(false);
     setEditError('');
   };
 
   const handleAddNewStage = () => {
     setAddingNewStage(true);
     setNewStageName('');
-    setNewStageColor('#F05A30');
+    setNewStageColor(getNextStageColor(allStages));
+    setNewStageMaxParticipants('');
+    setNewStageLimitEnabled(false);
     setNewStageError('');
   };
 
@@ -126,23 +449,112 @@ export function StageManagementItem({ studyId }: { studyId: string }) {
 
     if (storageEngine) {
       // Add the new stage by setting it as current (which adds it to allStages)
-      await storageEngine.setCurrentStage(studyId, normalizedStageName, newStageColor);
+      if (!newStageLimitEnabled || newStageMaxParticipants === '') {
+        await storageEngine.setCurrentStage(studyId, normalizedStageName, newStageColor);
+      } else {
+        await storageEngine.setCurrentStage(studyId, normalizedStageName, newStageColor, newStageMaxParticipants);
+      }
 
       // Refresh data
-      const stageData = await storageEngine.getStageData(studyId);
-      setCurrentStage(stageData.currentStage);
-      setAllStages(stageData.allStages);
+      await refreshStageData();
       setAddingNewStage(false);
       setNewStageName('');
-      setNewStageColor('#F05A30');
+      setNewStageColor(DEFAULT_STAGE_COLOR);
+      setNewStageMaxParticipants('');
+      setNewStageLimitEnabled(false);
     }
   };
 
   const handleCancelAddNewStage = () => {
     setAddingNewStage(false);
     setNewStageName('');
-    setNewStageColor('#F05A30');
+    setNewStageColor(DEFAULT_STAGE_COLOR);
+    setNewStageMaxParticipants('');
+    setNewStageLimitEnabled(false);
     setNewStageError('');
+  };
+
+  const toggleStageExpanded = (stageName: string) => {
+    setExpandedStageNames((stageNames) => (
+      stageNames.includes(stageName)
+        ? stageNames.filter((name) => name !== stageName)
+        : [...stageNames, stageName]
+    ));
+  };
+
+  const handleToggleBetweenSubjectsCombination = async (
+    stage: StageInfo,
+    combinationKey: string,
+    enabled: boolean,
+  ) => {
+    if (!storageEngine) {
+      return;
+    }
+
+    const disabledCombinations = stage.disabledBetweenSubjectsCombinations || [];
+    const nextDisabledCombinations = enabled
+      ? disabledCombinations.filter((key) => key !== combinationKey)
+      : [...new Set([...disabledCombinations, combinationKey])];
+    await storageEngine.updateStage(studyId, stage.stageName, {
+      disabledBetweenSubjectsCombinations: nextDisabledCombinations.length === 0
+        ? null
+        : nextDisabledCombinations,
+    });
+    await refreshStageData();
+  };
+
+  const handleSetDesiredParticipants = async (
+    stage: StageInfo,
+    combinationKey: string,
+    desiredParticipants: number | '',
+  ) => {
+    if (!storageEngine) {
+      return;
+    }
+
+    const nextDesiredParticipantsByCombination = {
+      ...stage.desiredParticipantsByCombination,
+    };
+    const currentDesiredParticipantCounts = getDesiredParticipantCounts(
+      stage.maxParticipants,
+      betweenSubjectsCombinations,
+      stage.desiredParticipantsByCombination,
+    );
+    betweenSubjectsCombinations.forEach((combination) => {
+      if (combination.key === combinationKey) {
+        return;
+      }
+
+      const currentCount = currentDesiredParticipantCounts[combination.key];
+      if (typeof currentCount === 'number') {
+        nextDesiredParticipantsByCombination[combination.key] = currentCount;
+      }
+    });
+
+    if (desiredParticipants === '') {
+      delete nextDesiredParticipantsByCombination[combinationKey];
+    } else {
+      nextDesiredParticipantsByCombination[combinationKey] = desiredParticipants;
+    }
+
+    const nextDesiredParticipantCounts = getDesiredParticipantCounts(
+      stage.maxParticipants,
+      betweenSubjectsCombinations,
+      nextDesiredParticipantsByCombination,
+    );
+    const totalDesiredParticipants = Object.values(nextDesiredParticipantCounts)
+      .reduce<number>((total, count) => total + (typeof count === 'number' ? count : 0), 0);
+    const hasDesiredParticipantOverrides = Object.keys(nextDesiredParticipantsByCombination).length > 0;
+
+    await storageEngine.updateStage(studyId, stage.stageName, {
+      desiredParticipantsByCombination: hasDesiredParticipantOverrides
+        ? nextDesiredParticipantsByCombination
+        : null,
+      maxParticipants: stage.maxParticipants === undefined && !hasDesiredParticipantOverrides
+        ? null
+        : totalDesiredParticipants,
+    });
+    await refreshStageData();
   };
 
   if (!asyncStatus) {
@@ -165,95 +577,182 @@ export function StageManagementItem({ studyId }: { studyId: string }) {
         )}
       </Group>
 
-      <Table striped highlightOnHover withTableBorder>
+      <Table striped highlightOnHover withTableBorder style={{ tableLayout: 'fixed', width: '100%' }}>
+        <colgroup>
+          <col style={{ width: 44 }} />
+          <col style={{ width: 80 }} />
+          <col />
+          <col style={{ width: 100 }} />
+          <col style={{ width: 150 }} />
+          <col style={{ width: 200 }} />
+          <col style={{ width: 80 }} />
+        </colgroup>
         <Table.Thead>
           <Table.Tr>
+            <Table.Th style={{ width: '44px' }} />
             <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Current</Table.Th>
             <Table.Th>Stage Name</Table.Th>
+            <Table.Th style={{ width: '100px', whiteSpace: 'nowrap' }}>Participants</Table.Th>
+            <Table.Th style={{ width: '150px', whiteSpace: 'nowrap' }}>Max Participants</Table.Th>
             <Table.Th style={{ width: '200px' }}>Color</Table.Th>
             <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Edit</Table.Th>
           </Table.Tr>
         </Table.Thead>
         <Table.Tbody>
-          {allStages.map((stage, index) => (
-            <Table.Tr key={stage.stageName}>
-              <Table.Td>
-                <Radio
-                  aria-label={`Set current stage to ${stage.stageName}`}
-                  checked={currentStage.stageName === stage.stageName}
-                  onChange={() => handleSetCurrentStage(stage.stageName, stage.color)}
-                />
-              </Table.Td>
-              <Table.Td>
-                {editingIndex === index ? (
-                  <TextInput
-                    value={editingStageName}
-                    onChange={(e) => setEditingStageName(e.currentTarget.value)}
-                    error={editError}
-                    size="xs"
-                    disabled
-                  />
-                ) : (
-                  <Text size="sm">{stage.stageName}</Text>
-                )}
-              </Table.Td>
-              <Table.Td>
-                {editingIndex === index ? (
-                  <ColorInput
-                    value={editingStageColor}
-                    onChange={setEditingStageColor}
-                    size="xs"
-                  />
-                ) : (
-                  <Group gap="xs">
-                    <div
-                      style={{
-                        width: 20,
-                        height: 20,
-                        backgroundColor: stage.color,
-                        border: '1px solid #dee2e6',
-                        borderRadius: 4,
-                      }}
-                    />
-                    <Text size="sm" c="dimmed">{stage.color}</Text>
-                  </Group>
-                )}
-              </Table.Td>
-              <Table.Td>
-                {editingIndex === index ? (
-                  <Group gap="xs">
+          {allStages.map((stage, index) => {
+            const isExpanded = expandedStageNames.includes(stage.stageName);
+
+            return (
+              <Fragment key={stage.stageName}>
+                <Table.Tr key={stage.stageName}>
+                  <Table.Td>
                     <ActionIcon
                       size="sm"
-                      aria-label={`Save stage ${stage.stageName}`}
-                      color="green"
-                      onClick={() => handleSaveEdit(stage.stageName)}
-                    >
-                      <IconCheck size={16} />
-                    </ActionIcon>
-                    <ActionIcon
-                      size="sm"
-                      aria-label={`Cancel editing stage ${stage.stageName}`}
                       color="gray"
-                      onClick={handleCancelEdit}
+                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} stage ${stage.stageName}`}
+                      onClick={() => toggleStageExpanded(stage.stageName)}
                     >
-                      <IconX size={16} />
+                      {isExpanded ? <IconChevronUp size={16} /> : <IconChevronDown size={16} />}
                     </ActionIcon>
-                  </Group>
-                ) : (
-                  <ActionIcon
-                    size="sm"
-                    aria-label={`Edit stage ${stage.stageName}`}
-                    onClick={() => handleEditStage(index)}
-                  >
-                    <IconEdit size={16} />
-                  </ActionIcon>
+                  </Table.Td>
+                  <Table.Td>
+                    <Radio
+                      aria-label={`Set current stage to ${stage.stageName}`}
+                      checked={currentStage.stageName === stage.stageName}
+                      onChange={() => handleSetCurrentStage(stage.stageName, stage.color)}
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    {editingIndex === index ? (
+                      <TextInput
+                        value={editingStageName}
+                        onChange={(e) => setEditingStageName(e.currentTarget.value)}
+                        error={editError}
+                        size="xs"
+                        disabled
+                        w="100%"
+                      />
+                    ) : (
+                      <Text size="sm">{stage.stageName}</Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm">{stageParticipantCounts[stage.stageName] || 0}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    {editingIndex === index ? (
+                      <Group gap={4} wrap="nowrap">
+                        <Button
+                          aria-label={`Limit participants for ${stage.stageName}`}
+                          size="compact-xs"
+                          variant={editingStageLimitEnabled ? 'light' : 'subtle'}
+                          color={editingStageLimitEnabled ? 'blue' : 'gray'}
+                          onClick={() => {
+                            setEditingStageLimitEnabled(!editingStageLimitEnabled);
+                            if (editingStageLimitEnabled) {
+                              setEditingStageMaxParticipants('');
+                            }
+                          }}
+                        >
+                          {editingStageLimitEnabled ? <IconToggleRight size={16} /> : <IconToggleLeft size={16} />}
+                        </Button>
+                        {editingStageLimitEnabled && (
+                          <NumberInput
+                            aria-label={`Maximum participants for ${stage.stageName}`}
+                            value={editingStageMaxParticipants}
+                            onChange={(value) => setEditingStageMaxParticipants(typeof value === 'number' ? value : '')}
+                            min={0}
+                            allowDecimal={false}
+                            size="xs"
+                            style={{ flex: 1, minWidth: 0 }}
+                          />
+                        )}
+                      </Group>
+                    ) : (
+                      <Text size="sm">{stage.maxParticipants ?? 'Unlimited'}</Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    {editingIndex === index ? (
+                      <ColorInput
+                        value={editingStageColor}
+                        onChange={setEditingStageColor}
+                        size="xs"
+                        w="100%"
+                      />
+                    ) : (
+                      <Group gap="xs">
+                        <div
+                          style={{
+                            width: 20,
+                            height: 20,
+                            backgroundColor: stage.color,
+                            border: '1px solid #dee2e6',
+                            borderRadius: 4,
+                          }}
+                        />
+                        <Text size="sm" c="dimmed">{stage.color}</Text>
+                      </Group>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    {editingIndex === index ? (
+                      <Group gap="xs">
+                        <ActionIcon
+                          size="sm"
+                          aria-label={`Save stage ${stage.stageName}`}
+                          color="green"
+                          onClick={() => handleSaveEdit(stage.stageName)}
+                        >
+                          <IconCheck size={16} />
+                        </ActionIcon>
+                        <ActionIcon
+                          size="sm"
+                          aria-label={`Cancel editing stage ${stage.stageName}`}
+                          color="gray"
+                          onClick={handleCancelEdit}
+                        >
+                          <IconX size={16} />
+                        </ActionIcon>
+                      </Group>
+                    ) : (
+                      <ActionIcon
+                        size="sm"
+                        aria-label={`Edit stage ${stage.stageName}`}
+                        onClick={() => handleEditStage(index)}
+                      >
+                        <IconEdit size={16} />
+                      </ActionIcon>
+                    )}
+                  </Table.Td>
+                </Table.Tr>
+                {isExpanded && (
+                  <Table.Tr key={`${stage.stageName}-conditions`}>
+                    <Table.Td colSpan={7} style={{ maxWidth: 0, overflow: 'hidden' }}>
+                      <Paper p="sm" radius="sm" withBorder bg="gray.0" style={{ maxWidth: '100%', minWidth: 0 }}>
+                        {betweenSubjectsFactors.length === 0 ? (
+                          <Text size="sm" c="dimmed">This study has no between-subjects factors.</Text>
+                        ) : (
+                          <BetweenSubjectsCombinationTable
+                            stage={stage}
+                            participants={participants}
+                            betweenSubjectsFactors={betweenSubjectsFactors}
+                            combinations={betweenSubjectsCombinations}
+                            onToggle={handleToggleBetweenSubjectsCombination}
+                            onSetDesiredParticipants={handleSetDesiredParticipants}
+                          />
+                        )}
+                      </Paper>
+                    </Table.Td>
+                  </Table.Tr>
                 )}
-              </Table.Td>
-            </Table.Tr>
-          ))}
+              </Fragment>
+            );
+          })}
 
           {addingNewStage && (
             <Table.Tr style={{ backgroundColor: '#f8f9fa' }}>
+              <Table.Td />
               <Table.Td />
               <Table.Td>
                 <TextInput
@@ -262,13 +761,47 @@ export function StageManagementItem({ studyId }: { studyId: string }) {
                   onChange={(e) => setNewStageName(e.currentTarget.value)}
                   error={newStageError}
                   size="xs"
+                  w="100%"
                 />
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm">0</Text>
+              </Table.Td>
+              <Table.Td>
+                <Group gap={4} wrap="nowrap">
+                  <Button
+                    aria-label="Limit participants for new stage"
+                    size="compact-xs"
+                    variant={newStageLimitEnabled ? 'light' : 'subtle'}
+                    color={newStageLimitEnabled ? 'blue' : 'gray'}
+                    onClick={() => {
+                      setNewStageLimitEnabled(!newStageLimitEnabled);
+                      if (newStageLimitEnabled) {
+                        setNewStageMaxParticipants('');
+                      }
+                    }}
+                  >
+                    {newStageLimitEnabled ? <IconToggleRight size={16} /> : <IconToggleLeft size={16} />}
+                  </Button>
+                  {newStageLimitEnabled && (
+                    <NumberInput
+                      aria-label="Maximum participants for new stage"
+                      value={newStageMaxParticipants}
+                      onChange={(value) => setNewStageMaxParticipants(typeof value === 'number' ? value : '')}
+                      min={0}
+                      allowDecimal={false}
+                      size="xs"
+                      style={{ flex: 1, minWidth: 0 }}
+                    />
+                  )}
+                </Group>
               </Table.Td>
               <Table.Td>
                 <ColorInput
                   value={newStageColor}
                   onChange={setNewStageColor}
                   size="xs"
+                  w="100%"
                 />
               </Table.Td>
               <Table.Td>

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch, Collapse, Badge,
+  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch, Collapse, Badge, Popover, ScrollArea,
   Title,
 } from '@mantine/core';
 import {
@@ -317,6 +317,8 @@ function BetweenSubjectsCombinationTable({
   onToggle,
   onSetDesiredParticipants,
   onReviewInProgress,
+  showParticipantCounts,
+  showParticipantLimits,
 }: {
   stage: StageInfo;
   participants: ParticipantDataWithStatus[];
@@ -325,6 +327,8 @@ function BetweenSubjectsCombinationTable({
   onToggle: (stage: StageInfo, combinationKey: string, enabled: boolean) => Promise<void>;
   onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>;
   onReviewInProgress: (participants: ParticipantDataWithStatus[], description: string) => void;
+  showParticipantCounts: boolean;
+  showParticipantLimits: boolean;
 }) {
   const data = useMemo<BetweenSubjectsCombinationRow[]>(() => {
     const desiredParticipantCounts = getDesiredParticipantCounts(
@@ -379,31 +383,38 @@ function BetweenSubjectsCombinationTable({
       accessorKey: factor.factorName,
       header: factor.factorName,
     } satisfies MrtColumnDef<BetweenSubjectsCombinationRow>)),
-    {
+    ...(showParticipantCounts ? [{
       accessorKey: 'participantStatusCounts',
       header: 'Participants',
-      Cell: ({ row }) => renderParticipantStatusCell(row.original, handleReviewInProgress),
-    },
-    {
+      Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderParticipantStatusCell(row.original, handleReviewInProgress),
+    }] : []),
+    ...(showParticipantLimits ? [{
       accessorKey: 'desiredParticipants',
       header: 'Desired Participants',
-      Cell: ({ row }) => renderDesiredParticipantsCell(
+      Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderDesiredParticipantsCell(
         row.original,
         stage,
         onSetDesiredParticipants,
       ),
-    },
-    {
+    }, {
       accessorKey: 'enabled',
       header: 'Enabled',
-      Cell: ({ row }) => renderCombinationEnabledCell(
+      Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderCombinationEnabledCell(
         row.original,
         stage,
         betweenSubjectsFactors,
         onToggle,
       ),
-    },
-  ], [betweenSubjectsFactors, handleReviewInProgress, onSetDesiredParticipants, onToggle, stage]);
+    }] : []),
+  ], [
+    betweenSubjectsFactors,
+    handleReviewInProgress,
+    onSetDesiredParticipants,
+    onToggle,
+    showParticipantCounts,
+    showParticipantLimits,
+    stage,
+  ]);
 
   const table = useMantineReactTable({
     columns,
@@ -462,14 +473,13 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editingStageName, setEditingStageName] = useState('');
   const [editingStageColor, setEditingStageColor] = useState(DEFAULT_STAGE_COLOR);
-  const [editingStageMaxParticipants, setEditingStageMaxParticipants] = useState<number | ''>('');
-  const [editingStageLimitEnabled, setEditingStageLimitEnabled] = useState(false);
+  const [limitPopoverStageName, setLimitPopoverStageName] = useState<string | null>(null);
+  const [editingLimitMaxParticipants, setEditingLimitMaxParticipants] = useState<number | ''>('');
+  const [editingLimitEnabled, setEditingLimitEnabled] = useState(false);
   const [editError, setEditError] = useState('');
   const [addingNewStage, setAddingNewStage] = useState(false);
   const [newStageName, setNewStageName] = useState('');
   const [newStageColor, setNewStageColor] = useState(DEFAULT_STAGE_COLOR);
-  const [newStageMaxParticipants, setNewStageMaxParticipants] = useState<number | ''>('');
-  const [newStageLimitEnabled, setNewStageLimitEnabled] = useState(false);
   const [newStageError, setNewStageError] = useState('');
   const betweenSubjectsFactors = getBetweenSubjectsFactors(studyConfig);
   const betweenSubjectsCombinations = getBetweenSubjectsCombinations(betweenSubjectsFactors);
@@ -526,20 +536,13 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     setEditingIndex(index);
     setEditingStageName(allStages[index].stageName);
     setEditingStageColor(allStages[index].color);
-    setEditingStageMaxParticipants(allStages[index].maxParticipants ?? '');
-    setEditingStageLimitEnabled(allStages[index].maxParticipants !== undefined);
     setEditError('');
   };
 
   const handleSaveEdit = async (originalName: string) => {
     if (storageEngine) {
-      const hasParticipantLimit = editingStageLimitEnabled && editingStageMaxParticipants !== '';
       await storageEngine.updateStage(studyId, originalName, {
         color: editingStageColor,
-        maxParticipants: hasParticipantLimit
-          ? editingStageMaxParticipants
-          : null,
-        ...(hasParticipantLimit ? {} : { desiredParticipantsByCombination: null }),
       });
 
       // Refresh data
@@ -553,17 +556,39 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     setEditingIndex(null);
     setEditingStageName('');
     setEditingStageColor(DEFAULT_STAGE_COLOR);
-    setEditingStageMaxParticipants('');
-    setEditingStageLimitEnabled(false);
     setEditError('');
+  };
+
+  const handleEditParticipantLimit = (stage: StageInfo) => {
+    setLimitPopoverStageName(stage.stageName);
+    setEditingLimitMaxParticipants(stage.maxParticipants ?? '');
+    setEditingLimitEnabled(stage.maxParticipants !== undefined);
+  };
+
+  const handleSaveParticipantLimit = async (stage: StageInfo) => {
+    if (!storageEngine) {
+      return;
+    }
+
+    const hasParticipantLimit = editingLimitEnabled && editingLimitMaxParticipants !== '';
+    await storageEngine.updateStage(studyId, stage.stageName, {
+      maxParticipants: hasParticipantLimit ? editingLimitMaxParticipants : null,
+      ...(hasParticipantLimit ? {} : { desiredParticipantsByCombination: null }),
+    });
+    await refreshStageData();
+    setLimitPopoverStageName(null);
+  };
+
+  const handleCancelParticipantLimit = () => {
+    setEditingLimitMaxParticipants('');
+    setEditingLimitEnabled(false);
+    setLimitPopoverStageName(null);
   };
 
   const handleAddNewStage = () => {
     setAddingNewStage(true);
     setNewStageName('');
     setNewStageColor(getNextStageColor(allStages));
-    setNewStageMaxParticipants('');
-    setNewStageLimitEnabled(false);
     setNewStageError('');
   };
 
@@ -578,20 +603,14 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     setNewStageError('');
 
     if (storageEngine) {
-      // Add the new stage by setting it as current (which adds it to allStages)
-      if (!newStageLimitEnabled || newStageMaxParticipants === '') {
-        await storageEngine.setCurrentStage(studyId, normalizedStageName, newStageColor);
-      } else {
-        await storageEngine.setCurrentStage(studyId, normalizedStageName, newStageColor, newStageMaxParticipants);
-      }
+      // Add the new stage by setting it as current (which adds it to allStages).
+      await storageEngine.setCurrentStage(studyId, normalizedStageName, newStageColor);
 
       // Refresh data
       await refreshStageData();
       setAddingNewStage(false);
       setNewStageName('');
       setNewStageColor(DEFAULT_STAGE_COLOR);
-      setNewStageMaxParticipants('');
-      setNewStageLimitEnabled(false);
     }
   };
 
@@ -599,8 +618,6 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     setAddingNewStage(false);
     setNewStageName('');
     setNewStageColor(DEFAULT_STAGE_COLOR);
-    setNewStageMaxParticipants('');
-    setNewStageLimitEnabled(false);
     setNewStageError('');
   };
 
@@ -725,14 +742,14 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
         refresh={refreshStageData}
       />
 
+      <Title order={5}>Participant Counts</Title>
       <Table striped highlightOnHover withTableBorder style={{ tableLayout: 'fixed', width: '100%' }}>
         <colgroup>
           <col style={{ width: 44 }} />
           <col style={{ width: 80 }} />
           <col />
           <col style={{ width: 210 }} />
-          <col style={{ width: 150 }} />
-          <col style={{ width: 200 }} />
+          <col style={{ width: 220 }} />
           <col style={{ width: 80 }} />
         </colgroup>
         <Table.Thead>
@@ -741,14 +758,14 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
             <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Current</Table.Th>
             <Table.Th>Stage Name</Table.Th>
             <Table.Th style={{ width: '210px', whiteSpace: 'nowrap' }}>Participants</Table.Th>
-            <Table.Th style={{ width: '150px', whiteSpace: 'nowrap' }}>Max Participants</Table.Th>
-            <Table.Th style={{ width: '200px' }}>Color</Table.Th>
+            <Table.Th style={{ width: '220px', whiteSpace: 'nowrap' }}>Max Participants</Table.Th>
             <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Edit</Table.Th>
           </Table.Tr>
         </Table.Thead>
         <Table.Tbody>
           {allStages.map((stage, index) => {
             const isExpanded = expandedStageNames.includes(stage.stageName);
+            const isLimitPopoverOpened = limitPopoverStageName === stage.stageName;
 
             return (
               <Fragment key={stage.stageName}>
@@ -772,16 +789,37 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                   </Table.Td>
                   <Table.Td>
                     {editingIndex === index ? (
-                      <TextInput
-                        value={editingStageName}
-                        onChange={(e) => setEditingStageName(e.currentTarget.value)}
-                        error={editError}
-                        size="xs"
-                        disabled
-                        w="100%"
-                      />
+                      <Group gap="xs" wrap="nowrap">
+                        <TextInput
+                          value={editingStageName}
+                          onChange={(e) => setEditingStageName(e.currentTarget.value)}
+                          error={editError}
+                          size="xs"
+                          disabled
+                          style={{ flex: 1, minWidth: 0 }}
+                        />
+                        <ColorInput
+                          value={editingStageColor}
+                          onChange={setEditingStageColor}
+                          size="xs"
+                          w={120}
+                        />
+                      </Group>
                     ) : (
-                      <Text size="sm">{stage.stageName}</Text>
+                      <Group gap="xs" wrap="nowrap">
+                        <div
+                          aria-label={`${stage.stageName} color`}
+                          style={{
+                            width: 14,
+                            height: 14,
+                            flex: '0 0 auto',
+                            backgroundColor: stage.color,
+                            border: '1px solid #dee2e6',
+                            borderRadius: 3,
+                          }}
+                        />
+                        <Text size="sm">{stage.stageName}</Text>
+                      </Group>
                     )}
                   </Table.Td>
                   <Table.Td>
@@ -794,65 +832,106 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                     />
                   </Table.Td>
                   <Table.Td>
-                    {editingIndex === index ? (
-                      <Group gap={4} wrap="nowrap">
-                        <Button
-                          aria-label={`Limit participants for ${stage.stageName}`}
-                          size="compact-xs"
-                          variant={editingStageLimitEnabled ? 'light' : 'subtle'}
-                          color={editingStageLimitEnabled ? 'blue' : 'gray'}
-                          onClick={() => {
-                            setEditingStageLimitEnabled(!editingStageLimitEnabled);
-                            if (editingStageLimitEnabled) {
-                              setEditingStageMaxParticipants('');
-                            }
-                          }}
-                        >
-                          {editingStageLimitEnabled ? <IconToggleRight size={16} /> : <IconToggleLeft size={16} />}
-                        </Button>
-                        {editingStageLimitEnabled && (
-                          <NumberInput
-                            aria-label={`Maximum participants for ${stage.stageName}`}
-                            value={editingStageMaxParticipants}
-                            onChange={(value) => setEditingStageMaxParticipants(typeof value === 'number' ? value : '')}
-                            min={0}
-                            allowDecimal={false}
-                            size="xs"
-                            style={{ flex: 1, minWidth: 0 }}
-                          />
-                        )}
-                      </Group>
-                    ) : (
-                      <Text size="sm">
-                        {(stageParticipantStatusCounts[stage.stageName]?.completed || 0)
-                          + (stageParticipantStatusCounts[stage.stageName]?.inProgress || 0)}
-                        {' / '}
-                        {stage.maxParticipants ?? 'Unlimited'}
-                      </Text>
-                    )}
-                  </Table.Td>
-                  <Table.Td>
-                    {editingIndex === index ? (
-                      <ColorInput
-                        value={editingStageColor}
-                        onChange={setEditingStageColor}
-                        size="xs"
-                        w="100%"
-                      />
-                    ) : (
-                      <Group gap="xs">
-                        <div
-                          style={{
-                            width: 20,
-                            height: 20,
-                            backgroundColor: stage.color,
-                            border: '1px solid #dee2e6',
-                            borderRadius: 4,
-                          }}
-                        />
-                        <Text size="sm" c="dimmed">{stage.color}</Text>
-                      </Group>
-                    )}
+                    <Group gap={4} wrap="nowrap" justify="flex-end" pr={64}>
+                      <Text size="sm">{stage.maxParticipants ?? 'Unlimited'}</Text>
+                      <Popover
+                        opened={isLimitPopoverOpened}
+                        onChange={(opened) => {
+                          if (!opened && isLimitPopoverOpened) {
+                            handleCancelParticipantLimit();
+                          }
+                        }}
+                        position="bottom-start"
+                        shadow="md"
+                        width={720}
+                      >
+                        <Popover.Target>
+                          <ActionIcon
+                            aria-label={`Edit participant limits for ${stage.stageName}`}
+                            onClick={() => {
+                              if (isLimitPopoverOpened) {
+                                handleCancelParticipantLimit();
+                              } else {
+                                handleEditParticipantLimit(stage);
+                              }
+                            }}
+                            size="sm"
+                            variant="subtle"
+                          >
+                            <IconEdit size={16} />
+                          </ActionIcon>
+                        </Popover.Target>
+                        <Popover.Dropdown>
+                          <Stack gap="sm">
+                            <Text fw={500}>
+                              Participant limits for
+                              {' '}
+                              {stage.stageName}
+                            </Text>
+                            <Group gap={4} wrap="nowrap">
+                              <Button
+                                aria-label={`Limit participants for ${stage.stageName}`}
+                                size="compact-xs"
+                                variant={editingLimitEnabled ? 'light' : 'subtle'}
+                                color={editingLimitEnabled ? 'blue' : 'gray'}
+                                onClick={() => {
+                                  setEditingLimitEnabled(!editingLimitEnabled);
+                                  if (editingLimitEnabled) {
+                                    setEditingLimitMaxParticipants('');
+                                  }
+                                }}
+                              >
+                                {editingLimitEnabled ? <IconToggleRight size={16} /> : <IconToggleLeft size={16} />}
+                              </Button>
+                              {editingLimitEnabled && (
+                                <NumberInput
+                                  aria-label={`Maximum participants for ${stage.stageName}`}
+                                  value={editingLimitMaxParticipants}
+                                  onChange={(value) => setEditingLimitMaxParticipants(typeof value === 'number' ? value : '')}
+                                  min={0}
+                                  allowDecimal={false}
+                                  size="xs"
+                                  style={{ flex: 1, minWidth: 0 }}
+                                />
+                              )}
+                              <ActionIcon
+                                size="sm"
+                                aria-label={`Save participant limit for ${stage.stageName}`}
+                                color="green"
+                                onClick={() => handleSaveParticipantLimit(stage)}
+                              >
+                                <IconCheck size={16} />
+                              </ActionIcon>
+                              <ActionIcon
+                                size="sm"
+                                aria-label={`Cancel participant limit for ${stage.stageName}`}
+                                color="gray"
+                                onClick={handleCancelParticipantLimit}
+                              >
+                                <IconX size={16} />
+                              </ActionIcon>
+                            </Group>
+                            {betweenSubjectsFactors.length === 0 ? (
+                              <Text size="sm" c="dimmed">This study has no between-subjects factors.</Text>
+                            ) : (
+                              <ScrollArea h={360} type="auto">
+                                <BetweenSubjectsCombinationTable
+                                  stage={stage}
+                                  participants={participants}
+                                  betweenSubjectsFactors={betweenSubjectsFactors}
+                                  combinations={betweenSubjectsCombinations}
+                                  onReviewInProgress={handleReviewInProgress}
+                                  onSetDesiredParticipants={handleSetDesiredParticipants}
+                                  onToggle={handleToggleBetweenSubjectsCombination}
+                                  showParticipantCounts={false}
+                                  showParticipantLimits
+                                />
+                              </ScrollArea>
+                            )}
+                          </Stack>
+                        </Popover.Dropdown>
+                      </Popover>
+                    </Group>
                   </Table.Td>
                   <Table.Td>
                     {editingIndex === index ? (
@@ -886,7 +965,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                   </Table.Td>
                 </Table.Tr>
                 <Table.Tr key={`${stage.stageName}-conditions`}>
-                  <Table.Td colSpan={7} p={0} style={{ maxWidth: 0, overflow: 'hidden' }}>
+                  <Table.Td colSpan={6} p={0} style={{ maxWidth: 0, overflow: 'hidden' }}>
                     <Collapse in={isExpanded} transitionDuration={200} transitionTimingFunction="ease">
                       <Paper m="sm" p="sm" radius="sm" withBorder bg="gray.0" style={{ maxWidth: '100%', minWidth: 0 }}>
                         {betweenSubjectsFactors.length === 0 ? (
@@ -897,9 +976,11 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                             participants={participants}
                             betweenSubjectsFactors={betweenSubjectsFactors}
                             combinations={betweenSubjectsCombinations}
-                            onToggle={handleToggleBetweenSubjectsCombination}
-                            onSetDesiredParticipants={handleSetDesiredParticipants}
                             onReviewInProgress={handleReviewInProgress}
+                            onSetDesiredParticipants={handleSetDesiredParticipants}
+                            onToggle={handleToggleBetweenSubjectsCombination}
+                            showParticipantCounts
+                            showParticipantLimits={false}
                           />
                         )}
                       </Paper>
@@ -915,54 +996,28 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
               <Table.Td />
               <Table.Td />
               <Table.Td>
-                <TextInput
-                  placeholder="Enter stage name"
-                  value={newStageName}
-                  onChange={(e) => setNewStageName(e.currentTarget.value)}
-                  error={newStageError}
-                  size="xs"
-                  w="100%"
-                />
+                <Group gap="xs" wrap="nowrap">
+                  <TextInput
+                    placeholder="Enter stage name"
+                    value={newStageName}
+                    onChange={(e) => setNewStageName(e.currentTarget.value)}
+                    error={newStageError}
+                    size="xs"
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                  <ColorInput
+                    value={newStageColor}
+                    onChange={setNewStageColor}
+                    size="xs"
+                    w={120}
+                  />
+                </Group>
               </Table.Td>
               <Table.Td>
                 <Text size="sm">0</Text>
               </Table.Td>
               <Table.Td>
-                <Group gap={4} wrap="nowrap">
-                  <Button
-                    aria-label="Limit participants for new stage"
-                    size="compact-xs"
-                    variant={newStageLimitEnabled ? 'light' : 'subtle'}
-                    color={newStageLimitEnabled ? 'blue' : 'gray'}
-                    onClick={() => {
-                      setNewStageLimitEnabled(!newStageLimitEnabled);
-                      if (newStageLimitEnabled) {
-                        setNewStageMaxParticipants('');
-                      }
-                    }}
-                  >
-                    {newStageLimitEnabled ? <IconToggleRight size={16} /> : <IconToggleLeft size={16} />}
-                  </Button>
-                  {newStageLimitEnabled && (
-                    <NumberInput
-                      aria-label="Maximum participants for new stage"
-                      value={newStageMaxParticipants}
-                      onChange={(value) => setNewStageMaxParticipants(typeof value === 'number' ? value : '')}
-                      min={0}
-                      allowDecimal={false}
-                      size="xs"
-                      style={{ flex: 1, minWidth: 0 }}
-                    />
-                  )}
-                </Group>
-              </Table.Td>
-              <Table.Td>
-                <ColorInput
-                  value={newStageColor}
-                  onChange={setNewStageColor}
-                  size="xs"
-                  w="100%"
-                />
+                <Text size="sm" c="dimmed">Set after creating</Text>
               </Table.Td>
               <Table.Td>
                 <Group gap="xs">

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch, Collapse,
+  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch, Collapse, Badge,
   Title,
 } from '@mantine/core';
 import {
@@ -55,11 +55,21 @@ export function getBetweenSubjectsFactors(studyConfig?: StudyConfig): BetweenSub
   }) || [];
 }
 
-export function getStageParticipantCounts(participants: ParticipantDataWithStatus[]) {
-  return participants.reduce<Record<string, number>>((counts, participant) => {
-    if (!participant.rejected) {
-      counts[participant.stage] = (counts[participant.stage] || 0) + 1;
+type StageParticipantStatusCounts = Record<string, { completed: number; inProgress: number }>;
+
+export function getStageParticipantStatusCounts(participants: ParticipantDataWithStatus[]) {
+  return participants.reduce<StageParticipantStatusCounts>((counts, participant) => {
+    if (participant.rejected) {
+      return counts;
     }
+
+    const stageCounts = counts[participant.stage] || { completed: 0, inProgress: 0 };
+    if (participant.completed) {
+      stageCounts.completed += 1;
+    } else {
+      stageCounts.inProgress += 1;
+    }
+    counts[participant.stage] = stageCounts;
     return counts;
   }, {});
 }
@@ -334,7 +344,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
   const [asyncStatus, setAsyncStatus] = useState(false);
   const [currentStage, setCurrentStage] = useState<StageInfo>({ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR });
   const [allStages, setAllStages] = useState<StageInfo[]>([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]);
-  const [stageParticipantCounts, setStageParticipantCounts] = useState<Record<string, number>>({});
+  const [stageParticipantStatusCounts, setStageParticipantStatusCounts] = useState<StageParticipantStatusCounts>({});
   const [participants, setParticipants] = useState<ParticipantDataWithStatus[]>([]);
   const [expandedStageNames, setExpandedStageNames] = useState<string[]>([]);
   const currentStageNameRef = useRef<string | undefined>(undefined);
@@ -371,7 +381,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     }
     setAllStages(stageData.allStages);
     setParticipants(allParticipants);
-    setStageParticipantCounts(getStageParticipantCounts(allParticipants));
+    setStageParticipantStatusCounts(getStageParticipantStatusCounts(allParticipants));
   }, [storageEngine, studyId]);
 
   useEffect(() => {
@@ -383,7 +393,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
         // Set defaults on error
         setCurrentStage({ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR });
         setAllStages([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]);
-        setStageParticipantCounts({});
+        setStageParticipantStatusCounts({});
         setParticipants([]);
       } finally {
         setAsyncStatus(true);
@@ -591,7 +601,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
           <col style={{ width: 44 }} />
           <col style={{ width: 80 }} />
           <col />
-          <col style={{ width: 100 }} />
+          <col style={{ width: 210 }} />
           <col style={{ width: 150 }} />
           <col style={{ width: 200 }} />
           <col style={{ width: 80 }} />
@@ -601,7 +611,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
             <Table.Th style={{ width: '44px' }} />
             <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Current</Table.Th>
             <Table.Th>Stage Name</Table.Th>
-            <Table.Th style={{ width: '100px', whiteSpace: 'nowrap' }}>Participants</Table.Th>
+            <Table.Th style={{ width: '210px', whiteSpace: 'nowrap' }}>Participants</Table.Th>
             <Table.Th style={{ width: '150px', whiteSpace: 'nowrap' }}>Max Participants</Table.Th>
             <Table.Th style={{ width: '200px' }}>Color</Table.Th>
             <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Edit</Table.Th>
@@ -646,7 +656,18 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                     )}
                   </Table.Td>
                   <Table.Td>
-                    <Text size="sm">{stageParticipantCounts[stage.stageName] || 0}</Text>
+                    <Group gap={4} wrap="nowrap">
+                      <Badge color="teal" variant="light" size="sm">
+                        Completed
+                        {' '}
+                        {stageParticipantStatusCounts[stage.stageName]?.completed || 0}
+                      </Badge>
+                      <Badge color="blue" variant="light" size="sm">
+                        In Progress
+                        {' '}
+                        {stageParticipantStatusCounts[stage.stageName]?.inProgress || 0}
+                      </Badge>
+                    </Group>
                   </Table.Td>
                   <Table.Td>
                     {editingIndex === index ? (

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -1,9 +1,9 @@
 import {
-  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch,
+  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch, Collapse,
   Title,
 } from '@mantine/core';
 import {
-  Fragment, useCallback, useEffect, useMemo, useState,
+  Fragment, useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import isEqual from 'lodash.isequal';
 import {
@@ -337,6 +337,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
   const [stageParticipantCounts, setStageParticipantCounts] = useState<Record<string, number>>({});
   const [participants, setParticipants] = useState<ParticipantDataWithStatus[]>([]);
   const [expandedStageNames, setExpandedStageNames] = useState<string[]>([]);
+  const currentStageNameRef = useRef<string | undefined>(undefined);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editingStageName, setEditingStageName] = useState('');
   const [editingStageColor, setEditingStageColor] = useState(DEFAULT_STAGE_COLOR);
@@ -362,6 +363,12 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
       storageEngine.getAllParticipantsData(studyId),
     ]);
     setCurrentStage(stageData.currentStage);
+    const nextCurrentStageName = stageData.currentStage.stageName;
+    const currentStageChanged = currentStageNameRef.current !== nextCurrentStageName;
+    currentStageNameRef.current = nextCurrentStageName;
+    if (currentStageChanged) {
+      setExpandedStageNames([nextCurrentStageName]);
+    }
     setAllStages(stageData.allStages);
     setParticipants(allParticipants);
     setStageParticipantCounts(getStageParticipantCounts(allParticipants));
@@ -389,6 +396,8 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     if (storageEngine) {
       await storageEngine.setCurrentStage(studyId, stageName, color);
       setCurrentStage({ stageName, color });
+      currentStageNameRef.current = stageName;
+      setExpandedStageNames([stageName]);
     }
   };
 
@@ -478,7 +487,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     setExpandedStageNames((stageNames) => (
       stageNames.includes(stageName)
         ? stageNames.filter((name) => name !== stageName)
-        : [...stageNames, stageName]
+        : [stageName]
     ));
   };
 
@@ -726,10 +735,10 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                     )}
                   </Table.Td>
                 </Table.Tr>
-                {isExpanded && (
-                  <Table.Tr key={`${stage.stageName}-conditions`}>
-                    <Table.Td colSpan={7} style={{ maxWidth: 0, overflow: 'hidden' }}>
-                      <Paper p="sm" radius="sm" withBorder bg="gray.0" style={{ maxWidth: '100%', minWidth: 0 }}>
+                <Table.Tr key={`${stage.stageName}-conditions`}>
+                  <Table.Td colSpan={7} p={0} style={{ maxWidth: 0, overflow: 'hidden' }}>
+                    <Collapse in={isExpanded} transitionDuration={200} transitionTimingFunction="ease">
+                      <Paper m="sm" p="sm" radius="sm" withBorder bg="gray.0" style={{ maxWidth: '100%', minWidth: 0 }}>
                         {betweenSubjectsFactors.length === 0 ? (
                           <Text size="sm" c="dimmed">This study has no between-subjects factors.</Text>
                         ) : (
@@ -743,9 +752,9 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                           />
                         )}
                       </Paper>
-                    </Table.Td>
-                  </Table.Tr>
-                )}
+                    </Collapse>
+                  </Table.Td>
+                </Table.Tr>
               </Fragment>
             );
           })}

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -1,13 +1,13 @@
 import {
-  Stack, TextInput, Button, Group, Table, Text, ColorInput, Loader, ActionIcon, Radio, NumberInput, Paper, Switch, Collapse, Badge, Popover, ScrollArea,
-  Title,
+  Stack, TextInput, Button, Group, Table, Text, ColorInput, ColorPicker, Loader, ActionIcon, NumberInput, Paper, Switch, ScrollArea,
+  Title, Divider, SegmentedControl, Modal, Popover, Tooltip,
 } from '@mantine/core';
 import {
-  Fragment, useCallback, useEffect, useMemo, useRef, useState,
+  useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import isEqual from 'lodash.isequal';
 import {
-  IconEdit, IconCheck, IconX, IconChevronDown, IconChevronUp, IconToggleLeft, IconToggleRight,
+  IconEdit, IconCheck, IconQuestionMark, IconX,
 } from '@tabler/icons-react';
 import {
   MantineReactTable,
@@ -42,6 +42,22 @@ type BetweenSubjectsCombinationRow = {
 };
 
 const DEFAULT_STAGE_COLOR = DISTINCT_COLOR_PALETTE[0];
+
+function getParticipantAssignmentMode(stage: StageInfo): 'even' | 'manual' {
+  return stage.participantAssignmentMode
+    ?? (stage.desiredParticipantsByCombination ? 'manual' : 'even');
+}
+
+function getManualDesiredParticipants(stage: StageInfo) {
+  return stage.manualDesiredParticipantsByCombination
+    ?? stage.desiredParticipantsByCombination;
+}
+
+function getActiveDesiredParticipants(stage: StageInfo) {
+  return getParticipantAssignmentMode(stage) === 'manual'
+    ? getManualDesiredParticipants(stage)
+    : undefined;
+}
 
 export function getBetweenSubjectsFactors(studyConfig?: StudyConfig): BetweenSubjectsFactor[] {
   return studyConfig?.betweenSubjects?.flatMap((factorName) => {
@@ -131,49 +147,6 @@ function getBetweenSubjectsCombinationStatusCounts(
     }
     return counts;
   }, { completed: 0, inProgress: 0 });
-}
-
-function StageParticipantStatusBadges({
-  completed,
-  inProgress,
-  onInProgressClick,
-}: {
-  completed: number;
-  inProgress: number;
-  onInProgressClick?: () => void;
-}) {
-  return (
-    <Stack gap={4} align="flex-start">
-      <Badge color="green" variant="filled" size="sm" c="gray.0">
-        Completed
-        {' '}
-        {completed}
-      </Badge>
-      {onInProgressClick && inProgress > 0 ? (
-        <Badge
-          aria-label={`Review ${inProgress} in-progress participant${inProgress === 1 ? '' : 's'}`}
-          color="orange"
-          component="button"
-          c="gray.0"
-          onClick={onInProgressClick}
-          size="sm"
-          style={{ cursor: 'pointer' }}
-          type="button"
-          variant="filled"
-        >
-          In Progress
-          {' '}
-          {inProgress}
-        </Badge>
-      ) : (
-        <Badge color="orange" variant="filled" size="sm" c="gray.0">
-          In Progress
-          {' '}
-          {inProgress}
-        </Badge>
-      )}
-    </Stack>
-  );
 }
 
 export function getDefaultDesiredParticipantCounts(
@@ -276,37 +249,106 @@ function renderCombinationEnabledCell(
   );
 }
 
-function renderDesiredParticipantsCell(
-  row: BetweenSubjectsCombinationRow,
-  stage: StageInfo,
-  onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>,
-) {
+function renderHeaderWithInformation(label: string, information: string) {
   return (
-    <NumberInput
-      aria-label={`Desired participants for ${row.combinationKey} in ${stage.stageName}`}
-      min={0}
-      allowDecimal={false}
-      value={row.desiredParticipants}
-      onChange={(value) => onSetDesiredParticipants(
-        stage,
-        row.combinationKey,
-        typeof value === 'number' ? value : '',
-      )}
-    />
+    <Group gap={4} wrap="nowrap">
+      <span>{label}</span>
+      <Tooltip label={information}>
+        <ActionIcon
+          aria-label={`Information about ${label.toLowerCase()} participants`}
+          color="gray"
+          onClick={(event) => event.stopPropagation()}
+          radius="xl"
+          size="sm"
+          variant="light"
+        >
+          <IconQuestionMark size={16} />
+        </ActionIcon>
+      </Tooltip>
+    </Group>
   );
 }
 
-function renderParticipantStatusCell(
+function renderCurrentHeader() {
+  return renderHeaderWithInformation(
+    'Current',
+    'Participants who have started but not yet completed the study',
+  );
+}
+
+function renderCompletedHeader() {
+  return renderHeaderWithInformation(
+    'Completed',
+    'Completed participants does not include Rejected participants',
+  );
+}
+
+function renderEnabledHeader() {
+  return renderHeaderWithInformation(
+    'Enabled',
+    'Enable or disable individual combinations of between subject conditions. New participants will only receive one of the active conditions.',
+  );
+}
+
+function renderDesiredParticipantsCell(
+  row: BetweenSubjectsCombinationRow,
+  stage: StageInfo,
+  disabled: boolean,
+  onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>,
+) {
+  const totalParticipants = row.participantStatusCounts.completed
+    + row.participantStatusCounts.inProgress;
+
+  if (disabled) {
+    return <Text size="sm">{`${totalParticipants} / ${row.desiredParticipants ?? '—'}`}</Text>;
+  }
+
+  return (
+    <Group gap={4} wrap="nowrap">
+      <Text size="sm">{`${totalParticipants} /`}</Text>
+      <NumberInput
+        aria-label={`Desired participants for ${row.combinationKey} in ${stage.stageName}`}
+        min={0}
+        allowDecimal={false}
+        hideControls
+        value={row.desiredParticipants}
+        onChange={(value) => onSetDesiredParticipants(
+          stage,
+          row.combinationKey,
+          typeof value === 'number' ? value : '',
+        )}
+        w={72}
+      />
+    </Group>
+  );
+}
+
+function renderCurrentParticipantsCell(
   row: BetweenSubjectsCombinationRow,
   onReviewInProgress: (combinationKey: string) => void,
 ) {
+  const { inProgress } = row.participantStatusCounts;
+
+  if (inProgress === 0) {
+    return <Text size="sm">0</Text>;
+  }
+
   return (
-    <StageParticipantStatusBadges
-      completed={row.participantStatusCounts.completed}
-      inProgress={row.participantStatusCounts.inProgress}
-      onInProgressClick={() => onReviewInProgress(row.combinationKey)}
-    />
+    <Button
+      aria-label={`Review ${inProgress} in-progress participant${inProgress === 1 ? '' : 's'}`}
+      color="dark"
+      onClick={() => onReviewInProgress(row.combinationKey)}
+      p={0}
+      size="compact-xs"
+      variant="transparent"
+    >
+      {inProgress}
+    </Button>
   );
+}
+
+function renderCompletedParticipantsCell(row: BetweenSubjectsCombinationRow) {
+  return <Text size="sm">{row.participantStatusCounts.completed}</Text>;
 }
 
 function BetweenSubjectsCombinationTable({
@@ -319,6 +361,7 @@ function BetweenSubjectsCombinationTable({
   onReviewInProgress,
   showParticipantCounts,
   showParticipantLimits,
+  desiredParticipantsDisabled = false,
 }: {
   stage: StageInfo;
   participants: ParticipantDataWithStatus[];
@@ -329,12 +372,13 @@ function BetweenSubjectsCombinationTable({
   onReviewInProgress: (participants: ParticipantDataWithStatus[], description: string) => void;
   showParticipantCounts: boolean;
   showParticipantLimits: boolean;
+  desiredParticipantsDisabled?: boolean;
 }) {
   const data = useMemo<BetweenSubjectsCombinationRow[]>(() => {
     const desiredParticipantCounts = getDesiredParticipantCounts(
       stage.maxParticipants,
       combinations,
-      stage.desiredParticipantsByCombination,
+      getActiveDesiredParticipants(stage),
     );
 
     return combinations.map((combination) => ({
@@ -385,20 +429,29 @@ function BetweenSubjectsCombinationTable({
     } satisfies MrtColumnDef<BetweenSubjectsCombinationRow>)),
     ...(showParticipantCounts ? [{
       accessorKey: 'participantStatusCounts',
-      header: 'Participants',
-      Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderParticipantStatusCell(row.original, handleReviewInProgress),
+      header: 'Current',
+      Header: renderCurrentHeader,
+      Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderCurrentParticipantsCell(row.original, handleReviewInProgress),
+    }, {
+      id: 'completedParticipants',
+      accessorFn: (row: BetweenSubjectsCombinationRow) => row.participantStatusCounts.completed,
+      header: 'Completed',
+      Header: renderCompletedHeader,
+      Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderCompletedParticipantsCell(row.original),
     }] : []),
     ...(showParticipantLimits ? [{
       accessorKey: 'desiredParticipants',
-      header: 'Desired Participants',
+      header: 'Total / Maximum',
       Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderDesiredParticipantsCell(
         row.original,
         stage,
+        desiredParticipantsDisabled,
         onSetDesiredParticipants,
       ),
     }, {
       accessorKey: 'enabled',
       header: 'Enabled',
+      Header: renderEnabledHeader,
       Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderCombinationEnabledCell(
         row.original,
         stage,
@@ -408,6 +461,7 @@ function BetweenSubjectsCombinationTable({
     }] : []),
   ], [
     betweenSubjectsFactors,
+    desiredParticipantsDisabled,
     handleReviewInProgress,
     onSetDesiredParticipants,
     onToggle,
@@ -420,8 +474,10 @@ function BetweenSubjectsCombinationTable({
     columns,
     data,
     enableBottomToolbar: false,
+    enableColumnActions: false,
     enableColumnDragging: true,
     enableColumnOrdering: true,
+    enableColumnResizing: true,
     enableDensityToggle: false,
     enablePagination: false,
     enableSorting: true,
@@ -433,7 +489,7 @@ function BetweenSubjectsCombinationTable({
       },
     },
     mantineTableContainerProps: { style: { maxWidth: '100%', overflowX: 'auto' } },
-    mantineTableProps: { style: { minWidth: 'max-content' } },
+    mantineTableProps: { style: { minWidth: 'max-content', width: '100%' } },
     mantineTableBodyCellProps: ({ column, row }) => {
       const factorIndex = betweenSubjectsFactors.findIndex((factor) => factor.factorName === column.id);
       if (factorIndex === -1) {
@@ -468,21 +524,30 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     participantIds: string[];
     description: string;
   } | null>(null);
-  const [expandedStageNames, setExpandedStageNames] = useState<string[]>([]);
-  const currentStageNameRef = useRef<string | undefined>(undefined);
+  const [pendingStageChange, setPendingStageChange] = useState<StageInfo | null>(null);
+  const [pendingConditionToggle, setPendingConditionToggle] = useState<{
+    stage: StageInfo;
+    combinationKey: string;
+    enabled: boolean;
+  } | null>(null);
+  const [activeStageTooltipName, setActiveStageTooltipName] = useState<string | null>(null);
+  const activeStageTooltipTimeoutRef = useRef<number | undefined>(undefined);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [editingStageName, setEditingStageName] = useState('');
   const [editingStageColor, setEditingStageColor] = useState(DEFAULT_STAGE_COLOR);
-  const [limitPopoverStageName, setLimitPopoverStageName] = useState<string | null>(null);
   const [editingLimitMaxParticipants, setEditingLimitMaxParticipants] = useState<number | ''>('');
   const [editingLimitEnabled, setEditingLimitEnabled] = useState(false);
-  const [editError, setEditError] = useState('');
+  const manualDesiredParticipantsRef = useRef<Record<string, Record<string, number>>>({});
+  const manualDesiredParticipantsWriteChainsRef = useRef<Record<string, Promise<void>>>({});
   const [addingNewStage, setAddingNewStage] = useState(false);
   const [newStageName, setNewStageName] = useState('');
   const [newStageColor, setNewStageColor] = useState(DEFAULT_STAGE_COLOR);
   const [newStageError, setNewStageError] = useState('');
   const betweenSubjectsFactors = getBetweenSubjectsFactors(studyConfig);
   const betweenSubjectsCombinations = getBetweenSubjectsCombinations(betweenSubjectsFactors);
+
+  useEffect(() => () => {
+    window.clearTimeout(activeStageTooltipTimeoutRef.current);
+  }, []);
 
   const refreshStageData = useCallback(async () => {
     if (!storageEngine) {
@@ -494,13 +559,16 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
       storageEngine.getAllParticipantsData(studyId),
     ]);
     setCurrentStage(stageData.currentStage);
-    const nextCurrentStageName = stageData.currentStage.stageName;
-    const currentStageChanged = currentStageNameRef.current !== nextCurrentStageName;
-    currentStageNameRef.current = nextCurrentStageName;
-    if (currentStageChanged) {
-      setExpandedStageNames([nextCurrentStageName]);
-    }
     setAllStages(stageData.allStages);
+    const selectedStage = stageData.allStages.find((stage) => (
+      stage.stageName === stageData.currentStage.stageName
+    ));
+    setEditingLimitMaxParticipants(selectedStage?.maxParticipants ?? '');
+    setEditingLimitEnabled(selectedStage?.maxParticipants !== undefined);
+    manualDesiredParticipantsRef.current = Object.fromEntries(stageData.allStages.map((stage) => [
+      stage.stageName,
+      getManualDesiredParticipants(stage) ?? {},
+    ]));
     setParticipants(allParticipants);
     setStageParticipantStatusCounts(getStageParticipantStatusCounts(allParticipants));
   }, [storageEngine, studyId]);
@@ -527,16 +595,45 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     if (storageEngine) {
       await storageEngine.setCurrentStage(studyId, stageName, color);
       setCurrentStage({ stageName, color });
-      currentStageNameRef.current = stageName;
-      setExpandedStageNames([stageName]);
+      const selectedStage = allStages.find((stage) => stage.stageName === stageName);
+      setEditingLimitMaxParticipants(selectedStage?.maxParticipants ?? '');
+      setEditingLimitEnabled(selectedStage?.maxParticipants !== undefined);
     }
+  };
+
+  const handleRequestSetCurrentStage = (stage: StageInfo) => {
+    if (stage.stageName !== currentStage.stageName) {
+      setPendingStageChange(stage);
+    }
+  };
+
+  const handleStageStatusButtonClick = (stage: StageInfo) => {
+    if (stage.stageName !== currentStage.stageName) {
+      handleRequestSetCurrentStage(stage);
+      return;
+    }
+
+    setActiveStageTooltipName(stage.stageName);
+    window.clearTimeout(activeStageTooltipTimeoutRef.current);
+    activeStageTooltipTimeoutRef.current = window.setTimeout(() => {
+      setActiveStageTooltipName((stageName) => (
+        stageName === stage.stageName ? null : stageName
+      ));
+    }, 1500);
+  };
+
+  const handleConfirmStageChange = async () => {
+    if (!pendingStageChange) {
+      return;
+    }
+
+    await handleSetCurrentStage(pendingStageChange.stageName, pendingStageChange.color);
+    setPendingStageChange(null);
   };
 
   const handleEditStage = (index: number) => {
     setEditingIndex(index);
-    setEditingStageName(allStages[index].stageName);
     setEditingStageColor(allStages[index].color);
-    setEditError('');
   };
 
   const handleSaveEdit = async (originalName: string) => {
@@ -548,41 +645,50 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
       // Refresh data
       await refreshStageData();
       setEditingIndex(null);
-      setEditError('');
     }
   };
 
   const handleCancelEdit = () => {
     setEditingIndex(null);
-    setEditingStageName('');
     setEditingStageColor(DEFAULT_STAGE_COLOR);
-    setEditError('');
   };
 
-  const handleEditParticipantLimit = (stage: StageInfo) => {
-    setLimitPopoverStageName(stage.stageName);
-    setEditingLimitMaxParticipants(stage.maxParticipants ?? '');
-    setEditingLimitEnabled(stage.maxParticipants !== undefined);
-  };
-
-  const handleSaveParticipantLimit = async (stage: StageInfo) => {
+  const handleSetParticipantLimitEnabled = async (stage: StageInfo, enabled: boolean) => {
     if (!storageEngine) {
       return;
     }
 
-    const hasParticipantLimit = editingLimitEnabled && editingLimitMaxParticipants !== '';
+    setEditingLimitEnabled(enabled);
+    if (enabled) {
+      const manualDesiredParticipants = getManualDesiredParticipants(stage);
+      const initialMaximumParticipants = getParticipantAssignmentMode(stage) === 'manual'
+        && manualDesiredParticipants
+        ? Object.values(manualDesiredParticipants).reduce((total, count) => total + count, 0)
+        : Math.max(betweenSubjectsCombinations.length, 1) * 10;
+      setEditingLimitMaxParticipants(initialMaximumParticipants);
+      await storageEngine.updateStage(studyId, stage.stageName, {
+        maxParticipants: initialMaximumParticipants,
+      });
+      await refreshStageData();
+      return;
+    }
+
+    setEditingLimitMaxParticipants('');
     await storageEngine.updateStage(studyId, stage.stageName, {
-      maxParticipants: hasParticipantLimit ? editingLimitMaxParticipants : null,
-      ...(hasParticipantLimit ? {} : { desiredParticipantsByCombination: null }),
+      maxParticipants: null,
     });
     await refreshStageData();
-    setLimitPopoverStageName(null);
   };
 
-  const handleCancelParticipantLimit = () => {
-    setEditingLimitMaxParticipants('');
-    setEditingLimitEnabled(false);
-    setLimitPopoverStageName(null);
+  const handleCommitParticipantLimit = async (stage: StageInfo) => {
+    if (!storageEngine || editingLimitMaxParticipants === '') {
+      return;
+    }
+
+    await storageEngine.updateStage(studyId, stage.stageName, {
+      maxParticipants: editingLimitMaxParticipants,
+    });
+    await refreshStageData();
   };
 
   const handleAddNewStage = () => {
@@ -621,14 +727,6 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     setNewStageError('');
   };
 
-  const toggleStageExpanded = (stageName: string) => {
-    setExpandedStageNames((stageNames) => (
-      stageNames.includes(stageName)
-        ? stageNames.filter((name) => name !== stageName)
-        : [stageName]
-    ));
-  };
-
   const handleToggleBetweenSubjectsCombination = async (
     stage: StageInfo,
     combinationKey: string,
@@ -650,6 +748,27 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     await refreshStageData();
   };
 
+  const handleRequestConditionToggle = async (
+    stage: StageInfo,
+    combinationKey: string,
+    enabled: boolean,
+  ) => {
+    setPendingConditionToggle({ stage, combinationKey, enabled });
+  };
+
+  const handleConfirmConditionToggle = async () => {
+    if (!pendingConditionToggle) {
+      return;
+    }
+
+    await handleToggleBetweenSubjectsCombination(
+      pendingConditionToggle.stage,
+      pendingConditionToggle.combinationKey,
+      pendingConditionToggle.enabled,
+    );
+    setPendingConditionToggle(null);
+  };
+
   const handleSetDesiredParticipants = async (
     stage: StageInfo,
     combinationKey: string,
@@ -659,47 +778,43 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
       return;
     }
 
+    const currentDesiredParticipantCounts = manualDesiredParticipantsRef.current[stage.stageName]
+      ?? getDesiredParticipantCounts(
+        stage.maxParticipants,
+        betweenSubjectsCombinations,
+        getManualDesiredParticipants(stage),
+      );
     const nextDesiredParticipantsByCombination = {
-      ...stage.desiredParticipantsByCombination,
+      ...currentDesiredParticipantCounts,
+      [combinationKey]: desiredParticipants === '' ? 0 : desiredParticipants,
     };
-    const currentDesiredParticipantCounts = getDesiredParticipantCounts(
-      stage.maxParticipants,
-      betweenSubjectsCombinations,
-      stage.desiredParticipantsByCombination,
-    );
-    betweenSubjectsCombinations.forEach((combination) => {
-      if (combination.key === combinationKey) {
-        return;
-      }
+    manualDesiredParticipantsRef.current[stage.stageName] = nextDesiredParticipantsByCombination;
 
-      const currentCount = currentDesiredParticipantCounts[combination.key];
-      if (typeof currentCount === 'number') {
-        nextDesiredParticipantsByCombination[combination.key] = currentCount;
-      }
+    const previousWrite = manualDesiredParticipantsWriteChainsRef.current[stage.stageName]
+      ?? Promise.resolve();
+    const write = previousWrite.catch(() => undefined).then(async () => {
+      await storageEngine.updateStage(studyId, stage.stageName, {
+        manualDesiredParticipantsByCombination: nextDesiredParticipantsByCombination,
+        maxParticipants: Object.values(nextDesiredParticipantsByCombination)
+          .reduce<number>((total, count) => total + count, 0),
+        participantAssignmentMode: 'manual',
+      });
+      await refreshStageData();
     });
+    manualDesiredParticipantsWriteChainsRef.current[stage.stageName] = write;
+    await write;
+  };
 
-    if (desiredParticipants === '') {
-      delete nextDesiredParticipantsByCombination[combinationKey];
-    } else {
-      nextDesiredParticipantsByCombination[combinationKey] = desiredParticipants;
+  const handleSetParticipantAssignmentMode = async (stage: StageInfo, mode: string) => {
+    if (!storageEngine || stage.maxParticipants === undefined) {
+      return;
     }
 
-    const nextDesiredParticipantCounts = getDesiredParticipantCounts(
-      stage.maxParticipants,
-      betweenSubjectsCombinations,
-      nextDesiredParticipantsByCombination,
-    );
-    const totalDesiredParticipants = Object.values(nextDesiredParticipantCounts)
-      .reduce<number>((total, count) => total + (typeof count === 'number' ? count : 0), 0);
-    const hasDesiredParticipantOverrides = Object.keys(nextDesiredParticipantsByCombination).length > 0;
-
     await storageEngine.updateStage(studyId, stage.stageName, {
-      desiredParticipantsByCombination: hasDesiredParticipantOverrides
-        ? nextDesiredParticipantsByCombination
-        : null,
-      maxParticipants: stage.maxParticipants === undefined && !hasDesiredParticipantOverrides
-        ? null
-        : totalDesiredParticipants,
+      participantAssignmentMode: mode as 'even' | 'manual',
+      ...(mode === 'manual' && !getManualDesiredParticipants(stage)
+        ? { manualDesiredParticipantsByCombination: getDefaultDesiredParticipantCounts(stage.maxParticipants, betweenSubjectsCombinations) }
+        : {}),
     });
     await refreshStageData();
   };
@@ -711,6 +826,20 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     });
   }, []);
 
+  const selectedStage = allStages.find((stage) => stage.stageName === currentStage.stageName)
+    ?? allStages[0];
+  const participantAssignmentMode = selectedStage
+    ? getParticipantAssignmentMode(selectedStage)
+    : 'even';
+  const selectedStageDesiredParticipantCounts = selectedStage
+    ? getDesiredParticipantCounts(
+      selectedStage.maxParticipants,
+      betweenSubjectsCombinations,
+      getActiveDesiredParticipants(selectedStage),
+    )
+    : {};
+  const manuallyAssignedParticipantTotal = Object.values(selectedStageDesiredParticipantCounts)
+    .reduce<number>((total, count) => total + (typeof count === 'number' ? count : 0), 0);
   if (!asyncStatus) {
     return (
       <Stack align="center" p="md">
@@ -722,10 +851,18 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
 
   return (
     <Stack>
-      <Group>
-        <Title order={4} mb="sm">Stage Management</Title>
+      <Group align="flex-start" justify="space-between">
+        <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+          <Title order={4}>Stage Management</Title>
+          <Text size="sm">
+            Stages let you manage the phases of your study. For example, an experiment might have stages for &quot;testing&quot;, &quot;pilots&quot; and &quot;main experiment&quot;.
+          </Text>
+          <Text size="sm">
+            Stage labels are added to the data so you can easily filter them during data analysis. You can control desired numbers of participants in between subject studies for each stage.
+          </Text>
+        </Stack>
         {!addingNewStage && (
-          <Button size="sm" onClick={handleAddNewStage} ml="auto">
+          <Button size="sm" onClick={handleAddNewStage}>
             Add New Stage
           </Button>
         )}
@@ -742,258 +879,181 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
         refresh={refreshStageData}
       />
 
-      <Title order={5}>Participant Counts</Title>
+      <Modal
+        centered
+        onClose={() => setPendingStageChange(null)}
+        opened={pendingStageChange !== null}
+        title="Activate stage?"
+      >
+        <Stack gap="md">
+          <Text>
+            {`New participants will enter ${pendingStageChange?.stageName ?? 'this'} stage. Existing participant records will remain in their current stages.`}
+          </Text>
+          <Group justify="flex-end">
+            <Button onClick={() => setPendingStageChange(null)} variant="default">Cancel</Button>
+            <Button onClick={handleConfirmStageChange}>Yes, activate stage</Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        centered
+        onClose={() => setPendingConditionToggle(null)}
+        opened={pendingConditionToggle !== null}
+        title={pendingConditionToggle?.enabled ? 'Enable condition?' : 'Disable condition?'}
+      >
+        <Stack gap="md">
+          <Text>
+            {pendingConditionToggle?.enabled
+              ? 'This condition will be available for future participant assignments. Existing participant data will not change.'
+              : 'This condition will no longer receive future participant assignments. Existing participant data will not change.'}
+          </Text>
+          <Group justify="flex-end">
+            <Button onClick={() => setPendingConditionToggle(null)} variant="default">Cancel</Button>
+            <Button onClick={handleConfirmConditionToggle}>
+              {pendingConditionToggle?.enabled ? 'Yes, enable condition' : 'Yes, disable condition'}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
       <Table striped highlightOnHover withTableBorder style={{ tableLayout: 'fixed', width: '100%' }}>
         <colgroup>
-          <col style={{ width: 44 }} />
           <col style={{ width: 80 }} />
           <col />
-          <col style={{ width: 210 }} />
-          <col style={{ width: 220 }} />
-          <col style={{ width: 80 }} />
+          <col style={{ width: 90 }} />
+          <col style={{ width: 90 }} />
+          <col style={{ width: 150 }} />
         </colgroup>
         <Table.Thead>
           <Table.Tr>
-            <Table.Th style={{ width: '44px' }} />
-            <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Current</Table.Th>
+            <Table.Th aria-label="Stage status" style={{ width: '80px' }} />
             <Table.Th>Stage Name</Table.Th>
-            <Table.Th style={{ width: '210px', whiteSpace: 'nowrap' }}>Participants</Table.Th>
-            <Table.Th style={{ width: '220px', whiteSpace: 'nowrap' }}>Max Participants</Table.Th>
-            <Table.Th style={{ width: '80px', whiteSpace: 'nowrap' }}>Edit</Table.Th>
+            <Table.Th style={{ width: '90px', whiteSpace: 'nowrap' }}>Current</Table.Th>
+            <Table.Th style={{ width: '90px', whiteSpace: 'nowrap' }}>Completed</Table.Th>
+            <Table.Th style={{ width: '150px', whiteSpace: 'nowrap' }}>Total / Maximum</Table.Th>
           </Table.Tr>
         </Table.Thead>
         <Table.Tbody>
           {allStages.map((stage, index) => {
-            const isExpanded = expandedStageNames.includes(stage.stageName);
-            const isLimitPopoverOpened = limitPopoverStageName === stage.stageName;
+            const participantCounts = stageParticipantStatusCounts[stage.stageName] || {
+              completed: 0,
+              inProgress: 0,
+            };
+            const totalParticipants = participantCounts.completed + participantCounts.inProgress;
 
             return (
-              <Fragment key={stage.stageName}>
-                <Table.Tr key={stage.stageName}>
-                  <Table.Td>
-                    <ActionIcon
-                      size="sm"
-                      color="gray"
-                      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} stage ${stage.stageName}`}
-                      onClick={() => toggleStageExpanded(stage.stageName)}
+              <Table.Tr key={stage.stageName}>
+                <Table.Td>
+                  <Tooltip
+                    label="This stage is already active"
+                    opened={activeStageTooltipName === stage.stageName}
+                    withArrow
+                  >
+                    <Button
+                      aria-label={`${currentStage.stageName === stage.stageName ? 'Active' : 'Inactive'} stage ${stage.stageName}`}
+                      color={currentStage.stageName === stage.stageName ? 'green' : 'gray'}
+                      onClick={() => handleStageStatusButtonClick(stage)}
+                      size="compact-xs"
+                      variant={currentStage.stageName === stage.stageName ? 'filled' : 'default'}
+                      w={72}
                     >
-                      {isExpanded ? <IconChevronUp size={16} /> : <IconChevronDown size={16} />}
-                    </ActionIcon>
-                  </Table.Td>
-                  <Table.Td>
-                    <Radio
-                      aria-label={`Set current stage to ${stage.stageName}`}
-                      checked={currentStage.stageName === stage.stageName}
-                      onChange={() => handleSetCurrentStage(stage.stageName, stage.color)}
+                      {currentStage.stageName === stage.stageName ? 'Active' : 'Inactive'}
+                    </Button>
+                  </Tooltip>
+                </Table.Td>
+                <Table.Td>
+                  <Group gap="xs" wrap="nowrap">
+                    <div
+                      aria-label={`${stage.stageName} color`}
+                      style={{
+                        width: 14,
+                        height: 14,
+                        flex: '0 0 auto',
+                        backgroundColor: stage.color,
+                        border: '1px solid #dee2e6',
+                        borderRadius: 3,
+                      }}
                     />
-                  </Table.Td>
-                  <Table.Td>
-                    {editingIndex === index ? (
-                      <Group gap="xs" wrap="nowrap">
-                        <TextInput
-                          value={editingStageName}
-                          onChange={(e) => setEditingStageName(e.currentTarget.value)}
-                          error={editError}
-                          size="xs"
-                          disabled
-                          style={{ flex: 1, minWidth: 0 }}
-                        />
-                        <ColorInput
-                          value={editingStageColor}
-                          onChange={setEditingStageColor}
-                          size="xs"
-                          w={120}
-                        />
-                      </Group>
-                    ) : (
-                      <Group gap="xs" wrap="nowrap">
-                        <div
-                          aria-label={`${stage.stageName} color`}
-                          style={{
-                            width: 14,
-                            height: 14,
-                            flex: '0 0 auto',
-                            backgroundColor: stage.color,
-                            border: '1px solid #dee2e6',
-                            borderRadius: 3,
-                          }}
-                        />
-                        <Text size="sm">{stage.stageName}</Text>
-                      </Group>
-                    )}
-                  </Table.Td>
-                  <Table.Td>
-                    <StageParticipantStatusBadges
-                      completed={stageParticipantStatusCounts[stage.stageName]?.completed || 0}
-                      inProgress={stageParticipantStatusCounts[stage.stageName]?.inProgress || 0}
-                      onInProgressClick={() => handleReviewInProgress(participants.filter((participant) => (
+                    <Text size="sm">{stage.stageName}</Text>
+                    <Popover
+                      onChange={(opened) => {
+                        if (!opened && editingIndex === index) {
+                          handleCancelEdit();
+                        }
+                      }}
+                      opened={editingIndex === index}
+                      position="bottom-start"
+                      shadow="md"
+                    >
+                      <Popover.Target>
+                        <ActionIcon
+                          size="sm"
+                          aria-label={`Edit color for stage ${stage.stageName}`}
+                          onClick={() => handleEditStage(index)}
+                          variant="subtle"
+                        >
+                          <IconEdit size={16} />
+                        </ActionIcon>
+                      </Popover.Target>
+                      <Popover.Dropdown>
+                        <Stack gap="xs">
+                          <Text fw={500} size="sm">ReVISit color palette</Text>
+                          <ColorPicker
+                            aria-label={`Color for stage ${stage.stageName}`}
+                            format="hex"
+                            onChange={setEditingStageColor}
+                            size="md"
+                            swatches={DISTINCT_COLOR_PALETTE}
+                            swatchesPerRow={10}
+                            value={editingStageColor}
+                          />
+                          <Group justify="flex-end">
+                            <Button
+                              color="green"
+                              onClick={() => handleSaveEdit(stage.stageName)}
+                              size="xs"
+                            >
+                              Save
+                            </Button>
+                            <Button color="gray" onClick={handleCancelEdit} size="xs" variant="default">
+                              Cancel
+                            </Button>
+                          </Group>
+                        </Stack>
+                      </Popover.Dropdown>
+                    </Popover>
+                  </Group>
+                </Table.Td>
+                <Table.Td>
+                  {participantCounts.inProgress > 0 ? (
+                    <Button
+                      aria-label={`Review ${participantCounts.inProgress} in-progress participant${participantCounts.inProgress === 1 ? '' : 's'}`}
+                      color="dark"
+                      onClick={() => handleReviewInProgress(participants.filter((participant) => (
                         participant.stage === stage.stageName && !participant.completed && !participant.rejected
                       )), `Showing only in-progress participants in the ${stage.stageName} stage — not all in-progress participants in the study.`)}
-                    />
-                  </Table.Td>
-                  <Table.Td>
-                    <Group gap={4} wrap="nowrap" justify="flex-end" pr={64}>
-                      <Text size="sm">{stage.maxParticipants ?? 'Unlimited'}</Text>
-                      <Popover
-                        opened={isLimitPopoverOpened}
-                        onChange={(opened) => {
-                          if (!opened && isLimitPopoverOpened) {
-                            handleCancelParticipantLimit();
-                          }
-                        }}
-                        position="bottom-start"
-                        shadow="md"
-                        width={720}
-                      >
-                        <Popover.Target>
-                          <ActionIcon
-                            aria-label={`Edit participant limits for ${stage.stageName}`}
-                            onClick={() => {
-                              if (isLimitPopoverOpened) {
-                                handleCancelParticipantLimit();
-                              } else {
-                                handleEditParticipantLimit(stage);
-                              }
-                            }}
-                            size="sm"
-                            variant="subtle"
-                          >
-                            <IconEdit size={16} />
-                          </ActionIcon>
-                        </Popover.Target>
-                        <Popover.Dropdown>
-                          <Stack gap="sm">
-                            <Text fw={500}>
-                              Participant limits for
-                              {' '}
-                              {stage.stageName}
-                            </Text>
-                            <Group gap={4} wrap="nowrap">
-                              <Button
-                                aria-label={`Limit participants for ${stage.stageName}`}
-                                size="compact-xs"
-                                variant={editingLimitEnabled ? 'light' : 'subtle'}
-                                color={editingLimitEnabled ? 'blue' : 'gray'}
-                                onClick={() => {
-                                  setEditingLimitEnabled(!editingLimitEnabled);
-                                  if (editingLimitEnabled) {
-                                    setEditingLimitMaxParticipants('');
-                                  }
-                                }}
-                              >
-                                {editingLimitEnabled ? <IconToggleRight size={16} /> : <IconToggleLeft size={16} />}
-                              </Button>
-                              {editingLimitEnabled && (
-                                <NumberInput
-                                  aria-label={`Maximum participants for ${stage.stageName}`}
-                                  value={editingLimitMaxParticipants}
-                                  onChange={(value) => setEditingLimitMaxParticipants(typeof value === 'number' ? value : '')}
-                                  min={0}
-                                  allowDecimal={false}
-                                  size="xs"
-                                  style={{ flex: 1, minWidth: 0 }}
-                                />
-                              )}
-                              <ActionIcon
-                                size="sm"
-                                aria-label={`Save participant limit for ${stage.stageName}`}
-                                color="green"
-                                onClick={() => handleSaveParticipantLimit(stage)}
-                              >
-                                <IconCheck size={16} />
-                              </ActionIcon>
-                              <ActionIcon
-                                size="sm"
-                                aria-label={`Cancel participant limit for ${stage.stageName}`}
-                                color="gray"
-                                onClick={handleCancelParticipantLimit}
-                              >
-                                <IconX size={16} />
-                              </ActionIcon>
-                            </Group>
-                            {betweenSubjectsFactors.length === 0 ? (
-                              <Text size="sm" c="dimmed">This study has no between-subjects factors.</Text>
-                            ) : (
-                              <ScrollArea h={360} type="auto">
-                                <BetweenSubjectsCombinationTable
-                                  stage={stage}
-                                  participants={participants}
-                                  betweenSubjectsFactors={betweenSubjectsFactors}
-                                  combinations={betweenSubjectsCombinations}
-                                  onReviewInProgress={handleReviewInProgress}
-                                  onSetDesiredParticipants={handleSetDesiredParticipants}
-                                  onToggle={handleToggleBetweenSubjectsCombination}
-                                  showParticipantCounts={false}
-                                  showParticipantLimits
-                                />
-                              </ScrollArea>
-                            )}
-                          </Stack>
-                        </Popover.Dropdown>
-                      </Popover>
-                    </Group>
-                  </Table.Td>
-                  <Table.Td>
-                    {editingIndex === index ? (
-                      <Group gap="xs">
-                        <ActionIcon
-                          size="sm"
-                          aria-label={`Save stage ${stage.stageName}`}
-                          color="green"
-                          onClick={() => handleSaveEdit(stage.stageName)}
-                        >
-                          <IconCheck size={16} />
-                        </ActionIcon>
-                        <ActionIcon
-                          size="sm"
-                          aria-label={`Cancel editing stage ${stage.stageName}`}
-                          color="gray"
-                          onClick={handleCancelEdit}
-                        >
-                          <IconX size={16} />
-                        </ActionIcon>
-                      </Group>
-                    ) : (
-                      <ActionIcon
-                        size="sm"
-                        aria-label={`Edit stage ${stage.stageName}`}
-                        onClick={() => handleEditStage(index)}
-                      >
-                        <IconEdit size={16} />
-                      </ActionIcon>
-                    )}
-                  </Table.Td>
-                </Table.Tr>
-                <Table.Tr key={`${stage.stageName}-conditions`}>
-                  <Table.Td colSpan={6} p={0} style={{ maxWidth: 0, overflow: 'hidden' }}>
-                    <Collapse in={isExpanded} transitionDuration={200} transitionTimingFunction="ease">
-                      <Paper m="sm" p="sm" radius="sm" withBorder bg="gray.0" style={{ maxWidth: '100%', minWidth: 0 }}>
-                        {betweenSubjectsFactors.length === 0 ? (
-                          <Text size="sm" c="dimmed">This study has no between-subjects factors.</Text>
-                        ) : (
-                          <BetweenSubjectsCombinationTable
-                            stage={stage}
-                            participants={participants}
-                            betweenSubjectsFactors={betweenSubjectsFactors}
-                            combinations={betweenSubjectsCombinations}
-                            onReviewInProgress={handleReviewInProgress}
-                            onSetDesiredParticipants={handleSetDesiredParticipants}
-                            onToggle={handleToggleBetweenSubjectsCombination}
-                            showParticipantCounts
-                            showParticipantLimits={false}
-                          />
-                        )}
-                      </Paper>
-                    </Collapse>
-                  </Table.Td>
-                </Table.Tr>
-              </Fragment>
+                      p={0}
+                      size="compact-xs"
+                      variant="transparent"
+                    >
+                      {participantCounts.inProgress}
+                    </Button>
+                  ) : (
+                    <Text size="sm">0</Text>
+                  )}
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm">{participantCounts.completed}</Text>
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm">{`${totalParticipants} / ${stage.maxParticipants ?? 'Unlimited'}`}</Text>
+                </Table.Td>
+              </Table.Tr>
             );
           })}
 
           {addingNewStage && (
             <Table.Tr style={{ backgroundColor: '#f8f9fa' }}>
-              <Table.Td />
               <Table.Td />
               <Table.Td>
                 <Group gap="xs" wrap="nowrap">
@@ -1011,16 +1071,6 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                     size="xs"
                     w={120}
                   />
-                </Group>
-              </Table.Td>
-              <Table.Td>
-                <Text size="sm">0</Text>
-              </Table.Td>
-              <Table.Td>
-                <Text size="sm" c="dimmed">Set after creating</Text>
-              </Table.Td>
-              <Table.Td>
-                <Group gap="xs">
                   <ActionIcon
                     size="sm"
                     aria-label="Save new stage"
@@ -1039,16 +1089,130 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                   </ActionIcon>
                 </Group>
               </Table.Td>
+              <Table.Td>
+                <Text size="sm">0</Text>
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm">0</Text>
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm" c="dimmed">0 / Set after creating</Text>
+              </Table.Td>
             </Table.Tr>
           )}
         </Table.Tbody>
       </Table>
 
-      {editError && (
-        <Text size="sm" c="red" mt="xs">
-          Note: Stage names cannot be changed, only colors can be edited.
-        </Text>
-      )}
+      <Divider my="sm" />
+
+      {selectedStage ? (
+        <Paper p="sm" radius="sm" withBorder style={{ minWidth: 0 }}>
+          <Stack gap="sm">
+            <Group align="center" justify="space-between" wrap="nowrap">
+              <Group align="center" gap="xs" style={{ minWidth: 0 }} wrap="wrap">
+                <Title order={5}>
+                  Participant limits for
+                  {' '}
+                  <span style={{ whiteSpace: 'nowrap' }}>
+                    <span
+                      aria-hidden
+                      style={{
+                        width: 14,
+                        height: 14,
+                        display: 'inline-block',
+                        marginRight: 4,
+                        verticalAlign: '-2px',
+                        backgroundColor: selectedStage.color,
+                        border: '1px solid #dee2e6',
+                        borderRadius: 3,
+                      }}
+                    />
+                    {selectedStage.stageName}
+                  </span>
+                </Title>
+              </Group>
+            </Group>
+            <Stack gap="xs">
+              <Stack gap={2}>
+                <Text fw={500} size="sm">Limit participants</Text>
+                <Switch
+                  aria-label="Limit participants"
+                  checked={editingLimitEnabled}
+                  onChange={(event) => handleSetParticipantLimitEnabled(
+                    selectedStage,
+                    event.currentTarget.checked,
+                  )}
+                  size="sm"
+                />
+                <Text c="dimmed" size="xs">
+                  Set a maximum number of participants who can enter this stage.
+                </Text>
+              </Stack>
+              <Stack align="flex-start" gap={2}>
+                <Text fw={500} size="sm">Assign participants</Text>
+                <SegmentedControl
+                  aria-label={`Participant assignment mode for ${selectedStage.stageName}`}
+                  data={[
+                    { label: 'Evenly', value: 'even' },
+                    { label: 'Manually', value: 'manual' },
+                  ]}
+                  disabled={!editingLimitEnabled || selectedStage.maxParticipants === undefined}
+                  onChange={(mode) => handleSetParticipantAssignmentMode(selectedStage, mode)}
+                  size="sm"
+                  value={participantAssignmentMode}
+                />
+                <Text c="dimmed" size="xs">
+                  Choose whether that maximum is divided evenly or set for each condition.
+                </Text>
+              </Stack>
+              <Stack gap={2}>
+                <NumberInput
+                  aria-label={`Maximum participants for ${selectedStage.stageName}`}
+                  disabled={!editingLimitEnabled || (
+                    participantAssignmentMode === 'manual'
+                    && selectedStage.maxParticipants !== undefined
+                  )}
+                  label={<Text fw={500} size="sm">Maximum participants</Text>}
+                  min={0}
+                  allowDecimal={false}
+                  hideControls
+                  onBlur={() => handleCommitParticipantLimit(selectedStage)}
+                  onChange={(value) => setEditingLimitMaxParticipants(typeof value === 'number' ? value : '')}
+                  size="sm"
+                  value={participantAssignmentMode === 'manual' && selectedStage.maxParticipants !== undefined
+                    ? manuallyAssignedParticipantTotal
+                    : editingLimitMaxParticipants}
+                  w={160}
+                />
+                <Text c="dimmed" size="xs">
+                  {participantAssignmentMode === 'manual'
+                    ? 'In manual mode, this total follows the condition maximums below.'
+                    : 'Enter the maximum number of participants for this stage.'}
+                </Text>
+              </Stack>
+            </Stack>
+
+            {betweenSubjectsFactors.length === 0 ? (
+              <Text size="sm" c="dimmed">This study has no between-subjects factors to allocate.</Text>
+            ) : (
+              <ScrollArea h={360} type="auto">
+                <BetweenSubjectsCombinationTable
+                  stage={selectedStage}
+                  participants={participants}
+                  betweenSubjectsFactors={betweenSubjectsFactors}
+                  combinations={betweenSubjectsCombinations}
+                  desiredParticipantsDisabled={!editingLimitEnabled || participantAssignmentMode === 'even'}
+                  onReviewInProgress={handleReviewInProgress}
+                  onSetDesiredParticipants={handleSetDesiredParticipants}
+                  onToggle={handleRequestConditionToggle}
+                  showParticipantCounts
+                  showParticipantLimits
+                />
+              </ScrollArea>
+            )}
+          </Stack>
+        </Paper>
+      ) : null}
     </Stack>
   );
 }

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -19,6 +19,7 @@ import { FactorObject, FactorPrimitive, StudyConfig } from '../../../parser/type
 import { ParticipantDataWithStatus } from '../../../storage/types';
 import { getBetweenSubjectsCombinationKey, StageInfo } from '../../../storage/engines/types';
 import { DISTINCT_COLOR_PALETTE, getDistinctColorShade } from '../../../utils/colors';
+import { ParticipantTimeoutModal } from '../ParticipantTimeoutModal';
 
 type BetweenSubjectsLevel = FactorPrimitive | FactorObject;
 
@@ -34,10 +35,10 @@ type BetweenSubjectsCombination = {
 
 type BetweenSubjectsCombinationRow = {
   combinationKey: string;
-  participantCount: number;
+  participantStatusCounts: { completed: number; inProgress: number };
   desiredParticipants: number | '';
   enabled: boolean;
-  [factorName: string]: string | number | boolean;
+  [factorName: string]: string | number | boolean | { completed: number; inProgress: number };
 };
 
 const DEFAULT_STAGE_COLOR = DISTINCT_COLOR_PALETTE[0];
@@ -94,19 +95,85 @@ export function getBetweenSubjectsCombinations(
   }));
 }
 
-export function getBetweenSubjectsCombinationCount(
+function participantMatchesBetweenSubjectsCombination(
+  participant: ParticipantDataWithStatus,
+  stageName: string,
+  combination: BetweenSubjectsCombination,
+  betweenSubjectsFactors: BetweenSubjectsFactor[],
+) {
+  return participant.stage === stageName
+    && betweenSubjectsFactors.every((factor) => (
+      isEqual(participant.sequence.parameters?.[factor.factorName], combination.parameters[factor.factorName])
+    ));
+}
+
+function getBetweenSubjectsCombinationStatusCounts(
   participants: ParticipantDataWithStatus[],
   stageName: string,
   combination: BetweenSubjectsCombination,
   betweenSubjectsFactors: BetweenSubjectsFactor[],
 ) {
-  return participants.filter((participant) => (
-    !participant.rejected
-    && participant.stage === stageName
-    && betweenSubjectsFactors.every((factor) => (
-      isEqual(participant.sequence.parameters?.[factor.factorName], combination.parameters[factor.factorName])
-    ))
-  )).length;
+  return participants.reduce((counts, participant) => {
+    const matchesCombination = !participant.rejected && participantMatchesBetweenSubjectsCombination(
+      participant,
+      stageName,
+      combination,
+      betweenSubjectsFactors,
+    );
+    if (!matchesCombination) {
+      return counts;
+    }
+
+    if (participant.completed) {
+      counts.completed += 1;
+    } else {
+      counts.inProgress += 1;
+    }
+    return counts;
+  }, { completed: 0, inProgress: 0 });
+}
+
+function StageParticipantStatusBadges({
+  completed,
+  inProgress,
+  onInProgressClick,
+}: {
+  completed: number;
+  inProgress: number;
+  onInProgressClick?: () => void;
+}) {
+  return (
+    <Stack gap={4} align="flex-start">
+      <Badge color="green" variant="filled" size="sm" c="gray.0">
+        Completed
+        {' '}
+        {completed}
+      </Badge>
+      {onInProgressClick && inProgress > 0 ? (
+        <Badge
+          aria-label={`Review ${inProgress} in-progress participant${inProgress === 1 ? '' : 's'}`}
+          color="orange"
+          component="button"
+          c="gray.0"
+          onClick={onInProgressClick}
+          size="sm"
+          style={{ cursor: 'pointer' }}
+          type="button"
+          variant="filled"
+        >
+          In Progress
+          {' '}
+          {inProgress}
+        </Badge>
+      ) : (
+        <Badge color="orange" variant="filled" size="sm" c="gray.0">
+          In Progress
+          {' '}
+          {inProgress}
+        </Badge>
+      )}
+    </Stack>
+  );
 }
 
 export function getDefaultDesiredParticipantCounts(
@@ -229,6 +296,19 @@ function renderDesiredParticipantsCell(
   );
 }
 
+function renderParticipantStatusCell(
+  row: BetweenSubjectsCombinationRow,
+  onReviewInProgress: (combinationKey: string) => void,
+) {
+  return (
+    <StageParticipantStatusBadges
+      completed={row.participantStatusCounts.completed}
+      inProgress={row.participantStatusCounts.inProgress}
+      onInProgressClick={() => onReviewInProgress(row.combinationKey)}
+    />
+  );
+}
+
 function BetweenSubjectsCombinationTable({
   stage,
   participants,
@@ -236,6 +316,7 @@ function BetweenSubjectsCombinationTable({
   combinations,
   onToggle,
   onSetDesiredParticipants,
+  onReviewInProgress,
 }: {
   stage: StageInfo;
   participants: ParticipantDataWithStatus[];
@@ -243,6 +324,7 @@ function BetweenSubjectsCombinationTable({
   combinations: BetweenSubjectsCombination[];
   onToggle: (stage: StageInfo, combinationKey: string, enabled: boolean) => Promise<void>;
   onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>;
+  onReviewInProgress: (participants: ParticipantDataWithStatus[]) => void;
 }) {
   const data = useMemo<BetweenSubjectsCombinationRow[]>(() => {
     const desiredParticipantCounts = getDesiredParticipantCounts(
@@ -253,7 +335,7 @@ function BetweenSubjectsCombinationTable({
 
     return combinations.map((combination) => ({
       combinationKey: combination.key,
-      participantCount: getBetweenSubjectsCombinationCount(
+      participantStatusCounts: getBetweenSubjectsCombinationStatusCounts(
         participants,
         stage.stageName,
         combination,
@@ -268,14 +350,33 @@ function BetweenSubjectsCombinationTable({
     }));
   }, [betweenSubjectsFactors, combinations, participants, stage]);
 
+  const handleReviewInProgress = useCallback((combinationKey: string) => {
+    const combination = combinations.find((item) => item.key === combinationKey);
+    if (!combination) {
+      return;
+    }
+
+    onReviewInProgress(participants.filter((participant) => (
+      !participant.completed
+      && !participant.rejected
+      && participantMatchesBetweenSubjectsCombination(
+        participant,
+        stage.stageName,
+        combination,
+        betweenSubjectsFactors,
+      )
+    )));
+  }, [betweenSubjectsFactors, combinations, onReviewInProgress, participants, stage.stageName]);
+
   const columns = useMemo<MrtColumnDef<BetweenSubjectsCombinationRow>[]>(() => [
     ...betweenSubjectsFactors.map((factor) => ({
       accessorKey: factor.factorName,
       header: factor.factorName,
     } satisfies MrtColumnDef<BetweenSubjectsCombinationRow>)),
     {
-      accessorKey: 'participantCount',
+      accessorKey: 'participantStatusCounts',
       header: 'Participants',
+      Cell: ({ row }) => renderParticipantStatusCell(row.original, handleReviewInProgress),
     },
     {
       accessorKey: 'desiredParticipants',
@@ -296,7 +397,7 @@ function BetweenSubjectsCombinationTable({
         onToggle,
       ),
     },
-  ], [betweenSubjectsFactors, onSetDesiredParticipants, onToggle, stage]);
+  ], [betweenSubjectsFactors, handleReviewInProgress, onSetDesiredParticipants, onToggle, stage]);
 
   const table = useMantineReactTable({
     columns,
@@ -346,6 +447,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
   const [allStages, setAllStages] = useState<StageInfo[]>([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]);
   const [stageParticipantStatusCounts, setStageParticipantStatusCounts] = useState<StageParticipantStatusCounts>({});
   const [participants, setParticipants] = useState<ParticipantDataWithStatus[]>([]);
+  const [participantIdsForTimeout, setParticipantIdsForTimeout] = useState<string[] | null>(null);
   const [expandedStageNames, setExpandedStageNames] = useState<string[]>([]);
   const currentStageNameRef = useRef<string | undefined>(undefined);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -576,6 +678,10 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     await refreshStageData();
   };
 
+  const handleReviewInProgress = useCallback((selectedParticipants: ParticipantDataWithStatus[]) => {
+    setParticipantIdsForTimeout(selectedParticipants.map((participant) => participant.participantId));
+  }, []);
+
   if (!asyncStatus) {
     return (
       <Stack align="center" p="md">
@@ -595,6 +701,16 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
           </Button>
         )}
       </Group>
+
+      <ParticipantTimeoutModal
+        hideReviewButton
+        onClose={() => setParticipantIdsForTimeout(null)}
+        opened={participantIdsForTimeout !== null}
+        participants={participantIdsForTimeout === null
+          ? []
+          : participants.filter((participant) => participantIdsForTimeout.includes(participant.participantId))}
+        refresh={refreshStageData}
+      />
 
       <Table striped highlightOnHover withTableBorder style={{ tableLayout: 'fixed', width: '100%' }}>
         <colgroup>
@@ -656,18 +772,13 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                     )}
                   </Table.Td>
                   <Table.Td>
-                    <Group gap={4} wrap="nowrap">
-                      <Badge color="teal" variant="light" size="sm">
-                        Completed
-                        {' '}
-                        {stageParticipantStatusCounts[stage.stageName]?.completed || 0}
-                      </Badge>
-                      <Badge color="blue" variant="light" size="sm">
-                        In Progress
-                        {' '}
-                        {stageParticipantStatusCounts[stage.stageName]?.inProgress || 0}
-                      </Badge>
-                    </Group>
+                    <StageParticipantStatusBadges
+                      completed={stageParticipantStatusCounts[stage.stageName]?.completed || 0}
+                      inProgress={stageParticipantStatusCounts[stage.stageName]?.inProgress || 0}
+                      onInProgressClick={() => handleReviewInProgress(participants.filter((participant) => (
+                        participant.stage === stage.stageName && !participant.completed && !participant.rejected
+                      )))}
+                    />
                   </Table.Td>
                   <Table.Td>
                     {editingIndex === index ? (
@@ -699,7 +810,12 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                         )}
                       </Group>
                     ) : (
-                      <Text size="sm">{stage.maxParticipants ?? 'Unlimited'}</Text>
+                      <Text size="sm">
+                        {(stageParticipantStatusCounts[stage.stageName]?.completed || 0)
+                          + (stageParticipantStatusCounts[stage.stageName]?.inProgress || 0)}
+                        {' / '}
+                        {stage.maxParticipants ?? 'Unlimited'}
+                      </Text>
                     )}
                   </Table.Td>
                   <Table.Td>
@@ -770,6 +886,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                             combinations={betweenSubjectsCombinations}
                             onToggle={handleToggleBetweenSubjectsCombination}
                             onSetDesiredParticipants={handleSetDesiredParticipants}
+                            onReviewInProgress={handleReviewInProgress}
                           />
                         )}
                       </Paper>

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -324,7 +324,7 @@ function BetweenSubjectsCombinationTable({
   combinations: BetweenSubjectsCombination[];
   onToggle: (stage: StageInfo, combinationKey: string, enabled: boolean) => Promise<void>;
   onSetDesiredParticipants: (stage: StageInfo, combinationKey: string, desiredParticipants: number | '') => Promise<void>;
-  onReviewInProgress: (participants: ParticipantDataWithStatus[]) => void;
+  onReviewInProgress: (participants: ParticipantDataWithStatus[], description: string) => void;
 }) {
   const data = useMemo<BetweenSubjectsCombinationRow[]>(() => {
     const desiredParticipantCounts = getDesiredParticipantCounts(
@@ -356,16 +356,22 @@ function BetweenSubjectsCombinationTable({
       return;
     }
 
-    onReviewInProgress(participants.filter((participant) => (
-      !participant.completed
-      && !participant.rejected
-      && participantMatchesBetweenSubjectsCombination(
-        participant,
-        stage.stageName,
-        combination,
-        betweenSubjectsFactors,
-      )
-    )));
+    const combinationDescription = betweenSubjectsFactors
+      .map((factor) => `${factor.factorName} = ${formatBetweenSubjectsLevel(combination.parameters[factor.factorName])}`)
+      .join(', ');
+    onReviewInProgress(
+      participants.filter((participant) => (
+        !participant.completed
+        && !participant.rejected
+        && participantMatchesBetweenSubjectsCombination(
+          participant,
+          stage.stageName,
+          combination,
+          betweenSubjectsFactors,
+        )
+      )),
+      `Showing only in-progress participants in the ${stage.stageName} stage with ${combinationDescription} — not all in-progress participants in the study.`,
+    );
   }, [betweenSubjectsFactors, combinations, onReviewInProgress, participants, stage.stageName]);
 
   const columns = useMemo<MrtColumnDef<BetweenSubjectsCombinationRow>[]>(() => [
@@ -447,7 +453,10 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
   const [allStages, setAllStages] = useState<StageInfo[]>([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]);
   const [stageParticipantStatusCounts, setStageParticipantStatusCounts] = useState<StageParticipantStatusCounts>({});
   const [participants, setParticipants] = useState<ParticipantDataWithStatus[]>([]);
-  const [participantIdsForTimeout, setParticipantIdsForTimeout] = useState<string[] | null>(null);
+  const [timeoutParticipantSelection, setTimeoutParticipantSelection] = useState<{
+    participantIds: string[];
+    description: string;
+  } | null>(null);
   const [expandedStageNames, setExpandedStageNames] = useState<string[]>([]);
   const currentStageNameRef = useRef<string | undefined>(undefined);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -678,8 +687,11 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
     await refreshStageData();
   };
 
-  const handleReviewInProgress = useCallback((selectedParticipants: ParticipantDataWithStatus[]) => {
-    setParticipantIdsForTimeout(selectedParticipants.map((participant) => participant.participantId));
+  const handleReviewInProgress = useCallback((selectedParticipants: ParticipantDataWithStatus[], description: string) => {
+    setTimeoutParticipantSelection({
+      participantIds: selectedParticipants.map((participant) => participant.participantId),
+      description,
+    });
   }, []);
 
   if (!asyncStatus) {
@@ -703,12 +715,13 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
       </Group>
 
       <ParticipantTimeoutModal
+        description={timeoutParticipantSelection?.description}
         hideReviewButton
-        onClose={() => setParticipantIdsForTimeout(null)}
-        opened={participantIdsForTimeout !== null}
-        participants={participantIdsForTimeout === null
+        onClose={() => setTimeoutParticipantSelection(null)}
+        opened={timeoutParticipantSelection !== null}
+        participants={timeoutParticipantSelection === null
           ? []
-          : participants.filter((participant) => participantIdsForTimeout.includes(participant.participantId))}
+          : participants.filter((participant) => timeoutParticipantSelection.participantIds.includes(participant.participantId))}
         refresh={refreshStageData}
       />
 
@@ -777,7 +790,7 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                       inProgress={stageParticipantStatusCounts[stage.stageName]?.inProgress || 0}
                       onInProgressClick={() => handleReviewInProgress(participants.filter((participant) => (
                         participant.stage === stage.stageName && !participant.completed && !participant.rejected
-                      )))}
+                      )), `Showing only in-progress participants in the ${stage.stageName} stage — not all in-progress participants in the study.`)}
                     />
                   </Table.Td>
                   <Table.Td>

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -41,10 +41,17 @@ vi.mock('../../ParticipantTimeoutModal', () => ({
   ParticipantTimeoutModal: ({
     opened,
     participants,
+    description,
   }: {
     opened?: boolean;
     participants: { participantId: string }[];
-  }) => (opened ? <div data-testid="timeout-participants">{participants.map((participant) => participant.participantId).join(',')}</div> : null),
+    description?: string;
+  }) => (opened ? (
+    <div>
+      <div data-testid="timeout-participants">{participants.map((participant) => participant.participantId).join(',')}</div>
+      <div data-testid="timeout-description">{description}</div>
+    </div>
+  ) : null),
 }));
 
 vi.mock('@mantine/core', () => ({
@@ -448,6 +455,9 @@ describe('ManageView', () => {
     });
 
     expect(screen.getByTestId('timeout-participants').textContent).toBe('in-progress');
+    expect(screen.getByTestId('timeout-description').textContent).toBe(
+      'Showing only in-progress participants in the DEFAULT stage — not all in-progress participants in the study.',
+    );
   });
 
   test('StageManagementItem expands between-subjects combinations with counts and switches', async () => {

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -81,6 +81,7 @@ vi.mock('@mantine/core', () => ({
   Space: () => <div />,
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Collapse: ({ children, in: open }: { children: ReactNode; in: boolean }) => (open ? <div>{children}</div> : null),
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   Table: Object.assign(
     ({ children }: { children: ReactNode }) => <table>{children}</table>,
     {
@@ -383,8 +384,8 @@ describe('ManageView', () => {
       allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR, maxParticipants: 5 }],
     });
     mockStorageEngine!.getAllParticipantsData.mockResolvedValue([
-      { stage: 'DEFAULT', rejected: false },
-      { stage: 'DEFAULT', rejected: false },
+      { stage: 'DEFAULT', rejected: false, completed: true },
+      { stage: 'DEFAULT', rejected: false, completed: false },
       { stage: 'DEFAULT', rejected: { reason: 'test', timestamp: 1 } },
     ]);
 
@@ -394,7 +395,8 @@ describe('ManageView', () => {
 
     expect(screen.getByText('Participants')).toBeDefined();
     expect(screen.getByText('Max Participants')).toBeDefined();
-    expect(screen.getByText('2')).toBeDefined();
+    expect(screen.getByText('Completed 1')).toBeDefined();
+    expect(screen.getByText('In Progress 1')).toBeDefined();
     expect(screen.getByText('5')).toBeDefined();
   });
 

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -9,16 +9,21 @@ import {
 import { openConfirmModal } from '@mantine/modals';
 import { ManageView } from '../ManageView';
 import { RevisitModesItem } from '../RevisitModesItem';
-import { StageManagementItem } from '../StageManagementItem';
+import {
+  getDefaultDesiredParticipantCounts, getDesiredParticipantCounts, getNextStageColor, StageManagementItem,
+} from '../StageManagementItem';
 import { DataManagementItem } from '../DataManagementItem';
 import { showNotification } from '../../../../utils/notifications';
+import { StudyConfig } from '../../../../parser/types';
+import { getBetweenSubjectsCombinationKey } from '../../../../storage/engines/types';
 
 let mockStorageEngine: {
   getModes: ReturnType<typeof vi.fn>;
   setMode: ReturnType<typeof vi.fn>;
   getStageData: ReturnType<typeof vi.fn>;
+  getAllSequenceAssignments: ReturnType<typeof vi.fn>;
   setCurrentStage: ReturnType<typeof vi.fn>;
-  updateStageColor: ReturnType<typeof vi.fn>;
+  updateStage: ReturnType<typeof vi.fn>;
   getSnapshots: ReturnType<typeof vi.fn>;
   createSnapshot: ReturnType<typeof vi.fn>;
   renameSnapshot: ReturnType<typeof vi.fn>;
@@ -46,6 +51,11 @@ vi.mock('@mantine/core', () => ({
   TextInput: ({ onChange, placeholder }: { onChange?: React.ChangeEventHandler<HTMLInputElement>; placeholder?: string }) => (
     <input placeholder={placeholder} onChange={onChange} />
   ),
+  NumberInput: ({
+    onChange, placeholder, value, 'aria-label': ariaLabel,
+  }: { onChange?: (value: number | string) => void; placeholder?: string; value?: number | string; 'aria-label'?: string }) => (
+    <input aria-label={ariaLabel} placeholder={placeholder} value={value ?? ''} onChange={(event) => onChange?.(event.currentTarget.value === '' ? '' : Number(event.currentTarget.value))} />
+  ),
   ColorInput: ({ value }: { value?: string }) => <input readOnly value={value ?? ''} />,
   Loader: () => <div>Loading...</div>,
   LoadingOverlay: () => null,
@@ -57,8 +67,13 @@ vi.mock('@mantine/core', () => ({
   Radio: ({ checked, onChange, 'aria-label': ariaLabel }: { checked: boolean; onChange?: () => void; 'aria-label'?: string }) => (
     <input type="radio" readOnly checked={checked} onChange={onChange} aria-label={ariaLabel} />
   ),
-  Switch: ({ checked, onChange, 'aria-label': ariaLabel }: { checked?: boolean; onChange?: React.ChangeEventHandler<HTMLInputElement>; 'aria-label'?: string }) => (
-    <input type="checkbox" defaultChecked={checked} onChange={onChange} aria-label={ariaLabel} />
+  Switch: ({
+    checked, label, onChange, 'aria-label': ariaLabel,
+  }: { checked?: boolean; label?: ReactNode; onChange?: React.ChangeEventHandler<HTMLInputElement>; 'aria-label'?: string }) => (
+    <label>
+      {label}
+      <input type="checkbox" defaultChecked={checked} onChange={onChange} aria-label={ariaLabel} />
+    </label>
   ),
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Modal: ({ opened, children }: { opened: boolean; children: ReactNode }) => (opened ? <div>{children}</div> : null),
@@ -81,6 +96,8 @@ vi.mock('@tabler/icons-react', () => ({
   IconEdit: () => <span>edit</span>,
   IconCheck: () => <span>check</span>,
   IconX: () => <span>x</span>,
+  IconChevronDown: () => <span>down</span>,
+  IconChevronUp: () => <span>up</span>,
   IconTrashX: () => <span>trash</span>,
   IconRefresh: () => <span>refresh</span>,
   IconPencil: () => <span>pencil</span>,
@@ -99,7 +116,8 @@ vi.mock('../../../../components/downloader/DownloadButtons', () => ({
 }));
 
 const successResponse = { status: 'SUCCESS', notifications: [] };
-const DEFAULT_STAGE_COLOR = '#F05A30';
+const DEFAULT_STAGE_COLOR = '#F35C34';
+const FIRST_ADDITIONAL_STAGE_COLOR = '#F35C34';
 
 const makeEngine = () => ({
   getModes: vi.fn().mockResolvedValue({
@@ -112,8 +130,9 @@ const makeEngine = () => ({
     currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
     allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }],
   }),
+  getAllSequenceAssignments: vi.fn().mockResolvedValue([]),
   setCurrentStage: vi.fn().mockResolvedValue(undefined),
-  updateStageColor: vi.fn().mockResolvedValue(undefined),
+  updateStage: vi.fn().mockResolvedValue(undefined),
   getSnapshots: vi.fn().mockResolvedValue({}),
   createSnapshot: vi.fn().mockResolvedValue(successResponse),
   renameSnapshot: vi.fn().mockResolvedValue(successResponse),
@@ -260,8 +279,8 @@ describe('ManageView', () => {
     expect(screen.getByRole('button', { name: 'Edit stage DEFAULT' })).toBeDefined();
   });
 
-  test('StageManagementItem handleSaveEdit calls updateStageColor then refreshes', async () => {
-    mockStorageEngine!.updateStageColor = vi.fn().mockResolvedValue(undefined);
+  test('StageManagementItem handleSaveEdit updates the stage maximum then refreshes', async () => {
+    mockStorageEngine!.updateStage = vi.fn().mockResolvedValue(undefined);
     await act(async () => {
       render(<StageManagementItem studyId="test-study" />);
     });
@@ -269,7 +288,11 @@ describe('ManageView', () => {
     await act(async () => { fireEvent.click(editBtn); });
     const saveBtn = screen.getByRole('button', { name: 'Save stage DEFAULT' });
     await act(async () => { fireEvent.click(saveBtn); });
-    expect(mockStorageEngine!.updateStageColor).toHaveBeenCalledWith('test-study', 'DEFAULT', DEFAULT_STAGE_COLOR);
+    expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
+      color: DEFAULT_STAGE_COLOR,
+      maxParticipants: null,
+      desiredParticipantsByCombination: null,
+    });
     expect(mockStorageEngine!.getStageData).toHaveBeenCalledTimes(2);
   });
 
@@ -281,6 +304,45 @@ describe('ManageView', () => {
     expect(screen.getByPlaceholderText('Enter stage name')).toBeDefined();
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Cancel new stage' })); });
     expect(screen.getByText('Add New Stage')).toBeDefined();
+  });
+
+  test('getNextStageColor selects an unused color from the shared palette', () => {
+    expect(getNextStageColor([{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }]))
+      .toBe(FIRST_ADDITIONAL_STAGE_COLOR);
+    expect(getNextStageColor([
+      { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      { stageName: 'STAGE 2', color: FIRST_ADDITIONAL_STAGE_COLOR },
+    ])).not.toBe(FIRST_ADDITIONAL_STAGE_COLOR);
+  });
+
+  test('getDefaultDesiredParticipantCounts evenly distributes a stage maximum', () => {
+    const combinations = [
+      { key: 'a', parameters: {} },
+      { key: 'b', parameters: {} },
+      { key: 'c', parameters: {} },
+      { key: 'd', parameters: {} },
+    ];
+
+    expect(getDefaultDesiredParticipantCounts(10, combinations)).toEqual({
+      a: 3, b: 3, c: 2, d: 2,
+    });
+    expect(getDefaultDesiredParticipantCounts(undefined, combinations)).toEqual({});
+  });
+
+  test('getDesiredParticipantCounts distributes the remaining maximum after overrides', () => {
+    const combinations = [
+      { key: 'a', parameters: {} },
+      { key: 'b', parameters: {} },
+      { key: 'c', parameters: {} },
+      { key: 'd', parameters: {} },
+    ];
+
+    expect(getDesiredParticipantCounts(10, combinations, { a: 4 })).toEqual({
+      a: 4, b: 2, c: 2, d: 2,
+    });
+    expect(getDesiredParticipantCounts(10, combinations, { a: 4, d: 1 })).toEqual({
+      a: 4, b: 3, c: 2, d: 1,
+    });
   });
 
   test('StageManagementItem handleSaveNewStage shows error for invalid name', async () => {
@@ -299,10 +361,10 @@ describe('ManageView', () => {
         allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }],
       })
       .mockResolvedValueOnce({
-        currentStage: { stageName: 'NEWSTAGE', color: DEFAULT_STAGE_COLOR },
+        currentStage: { stageName: 'NEWSTAGE', color: FIRST_ADDITIONAL_STAGE_COLOR },
         allStages: [
           { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
-          { stageName: 'NEWSTAGE', color: DEFAULT_STAGE_COLOR },
+          { stageName: 'NEWSTAGE', color: FIRST_ADDITIONAL_STAGE_COLOR },
         ],
       });
     await act(async () => {
@@ -311,8 +373,83 @@ describe('ManageView', () => {
     await act(async () => { fireEvent.click(screen.getByText('Add New Stage')); });
     fireEvent.change(screen.getByPlaceholderText('Enter stage name'), { target: { value: 'NEWSTAGE' } });
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Save new stage' })); });
-    expect(mockStorageEngine!.setCurrentStage).toHaveBeenCalledWith('test-study', 'NEWSTAGE', DEFAULT_STAGE_COLOR);
+    expect(mockStorageEngine!.setCurrentStage).toHaveBeenCalledWith('test-study', 'NEWSTAGE', FIRST_ADDITIONAL_STAGE_COLOR);
     expect(mockStorageEngine!.getStageData).toHaveBeenCalledTimes(2);
+  });
+
+  test('StageManagementItem shows each stage participant count and maximum', async () => {
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR, maxParticipants: 5 }],
+    });
+    mockStorageEngine!.getAllParticipantsData.mockResolvedValue([
+      { stage: 'DEFAULT', rejected: false },
+      { stage: 'DEFAULT', rejected: false },
+      { stage: 'DEFAULT', rejected: { reason: 'test', timestamp: 1 } },
+    ]);
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" />);
+    });
+
+    expect(screen.getByText('Participants')).toBeDefined();
+    expect(screen.getByText('Max Participants')).toBeDefined();
+    expect(screen.getByText('2')).toBeDefined();
+    expect(screen.getByText('5')).toBeDefined();
+  });
+
+  test('StageManagementItem expands between-subjects combinations with counts and switches', async () => {
+    const disabledCombination = getBetweenSubjectsCombinationKey(
+      { letter: 'a', number: 2 },
+      ['letter', 'number'],
+    );
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [{
+        stageName: 'DEFAULT',
+        color: DEFAULT_STAGE_COLOR,
+        disabledBetweenSubjectsCombinations: [disabledCombination],
+      }],
+    });
+    mockStorageEngine!.getAllParticipantsData.mockResolvedValue([
+      {
+        stage: 'DEFAULT',
+        rejected: false,
+        sequence: { parameters: { letter: 'a', number: 1 } },
+      },
+      {
+        stage: 'DEFAULT',
+        rejected: false,
+        sequence: { parameters: { letter: 'a', number: 2 } },
+      },
+      {
+        stage: 'DEFAULT',
+        rejected: false,
+        sequence: { parameters: { letter: 'b', number: 1 } },
+      },
+    ]);
+    const studyConfig = {
+      factors: { letter: ['a', 'b'], number: [1, 2] },
+      betweenSubjects: ['letter', 'number'],
+    } as unknown as StudyConfig;
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Expand stage DEFAULT' }));
+    });
+
+    expect(screen.getByText('letter')).toBeDefined();
+    expect(screen.getByText('number')).toBeDefined();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(4);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Enable a / 2 for DEFAULT' }));
+    });
+    expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
+      disabledBetweenSubjectsCombinations: null,
+    });
   });
 
   // ── DataManagementItem ───────────────────────────────────────────────────

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -37,6 +37,16 @@ vi.mock('../../../../storage/storageEngineHooks', () => ({
   useStorageEngine: () => ({ storageEngine: mockStorageEngine }),
 }));
 
+vi.mock('../../ParticipantTimeoutModal', () => ({
+  ParticipantTimeoutModal: ({
+    opened,
+    participants,
+  }: {
+    opened?: boolean;
+    participants: { participantId: string }[];
+  }) => (opened ? <div data-testid="timeout-participants">{participants.map((participant) => participant.participantId).join(',')}</div> : null),
+}));
+
 vi.mock('@mantine/core', () => ({
   Paper: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -81,7 +91,16 @@ vi.mock('@mantine/core', () => ({
   Space: () => <div />,
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Collapse: ({ children, in: open }: { children: ReactNode; in: boolean }) => (open ? <div>{children}</div> : null),
-  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Badge: ({
+    children, component, onClick, 'aria-label': ariaLabel,
+  }: {
+    children: ReactNode;
+    component?: string;
+    onClick?: () => void;
+    'aria-label'?: string;
+  }) => (component === 'button'
+    ? <button type="button" aria-label={ariaLabel} onClick={onClick}>{children}</button>
+    : <span>{children}</span>),
   Table: Object.assign(
     ({ children }: { children: ReactNode }) => <table>{children}</table>,
     {
@@ -397,7 +416,38 @@ describe('ManageView', () => {
     expect(screen.getByText('Max Participants')).toBeDefined();
     expect(screen.getByText('Completed 1')).toBeDefined();
     expect(screen.getByText('In Progress 1')).toBeDefined();
-    expect(screen.getByText('5')).toBeDefined();
+    expect(screen.getByText('2 / 5')).toBeDefined();
+  });
+
+  test('StageManagementItem reviews only the clicked stage in-progress participants', async () => {
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }],
+    });
+    mockStorageEngine!.getAllParticipantsData.mockResolvedValue([
+      {
+        participantId: 'in-progress', stage: 'DEFAULT', rejected: false, completed: false,
+      },
+      {
+        participantId: 'completed', stage: 'DEFAULT', rejected: false, completed: true,
+      },
+      {
+        participantId: 'other-stage', stage: 'OTHER', rejected: false, completed: false,
+      },
+      {
+        participantId: 'rejected', stage: 'DEFAULT', rejected: { reason: 'test', timestamp: 1 }, completed: false,
+      },
+    ]);
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Review 1 in-progress participant' }));
+    });
+
+    expect(screen.getByTestId('timeout-participants').textContent).toBe('in-progress');
   });
 
   test('StageManagementItem expands between-subjects combinations with counts and switches', async () => {

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -94,6 +94,14 @@ vi.mock('@mantine/core', () => ({
   ),
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Modal: ({ opened, children }: { opened: boolean; children: ReactNode }) => (opened ? <div>{children}</div> : null),
+  Popover: Object.assign(
+    ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    {
+      Target: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      Dropdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    },
+  ),
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Space: () => <div />,
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -423,7 +431,7 @@ describe('ManageView', () => {
     expect(screen.getByText('Max Participants')).toBeDefined();
     expect(screen.getByText('Completed 1')).toBeDefined();
     expect(screen.getByText('In Progress 1')).toBeDefined();
-    expect(screen.getByText('2 / 5')).toBeDefined();
+    expect(screen.getByText('5')).toBeDefined();
   });
 
   test('StageManagementItem reviews only the clicked stage in-progress participants', async () => {
@@ -502,6 +510,9 @@ describe('ManageView', () => {
     expect(screen.getByRole('button', { name: 'Collapse stage DEFAULT' })).toBeDefined();
     expect(screen.getByText('letter')).toBeDefined();
     expect(screen.getByText('number')).toBeDefined();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit participant limits for DEFAULT' }));
+    });
     expect(screen.getAllByRole('checkbox')).toHaveLength(4);
 
     await act(async () => {

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -80,6 +80,7 @@ vi.mock('@mantine/core', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Space: () => <div />,
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Collapse: ({ children, in: open }: { children: ReactNode; in: boolean }) => (open ? <div>{children}</div> : null),
   Table: Object.assign(
     ({ children }: { children: ReactNode }) => <table>{children}</table>,
     {
@@ -155,12 +156,11 @@ describe('ManageView', () => {
 
   // ── ManageView layout ────────────────────────────────────────────────────
 
-  test('renders all three management sections', async () => {
+  test('renders modes and data management sections', async () => {
     await act(async () => {
       render(<ManageView studyId="my-study" refresh={async () => []} />);
     });
     expect(screen.getByText('ReVISit Modes')).toBeDefined();
-    expect(screen.getByText('Stage Management')).toBeDefined();
     expect(screen.getByText('Data Management')).toBeDefined();
   });
 
@@ -436,10 +436,8 @@ describe('ManageView', () => {
     await act(async () => {
       render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
     });
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Expand stage DEFAULT' }));
-    });
 
+    expect(screen.getByRole('button', { name: 'Collapse stage DEFAULT' })).toBeDefined();
     expect(screen.getByText('letter')).toBeDefined();
     expect(screen.getByText('number')).toBeDefined();
     expect(screen.getAllByRole('checkbox')).toHaveLength(4);

--- a/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
+++ b/src/analysis/individualStudy/management/tests/ManageView.spec.tsx
@@ -59,7 +59,9 @@ vi.mock('@mantine/core', () => ({
   Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Title: ({ children }: { children: ReactNode }) => <h3>{children}</h3>,
-  Text: ({ children, span }: { children: ReactNode; span?: boolean }) => (span ? <span>{children}</span> : <p>{children}</p>),
+  Text: ({
+    children, span, role,
+  }: { children: ReactNode; span?: boolean; role?: string }) => (span ? <span role={role}>{children}</span> : <p role={role}>{children}</p>),
   Button: ({
     children, onClick, disabled, 'aria-label': ariaLabel,
   }: { children: ReactNode; onClick?: () => void; disabled?: boolean; 'aria-label'?: string }) => (
@@ -69,20 +71,30 @@ vi.mock('@mantine/core', () => ({
     <input placeholder={placeholder} onChange={onChange} />
   ),
   NumberInput: ({
-    onChange, placeholder, value, 'aria-label': ariaLabel,
-  }: { onChange?: (value: number | string) => void; placeholder?: string; value?: number | string; 'aria-label'?: string }) => (
-    <input aria-label={ariaLabel} placeholder={placeholder} value={value ?? ''} onChange={(event) => onChange?.(event.currentTarget.value === '' ? '' : Number(event.currentTarget.value))} />
+    disabled, onChange, placeholder, value, 'aria-label': ariaLabel,
+  }: { disabled?: boolean; onChange?: (value: number | string) => void; placeholder?: string; value?: number | string; 'aria-label'?: string }) => (
+    <input disabled={disabled} aria-label={ariaLabel} placeholder={placeholder} value={value ?? ''} onChange={(event) => onChange?.(event.currentTarget.value === '' ? '' : Number(event.currentTarget.value))} />
   ),
-  ColorInput: ({ value }: { value?: string }) => <input readOnly value={value ?? ''} />,
+  ColorInput: ({
+    value, onChange, 'aria-label': ariaLabel,
+  }: {
+    value?: string;
+    onChange?: (value: string) => void;
+    'aria-label'?: string;
+  }) => <input aria-label={ariaLabel} value={value ?? ''} onChange={(event) => onChange?.(event.currentTarget.value)} />,
+  ColorPicker: ({
+    value, onChange, 'aria-label': ariaLabel,
+  }: {
+    value?: string;
+    onChange?: (value: string) => void;
+    'aria-label'?: string;
+  }) => <input aria-label={ariaLabel} value={value ?? ''} onChange={(event) => onChange?.(event.currentTarget.value)} />,
   Loader: () => <div>Loading...</div>,
   LoadingOverlay: () => null,
   ActionIcon: ({
     children, onClick, 'aria-label': ariaLabel,
   }: { children: ReactNode; onClick?: () => void; 'aria-label'?: string }) => (
     <button type="button" onClick={onClick} aria-label={ariaLabel}>{children}</button>
-  ),
-  Radio: ({ checked, onChange, 'aria-label': ariaLabel }: { checked: boolean; onChange?: () => void; 'aria-label'?: string }) => (
-    <input type="radio" readOnly checked={checked} onChange={onChange} aria-label={ariaLabel} />
   ),
   Switch: ({
     checked, label, onChange, 'aria-label': ariaLabel,
@@ -102,7 +114,35 @@ vi.mock('@mantine/core', () => ({
     },
   ),
   ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Divider: () => <hr />,
+  SegmentedControl: ({
+    data, disabled, onChange, value,
+  }: {
+    data: { label: string; value: string }[];
+    disabled?: boolean;
+    onChange?: (value: string) => void;
+    value?: string;
+  }) => (
+    <div>
+      {data.map((option) => (
+        <button
+          aria-pressed={value === option.value}
+          disabled={disabled}
+          key={option.value}
+          onClick={() => onChange?.(option.value)}
+          type="button"
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+  Tooltip: ({ children, label, opened }: { children: ReactNode; label?: ReactNode; opened?: boolean }) => (
+    <div>
+      {opened ? <span>{label}</span> : null}
+      {children}
+    </div>
+  ),
   Space: () => <div />,
   Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Collapse: ({ children, in: open }: { children: ReactNode; in: boolean }) => (open ? <div>{children}</div> : null),
@@ -131,6 +171,7 @@ vi.mock('@mantine/core', () => ({
 vi.mock('@tabler/icons-react', () => ({
   IconEdit: () => <span>edit</span>,
   IconCheck: () => <span>check</span>,
+  IconQuestionMark: () => <span>?</span>,
   IconX: () => <span>x</span>,
   IconChevronDown: () => <span>down</span>,
   IconChevronUp: () => <span>up</span>,
@@ -285,7 +326,7 @@ describe('ManageView', () => {
     expect(screen.getByText('DEFAULT')).toBeDefined();
   });
 
-  test('StageManagementItem handleSetCurrentStage calls setCurrentStage when radio clicked', async () => {
+  test('StageManagementItem confirms before activating a stage', async () => {
     mockStorageEngine!.getStageData.mockResolvedValue({
       currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
       allStages: [
@@ -296,37 +337,75 @@ describe('ManageView', () => {
     await act(async () => {
       render(<StageManagementItem studyId="test-study" />);
     });
-    const reviewRadio = screen.getByRole('radio', { name: 'Set current stage to REVIEW' });
+    const reviewButton = screen.getByRole('button', { name: 'Inactive stage REVIEW' });
     await act(async () => {
-      fireEvent.click(reviewRadio);
+      fireEvent.click(reviewButton);
+    });
+    expect(screen.getByText('New participants will enter REVIEW stage. Existing participant records will remain in their current stages.')).toBeDefined();
+    expect(mockStorageEngine!.setCurrentStage).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, activate stage' }));
     });
     expect(mockStorageEngine!.setCurrentStage).toHaveBeenCalledWith('test-study', 'REVIEW', '#00AAFF');
   });
 
-  test('StageManagementItem handleEditStage shows edit inputs, handleCancelEdit resets', async () => {
+  test('StageManagementItem explains when the active stage is clicked', async () => {
     await act(async () => {
       render(<StageManagementItem studyId="test-study" />);
     });
-    const editBtn = screen.getByRole('button', { name: 'Edit stage DEFAULT' });
-    await act(async () => { fireEvent.click(editBtn); });
-    const cancelBtn = screen.getByRole('button', { name: 'Cancel editing stage DEFAULT' });
-    await act(async () => { fireEvent.click(cancelBtn); });
-    expect(screen.getByRole('button', { name: 'Edit stage DEFAULT' })).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Active stage DEFAULT' }));
+    });
+
+    expect(screen.getByText('This stage is already active')).toBeDefined();
   });
 
-  test('StageManagementItem handleSaveEdit updates the stage maximum then refreshes', async () => {
+  test('StageManagementItem cancels a requested stage activation', async () => {
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [
+        { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+        { stageName: 'REVIEW', color: '#00AAFF' },
+      ],
+    });
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Inactive stage REVIEW' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+    expect(mockStorageEngine!.setCurrentStage).not.toHaveBeenCalled();
+    expect(screen.queryByText('New participants will enter REVIEW stage. Existing participant records will remain in their current stages.')).toBeNull();
+  });
+
+  test('StageManagementItem edits stage colors beside the stage name and can cancel', async () => {
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" />);
+    });
+    expect(screen.queryByRole('columnheader', { name: 'Edit' })).toBeNull();
+    const editBtn = screen.getByRole('button', { name: 'Edit color for stage DEFAULT' });
+    await act(async () => { fireEvent.click(editBtn); });
+    expect(screen.getByLabelText('Color for stage DEFAULT')).toBeDefined();
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+    await act(async () => { fireEvent.click(cancelBtn); });
+    expect(screen.getByRole('button', { name: 'Edit color for stage DEFAULT' })).toBeDefined();
+  });
+
+  test('StageManagementItem saves only the stage color then refreshes', async () => {
     mockStorageEngine!.updateStage = vi.fn().mockResolvedValue(undefined);
     await act(async () => {
       render(<StageManagementItem studyId="test-study" />);
     });
-    const editBtn = screen.getByRole('button', { name: 'Edit stage DEFAULT' });
+    const editBtn = screen.getByRole('button', { name: 'Edit color for stage DEFAULT' });
     await act(async () => { fireEvent.click(editBtn); });
-    const saveBtn = screen.getByRole('button', { name: 'Save stage DEFAULT' });
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
     await act(async () => { fireEvent.click(saveBtn); });
     expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
       color: DEFAULT_STAGE_COLOR,
-      maxParticipants: null,
-      desiredParticipantsByCombination: null,
     });
     expect(mockStorageEngine!.getStageData).toHaveBeenCalledTimes(2);
   });
@@ -427,11 +506,42 @@ describe('ManageView', () => {
       render(<StageManagementItem studyId="test-study" />);
     });
 
-    expect(screen.getByText('Participants')).toBeDefined();
-    expect(screen.getByText('Max Participants')).toBeDefined();
-    expect(screen.getByText('Completed 1')).toBeDefined();
-    expect(screen.getByText('In Progress 1')).toBeDefined();
-    expect(screen.getByText('5')).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'Current' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'Completed' })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: 'Total / Maximum' })).toBeDefined();
+    expect(screen.getAllByText('1')).toHaveLength(2);
+    expect(screen.getByText('2 / 5')).toBeDefined();
+  });
+
+  test('StageManagementItem shows allocation details only for the selected current stage', async () => {
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [
+        { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR, maxParticipants: 4 },
+        { stageName: 'REVIEW', color: '#00AAFF', maxParticipants: 6 },
+      ],
+    });
+    const studyConfig = {
+      factors: { letter: ['a', 'b'] },
+      betweenSubjects: ['letter'],
+    } as unknown as StudyConfig;
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
+    });
+
+    expect(screen.getByRole('heading', { name: 'Participant limits for DEFAULT' })).toBeDefined();
+    expect(screen.queryByRole('heading', { name: 'Participant limits for REVIEW' })).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Inactive stage REVIEW' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, activate stage' }));
+    });
+
+    expect(screen.getByRole('heading', { name: 'Participant limits for REVIEW' })).toBeDefined();
+    expect(screen.queryByRole('heading', { name: 'Participant limits for DEFAULT' })).toBeNull();
   });
 
   test('StageManagementItem reviews only the clicked stage in-progress participants', async () => {
@@ -468,7 +578,7 @@ describe('ManageView', () => {
     );
   });
 
-  test('StageManagementItem expands between-subjects combinations with counts and switches', async () => {
+  test('StageManagementItem always shows the current stage condition table below the stage list', async () => {
     const disabledCombination = getBetweenSubjectsCombinationKey(
       { letter: 'a', number: 2 },
       ['letter', 'number'],
@@ -507,19 +617,159 @@ describe('ManageView', () => {
       render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
     });
 
-    expect(screen.getByRole('button', { name: 'Collapse stage DEFAULT' })).toBeDefined();
+    expect(screen.getByText('Participant limits for DEFAULT')).toBeDefined();
     expect(screen.getByText('letter')).toBeDefined();
     expect(screen.getByText('number')).toBeDefined();
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Edit participant limits for DEFAULT' }));
-    });
-    expect(screen.getAllByRole('checkbox')).toHaveLength(4);
+    expect(screen.getAllByLabelText('Information about current participants')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Information about completed participants')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Information about enabled participants')).toHaveLength(1);
 
     await act(async () => {
       fireEvent.click(screen.getByRole('checkbox', { name: 'Enable a / 2 for DEFAULT' }));
     });
+    expect(screen.getByText('This condition will be available for future participant assignments. Existing participant data will not change.')).toBeDefined();
+    expect(mockStorageEngine!.updateStage).not.toHaveBeenCalledWith('test-study', 'DEFAULT', {
+      disabledBetweenSubjectsCombinations: null,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes, enable condition' }));
+    });
     expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
       disabledBetweenSubjectsCombinations: null,
+    });
+  });
+
+  test('StageManagementItem disables even allocations and enables manual assignments', async () => {
+    const combinations = [
+      getBetweenSubjectsCombinationKey({ letter: 'a' }, ['letter']),
+      getBetweenSubjectsCombinationKey({ letter: 'b' }, ['letter']),
+    ];
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [{
+        stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR, maxParticipants: 4,
+      }],
+    });
+    const studyConfig = {
+      factors: { letter: ['a', 'b'] },
+      betweenSubjects: ['letter'],
+    } as unknown as StudyConfig;
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
+    });
+
+    expect(screen.queryByLabelText(/Desired participants/)).toBeNull();
+    expect(screen.getByText('Assign participants')).toBeDefined();
+    expect(screen.getByText('Set a maximum number of participants who can enter this stage.')).toBeDefined();
+    expect(screen.getByText('Choose whether that maximum is divided evenly or set for each condition.')).toBeDefined();
+    expect(screen.getByText('Enter the maximum number of participants for this stage.')).toBeDefined();
+    expect(screen.queryByText('Set and save a maximum before allocating participants across conditions.')).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Manually' }));
+    });
+    expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
+      participantAssignmentMode: 'manual',
+      manualDesiredParticipantsByCombination: {
+        [combinations[0]]: 2,
+        [combinations[1]]: 2,
+      },
+    });
+  });
+
+  test('StageManagementItem sets an initial limit of ten participants per condition group', async () => {
+    mockStorageEngine!.getStageData
+      .mockResolvedValueOnce({
+        currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+        allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR }],
+      })
+      .mockResolvedValueOnce({
+        currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+        allStages: [{ stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR, maxParticipants: 20 }],
+      });
+    const studyConfig = {
+      factors: { letter: ['a', 'b'] },
+      betweenSubjects: ['letter'],
+    } as unknown as StudyConfig;
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Limit participants' }));
+    });
+
+    expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
+      maxParticipants: 20,
+    });
+    expect((screen.getByLabelText('Maximum participants for DEFAULT') as HTMLInputElement).value).toBe('20');
+  });
+
+  test('StageManagementItem restores the saved manual allocation total when limits are re-enabled', async () => {
+    const firstCombination = getBetweenSubjectsCombinationKey({ letter: 'a' }, ['letter']);
+    const secondCombination = getBetweenSubjectsCombinationKey({ letter: 'b' }, ['letter']);
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [{
+        stageName: 'DEFAULT',
+        color: DEFAULT_STAGE_COLOR,
+        participantAssignmentMode: 'manual',
+        manualDesiredParticipantsByCombination: {
+          [firstCombination]: 6,
+          [secondCombination]: 8,
+        },
+      }],
+    });
+    const studyConfig = {
+      factors: { letter: ['a', 'b'] },
+      betweenSubjects: ['letter'],
+    } as unknown as StudyConfig;
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Limit participants' }));
+    });
+
+    expect(mockStorageEngine!.updateStage).toHaveBeenCalledWith('test-study', 'DEFAULT', {
+      maxParticipants: 14,
+    });
+  });
+
+  test('StageManagementItem keeps the maximum in sync with manual assignments', async () => {
+    const firstCombination = getBetweenSubjectsCombinationKey({ letter: 'a' }, ['letter']);
+    const secondCombination = getBetweenSubjectsCombinationKey({ letter: 'b' }, ['letter']);
+    mockStorageEngine!.getStageData.mockResolvedValue({
+      currentStage: { stageName: 'DEFAULT', color: DEFAULT_STAGE_COLOR },
+      allStages: [{
+        stageName: 'DEFAULT',
+        color: DEFAULT_STAGE_COLOR,
+        maxParticipants: 4,
+        desiredParticipantsByCombination: {
+          [firstCombination]: 1,
+          [secondCombination]: 2,
+        },
+      }],
+    });
+    const studyConfig = {
+      factors: { letter: ['a', 'b'] },
+      betweenSubjects: ['letter'],
+    } as unknown as StudyConfig;
+
+    await act(async () => {
+      render(<StageManagementItem studyId="test-study" studyConfig={studyConfig} />);
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    const maximumParticipantInput = screen.getByLabelText('Maximum participants for DEFAULT') as HTMLInputElement;
+    expect(maximumParticipantInput.hasAttribute('disabled')).toBe(true);
+    expect(maximumParticipantInput.value).toBe('3');
+    screen.getAllByLabelText(/Desired participants/).forEach((input) => {
+      expect(input.hasAttribute('disabled')).toBe(false);
     });
   });
 

--- a/src/analysis/individualStudy/summary/OverviewStats.tsx
+++ b/src/analysis/individualStudy/summary/OverviewStats.tsx
@@ -26,7 +26,7 @@ export function OverviewStats({
           <Text size="sm" c="dimmed">Completed</Text>
         </Flex>
         <Flex direction="column">
-          <Text size="xl" fw="bold" c="yellow">{overviewData.participantCounts.inProgress}</Text>
+          <Text size="xl" fw="bold" c="orange">{overviewData.participantCounts.inProgress}</Text>
           <Text size="sm" c="dimmed">In Progress</Text>
         </Flex>
         <Flex direction="column">

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -27,6 +27,7 @@ import { MetaCell } from './MetaCell';
 import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
 import { DISTINCT_COLOR_PALETTE } from '../../../utils/colors';
+import { ParticipantTimeoutModal } from '../ParticipantTimeoutModal';
 
 function formatDate(date: Date): JSX.Element {
   if (date.valueOf() === 0 || Number.isNaN(date.valueOf())) {
@@ -38,6 +39,7 @@ function formatDate(date: Date): JSX.Element {
 
 export function TableView({
   visibleParticipants,
+  participantsForTimeout,
   studyConfig,
   allConfigs,
   refresh,
@@ -47,6 +49,7 @@ export function TableView({
   onSelectionChange,
 }: {
   visibleParticipants: ParticipantDataWithStatus[];
+  participantsForTimeout: ParticipantDataWithStatus[];
   studyConfig: StudyConfig;
   allConfigs: Record<string, StudyConfig>;
   refresh: () => Promise<ParticipantDataWithStatus[]>;
@@ -323,8 +326,8 @@ export function TableView({
             { value: 'uniform', label: 'Uniform' },
           ]}
         />
-        <Text size="xs" c="dimmed">Long gaps in Time mode are marked //</Text>
         <ParticipantRejectModal selectedParticipants={selectedParticipants} refresh={handleRefresh} />
+        <ParticipantTimeoutModal participants={participantsForTimeout} refresh={handleRefresh} />
       </Flex>
     ),
   });

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -26,6 +26,7 @@ import { getSequenceFlatMap } from '../../../utils/getSequenceFlatMap';
 import { MetaCell } from './MetaCell';
 import { componentAnswersAreCorrect } from '../../../utils/correctAnswer';
 import { studyComponentToIndividualComponent } from '../../../utils/handleComponentInheritance';
+import { DISTINCT_COLOR_PALETTE } from '../../../utils/colors';
 
 function formatDate(date: Date): JSX.Element {
   if (date.valueOf() === 0 || Number.isNaN(date.valueOf())) {
@@ -141,7 +142,7 @@ export function TableView({
               </Badge>
             );
           }
-          const stageColor = stageColors[stageName] || '#F05A30';
+          const stageColor = stageColors[stageName] || DISTINCT_COLOR_PALETTE[0];
           return (
             <Badge
               color={stageColor}

--- a/src/analysis/individualStudy/table/tests/TableView.spec.tsx
+++ b/src/analysis/individualStudy/table/tests/TableView.spec.tsx
@@ -66,6 +66,9 @@ vi.mock('../../replay/AllTasksTimeline', () => ({
 vi.mock('../../ParticipantRejectModal', () => ({
   ParticipantRejectModal: () => <div>ParticipantRejectModal</div>,
 }));
+vi.mock('../../ParticipantTimeoutModal', () => ({
+  ParticipantTimeoutModal: () => <div>ParticipantTimeoutModal</div>,
+}));
 
 vi.mock('../../../../utils/getSequenceFlatMap', () => ({
   getSequenceFlatMap: vi.fn(() => ['intro', 'trial1', 'trial2', 'end']),
@@ -99,6 +102,7 @@ function makeParticipant(overrides: Partial<ParticipantDataWithStatus> = {}) {
 }
 
 const defaultProps = {
+  participantsForTimeout: [] as ParticipantDataWithStatus[],
   studyConfig: emptyConfig,
   allConfigs: {} as Record<string, StudyConfig>,
   refresh: async () => [] as ParticipantDataWithStatus[],
@@ -146,7 +150,7 @@ describe('TableView', () => {
     expect(html).toContain('Answer time');
     expect(html).toContain('Time');
     expect(html).toContain('Uniform');
-    expect(html).toContain('Long gaps in Time mode are marked //');
+    expect(html).toContain('ParticipantTimeoutModal');
   });
 
   test('uses sequence ordering and time sizing by default for participant timelines', () => {

--- a/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
+++ b/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
@@ -82,7 +82,7 @@ describe('ParticipantTimeoutModal', () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Review In-Progress Participants (1)' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Review (1)' }));
     });
     expect(screen.getByText('In-Progress Participants')).toBeDefined();
     expect(screen.getByText('p1')).toBeDefined();
@@ -98,6 +98,6 @@ describe('ParticipantTimeoutModal', () => {
     mockUser = { isAdmin: false };
     render(<ParticipantTimeoutModal participants={[makeParticipant({ createdTime: 1 })]} refresh={vi.fn()} />);
 
-    expect((screen.getByRole('button', { name: 'Review In-Progress Participants (1)' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Review (1)' }) as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
+++ b/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
@@ -94,6 +94,20 @@ describe('ParticipantTimeoutModal', () => {
     expect(refresh).toHaveBeenCalledOnce();
   });
 
+  test('shows an error and does not refresh when timing out a participant fails', async () => {
+    mockStorageEngine!.rejectParticipant.mockRejectedValue(new Error('Storage unavailable'));
+    const refresh = vi.fn();
+    render(<ParticipantTimeoutModal participants={[makeParticipant({ participantId: 'p1', createdTime: 1 })]} refresh={refresh} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Review (1)' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Time Out' }));
+    });
+
+    expect(screen.getByText('The participant could not be timed out. Please try again.')).toBeDefined();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
   test('can be opened without its own review button', () => {
     render(
       <ParticipantTimeoutModal

--- a/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
+++ b/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
@@ -99,12 +99,14 @@ describe('ParticipantTimeoutModal', () => {
       <ParticipantTimeoutModal
         hideReviewButton
         opened
+        description="Showing a filtered set of in-progress participants."
         participants={[makeParticipant({ participantId: 'p1', createdTime: 1 })]}
         refresh={vi.fn()}
       />,
     );
 
     expect(screen.getByText('In-Progress Participants')).toBeDefined();
+    expect(screen.getByText('Showing a filtered set of in-progress participants.')).toBeDefined();
     expect(screen.getByText('p1')).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Review (1)' })).toBeNull();
   });

--- a/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
+++ b/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
@@ -1,0 +1,103 @@
+import { ReactNode } from 'react';
+import {
+  act, cleanup, fireEvent, render, screen,
+} from '@testing-library/react';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import {
+  formatElapsedTime, getInProgressParticipantsByElapsedTime, ParticipantTimeoutModal,
+} from '../individualStudy/ParticipantTimeoutModal';
+import { makeParticipant } from '../../tests/utils';
+
+let mockUser: { isAdmin: boolean };
+let mockStorageEngine: { rejectParticipant: ReturnType<typeof vi.fn> } | undefined;
+
+vi.mock('../../storage/storageEngineHooks', () => ({
+  useStorageEngine: () => ({ storageEngine: mockStorageEngine }),
+}));
+
+vi.mock('../../store/hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+vi.mock('@mantine/core', () => ({
+  Alert: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Button: ({
+    children, onClick, disabled, loading,
+  }: { children: ReactNode; onClick?: () => void; disabled?: boolean; loading?: boolean }) => (
+    <button type="button" onClick={onClick} disabled={disabled || loading}>{children}</button>
+  ),
+  Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Modal: ({ opened, children, title }: { opened: boolean; children: ReactNode; title: ReactNode }) => (
+    opened ? (
+      <div>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null
+  ),
+  Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@tabler/icons-react', () => ({
+  IconClockOff: () => <span>clock</span>,
+}));
+
+describe('ParticipantTimeoutModal', () => {
+  beforeEach(() => {
+    mockUser = { isAdmin: true };
+    mockStorageEngine = { rejectParticipant: vi.fn().mockResolvedValue(undefined) };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('lists only in-progress participants from longest to shortest', () => {
+    const participants = getInProgressParticipantsByElapsedTime([
+      makeParticipant({ participantId: 'completed', createdTime: 100, completed: true }),
+      makeParticipant({ participantId: 'rejected', createdTime: 100, rejected: { reason: 'test', timestamp: 1 } }),
+      makeParticipant({ participantId: 'short', createdTime: 900 }),
+      makeParticipant({ participantId: 'long', createdTime: 100 }),
+    ], 1000);
+
+    expect(participants.map((participant) => participant.participantId)).toEqual(['long', 'short']);
+    expect(participants.map((participant) => participant.elapsedTime)).toEqual([900, 100]);
+  });
+
+  test('formats elapsed time with days, hours, and minutes', () => {
+    expect(formatElapsedTime((((3 * 24 + 7) * 60 + 40) * 60_000))).toBe('3d 7h 40m');
+    expect(formatElapsedTime(2 * 60 * 60_000)).toBe('2h 0m');
+    expect(formatElapsedTime(45 * 60_000)).toBe('45m');
+  });
+
+  test('opens the review modal and times out the chosen participant', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    await act(async () => {
+      render(<ParticipantTimeoutModal participants={[makeParticipant({ participantId: 'p1', participantIndex: 2, createdTime: Date.now() - 1000 })]} refresh={refresh} />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Review In-Progress Participants (1)' }));
+    });
+    expect(screen.getByText('In-Progress Participants')).toBeDefined();
+    expect(screen.getByText('p1')).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Time Out' }));
+    });
+    expect(mockStorageEngine!.rejectParticipant).toHaveBeenCalledWith('p1', 'Timed out by admin');
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  test('disables the review button for non-admins', () => {
+    mockUser = { isAdmin: false };
+    render(<ParticipantTimeoutModal participants={[makeParticipant({ createdTime: 1 })]} refresh={vi.fn()} />);
+
+    expect((screen.getByRole('button', { name: 'Review In-Progress Participants (1)' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
+++ b/src/analysis/tests/ParticipantTimeoutModal.spec.tsx
@@ -94,6 +94,21 @@ describe('ParticipantTimeoutModal', () => {
     expect(refresh).toHaveBeenCalledOnce();
   });
 
+  test('can be opened without its own review button', () => {
+    render(
+      <ParticipantTimeoutModal
+        hideReviewButton
+        opened
+        participants={[makeParticipant({ participantId: 'p1', createdTime: 1 })]}
+        refresh={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('In-Progress Participants')).toBeDefined();
+    expect(screen.getByText('p1')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Review (1)' })).toBeNull();
+  });
+
   test('disables the review button for non-admins', () => {
     mockUser = { isAdmin: false };
     render(<ParticipantTimeoutModal participants={[makeParticipant({ createdTime: 1 })]} refresh={vi.fn()} />);

--- a/src/analysis/tests/StudyAnalysisTabs.spec.tsx
+++ b/src/analysis/tests/StudyAnalysisTabs.spec.tsx
@@ -108,6 +108,9 @@ vi.mock('../individualStudy/stats/StatsView', () => ({
 vi.mock('../individualStudy/management/ManageView', () => ({
   ManageView: () => <div>ManageView</div>,
 }));
+vi.mock('../individualStudy/management/StageManagementItem', () => ({
+  StageManagementItem: () => <div>StageManagementItem</div>,
+}));
 vi.mock('../individualStudy/thinkAloud/ThinkAloudAnalysis', () => ({
   ThinkAloudAnalysis: () => <div>ThinkAloudAnalysis</div>,
 }));
@@ -150,7 +153,7 @@ vi.mock('@mantine/core', () => ({
     return <div ref={ref}>{children}</div>;
   }),
   Tabs: Object.assign(
-    ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    ({ children, orientation }: { children: ReactNode; orientation?: string }) => <div data-orientation={orientation}>{children}</div>,
     {
       List: ({ children }: { children: ReactNode }) => <nav>{children}</nav>,
       Tab: ({ children, value }: { children: ReactNode; value: string }) => (
@@ -216,7 +219,9 @@ describe('StudyAnalysisTabs', () => {
     expect(html).toContain('Trial Stats');
     expect(html).toContain('Coding');
     expect(html).toContain('Config');
+    expect(html).toContain('Stage Management');
     expect(html).toContain('Manage');
+    expect(html).toContain('data-orientation="vertical"');
   });
 
   test('renders disabled Live Monitor tab and Firebase-only message when not Firebase', () => {

--- a/src/analysis/tests/StudyAnalysisTabs.spec.tsx
+++ b/src/analysis/tests/StudyAnalysisTabs.spec.tsx
@@ -146,6 +146,7 @@ vi.mock('@mantine/core', () => ({
     { Group: ({ children }: { children: ReactNode }) => <div>{children}</div> },
   ),
   Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Divider: () => <hr />,
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   LoadingOverlay: () => null,

--- a/src/analysis/tests/manageUtils.spec.ts
+++ b/src/analysis/tests/manageUtils.spec.ts
@@ -18,7 +18,7 @@ const participantMetadata: ParticipantMetadata = {
   ip: '122.122.122.122',
 };
 const existingStages: StageInfo[] = [
-  { stageName: 'DEFAULT', color: '#F05A30' },
+  { stageName: 'DEFAULT', color: '#F35C34' },
   { stageName: 'REVIEW', color: '#00AAFF' },
 ];
 

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_AUTO_ADVANCE_WARNING_TIME,
   getAutoAdvanceWarning,
 } from './nextButtonTimeout';
+import { useIsStartupPreview } from './StartupPreviewContext';
 
 const nextButtonJustify = {
   left: 'flex-start',
@@ -42,6 +43,7 @@ export function NextButton({
   onNext,
 }: Props) {
   const { isNextDisabled, goToNextStep } = useNextStep();
+  const isStartupPreview = useIsStartupPreview();
   const studyConfig = useStudyConfig();
   const navigate = useNavigate();
   const identifier = useCurrentIdentifier();
@@ -68,22 +70,22 @@ export function NextButton({
   }, [identifier]);
 
   useEffect(() => {
-    if (timer === undefined) {
+    if (isStartupPreview || timer === undefined) {
       return;
     }
     if (nextButtonDisableTime && timer >= nextButtonDisableTime && studyConfig.uiConfig.timeoutReject) {
       navigate(`./../__timedOut${window.location.search}`);
     }
-  }, [nextButtonDisableTime, timer, navigate, studyConfig.uiConfig.timeoutReject]);
+  }, [isStartupPreview, nextButtonDisableTime, timer, navigate, studyConfig.uiConfig.timeoutReject]);
 
   useEffect(() => {
-    if (timer === undefined || nextButtonAutoAdvanceTime === undefined || timer < nextButtonAutoAdvanceTime || autoAdvanceTriggered.current) {
+    if (isStartupPreview || timer === undefined || nextButtonAutoAdvanceTime === undefined || timer < nextButtonAutoAdvanceTime || autoAdvanceTriggered.current) {
       return;
     }
 
     autoAdvanceTriggered.current = true;
     goToNextStep(false);
-  }, [goToNextStep, nextButtonAutoAdvanceTime, timer]);
+  }, [goToNextStep, isStartupPreview, nextButtonAutoAdvanceTime, timer]);
 
   const buttonTimerSatisfied = useMemo(
     () => {
@@ -116,7 +118,7 @@ export function NextButton({
         onCheckAnswer();
         return;
       }
-      if (!disabled && !isNextDisabled && buttonTimerSatisfied) {
+      if (!isStartupPreview && !disabled && !isNextDisabled && buttonTimerSatisfied) {
         onNext();
       }
     };
@@ -127,9 +129,9 @@ export function NextButton({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [disabled, isNextDisabled, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter]);
+  }, [disabled, isStartupPreview, isNextDisabled, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter]);
 
-  const nextButtonDisabled = disabled || isNextDisabled || !buttonTimerSatisfied;
+  const nextButtonDisabled = isStartupPreview || disabled || isNextDisabled || !buttonTimerSatisfied;
   const previousButtonText = config?.previousButtonText ?? studyConfig.uiConfig.previousButtonText ?? 'Previous';
   const nextButtonAlignment = config?.nextButtonAlignment ?? studyConfig.uiConfig.nextButtonAlignment ?? 'right';
 
@@ -146,7 +148,14 @@ export function NextButton({
         <Button
           type="submit"
           disabled={nextButtonDisabled}
-          onClick={() => onNext()}
+          aria-busy={isStartupPreview || undefined}
+          color={isStartupPreview ? 'gray' : undefined}
+          onClick={() => {
+            if (!nextButtonDisabled) {
+              onNext();
+            }
+          }}
+          loading={isStartupPreview}
           px={location === 'sidebar' && checkAnswer ? 8 : undefined}
         >
           {label}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -7,7 +7,7 @@ import {
 import { Provider } from 'react-redux';
 import { RouteObject, useRoutes, useSearchParams } from 'react-router';
 import {
-  Button, Center, LoadingOverlay, Stack, Text, Title,
+  Anchor, Button, Center, Code, LoadingOverlay, Stack, Text, Title,
 } from '@mantine/core';
 import {
   GlobalConfig,
@@ -37,6 +37,7 @@ import { hash } from '../storage/engines/utils/storageEngineHelpers';
 import {
   StageCapacityExceededError,
   StageNoAvailableConditionsError,
+  StageOnlyDisabledConditionsHaveCapacityError,
   type StorageEngine,
   type REVISIT_MODE,
 } from '../storage/engines/types';
@@ -221,7 +222,9 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   const routeStudyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedConfig<StudyConfig> | null>(null);
   const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
-  const [stageEntryError, setStageEntryError] = useState<StageCapacityExceededError | StageNoAvailableConditionsError | null>(null);
+  const [stageEntryError, setStageEntryError] = useState<
+    StageCapacityExceededError | StageNoAvailableConditionsError | StageOnlyDisabledConditionsHaveCapacityError | null
+  >(null);
   const canonicalStudyId = useMemo(() => {
     if (routeStudyId === '__revisit-widget') {
       return routeStudyId;
@@ -521,7 +524,11 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         }
       } catch (error) {
         console.error('Error initializing user store routing:', error);
-        if (error instanceof StageCapacityExceededError || error instanceof StageNoAvailableConditionsError) {
+        if (
+          error instanceof StageCapacityExceededError
+          || error instanceof StageNoAvailableConditionsError
+          || error instanceof StageOnlyDisabledConditionsHaveCapacityError
+        ) {
           if (!isCancelled) {
             setStageEntryError(error);
             setIsCompletionCheckResolved(true);
@@ -628,7 +635,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   } else if (stageEntryError) {
     content = (
       <Center style={{ height: '80vh', flexDirection: 'column', textAlign: 'center' }}>
-        <Title order={2}>{stageEntryError instanceof StageCapacityExceededError ? 'Study full' : 'Study unavailable'}</Title>
+        <Title order={2}>Study full</Title>
         <Text mt="md">
           {stageEntryError instanceof StageCapacityExceededError ? (
             <>
@@ -639,15 +646,23 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
               stage at this time.
             </>
           ) : (
-            <>
-              Sorry, there are no active study versions in the
-              {' '}
-              {stageEntryError.stageName}
-              {' '}
-              stage at this time.
-            </>
+            <>Sorry, this study is full and cannot accept more participants at this time.</>
           )}
         </Text>
+        {!(stageEntryError instanceof StageCapacityExceededError) && (
+          <>
+            <Text mt="md">
+              Please email
+              {' '}
+              <Anchor href={`mailto:${activeConfig?.uiConfig.contactEmail}`}>
+                {activeConfig?.uiConfig.contactEmail}
+              </Anchor>
+              {' '}
+              if you think you are seeing this page in error, and include the following details:
+            </Text>
+            <Code block mt="sm" maw={700} ta="left">{`Study ID: ${canonicalStudyId}\nURL: ${window.location.href}\nParticipant ID: ${participantId || urlParticipantId || 'Not assigned'}\nTimestamp (UTC): ${new Date().toISOString()}\nStorage Engine: ${import.meta.env.VITE_STORAGE_ENGINE}\nUser Agent: ${navigator.userAgent}\nResolution: ${JSON.stringify(createParticipantMetadata().resolution, null, 2)}\nIP: Unavailable\nLanguage: ${navigator.language}`}</Code>
+          </>
+        )}
       </Center>
     );
   } else if (activeConfig && hasConfigErrors) {

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -318,7 +318,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     setStartupPreviewComponent(null);
     setStartupPreviewStore(null);
 
-    if (!storageEngine || !activeConfig || !canonicalStudyId
+    if (store || !storageEngine || !activeConfig || !canonicalStudyId
       || participantId || urlParticipantId || studyCondition.length > 0
       || (activeConfig.errors?.length ?? 0) > 0) {
       return () => {
@@ -367,7 +367,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     return () => {
       cancelled = true;
     };
-  }, [storageEngine, activeConfig, canonicalStudyId, participantId, urlParticipantId, studyCondition]);
+  }, [storageEngine, activeConfig, canonicalStudyId, participantId, urlParticipantId, studyCondition, store]);
 
   useEffect(() => {
     let isCancelled = false;

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -28,7 +28,7 @@ import { StepRenderer } from './StepRenderer';
 import { useStorageEngine } from '../storage/storageEngineHooks';
 import { generateSequenceArray } from '../utils/handleRandomSequences';
 import { getStudyConfig, resolveConfigKey } from '../utils/fetchConfig';
-import type { AlertModalState, ParticipantMetadata } from '../store/types';
+import type { AlertModalState, ParticipantMetadata, Sequence } from '../store/types';
 import { ErrorLoadingConfig } from './ErrorLoadingConfig';
 import { ResourceNotFound } from '../ResourceNotFound';
 import { encryptIndex } from '../utils/encryptDecryptIndex';
@@ -47,6 +47,8 @@ import {
 } from '../utils/handleConditionLogic';
 import { StartupErrorScreen } from './StartupErrorScreen';
 import { materializeParticipantConfig } from '../parser/libraryParser';
+import { getStaticFirstComponent, type StaticFirstComponentPreview } from '../utils/getStaticFirstComponent';
+import { StartupPreviewContext } from './StartupPreviewContext';
 
 type StartupStorageStatus = Pick<StorageEngine, 'getEngine' | 'isConnected'>;
 
@@ -54,6 +56,29 @@ const GENERIC_STARTUP_ERROR = 'There was a problem loading the study.';
 const RESUME_STARTUP_ERROR = 'This study session could not be resumed.';
 const STUDY_LOADING_MESSAGE = 'Loading your study. This may take a moment.';
 const STUDY_LOADING_MESSAGE_DELAY_MS = 1500;
+const STARTUP_PREVIEW_MODES: Record<REVISIT_MODE, boolean> = {
+  dataCollectionEnabled: true,
+  developmentModeEnabled: import.meta.env.DEV,
+  dataSharingEnabled: false,
+};
+
+function getParticipantRoutes() {
+  return [
+    {
+      element: <StepRenderer />,
+      children: [
+        {
+          path: '/',
+          element: <NavigateWithParams to={encryptIndex(0)} replace />,
+        },
+        {
+          path: '/:index/:funcIndex?',
+          element: <ComponentController />,
+        },
+      ],
+    },
+  ];
+}
 
 export function StudyLoadingOverlay({ visible }: { visible: boolean }) {
   const [showMessage, setShowMessage] = useState(false);
@@ -269,13 +294,86 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   const [routes, setRoutes] = useState<RouteObject[]>([]);
   const [store, setStore] = useState<Nullable<StudyStore>>(null);
+  const [startupPreviewStore, setStartupPreviewStore] = useState<Nullable<StudyStore>>(null);
   const [isCompletionCheckResolved, setIsCompletionCheckResolved] = useState(false);
   const [completionCheckError, setCompletionCheckError] = useState<string | null>(null);
+  const [startupPreviewComponent, setStartupPreviewComponent] = useState<StaticFirstComponentPreview | null>(null);
   const { storageEngine } = useStorageEngine();
   const [searchParams] = useSearchParams();
 
   const participantId = useMemo(() => searchParams.get('participantId'), [searchParams]);
   const studyCondition = useMemo(() => parseConditionParam(searchParams.get('condition')), [searchParams]);
+  const urlParticipantId = useMemo(() => (
+    activeConfig?.uiConfig.urlParticipantIdParam
+      ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) ?? undefined
+      : undefined
+  ), [activeConfig, searchParams]);
+  const canStartStaticPreview = useMemo(() => (
+    !!storageEngine
+    && !!activeConfig
+    && !!canonicalStudyId
+    && !participantId
+    && !urlParticipantId
+    && studyCondition.length === 0
+    && (activeConfig.errors?.length ?? 0) === 0
+    && getStaticFirstComponent(activeConfig) !== null
+  ), [storageEngine, activeConfig, canonicalStudyId, participantId, urlParticipantId, studyCondition]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStartupPreviewComponent(null);
+    setStartupPreviewStore(null);
+
+    if (!storageEngine || !activeConfig || !canonicalStudyId
+      || participantId || urlParticipantId || studyCondition.length > 0
+      || (activeConfig.errors?.length ?? 0) > 0) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    storageEngine.peekCurrentParticipantId(canonicalStudyId).then(async (existingParticipantId) => {
+      if (cancelled || existingParticipantId) {
+        return;
+      }
+
+      const previewComponent = getStaticFirstComponent(activeConfig);
+      if (!previewComponent) {
+        return;
+      }
+
+      const previewSequence: Sequence = {
+        id: 'startup-preview',
+        orderPath: 'startup-preview',
+        order: 'fixed',
+        components: [previewComponent.componentName],
+        skip: [],
+      };
+      const previewStore = await studyStoreCreator(
+        canonicalStudyId,
+        activeConfig,
+        previewSequence,
+        createEmptyParticipantMetadata(),
+        {},
+        STARTUP_PREVIEW_MODES,
+        '',
+        false,
+        false,
+      );
+
+      if (!cancelled) {
+        setStartupPreviewComponent(previewComponent);
+        setStartupPreviewStore(previewStore);
+        setRoutes(getParticipantRoutes());
+      }
+    }).catch(() => {
+      // Startup remains unchanged if preview construction is unavailable.
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [storageEngine, activeConfig, canonicalStudyId, participantId, urlParticipantId, studyCondition]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -303,9 +401,6 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       setStageEntryError(null);
 
       let modes: Record<REVISIT_MODE, boolean> | null = null;
-      const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam
-        ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) ?? undefined
-        : undefined;
       try {
         // Make sure that we have a study database and that the study database has a sequence array
         await storageEngine.initializeStudyDb(canonicalStudyId);
@@ -508,21 +603,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       }
 
       // Initialize the routing
-      setRoutes([
-        {
-          element: <StepRenderer />,
-          children: [
-            {
-              path: '/',
-              element: <NavigateWithParams to={encryptIndex(0)} replace />,
-            },
-            {
-              path: '/:index/:funcIndex?',
-              element: <ComponentController />,
-            },
-          ],
-        },
-      ]);
+      setRoutes(getParticipantRoutes());
     }
     initializeUserStoreRouting().catch((error) => {
       console.error('Unhandled error initializing user store routing:', error);
@@ -533,7 +614,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     return () => {
       isCancelled = true;
     };
-  }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, studyCondition]);
+  }, [storageEngine, activeConfig, canonicalStudyId, searchParams, participantId, urlParticipantId, studyCondition]);
 
   const routing = useRoutes(routes);
   const hasConfigErrors = (activeConfig?.errors?.length ?? 0) > 0;
@@ -545,6 +626,9 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     completionCheckError,
     hasStageCapacityError: stageEntryError !== null,
   });
+  const hasStartupPreview = startupPreviewComponent !== null && startupPreviewStore !== null && store === null;
+  const activeStore = store ?? startupPreviewStore;
+  const hasRenderableStudy = routing !== null && activeStore !== null;
 
   let content: ReactNode = null;
 
@@ -589,10 +673,12 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     );
   } else if (!isValidStudyId) {
     content = <ResourceNotFound />;
-  } else if (routing && store) {
+  } else if (routing && activeStore) {
     content = (
-      <StudyStoreContext.Provider value={store}>
-        <Provider store={store.store}>{routing}</Provider>
+      <StudyStoreContext.Provider value={activeStore}>
+        <StartupPreviewContext.Provider value={hasStartupPreview}>
+          <Provider store={activeStore.store}>{routing}</Provider>
+        </StartupPreviewContext.Provider>
       </StudyStoreContext.Provider>
     );
   } else if (!isLoading) {
@@ -601,7 +687,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   return (
     <>
-      <StudyLoadingOverlay visible={!startupError && !hasConfigErrors && isLoading} />
+      <StudyLoadingOverlay visible={!startupError && !hasConfigErrors && isLoading && !hasRenderableStudy && !canStartStaticPreview} />
       {!startupError && !hasConfigErrors && showCompletionCheckError && (
         <Stack
           align="center"

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -62,14 +62,16 @@ const STARTUP_PREVIEW_MODES: Record<REVISIT_MODE, boolean> = {
   dataSharingEnabled: false,
 };
 
-function getParticipantRoutes() {
+function getParticipantRoutes(startupPreview = false) {
   return [
     {
       element: <StepRenderer />,
       children: [
         {
           path: '/',
-          element: <NavigateWithParams to={encryptIndex(0)} replace />,
+          element: startupPreview
+            ? <ComponentController />
+            : <NavigateWithParams to={encryptIndex(0)} replace />,
         },
         {
           path: '/:index/:funcIndex?',
@@ -308,17 +310,6 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       ? searchParams.get(activeConfig.uiConfig.urlParticipantIdParam) ?? undefined
       : undefined
   ), [activeConfig, searchParams]);
-  const canStartStaticPreview = useMemo(() => (
-    !!storageEngine
-    && !!activeConfig
-    && !!canonicalStudyId
-    && !participantId
-    && !urlParticipantId
-    && studyCondition.length === 0
-    && (activeConfig.errors?.length ?? 0) === 0
-    && getStaticFirstComponent(activeConfig) !== null
-  ), [storageEngine, activeConfig, canonicalStudyId, participantId, urlParticipantId, studyCondition]);
-
   useEffect(() => {
     let cancelled = false;
     setStartupPreviewComponent(null);
@@ -364,7 +355,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       if (!cancelled) {
         setStartupPreviewComponent(previewComponent);
         setStartupPreviewStore(previewStore);
-        setRoutes(getParticipantRoutes());
+        setRoutes(getParticipantRoutes(true));
       }
     }).catch(() => {
       // Startup remains unchanged if preview construction is unavailable.
@@ -675,7 +666,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     content = <ResourceNotFound />;
   } else if (routing && activeStore) {
     content = (
-      <StudyStoreContext.Provider value={activeStore}>
+      <StudyStoreContext.Provider key={hasStartupPreview ? 'startup-preview' : 'participant-session'} value={activeStore}>
         <StartupPreviewContext.Provider value={hasStartupPreview}>
           <Provider store={activeStore.store}>{routing}</Provider>
         </StartupPreviewContext.Provider>
@@ -687,7 +678,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
 
   return (
     <>
-      <StudyLoadingOverlay visible={!startupError && !hasConfigErrors && isLoading && !hasRenderableStudy && !canStartStaticPreview} />
+      <StudyLoadingOverlay visible={!startupError && !hasConfigErrors && isLoading && !hasRenderableStudy} />
       {!startupError && !hasConfigErrors && showCompletionCheckError && (
         <Stack
           align="center"

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -7,7 +7,7 @@ import {
 import { Provider } from 'react-redux';
 import { RouteObject, useRoutes, useSearchParams } from 'react-router';
 import {
-  Button, LoadingOverlay, Stack, Text, Title,
+  Button, Center, LoadingOverlay, Stack, Text, Title,
 } from '@mantine/core';
 import {
   GlobalConfig,
@@ -34,7 +34,12 @@ import { ResourceNotFound } from '../ResourceNotFound';
 import { encryptIndex } from '../utils/encryptDecryptIndex';
 import { parseStudyConfig } from '../parser/parser';
 import { hash } from '../storage/engines/utils/storageEngineHelpers';
-import type { StorageEngine, REVISIT_MODE } from '../storage/engines/types';
+import {
+  StageCapacityExceededError,
+  StageNoAvailableConditionsError,
+  type StorageEngine,
+  type REVISIT_MODE,
+} from '../storage/engines/types';
 import {
   filterSequenceByCondition,
   parseConditionParam,
@@ -136,15 +141,17 @@ export function getShellUiState({
   hasStore,
   isCompletionCheckResolved,
   completionCheckError,
+  hasStageCapacityError = false,
 }: {
   isValidStudyId: boolean;
   hasRoutes: boolean;
   hasStore: boolean;
   isCompletionCheckResolved: boolean;
   completionCheckError: string | null;
+  hasStageCapacityError?: boolean;
 }) {
   return {
-    isLoading: isValidStudyId && (!hasRoutes || !hasStore || !isCompletionCheckResolved),
+    isLoading: isValidStudyId && !hasStageCapacityError && (!hasRoutes || !hasStore || !isCompletionCheckResolved),
     showCompletionCheckError: completionCheckError !== null,
   };
 }
@@ -187,6 +194,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
   const routeStudyId = useStudyId();
   const [activeConfig, setActiveConfig] = useState<ParsedConfig<StudyConfig> | null>(null);
   const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
+  const [stageEntryError, setStageEntryError] = useState<StageCapacityExceededError | StageNoAvailableConditionsError | null>(null);
   const canonicalStudyId = useMemo(() => {
     if (routeStudyId === '__revisit-widget') {
       return routeStudyId;
@@ -292,6 +300,7 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
       if (!storageEngine || !activeConfig || !canonicalStudyId || (activeConfig.errors?.length ?? 0) > 0) return;
       setIsCompletionCheckResolved(false);
       setCompletionCheckError(null);
+      setStageEntryError(null);
 
       let modes: Record<REVISIT_MODE, boolean> | null = null;
       const urlParticipantId = activeConfig.uiConfig.urlParticipantIdParam
@@ -426,6 +435,13 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
         }
       } catch (error) {
         console.error('Error initializing user store routing:', error);
+        if (error instanceof StageCapacityExceededError || error instanceof StageNoAvailableConditionsError) {
+          if (!isCancelled) {
+            setStageEntryError(error);
+            setIsCompletionCheckResolved(true);
+          }
+          return;
+        }
         const isStorageFailure = isStorageStartupFailure(
           storageEngine,
           import.meta.env.VITE_STORAGE_ENGINE,
@@ -527,12 +543,38 @@ export function Shell({ globalConfig }: { globalConfig: GlobalConfig }) {
     hasStore: store !== null,
     isCompletionCheckResolved,
     completionCheckError,
+    hasStageCapacityError: stageEntryError !== null,
   });
 
   let content: ReactNode = null;
 
   if (startupError) {
     content = <StartupErrorScreen error={startupError.error} />;
+  } else if (stageEntryError) {
+    content = (
+      <Center style={{ height: '80vh', flexDirection: 'column', textAlign: 'center' }}>
+        <Title order={2}>{stageEntryError instanceof StageCapacityExceededError ? 'Study full' : 'Study unavailable'}</Title>
+        <Text mt="md">
+          {stageEntryError instanceof StageCapacityExceededError ? (
+            <>
+              Sorry, no more participants can join the
+              {' '}
+              {stageEntryError.stageName}
+              {' '}
+              stage at this time.
+            </>
+          ) : (
+            <>
+              Sorry, there are no active study versions in the
+              {' '}
+              {stageEntryError.stageName}
+              {' '}
+              stage at this time.
+            </>
+          )}
+        </Text>
+      </Center>
+    );
   } else if (activeConfig && hasConfigErrors) {
     content = (
       <>

--- a/src/components/StartupPreviewContext.ts
+++ b/src/components/StartupPreviewContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const StartupPreviewContext = createContext(false);
+
+export function useIsStartupPreview() {
+  return useContext(StartupPreviewContext);
+}

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -220,7 +220,7 @@ export function StepRenderer() {
             {showTitleBar && (
             <AppHeader developmentModeEnabled={developmentModeEnabled} dataCollectionEnabled={dataCollectionEnabled} />
             )}
-            <DeviceWarning developmentModeEnabled={developmentModeEnabled} />
+            {!isStartupPreview && <DeviceWarning developmentModeEnabled={developmentModeEnabled} />}
             {isScreenRecordingUserRejected && <ScreenRecordingRejection />}
             <HelpModal />
             <AlertModal />

--- a/src/components/StepRenderer.tsx
+++ b/src/components/StepRenderer.tsx
@@ -1,4 +1,6 @@
-import { AppShell, Button, Flex } from '@mantine/core';
+import {
+  AppShell, Button, Center, Flex, Loader, Stack, Text,
+} from '@mantine/core';
 import { Outlet } from 'react-router';
 import {
   useEffect, useMemo, useRef,
@@ -28,10 +30,25 @@ import { ReplayContext, useReplay } from '../store/hooks/useReplay';
 import { DeviceWarning } from './interface/DeviceWarning';
 import { handleBeforeUnload, shouldConfirmTabClose } from '../utils/closeTabConfirmation';
 import { useStorageEngine } from '../storage/storageEngineHooks';
+import { useIsStartupPreview } from './StartupPreviewContext';
 
 const STUDY_BROWSER_WIDTH = 360;
 
+function StartupPreviewAside() {
+  return (
+    <AppShell.Aside className="studyBrowser" data-testid="startup-preview-aside" p="0">
+      <Center h="100%">
+        <Stack align="center" gap="sm">
+          <Loader size="sm" />
+          <Text size="sm">Preparing study browser…</Text>
+        </Stack>
+      </Center>
+    </AppShell.Aside>
+  );
+}
+
 export function StepRenderer() {
+  const isStartupPreview = useIsStartupPreview();
   const windowEvents = useRef<EventType[]>([]);
   const dispatch = useStoreDispatch();
   const { toggleStudyBrowser, setAlertModal } = useStoreActions();
@@ -61,7 +78,7 @@ export function StepRenderer() {
   const analysisCanPlayScreenRecording = useStoreSelector((state) => state.analysisCanPlayScreenRecording);
 
   useEffect(() => {
-    if (!storageEngine) {
+    if (isStartupPreview || !storageEngine) {
       return undefined;
     }
 
@@ -73,7 +90,7 @@ export function StepRenderer() {
         title: 'Failed to Save Response',
       }));
     });
-  }, [dispatch, setAlertModal, storageEngine]);
+  }, [dispatch, isStartupPreview, setAlertModal, storageEngine]);
 
   // Attach event listeners
   useEffect(() => {
@@ -199,7 +216,7 @@ export function StepRenderer() {
             footer={{ height: isAnalysis ? 125 + (hasAudio ? 55 : 0) : 0 }}
             style={{ '--app-shell-aside-offset': '0rem' } as CSSProperties}
           >
-            {asideOpen && <AppAside />}
+            {asideOpen && (isStartupPreview ? <StartupPreviewAside /> : <AppAside />)}
             {showTitleBar && (
             <AppHeader developmentModeEnabled={developmentModeEnabled} dataCollectionEnabled={dataCollectionEnabled} />
             )}

--- a/src/components/audioAnalysis/provenanceColors.ts
+++ b/src/components/audioAnalysis/provenanceColors.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-bitwise */
 import { TrrackedProvenance } from '../../store/types';
+import { DISTINCT_COLOR_PALETTE } from '../../utils/colors';
 
-export const PROVENANCE_COLOR_PALETTE = ['#4269d0', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7', '#a463f2', '#97bbf5', '#9c6b4e'];
+export const PROVENANCE_COLOR_PALETTE = DISTINCT_COLOR_PALETTE;
 export const ROOT_COLOR = '#efb118';
 export const UNKNOWN_COLOR = '#9498a0';
 export const FORM_UPDATE_COLOR = '#9498a0';

--- a/src/components/downloader/DownloadButtons.tsx
+++ b/src/components/downloader/DownloadButtons.tsx
@@ -120,7 +120,7 @@ export function DownloadButtons({
 
   return (
     <>
-      <Group style={{ gap }}>
+      <Group style={{ gap }} wrap="nowrap">
         <Tooltip label={`${tooltipText} as JSON`}>
           <Button
             variant="light"

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -46,6 +46,7 @@ import { useManagedTrrack } from '../../store/hooks/useRevisitTrrack';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { showNotification } from '../../utils/notifications';
 import { getAnswersFromAllLocations } from '../../utils/getAnswersFromAllLocations';
+import { useIsStartupPreview } from '../StartupPreviewContext';
 
 type Props = {
   status?: StoredAnswer;
@@ -83,6 +84,7 @@ export function ResponseBlock({
   status,
   style,
 }: Props) {
+  const isStartupPreview = useIsStartupPreview();
   const storeDispatch = useStoreDispatch();
   const {
     updateProvenance, updateResponseBlockValidation, saveIncorrectAnswer, saveTrialAnswer, setResponseSubmitAttempt, setStimulusSubmitAttempt, setCheckAnswerResult,
@@ -721,7 +723,7 @@ export function ResponseBlock({
                       response={response}
                       index={index}
                       config={config}
-                      disabled={disabledAttempts}
+                      disabled={isStartupPreview || disabledAttempts}
                       errors={errors}
                     />
                     <FeedbackAlert
@@ -767,15 +769,15 @@ export function ResponseBlock({
 
       {showBtnsInLocation && (
         <NextButton
-          disabled={(hasCorrectAnswerFeedback && !enableNextButton)}
+          disabled={isStartupPreview || (hasCorrectAnswerFeedback && !enableNextButton)}
           label={nextButtonText}
           config={config}
           location={location}
           onNext={handleNextClick}
-          onCheckAnswer={!isAnalysis && hasCorrectAnswerFeedback && !disabledAttempts ? checkAnswerProvideFeedback : undefined}
+          onCheckAnswer={!isStartupPreview && !isAnalysis && hasCorrectAnswerFeedback && !disabledAttempts ? checkAnswerProvideFeedback : undefined}
           checkAnswer={showBtnsInLocation && hasCorrectAnswerFeedback ? (
             <Button
-              disabled={disabledAttempts}
+              disabled={isStartupPreview || disabledAttempts}
               onClick={() => checkAnswerProvideFeedback()}
               px={location === 'sidebar' ? 8 : undefined}
             >

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -13,7 +13,7 @@ import { makeGlobalConfig, makeStudyConfig } from '../../tests/utils';
 import { studyStoreCreator } from '../../store/store';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
 import { parseStudyConfig } from '../../parser/parser';
-import { StageCapacityExceededError } from '../../storage/engines/types';
+import { StageCapacityExceededError, StageOnlyDisabledConditionsHaveCapacityError } from '../../storage/engines/types';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -91,10 +91,12 @@ vi.mock('react-router', () => ({
 }));
 
 vi.mock('@mantine/core', () => ({
+  Anchor: ({ children, href }: { children: ReactNode; href?: string }) => <a href={href}>{children}</a>,
   Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
     <button type="button" onClick={onClick}>{children}</button>
   ),
   Center: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Code: ({ children }: { children: ReactNode }) => <pre>{children}</pre>,
   LoadingOverlay: ({ visible }: { visible: boolean }) => (
     visible ? <div data-testid="loading-overlay" /> : null
   ),
@@ -384,6 +386,28 @@ describe('Shell', () => {
     await waitFor(() => expect(getByText('Study full')).toBeDefined(), { timeout: 3000 });
     expect(getByText(/no more participants can join the LIMITED stage/i)).toBeDefined();
     expect(queryByTestId('routing')).toBeNull();
+    consoleSpy.mockRestore();
+  });
+
+  test('explains when only disabled study versions have remaining capacity', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
+      getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
+      initializeParticipantSession: vi.fn().mockRejectedValue(new StageOnlyDisabledConditionsHaveCapacityError('LIMITED')),
+      isConnected: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+    };
+
+    const { getByText } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(getByText('Study full')).toBeDefined(), { timeout: 3000 });
+    expect(getByText(/this study is full and cannot accept more participants/i)).toBeDefined();
+    expect(getByText(/if you think you are seeing this page in error/i)).toBeDefined();
+    expect(getByText(/study id: test-study/i)).toBeDefined();
     consoleSpy.mockRestore();
   });
 

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -314,6 +314,37 @@ describe('Shell', () => {
     await waitFor(() => expect(vi.mocked(studyStoreCreator)).toHaveBeenCalled(), { timeout: 3000 });
   });
 
+  test('renders a fixed, response-free first component in the normal study shell while a new participant is assigned', async () => {
+    const previewConfig: ParsedConfig<StudyConfig> = {
+      ...mockActiveConfig,
+      components: {
+        intro: {
+          type: 'markdown',
+          path: 'test-study/assets/intro.md',
+          response: [],
+        },
+      },
+      sequence: { order: 'fixed', components: ['intro'] },
+    };
+    vi.mocked(getStudyConfig).mockResolvedValue(previewConfig);
+
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
+      getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
+      initializeParticipantSession: vi.fn().mockImplementation(() => new Promise(() => { })),
+      peekCurrentParticipantId: vi.fn().mockResolvedValue(undefined),
+      isConnected: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+    };
+
+    const { getByTestId, queryByTestId } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(getByTestId('routing')).toBeDefined());
+    expect(queryByTestId('loading-overlay')).toBeNull();
+  });
+
   test('calls setSequenceArray when getSequenceArray returns null', async () => {
     vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
 

--- a/src/components/tests/Shell.spec.tsx
+++ b/src/components/tests/Shell.spec.tsx
@@ -13,6 +13,7 @@ import { makeGlobalConfig, makeStudyConfig } from '../../tests/utils';
 import { studyStoreCreator } from '../../store/store';
 import { parseConditionParam } from '../../utils/handleConditionLogic';
 import { parseStudyConfig } from '../../parser/parser';
+import { StageCapacityExceededError } from '../../storage/engines/types';
 
 // ── mutable state ─────────────────────────────────────────────────────────────
 
@@ -93,6 +94,7 @@ vi.mock('@mantine/core', () => ({
   Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
     <button type="button" onClick={onClick}>{children}</button>
   ),
+  Center: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   LoadingOverlay: ({ visible }: { visible: boolean }) => (
     visible ? <div data-testid="loading-overlay" /> : null
   ),
@@ -331,6 +333,27 @@ describe('Shell', () => {
 
     render(<Shell globalConfig={globalConfig} />);
     await waitFor(() => expect(mockStorageEngine!.setSequenceArray).toHaveBeenCalled(), { timeout: 3000 });
+  });
+
+  test('shows the study-full screen when the current stage is at capacity', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    vi.mocked(getStudyConfig).mockResolvedValue(mockActiveConfig);
+    mockStorageEngine = {
+      initializeStudyDb: vi.fn().mockResolvedValue(undefined),
+      saveConfig: vi.fn().mockResolvedValue(undefined),
+      getSequenceArray: vi.fn().mockResolvedValue(['seq1']),
+      getModes: vi.fn().mockResolvedValue({ developmentModeEnabled: false, dataSharingEnabled: false, dataCollectionEnabled: true }),
+      initializeParticipantSession: vi.fn().mockRejectedValue(new StageCapacityExceededError('LIMITED')),
+      isConnected: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+    };
+
+    const { getByText, queryByTestId } = render(<Shell globalConfig={globalConfig} />);
+
+    await waitFor(() => expect(getByText('Study full')).toBeDefined(), { timeout: 3000 });
+    expect(getByText(/no more participants can join the LIMITED stage/i)).toBeDefined();
+    expect(queryByTestId('routing')).toBeNull();
+    consoleSpy.mockRestore();
   });
 
   test('covers study condition update path', async () => {

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -82,7 +82,17 @@ export function ComponentController() {
   const participantId = useMemo(() => searchParams.get('participantId'), [searchParams]);
 
   // Disable browser back button from all stimuli
-  useDisableBrowserBack();
+  useDisableBrowserBack(isStartupPreview);
+
+  useEffect(() => {
+    if (isStartupPreview || !storageEngine) {
+      return undefined;
+    }
+
+    return storageEngine.subscribeToCurrentParticipantRejection(() => {
+      navigate(`./../__timedOut${window.location.search}`);
+    });
+  }, [isStartupPreview, navigate, storageEngine]);
 
   // Check if we have issues connecting to the database, if so show alert modal
   const storeDispatch = useStoreDispatch();

--- a/src/controllers/ComponentController.tsx
+++ b/src/controllers/ComponentController.tsx
@@ -40,9 +40,11 @@ import { getComponentContainerStyle } from '../utils/componentStyle';
 import { compileTemplate } from '../utils/handlebars';
 import { generateStimulusErrorMessage } from '../components/response/stimulusErrors';
 import { getStimulusProvenanceState, getStimulusShowErrorsFromState } from '../components/response/stimulusProvenance';
+import { useIsStartupPreview } from '../components/StartupPreviewContext';
 
 // current active stimuli presented to the user
 export function ComponentController() {
+  const isStartupPreview = useIsStartupPreview();
   // Get the config for the current step
   const studyConfig = useStudyConfig();
   const currentStep = useCurrentStep();
@@ -111,7 +113,7 @@ export function ComponentController() {
   const [blockForStep, setBlockForStep] = useState<string[]>([]);
   const prevBlockForStepRef = useRef<string[]>([]);
   useEffect(() => {
-    if (isAnalysis) {
+    if (isAnalysis || isStartupPreview) {
       return;
     }
     async function updateBlockForStep() {
@@ -138,7 +140,7 @@ export function ComponentController() {
 
     updateBlockForStep().then(addParticipantTag);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentStep, storageEngine, sequence]);
+  }, [currentStep, isStartupPreview, storageEngine, sequence]);
 
   const currentConfig = useMemo(() => {
     const toReturn = currentComponent && currentComponent !== 'end' && !currentComponent.startsWith('__') && studyComponentToIndividualComponent(stepConfig, studyConfig) as IndividualComponent;
@@ -275,7 +277,7 @@ export function ComponentController() {
     return <ResourceNotFound email={studyConfig.uiConfig.contactEmail} />;
   }
 
-  if (!storageEngine?.isConnected()) {
+  if (!isStartupPreview && !storageEngine?.isConnected()) {
     return (
       <Center style={{ height: '80vh', flexDirection: 'column', textAlign: 'center' }}>
         <IconPlugConnectedX size={48} stroke={1.5} color="orange" />

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -1,5 +1,6 @@
 import { parse as hjsonParse } from 'hjson';
 import localforage from 'localforage';
+import { v4 as uuidv4 } from 'uuid';
 import { initializeApp } from 'firebase/app';
 import {
   deleteObject,
@@ -25,6 +26,7 @@ import {
   getDocs,
   initializeFirestore,
   onSnapshot,
+  runTransaction,
   serverTimestamp,
   setDoc,
   updateDoc,
@@ -293,6 +295,60 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       createdTime: data.createdTime instanceof Timestamp ? data.createdTime.toMillis() : data.createdTime,
       completed: data.completed instanceof Timestamp ? data.completed.toMillis() : data.completed,
     } as SequenceAssignment;
+  }
+
+  protected async _runWithLock<T>(lockKey: string, operation: () => Promise<T>) {
+    if (this.studyId === undefined) {
+      throw new Error('Study ID is not set');
+    }
+
+    const lockDocument = doc(this.studyCollection, 'locks');
+    const token = uuidv4();
+    const expiresInMs = 60_000;
+    const acquireLock = async (attempt: number): Promise<void> => {
+      const now = Date.now();
+      try {
+        await runTransaction(this.firestore, async (transaction) => {
+          const snapshot = await transaction.get(lockDocument);
+          const existingLock = snapshot.data()?.[lockKey] as {
+            token?: string;
+            expiresAt?: number;
+          } | undefined;
+          if (existingLock?.expiresAt && existingLock.expiresAt > now) {
+            throw new Error('Study lock is held');
+          }
+
+          transaction.set(lockDocument, {
+            [lockKey]: { token, expiresAt: now + expiresInMs },
+          }, { merge: true });
+        });
+      } catch (error) {
+        if (!(error instanceof Error) || error.message !== 'Study lock is held') {
+          throw error;
+        }
+        if (attempt >= 299) {
+          throw new Error('Timed out while waiting for a study update to finish');
+        }
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 100);
+        });
+        await acquireLock(attempt + 1);
+      }
+    };
+
+    await acquireLock(0);
+
+    try {
+      return await operation();
+    } finally {
+      await runTransaction(this.firestore, async (transaction) => {
+        const snapshot = await transaction.get(lockDocument);
+        const existingLock = snapshot.data()?.[lockKey] as { token?: string } | undefined;
+        if (existingLock?.token === token) {
+          transaction.update(lockDocument, { [lockKey]: deleteField() });
+        }
+      });
+    }
   }
 
   protected async _completeCurrentParticipantRealtime() {

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -5,6 +5,8 @@ import {
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
 export class LocalStorageEngine extends StorageEngine {
+  private static lockChains = new Map<string, Promise<void>>();
+
   private studyDatabase = localforage.createInstance({
     name: 'revisit',
   });
@@ -106,6 +108,27 @@ export class LocalStorageEngine extends StorageEngine {
     const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
     const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
     return sequenceAssignments[participantId] || null;
+  }
+
+  protected async _runWithLock<T>(lockKey: string, operation: () => Promise<T>) {
+    const scopedLockKey = `${this.collectionPrefix}${this.studyId}:${lockKey}`;
+    const previousLock = LocalStorageEngine.lockChains.get(scopedLockKey) ?? Promise.resolve();
+    let releaseLock: (() => void) | undefined;
+    const currentLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const queuedLock = previousLock.catch(() => undefined).then(() => currentLock);
+    LocalStorageEngine.lockChains.set(scopedLockKey, queuedLock);
+
+    await previousLock.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      releaseLock?.();
+      if (LocalStorageEngine.lockChains.get(scopedLockKey) === queuedLock) {
+        LocalStorageEngine.lockChains.delete(scopedLockKey);
+      }
+    }
   }
 
   protected async _completeCurrentParticipantRealtime() {

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -1,5 +1,6 @@
 import { AuthError, createClient } from '@supabase/supabase-js';
 import localforage from 'localforage';
+import { v4 as uuidv4 } from 'uuid';
 import {
   REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageObject, StorageObjectType, StoredUser,
   CloudStorageEngine, cleanupModes,
@@ -224,6 +225,89 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       timestamp: data.data.withServerTimestamp ? new Date(data.createdAt).getTime() : data.data.timestamp,
       createdTime: new Date(data.createdAt).getTime(),
     } as SequenceAssignment;
+  }
+
+  protected async _runWithLock<T>(lockKey: string, operation: () => Promise<T>) {
+    await this.verifyStudyDatabase();
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+
+    const studyId = `${this.collectionPrefix}${this.studyId}`;
+    const lockDocumentId = `lock_${lockKey}`;
+    const token = uuidv4();
+    const expiresInMs = 60_000;
+    const acquireLock = async (attempt: number): Promise<void> => {
+      const now = Date.now();
+      const { data: existingLockRow, error: readError } = await this.supabase
+        .from('revisit')
+        .select('data')
+        .eq('studyId', studyId)
+        .eq('docId', lockDocumentId)
+        .maybeSingle();
+
+      if (readError) {
+        throw new Error('Failed to read study update lock');
+      }
+
+      const existingLock = existingLockRow?.data as {
+        token?: string;
+        expiresAt?: number;
+      } | undefined;
+      if (!existingLockRow) {
+        const { error: createError } = await this.supabase
+          .from('revisit')
+          .insert({
+            studyId,
+            docId: lockDocumentId,
+            data: { token, expiresAt: now + expiresInMs },
+          });
+        if (!createError) {
+          return;
+        }
+        if (createError.code !== '23505') {
+          throw new Error('Failed to create study update lock');
+        }
+      } else if (!existingLock?.expiresAt || existingLock.expiresAt <= now) {
+        const { data: updatedLockRows, error: updateError } = await this.supabase
+          .from('revisit')
+          .update({ data: { token, expiresAt: now + expiresInMs } })
+          .eq('studyId', studyId)
+          .eq('docId', lockDocumentId)
+          .eq('data->>token', existingLock?.token ?? '')
+          .select('docId');
+        if (updateError) {
+          throw new Error('Failed to acquire expired study update lock');
+        }
+        if ((updatedLockRows?.length ?? 0) === 1) {
+          return;
+        }
+      }
+
+      if (attempt >= 299) {
+        throw new Error('Timed out while waiting for a study update to finish');
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      await acquireLock(attempt + 1);
+    };
+
+    await acquireLock(0);
+
+    try {
+      return await operation();
+    } finally {
+      const { error } = await this.supabase
+        .from('revisit')
+        .delete()
+        .eq('studyId', studyId)
+        .eq('docId', lockDocumentId)
+        .eq('data->>token', token);
+      if (error) {
+        console.warn('Failed to release study update lock:', error);
+      }
+    }
   }
 
   protected async _completeCurrentParticipantRealtime() {

--- a/src/storage/engines/tests/stageCapacity.spec.ts
+++ b/src/storage/engines/tests/stageCapacity.spec.ts
@@ -68,6 +68,22 @@ describe('stage capacity', () => {
     expect(getStageParticipantCounts(await storageEngine.getAllSequenceAssignments(studyId))).toEqual({ LIMITED: 1 });
   });
 
+  test('serializes concurrent entries so a stage limit is never exceeded', async () => {
+    const secondStorageEngine = new LocalStorageEngine(true);
+    await secondStorageEngine.connect();
+    await secondStorageEngine.initializeStudyDb(studyId);
+
+    const results = await Promise.allSettled([
+      storageEngine.initializeParticipantSession({}, config, metadata, 'first-participant'),
+      secondStorageEngine.initializeParticipantSession({}, config, metadata, 'second-participant'),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(getStageParticipantCounts(await storageEngine.getAllSequenceAssignments(studyId)))
+      .toEqual({ LIMITED: 1 });
+  });
+
   test('assigns only enabled between-subjects combinations for the current stage', async () => {
     await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
     await storageEngine.updateStage(studyId, 'LIMITED', {
@@ -100,7 +116,8 @@ describe('stage capacity', () => {
     const treatmentKey = getBetweenSubjectsCombinationKey({ version: 'treatment' }, ['version']);
     await storageEngine.updateStage(studyId, 'LIMITED', {
       maxParticipants: 4,
-      desiredParticipantsByCombination: { [controlKey]: 1, [treatmentKey]: 3 },
+      participantAssignmentMode: 'manual',
+      manualDesiredParticipantsByCombination: { [controlKey]: 1, [treatmentKey]: 3 },
     });
 
     const assignParticipants = async (remaining: number): Promise<string[]> => {
@@ -118,6 +135,53 @@ describe('stage capacity', () => {
 
     expect(assignedVersions.filter((version) => version === 'control')).toHaveLength(1);
     expect(assignedVersions.filter((version) => version === 'treatment')).toHaveLength(3);
+  });
+
+  test('does not apply capacity limits while data collection is disabled', async () => {
+    await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
+    const controlKey = getBetweenSubjectsCombinationKey({ version: 'control' }, ['version']);
+    const treatmentKey = getBetweenSubjectsCombinationKey({ version: 'treatment' }, ['version']);
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      maxParticipants: 2,
+      participantAssignmentMode: 'manual',
+      manualDesiredParticipantsByCombination: { [controlKey]: 1, [treatmentKey]: 1 },
+    });
+
+    await storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata, 'collected-one');
+    await storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata, 'collected-two');
+    await storageEngine.setMode(studyId, 'dataCollectionEnabled', false);
+
+    const previewParticipant = await storageEngine.initializeParticipantSession(
+      {},
+      betweenSubjectsConfig,
+      metadata,
+      'preview-participant',
+    );
+
+    expect(previewParticipant.sequence).toBeDefined();
+    expect(await storageEngine.getAllSequenceAssignments(studyId)).toHaveLength(2);
+  });
+
+  test('retains manual allocation targets while even allocation is active', async () => {
+    await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
+    const controlKey = getBetweenSubjectsCombinationKey({ version: 'control' }, ['version']);
+    const treatmentKey = getBetweenSubjectsCombinationKey({ version: 'treatment' }, ['version']);
+    const manualTargets = { [controlKey]: 1, [treatmentKey]: 3 };
+
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      maxParticipants: 4,
+      participantAssignmentMode: 'manual',
+      manualDesiredParticipantsByCombination: manualTargets,
+    });
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      participantAssignmentMode: 'even',
+    });
+
+    expect((await storageEngine.getStageData(studyId)).allStages).toContainEqual(expect.objectContaining({
+      stageName: 'LIMITED',
+      participantAssignmentMode: 'even',
+      manualDesiredParticipantsByCombination: manualTargets,
+    }));
   });
 
   test('explains when remaining capacity is only in disabled combinations', async () => {

--- a/src/storage/engines/tests/stageCapacity.spec.ts
+++ b/src/storage/engines/tests/stageCapacity.spec.ts
@@ -1,0 +1,112 @@
+import {
+  afterEach, beforeEach, describe, expect, test,
+} from 'vitest';
+import testConfigSimple from '../../tests/testConfigSimple.json';
+import { StudyConfig } from '../../../parser/types';
+import { ParticipantMetadata } from '../../../store/types';
+import { generateSequenceArray } from '../../../utils/handleRandomSequences';
+import { LocalStorageEngine } from '../LocalStorageEngine';
+import {
+  getBetweenSubjectsCombinationKey, getStageParticipantCounts, StageCapacityExceededError, StageNoAvailableConditionsError, StorageEngine, type SequenceAssignment,
+} from '../types';
+
+const studyId = 'stage-capacity-test';
+const config = testConfigSimple as StudyConfig;
+const betweenSubjectsConfig: StudyConfig = {
+  ...config,
+  uiConfig: { ...config.uiConfig, numSequences: 10 },
+  factors: { version: ['control', 'treatment'] },
+  betweenSubjects: ['version'],
+};
+const metadata: ParticipantMetadata = {
+  userAgent: 'test-user-agent',
+  resolution: { width: 1920, height: 1080 },
+  language: 'en-US',
+  ip: '127.0.0.1',
+};
+
+describe('stage capacity', () => {
+  let storageEngine: StorageEngine;
+
+  beforeEach(async () => {
+    storageEngine = new LocalStorageEngine(true);
+    await storageEngine.connect();
+    await storageEngine.initializeStudyDb(studyId);
+    await storageEngine.setSequenceArray(await generateSequenceArray(config));
+    await storageEngine.setCurrentStage(studyId, 'LIMITED', '#00AAFF', 1);
+  });
+
+  afterEach(async () => {
+    // @ts-expect-error Protected test-only cleanup.
+    await storageEngine._testingReset(studyId);
+  });
+
+  test('counts completed and in-progress participants but excludes rejected participants', () => {
+    expect(getStageParticipantCounts([
+      { stage: 'LIMITED', rejected: false },
+      { stage: 'LIMITED', rejected: false },
+      { stage: 'LIMITED', rejected: true },
+      { stage: 'OTHER', rejected: false },
+    ] as SequenceAssignment[])).toEqual({ LIMITED: 2, OTHER: 1 });
+  });
+
+  test('prevents a new participant from entering a full stage and allows replacement after rejection', async () => {
+    const firstParticipant = await storageEngine.initializeParticipantSession({}, config, metadata);
+    await storageEngine.clearCurrentParticipantId();
+
+    await expect(storageEngine.initializeParticipantSession({}, config, metadata))
+      .rejects.toBeInstanceOf(StageCapacityExceededError);
+
+    const assignmentsBeforeReject = await storageEngine.getAllSequenceAssignments(studyId);
+    expect(assignmentsBeforeReject).toHaveLength(1);
+
+    await storageEngine.rejectParticipant(firstParticipant.participantId, 'Test rejection');
+    await storageEngine.clearCurrentParticipantId();
+    const replacementParticipant = await storageEngine.initializeParticipantSession({}, config, metadata);
+
+    expect(replacementParticipant.participantId).not.toBe(firstParticipant.participantId);
+    expect(getStageParticipantCounts(await storageEngine.getAllSequenceAssignments(studyId))).toEqual({ LIMITED: 1 });
+  });
+
+  test('assigns only enabled between-subjects combinations for the current stage', async () => {
+    await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      disabledBetweenSubjectsCombinations: [
+        getBetweenSubjectsCombinationKey({ version: 'control' }, ['version']),
+      ],
+    });
+
+    const participant = await storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata);
+
+    expect(participant.sequence.parameters?.version).toBe('treatment');
+  });
+
+  test('stops entry when every between-subjects combination is disabled', async () => {
+    await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      disabledBetweenSubjectsCombinations: ['control', 'treatment'].map((version) => (
+        getBetweenSubjectsCombinationKey({ version }, ['version'])
+      )),
+    });
+
+    await expect(storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata))
+      .rejects.toBeInstanceOf(StageNoAvailableConditionsError);
+    expect(await storageEngine.getAllSequenceAssignments(studyId)).toHaveLength(0);
+  });
+
+  test('stores and clears manual desired participant counts for a combination', async () => {
+    const combinationKey = getBetweenSubjectsCombinationKey({ version: 'treatment' }, ['version']);
+
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      desiredParticipantsByCombination: { [combinationKey]: 12 },
+    });
+    expect((await storageEngine.getStageData(studyId)).allStages[1])
+      .toMatchObject({ desiredParticipantsByCombination: { [combinationKey]: 12 } });
+
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      desiredParticipantsByCombination: null,
+    });
+    expect((await storageEngine.getStageData(studyId)).allStages[1])
+      .not.toHaveProperty('desiredParticipantsByCombination');
+  });
+});

--- a/src/storage/engines/tests/stageCapacity.spec.ts
+++ b/src/storage/engines/tests/stageCapacity.spec.ts
@@ -7,7 +7,7 @@ import { ParticipantMetadata } from '../../../store/types';
 import { generateSequenceArray } from '../../../utils/handleRandomSequences';
 import { LocalStorageEngine } from '../LocalStorageEngine';
 import {
-  getBetweenSubjectsCombinationKey, getStageParticipantCounts, StageCapacityExceededError, StageNoAvailableConditionsError, StorageEngine, type SequenceAssignment,
+  getBetweenSubjectsCombinationKey, getStageParticipantCounts, StageCapacityExceededError, StageNoAvailableConditionsError, StageOnlyDisabledConditionsHaveCapacityError, StorageEngine, type SequenceAssignment,
 } from '../types';
 
 const studyId = 'stage-capacity-test';
@@ -92,6 +92,50 @@ describe('stage capacity', () => {
     await expect(storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata))
       .rejects.toBeInstanceOf(StageNoAvailableConditionsError);
     expect(await storageEngine.getAllSequenceAssignments(studyId)).toHaveLength(0);
+  });
+
+  test('does not assign more participants to a combination than its desired count', async () => {
+    await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
+    const controlKey = getBetweenSubjectsCombinationKey({ version: 'control' }, ['version']);
+    const treatmentKey = getBetweenSubjectsCombinationKey({ version: 'treatment' }, ['version']);
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      maxParticipants: 4,
+      desiredParticipantsByCombination: { [controlKey]: 1, [treatmentKey]: 3 },
+    });
+
+    const assignParticipants = async (remaining: number): Promise<string[]> => {
+      if (remaining === 0) {
+        return [];
+      }
+      const participant = await storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata);
+      await storageEngine.clearCurrentParticipantId();
+      return [
+        String(participant.sequence.parameters?.version),
+        ...await assignParticipants(remaining - 1),
+      ];
+    };
+    const assignedVersions = await assignParticipants(4);
+
+    expect(assignedVersions.filter((version) => version === 'control')).toHaveLength(1);
+    expect(assignedVersions.filter((version) => version === 'treatment')).toHaveLength(3);
+  });
+
+  test('explains when remaining capacity is only in disabled combinations', async () => {
+    await storageEngine.setSequenceArray(await generateSequenceArray(betweenSubjectsConfig));
+    const controlKey = getBetweenSubjectsCombinationKey({ version: 'control' }, ['version']);
+    const treatmentKey = getBetweenSubjectsCombinationKey({ version: 'treatment' }, ['version']);
+    await storageEngine.updateStage(studyId, 'LIMITED', {
+      maxParticipants: 2,
+      desiredParticipantsByCombination: { [controlKey]: 1, [treatmentKey]: 1 },
+      disabledBetweenSubjectsCombinations: [controlKey],
+    });
+
+    const participant = await storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata);
+    expect(participant.sequence.parameters?.version).toBe('treatment');
+    await storageEngine.clearCurrentParticipantId();
+
+    await expect(storageEngine.initializeParticipantSession({}, betweenSubjectsConfig, metadata))
+      .rejects.toBeInstanceOf(StageOnlyDisabledConditionsHaveCapacityError);
   });
 
   test('stores and clears manual desired participant counts for a combination', async () => {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -46,6 +46,7 @@ export type SequenceAssignment = {
   isDynamic: boolean; // Whether the study contains dynamic blocks
   stage: string; // The stage of the participant in the study
   conditions?: string[]; // The study condition(s) assigned to this participant.
+  betweenSubjectsCombinationKey?: string; // The between-subjects combination assigned to this participant.
 };
 
 export type REVISIT_MODE = 'dataCollectionEnabled' | 'developmentModeEnabled' | 'dataSharingEnabled';
@@ -88,6 +89,13 @@ export class StageNoAvailableConditionsError extends Error {
   constructor(public readonly stageName: string) {
     super(`The ${stageName} stage has no enabled between-subjects conditions`);
     this.name = 'StageNoAvailableConditionsError';
+  }
+}
+
+export class StageOnlyDisabledConditionsHaveCapacityError extends Error {
+  constructor(public readonly stageName: string) {
+    super(`The ${stageName} stage only has capacity in disabled between-subjects conditions`);
+    this.name = 'StageOnlyDisabledConditionsHaveCapacityError';
   }
 }
 
@@ -137,6 +145,39 @@ export function isSequenceEnabledForStage(
   return !disabledCombinations.includes(
     getBetweenSubjectsCombinationKey(sequence.parameters, betweenSubjects),
   );
+}
+
+function getDesiredParticipantCountsByCombination(
+  stage: StageInfo,
+  sequenceArray: Sequence[],
+  betweenSubjects: string[],
+) {
+  if (stage.maxParticipants === undefined || betweenSubjects.length === 0) {
+    return undefined;
+  }
+
+  const combinationKeys = [...new Set(sequenceArray.map((sequence) => (
+    getBetweenSubjectsCombinationKey(sequence.parameters, betweenSubjects)
+  )))];
+  const manuallySpecifiedCounts = stage.desiredParticipantsByCombination || {};
+  const manualCount = combinationKeys.reduce(
+    (total, key) => total + (manuallySpecifiedCounts[key] ?? 0),
+    0,
+  );
+  const unspecifiedCombinationKeys = combinationKeys.filter((key) => !Object.hasOwn(manuallySpecifiedCounts, key));
+  const remainingCount = Math.max(stage.maxParticipants - manualCount, 0);
+  const countPerUnspecifiedCombination = unspecifiedCombinationKeys.length === 0
+    ? 0
+    : Math.floor(remainingCount / unspecifiedCombinationKeys.length);
+  const remainder = unspecifiedCombinationKeys.length === 0
+    ? 0
+    : remainingCount % unspecifiedCombinationKeys.length;
+
+  return Object.fromEntries(combinationKeys.map((key) => [
+    key,
+    manuallySpecifiedCounts[key]
+      ?? countPerUnspecifiedCombination + (unspecifiedCombinationKeys.indexOf(key) < remainder ? 1 : 0),
+  ]));
 }
 
 export type StorageObjectType = 'sequenceArray' | 'participantData' | 'config' | string;
@@ -1039,6 +1080,59 @@ export abstract class StorageEngine {
       throw new StageNoAvailableConditionsError(currentStage);
     }
 
+    let availableSequenceArray = enabledSequenceArray;
+    const betweenSubjects = config?.betweenSubjects || [];
+    const desiredParticipantCountsByCombination = currentStageInfo
+      ? getDesiredParticipantCountsByCombination(currentStageInfo, sequenceArray, betweenSubjects)
+      : undefined;
+    if (desiredParticipantCountsByCombination && currentStageInfo) {
+      const combinationCounts: Record<string, number> = {};
+      const assignmentsMissingCombinationKey = sequenceAssignments.filter((assignment) => (
+        !assignment.rejected
+        && assignment.stage === currentStage
+        && assignment.betweenSubjectsCombinationKey === undefined
+      ));
+
+      sequenceAssignments.forEach((assignment) => {
+        if (!assignment.rejected && assignment.stage === currentStage && assignment.betweenSubjectsCombinationKey) {
+          combinationCounts[assignment.betweenSubjectsCombinationKey] = (
+            combinationCounts[assignment.betweenSubjectsCombinationKey] || 0
+          ) + 1;
+        }
+      });
+
+      const missingCombinationKeys = await Promise.all(assignmentsMissingCombinationKey.map(async (assignment) => {
+        const participant = await this._getFromStorage(
+          `participants/${assignment.participantId}`,
+          'participantData',
+        );
+        return isParticipantData(participant)
+          ? getBetweenSubjectsCombinationKey(participant.sequence.parameters, betweenSubjects)
+          : undefined;
+      }));
+      missingCombinationKeys.forEach((combinationKey) => {
+        if (combinationKey) {
+          combinationCounts[combinationKey] = (combinationCounts[combinationKey] || 0) + 1;
+        }
+      });
+
+      const hasRemainingCapacity = (sequence: Sequence) => {
+        const combinationKey = getBetweenSubjectsCombinationKey(sequence.parameters, betweenSubjects);
+        return (combinationCounts[combinationKey] || 0) < desiredParticipantCountsByCombination[combinationKey];
+      };
+      availableSequenceArray = enabledSequenceArray.filter(hasRemainingCapacity);
+      if (availableSequenceArray.length === 0) {
+        const hasCapacityInDisabledCondition = sequenceArray.some((sequence) => (
+          !isSequenceEnabledForStage(sequence, currentStageInfo, betweenSubjects)
+          && hasRemainingCapacity(sequence)
+        ));
+        if (hasCapacityInDisabledCondition) {
+          throw new StageOnlyDisabledConditionsHaveCapacityError(currentStage);
+        }
+        throw new StageCapacityExceededError(currentStage);
+      }
+    }
+
     // Find all rejected documents
     const rejectedDocs = sequenceAssignments
       .filter((doc) => doc.rejected && !doc.claimed);
@@ -1092,18 +1186,24 @@ export abstract class StorageEngine {
       (assignment) => !assignment.rejected && assignment.stage === currentStage,
     ).findIndex(
       (assignment) => assignment.participantId === this.currentParticipantId,
-    ) % enabledSequenceArray.length;
+    ) % availableSequenceArray.length;
     // If index = -1, we probably have data collection disabled. Give a random assignment.
     if (intentIndex === -1) {
       return {
-        currentRow: enabledSequenceArray[Math.floor(Math.random() * enabledSequenceArray.length)],
+        currentRow: availableSequenceArray[Math.floor(Math.random() * availableSequenceArray.length)],
         creationIndex: 1,
       };
     }
-    const currentRow = enabledSequenceArray[intentIndex];
+    const currentRow = availableSequenceArray[intentIndex];
 
     if (!currentRow) {
       throw new Error('Latin square is empty');
+    }
+
+    if (modes.dataCollectionEnabled && betweenSubjects.length > 0) {
+      await this._updateSequenceAssignmentFields(this.currentParticipantId, {
+        betweenSubjectsCombinationKey: getBetweenSubjectsCombinationKey(currentRow.parameters, betweenSubjects),
+      });
     }
 
     const creationSorted = sequenceAssignments.sort((a, b) => a.createdTime - b.createdTime);

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -74,8 +74,12 @@ export interface StageInfo {
   maxParticipants?: number;
   /** Disabled between-subjects condition keys. Undefined means every condition is enabled. */
   disabledBetweenSubjectsCombinations?: string[];
-  /** Optional manual target participant-count overrides for individual between-subjects conditions. */
+  /** Legacy manual target participant-count overrides for individual between-subjects conditions. */
   desiredParticipantsByCombination?: Record<string, number>;
+  /** The active participant allocation strategy. Stages created before this field existed infer manual mode from legacy overrides. */
+  participantAssignmentMode?: 'even' | 'manual';
+  /** Saved manual condition allocations, retained while the stage is using even allocation. */
+  manualDesiredParticipantsByCombination?: Record<string, number>;
 }
 
 export class StageCapacityExceededError extends Error {
@@ -159,7 +163,11 @@ function getDesiredParticipantCountsByCombination(
   const combinationKeys = [...new Set(sequenceArray.map((sequence) => (
     getBetweenSubjectsCombinationKey(sequence.parameters, betweenSubjects)
   )))];
-  const manuallySpecifiedCounts = stage.desiredParticipantsByCombination || {};
+  const participantAssignmentMode = stage.participantAssignmentMode
+    ?? (stage.desiredParticipantsByCombination ? 'manual' : 'even');
+  const manuallySpecifiedCounts = participantAssignmentMode === 'manual'
+    ? (stage.manualDesiredParticipantsByCombination ?? stage.desiredParticipantsByCombination ?? {})
+    : {};
   const manualCount = combinationKeys.reduce(
     (total, key) => total + (manuallySpecifiedCounts[key] ?? 0),
     0,
@@ -391,6 +399,11 @@ export abstract class StorageEngine {
   // Helper function to claim a sequence assignment of the given participant in the realtime database.
   protected abstract _claimSequenceAssignment(participantId: string, sequenceAssignment: SequenceAssignment): Promise<void>;
 
+  // Runs an operation while holding a distributed lock for this study. This is used for
+  // operations whose correctness depends on multiple reads and writes, such as assigning
+  // the final available participant slot or rejecting a participant with a pending save.
+  protected abstract _runWithLock<T>(lockKey: string, operation: () => Promise<T>): Promise<T>;
+
   // Sets up the study database (firestore, indexedDB, etc.) for the given studyId. Also sets the studyId in the storage engine.
   abstract initializeStudyDb(studyId: string): Promise<void>;
 
@@ -586,30 +599,32 @@ export abstract class StorageEngine {
     const write = async () => {
       this.participantDataWriteError = null;
       try {
-        // An admin can reject a participant in another browser while this
-        // client still has a debounced full-record write pending. Read the
-        // latest record immediately before writing so that stale snapshots
-        // cannot clear that rejection.
-        const latestParticipant = await this._getFromStorage(
-          `participants/${participantId}`,
-          'participantData',
-        );
-        if (isParticipantData(latestParticipant) && latestParticipant.rejected) {
-          if (participantId === this.currentParticipantId) {
-            this.participantData = latestParticipant;
-            this.clearPendingParticipantDataWriteTimer();
-            this.pendingParticipantDataWrite = undefined;
-            await this.cacheParticipantDataSnapshot(latestParticipant, participantId);
-            this.participantRejectionListeners.forEach((listener) => listener());
+        await this._runWithLock(`participant-${participantId}`, async () => {
+          // An admin can reject a participant in another browser while this
+          // client still has a debounced full-record write pending. The same
+          // lock is held by rejectParticipant, so the check and write cannot
+          // race with a rejection.
+          const latestParticipant = await this._getFromStorage(
+            `participants/${participantId}`,
+            'participantData',
+          );
+          if (isParticipantData(latestParticipant) && latestParticipant.rejected) {
+            if (participantId === this.currentParticipantId) {
+              this.participantData = latestParticipant;
+              this.clearPendingParticipantDataWriteTimer();
+              this.pendingParticipantDataWrite = undefined;
+              await this.cacheParticipantDataSnapshot(latestParticipant, participantId);
+              this.participantRejectionListeners.forEach((listener) => listener());
+            }
+            return;
           }
-          return;
-        }
 
-        await this._pushToStorage(
-          `participants/${participantId}`,
-          'participantData',
-          snapshot,
-        );
+          await this._pushToStorage(
+            `participants/${participantId}`,
+            'participantData',
+            snapshot,
+          );
+        });
 
         if (cache) {
           await this._cacheStorageObject(
@@ -879,6 +894,8 @@ export abstract class StorageEngine {
       maxParticipants?: number | null;
       disabledBetweenSubjectsCombinations?: string[] | null;
       desiredParticipantsByCombination?: Record<string, number> | null;
+      participantAssignmentMode?: 'even' | 'manual' | null;
+      manualDesiredParticipantsByCombination?: Record<string, number> | null;
     },
   ): Promise<void> {
     const modesDoc = await this.getModes(studyId);
@@ -890,6 +907,8 @@ export abstract class StorageEngine {
     const updatesMaxParticipants = Object.hasOwn(updates, 'maxParticipants');
     const updatesDisabledBetweenSubjectsCombinations = Object.hasOwn(updates, 'disabledBetweenSubjectsCombinations');
     const updatesDesiredParticipantsByCombination = Object.hasOwn(updates, 'desiredParticipantsByCombination');
+    const updatesParticipantAssignmentMode = Object.hasOwn(updates, 'participantAssignmentMode');
+    const updatesManualDesiredParticipantsByCombination = Object.hasOwn(updates, 'manualDesiredParticipantsByCombination');
     const updatedAllStages = modesDoc.stage.allStages.map(
       (stage) => {
         if (stage.stageName !== stageName) {
@@ -919,6 +938,20 @@ export abstract class StorageEngine {
             delete updatedStage.desiredParticipantsByCombination;
           } else {
             updatedStage.desiredParticipantsByCombination = updates.desiredParticipantsByCombination;
+          }
+        }
+        if (updatesParticipantAssignmentMode) {
+          if (updates.participantAssignmentMode === null) {
+            delete updatedStage.participantAssignmentMode;
+          } else {
+            updatedStage.participantAssignmentMode = updates.participantAssignmentMode;
+          }
+        }
+        if (updatesManualDesiredParticipantsByCombination) {
+          if (updates.manualDesiredParticipantsByCombination === null) {
+            delete updatedStage.manualDesiredParticipantsByCombination;
+          } else {
+            updatedStage.manualDesiredParticipantsByCombination = updates.manualDesiredParticipantsByCombination;
           }
         }
         return updatedStage;
@@ -1085,7 +1118,7 @@ export abstract class StorageEngine {
     const desiredParticipantCountsByCombination = currentStageInfo
       ? getDesiredParticipantCountsByCombination(currentStageInfo, sequenceArray, betweenSubjects)
       : undefined;
-    if (desiredParticipantCountsByCombination && currentStageInfo) {
+    if (modes.dataCollectionEnabled && desiredParticipantCountsByCombination && currentStageInfo) {
       const combinationCounts: Record<string, number> = {};
       const assignmentsMissingCombinationKey = sequenceAssignments.filter((assignment) => (
         !assignment.rejected
@@ -1244,9 +1277,6 @@ export abstract class StorageEngine {
       throw new Error('Study ID is not set');
     }
 
-    const { modes, stageData } = await this.getModesAndStageData(this.studyId);
-    const currentStage = stageData.currentStage.stageName;
-
     if (isParticipantData(participant)) {
       // Participant already initialized
       this.participantData = participant;
@@ -1254,45 +1284,72 @@ export abstract class StorageEngine {
       return participant;
     }
 
-    const currentStageInfo = stageData.allStages.find((stage) => stage.stageName === currentStage);
-    if (modes.dataCollectionEnabled && currentStageInfo?.maxParticipants !== undefined) {
-      const stageParticipantCounts = getStageParticipantCounts(await this.getAllSequenceAssignments(this.studyId));
-      if ((stageParticipantCounts[currentStage] || 0) >= currentStageInfo.maxParticipants) {
-        throw new StageCapacityExceededError(currentStage);
+    const initializedParticipant = await this._runWithLock<{
+      participant: ParticipantData;
+      modes: Record<REVISIT_MODE, boolean> | null;
+    }>('participant-assignment', async () => {
+      // Another session may have completed initialization while this session waited
+      // for the lock, so always read the participant record again inside it.
+      const existingParticipant = await this._getFromStorage(
+        `participants/${this.currentParticipantId}`,
+        'participantData',
+      );
+      if (isParticipantData(existingParticipant)) {
+        return { participant: existingParticipant, modes: null };
       }
+
+      const { modes, stageData } = await this.getModesAndStageData(this.studyId!);
+      const currentStage = stageData.currentStage.stageName;
+      const currentStageInfo = stageData.allStages.find((stage) => stage.stageName === currentStage);
+      if (modes.dataCollectionEnabled && currentStageInfo?.maxParticipants !== undefined) {
+        const stageParticipantCounts = getStageParticipantCounts(await this.getAllSequenceAssignments(this.studyId!));
+        if ((stageParticipantCounts[currentStage] || 0) >= currentStageInfo.maxParticipants) {
+          throw new StageCapacityExceededError(currentStage);
+        }
+      }
+
+      const participantConfigHash = await hash(JSON.stringify(config));
+      const parsedConditions = parseConditionParam(searchParams.condition);
+      const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
+      const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData }, config);
+      return {
+        participant: {
+          participantId: this.currentParticipantId!,
+          participantConfigHash,
+          sequence: currentRow,
+          participantIndex: creationIndex,
+          answers: {},
+          searchParams,
+          conditions,
+          metadata,
+          rejected: false as const,
+          participantTags: [],
+          stage: currentStage,
+          createdTime: Date.now(),
+        },
+        modes,
+      };
+    });
+
+    const participantData = initializedParticipant.participant;
+    this.participantData = participantData;
+
+    if (!initializedParticipant.modes) {
+      await this.cacheParticipantDataSnapshot(participantData, this.currentParticipantId);
+      return participantData;
     }
 
-    // Initialize participant
-    const participantConfigHash = await hash(JSON.stringify(config));
-    const parsedConditions = parseConditionParam(searchParams.condition);
-    const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
-    const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData }, config);
-    this.participantData = {
-      participantId: this.currentParticipantId,
-      participantConfigHash,
-      sequence: currentRow,
-      participantIndex: creationIndex,
-      answers: {},
-      searchParams,
-      conditions,
-      metadata,
-      rejected: false,
-      participantTags: [],
-      stage: currentStage,
-      createdTime: Date.now(),
-    };
-
-    if (modes.dataCollectionEnabled) {
+    if (initializedParticipant.modes.dataCollectionEnabled) {
       if (this.shouldDeferInitialParticipantDataPersistence()) {
         this.persistCurrentParticipantData({ immediate: true }).catch(() => undefined);
       } else {
         await this.persistCurrentParticipantData({ immediate: true });
       }
     } else {
-      await this.cacheParticipantDataSnapshot(this.participantData, this.currentParticipantId);
+      await this.cacheParticipantDataSnapshot(participantData, this.currentParticipantId);
     }
 
-    return this.participantData;
+    return participantData;
   }
 
   // Gets all participant IDs for the given studyId
@@ -1487,83 +1544,86 @@ export abstract class StorageEngine {
 
   // Rejects a participant with the given participantId and reason.
   async rejectParticipant(participantId: string, reason: string) {
-    const participant = participantId === this.currentParticipantId && this.participantData
-      ? this.participantData
-      : await this._getFromStorage(
-        `participants/${participantId}`,
-        'participantData',
-      );
-    let participantRecordUpdated = false;
-
-    try {
-      // If the user doesn't exist or is already rejected, return
-      if (
-        !participant
-        || !isParticipantData(participant)
-        || participant.rejected
-      ) {
-        return;
-      }
-
-      // Create a copy with rejected flag for storage write
-      // so that if the write fails, in-memory state is unchanged
-      const rejectedParticipant: ParticipantData = {
-        ...participant,
-        rejected: {
-          reason,
-          timestamp: new Date().getTime(),
-        },
-      };
-      // Push rejected copy to storage first
-      await this._pushToStorage(
-        `participants/${participantId}`,
-        'participantData',
-        rejectedParticipant,
-      );
-      participantRecordUpdated = true;
-
-      await this._rejectParticipantRealtime(participantId);
-
-      // Update in-memory state only after the participant record and
-      // sequence-assignment updates have both succeeded.
-      if (participantId === this.currentParticipantId && this.participantData) {
-        this.participantData = rejectedParticipant;
-      }
-    } catch (error) {
-      let realtimeRollbackError: unknown = null;
-      try {
-        if (participantRecordUpdated) {
-          const originalCurrentParticipantId = this.currentParticipantId;
-          if (!this.currentParticipantId) {
-            this.currentParticipantId = participantId;
-          }
-          try {
-            await this._undoRejectParticipantRealtime(participantId);
-          } finally {
-            this.currentParticipantId = originalCurrentParticipantId;
-          }
-        }
-      } catch (rollbackError) {
-        realtimeRollbackError = rollbackError;
-        console.warn('Error rolling back rejected participant realtime state:', rollbackError);
-      }
+    return await this._runWithLock(`participant-${participantId}`, async () => {
+      const participant = participantId === this.currentParticipantId && this.participantData
+        ? this.participantData
+        : await this._getFromStorage(
+          `participants/${participantId}`,
+          'participantData',
+        );
+      let participantRecordUpdated = false;
 
       try {
-        if (participantRecordUpdated && participant && isParticipantData(participant)) {
-          await this._pushToStorage(
-            `participants/${participantId}`,
-            'participantData',
-            participant,
-          );
+        // If the user doesn't exist or is already rejected, return
+        if (
+          !participant
+          || !isParticipantData(participant)
+          || participant.rejected
+        ) {
+          return;
         }
-      } catch (rollbackError) {
-        console.warn('Error rolling back rejected participant state:', rollbackError);
+
+        // Create a copy with rejected flag for storage write
+        // so that if the write fails, in-memory state is unchanged
+        const rejectedParticipant: ParticipantData = {
+          ...participant,
+          rejected: {
+            reason,
+            timestamp: new Date().getTime(),
+          },
+        };
+        // Push rejected copy to storage first
+        await this._pushToStorage(
+          `participants/${participantId}`,
+          'participantData',
+          rejectedParticipant,
+        );
+        participantRecordUpdated = true;
+
+        await this._rejectParticipantRealtime(participantId);
+
+        // Update in-memory state only after the participant record and
+        // sequence-assignment updates have both succeeded.
+        if (participantId === this.currentParticipantId && this.participantData) {
+          this.participantData = rejectedParticipant;
+        }
+      } catch (error) {
+        let realtimeRollbackError: unknown = null;
+        try {
+          if (participantRecordUpdated) {
+            const originalCurrentParticipantId = this.currentParticipantId;
+            if (!this.currentParticipantId) {
+              this.currentParticipantId = participantId;
+            }
+            try {
+              await this._undoRejectParticipantRealtime(participantId);
+            } finally {
+              this.currentParticipantId = originalCurrentParticipantId;
+            }
+          }
+        } catch (rollbackError) {
+          realtimeRollbackError = rollbackError;
+          console.warn('Error rolling back rejected participant realtime state:', rollbackError);
+        }
+
+        try {
+          if (participantRecordUpdated && participant && isParticipantData(participant)) {
+            await this._pushToStorage(
+              `participants/${participantId}`,
+              'participantData',
+              participant,
+            );
+          }
+        } catch (rollbackError) {
+          console.warn('Error rolling back rejected participant state:', rollbackError);
+        }
+        if (realtimeRollbackError) {
+          console.warn('Participant rejection rollback completed with realtime inconsistencies.');
+        }
+        console.warn('Error rejecting participant:', error);
+        throw normalizeError(error);
       }
-      if (realtimeRollbackError) {
-        console.warn('Participant rejection rollback completed with realtime inconsistencies.');
-      }
-      console.warn('Error rejecting participant:', error);
-    }
+    });
   }
 
   // Rejects the current participant with the given reason.

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -2,6 +2,7 @@ import localforage from 'localforage';
 import throttle from 'lodash.throttle';
 import { v4 as uuidv4 } from 'uuid';
 import { StudyConfig } from '../../parser/types';
+import { DISTINCT_COLOR_PALETTE } from '../../utils/colors';
 import { ParticipantMetadata, Sequence, StoredProvenance } from '../../store/types';
 import { ParticipantData, ParticipantDataWithStatus } from '../types';
 import { hash, isParticipantData } from './utils/storageEngineHelpers';
@@ -68,6 +69,26 @@ export function cleanupModes(modes: Record<string, boolean>): Record<REVISIT_MOD
 export interface StageInfo {
   stageName: string;
   color: string;
+  /** Maximum number of non-rejected participants allowed in this stage. Undefined means unlimited. */
+  maxParticipants?: number;
+  /** Disabled between-subjects condition keys. Undefined means every condition is enabled. */
+  disabledBetweenSubjectsCombinations?: string[];
+  /** Optional manual target participant-count overrides for individual between-subjects conditions. */
+  desiredParticipantsByCombination?: Record<string, number>;
+}
+
+export class StageCapacityExceededError extends Error {
+  constructor(public readonly stageName: string) {
+    super(`The ${stageName} stage has reached its participant limit`);
+    this.name = 'StageCapacityExceededError';
+  }
+}
+
+export class StageNoAvailableConditionsError extends Error {
+  constructor(public readonly stageName: string) {
+    super(`The ${stageName} stage has no enabled between-subjects conditions`);
+    this.name = 'StageNoAvailableConditionsError';
+  }
 }
 
 interface StageData {
@@ -85,7 +106,38 @@ export interface ConditionData {
   conditionCounts: Record<string, number>;
 }
 
-const defaultStageColor = '#F05A30';
+const defaultStageColor = DISTINCT_COLOR_PALETTE[0];
+
+export function getStageParticipantCounts(sequenceAssignments: SequenceAssignment[]) {
+  return sequenceAssignments.reduce<Record<string, number>>((counts, assignment) => {
+    if (!assignment.rejected) {
+      counts[assignment.stage] = (counts[assignment.stage] || 0) + 1;
+    }
+    return counts;
+  }, {});
+}
+
+export function getBetweenSubjectsCombinationKey(
+  parameters: Record<string, unknown> | undefined,
+  factorNames: string[],
+) {
+  return JSON.stringify(factorNames.map((factorName) => [factorName, parameters?.[factorName]]));
+}
+
+export function isSequenceEnabledForStage(
+  sequence: Sequence,
+  stage: StageInfo,
+  betweenSubjects: string[],
+) {
+  const disabledCombinations = stage.disabledBetweenSubjectsCombinations;
+  if (!disabledCombinations) {
+    return true;
+  }
+
+  return !disabledCombinations.includes(
+    getBetweenSubjectsCombinationKey(sequence.parameters, betweenSubjects),
+  );
+}
 
 export type StorageObjectType = 'sequenceArray' | 'participantData' | 'config' | string;
 export type StorageObject<T extends StorageObjectType> =
@@ -705,7 +757,12 @@ export abstract class StorageEngine {
   }
 
   // Setting current stage
-  async setCurrentStage(studyId: string, stageName: string, color: string = defaultStageColor): Promise<void> {
+  async setCurrentStage(
+    studyId: string,
+    stageName: string,
+    color: string = defaultStageColor,
+    maxParticipants?: number,
+  ): Promise<void> {
     const modesDoc = await this.getModes(studyId);
 
     // Initialize if doesn't exist or invalid
@@ -722,7 +779,11 @@ export abstract class StorageEngine {
     );
 
     if (existingStageIndex === -1) {
-      modesDoc.stage.allStages.push({ stageName, color });
+      modesDoc.stage.allStages.push({
+        stageName,
+        color,
+        ...(maxParticipants === undefined ? {} : { maxParticipants }),
+      });
     }
 
     modesDoc.stage.currentStage = { stageName, color };
@@ -737,18 +798,68 @@ export abstract class StorageEngine {
 
   // Updating stage color
   async updateStageColor(studyId: string, stageName: string, color: string): Promise<void> {
+    await this.updateStage(studyId, stageName, { color });
+  }
+
+  async updateStage(
+    studyId: string,
+    stageName: string,
+    updates: {
+      color?: string;
+      maxParticipants?: number | null;
+      disabledBetweenSubjectsCombinations?: string[] | null;
+      desiredParticipantsByCombination?: Record<string, number> | null;
+    },
+  ): Promise<void> {
     const modesDoc = await this.getModes(studyId);
 
     if (!modesDoc.stage) {
       throw new Error('Stage data not initialized');
     }
 
+    const updatesMaxParticipants = Object.hasOwn(updates, 'maxParticipants');
+    const updatesDisabledBetweenSubjectsCombinations = Object.hasOwn(updates, 'disabledBetweenSubjectsCombinations');
+    const updatesDesiredParticipantsByCombination = Object.hasOwn(updates, 'desiredParticipantsByCombination');
     const updatedAllStages = modesDoc.stage.allStages.map(
-      (s) => (s.stageName === stageName ? { ...s, color } : s),
+      (stage) => {
+        if (stage.stageName !== stageName) {
+          return stage;
+        }
+
+        const updatedStage = {
+          ...stage,
+          ...(updates.color === undefined ? {} : { color: updates.color }),
+        };
+        if (updatesMaxParticipants) {
+          if (updates.maxParticipants === null) {
+            delete updatedStage.maxParticipants;
+          } else {
+            updatedStage.maxParticipants = updates.maxParticipants;
+          }
+        }
+        if (updatesDisabledBetweenSubjectsCombinations) {
+          if (updates.disabledBetweenSubjectsCombinations === null) {
+            delete updatedStage.disabledBetweenSubjectsCombinations;
+          } else {
+            updatedStage.disabledBetweenSubjectsCombinations = updates.disabledBetweenSubjectsCombinations;
+          }
+        }
+        if (updatesDesiredParticipantsByCombination) {
+          if (updates.desiredParticipantsByCombination === null) {
+            delete updatedStage.desiredParticipantsByCombination;
+          } else {
+            updatedStage.desiredParticipantsByCombination = updates.desiredParticipantsByCombination;
+          }
+        }
+        return updatedStage;
+      },
     );
 
     const updatedCurrentStage = modesDoc.stage.currentStage.stageName === stageName
-      ? { ...modesDoc.stage.currentStage, color }
+      ? {
+        ...modesDoc.stage.currentStage,
+        ...(updates.color === undefined ? {} : { color: updates.color }),
+      }
       : modesDoc.stage.currentStage;
 
     const updatedStageData = {
@@ -867,7 +978,11 @@ export abstract class StorageEngine {
   // This function is one of the most critical functions in the storage engine.
   // It uses the notion of sequence intents and assignments to determine the current sequence for the participant.
   // It handles rejected participants and allows for reusing a rejected participant's sequence.
-  protected async _getSequence(conditions?: string[], bootstrapData?: ModesAndStageData) {
+  protected async _getSequence(
+    conditions?: string[],
+    bootstrapData?: ModesAndStageData,
+    config?: StudyConfig,
+  ) {
     if (!this.currentParticipantId) {
       throw new Error('Participant not initialized');
     }
@@ -878,6 +993,22 @@ export abstract class StorageEngine {
 
     const { modes, stageData } = bootstrapData ?? await this.getModesAndStageData(this.studyId);
     const currentStage = stageData.currentStage.stageName;
+    const sequenceArray = await this.getSequenceArray();
+    if (!sequenceArray) {
+      throw new Error('Latin square not initialized');
+    }
+
+    const currentStageInfo = stageData.allStages.find((stage) => stage.stageName === currentStage);
+    const enabledSequenceArray = currentStageInfo && config
+      ? sequenceArray.filter((sequence) => isSequenceEnabledForStage(
+        sequence,
+        currentStageInfo,
+        config.betweenSubjects || [],
+      ))
+      : sequenceArray;
+    if (enabledSequenceArray.length === 0) {
+      throw new StageNoAvailableConditionsError(currentStage);
+    }
 
     // Find all rejected documents
     const rejectedDocs = sequenceAssignments
@@ -927,27 +1058,20 @@ export abstract class StorageEngine {
     // Query all the intents to get a sequence and find our position in the queue
     sequenceAssignments = await this.getAllSequenceAssignments(this.studyId);
 
-    // Get the latin square
-    const sequenceArray = await this.getSequenceArray();
-    if (!sequenceArray) {
-      throw new Error('Latin square not initialized');
-    }
-
     // Get the current row
-    const intentIndex = sequenceAssignments.filter((assignment) => !assignment.rejected).findIndex(
+    const intentIndex = sequenceAssignments.filter(
+      (assignment) => !assignment.rejected && assignment.stage === currentStage,
+    ).findIndex(
       (assignment) => assignment.participantId === this.currentParticipantId,
-    ) % sequenceArray.length;
-    if (sequenceArray.length === 0) {
-      throw new Error('Something really bad happened with sequence assignment');
-    }
+    ) % enabledSequenceArray.length;
     // If index = -1, we probably have data collection disabled. Give a random assignment.
     if (intentIndex === -1) {
       return {
-        currentRow: sequenceArray[Math.floor(Math.random() * sequenceArray.length)],
+        currentRow: enabledSequenceArray[Math.floor(Math.random() * enabledSequenceArray.length)],
         creationIndex: 1,
       };
     }
-    const currentRow = sequenceArray[intentIndex];
+    const currentRow = enabledSequenceArray[intentIndex];
 
     if (!currentRow) {
       throw new Error('Latin square is empty');
@@ -1000,11 +1124,20 @@ export abstract class StorageEngine {
       await this.cacheParticipantDataSnapshot(participant, this.currentParticipantId);
       return participant;
     }
+
+    const currentStageInfo = stageData.allStages.find((stage) => stage.stageName === currentStage);
+    if (modes.dataCollectionEnabled && currentStageInfo?.maxParticipants !== undefined) {
+      const stageParticipantCounts = getStageParticipantCounts(await this.getAllSequenceAssignments(this.studyId));
+      if ((stageParticipantCounts[currentStage] || 0) >= currentStageInfo.maxParticipants) {
+        throw new StageCapacityExceededError(currentStage);
+      }
+    }
+
     // Initialize participant
     const participantConfigHash = await hash(JSON.stringify(config));
     const parsedConditions = parseConditionParam(searchParams.condition);
     const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
-    const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData });
+    const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData }, config);
     this.participantData = {
       participantId: this.currentParticipantId,
       participantConfigHash,

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -243,6 +243,8 @@ export abstract class StorageEngine {
 
   private participantDataWriteErrorListeners = new Set<(error: Error) => void>();
 
+  private participantRejectionListeners = new Set<() => void>();
+
   private pendingAssetUploads = new Map<string, Promise<void>>();
 
   private pendingAssetOperations = new Set<Promise<unknown>>();
@@ -277,6 +279,14 @@ export abstract class StorageEngine {
 
     return () => {
       this.participantDataWriteErrorListeners.delete(callback);
+    };
+  }
+
+  subscribeToCurrentParticipantRejection(callback: () => void) {
+    this.participantRejectionListeners.add(callback);
+
+    return () => {
+      this.participantRejectionListeners.delete(callback);
     };
   }
 
@@ -535,6 +545,25 @@ export abstract class StorageEngine {
     const write = async () => {
       this.participantDataWriteError = null;
       try {
+        // An admin can reject a participant in another browser while this
+        // client still has a debounced full-record write pending. Read the
+        // latest record immediately before writing so that stale snapshots
+        // cannot clear that rejection.
+        const latestParticipant = await this._getFromStorage(
+          `participants/${participantId}`,
+          'participantData',
+        );
+        if (isParticipantData(latestParticipant) && latestParticipant.rejected) {
+          if (participantId === this.currentParticipantId) {
+            this.participantData = latestParticipant;
+            this.clearPendingParticipantDataWriteTimer();
+            this.pendingParticipantDataWrite = undefined;
+            await this.cacheParticipantDataSnapshot(latestParticipant, participantId);
+            this.participantRejectionListeners.forEach((listener) => listener());
+          }
+          return;
+        }
+
         await this._pushToStorage(
           `participants/${participantId}`,
           'participantData',

--- a/src/storage/tests/edgeCases.spec.ts
+++ b/src/storage/tests/edgeCases.spec.ts
@@ -967,6 +967,26 @@ describe('StorageEngine edge cases', () => {
   // ── Reject / undo-reject cycles ──────────────────────────────────────────
 
   describe('reject and undo-reject cycles', () => {
+    test('a pending answer write cannot undo a rejection', async () => {
+      const session = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+      await storageEngine.saveAnswers({
+        trial_0: makeStoredAnswer({
+          componentName: 'trial', identifier: 'trial_0', answer: { user: 'participant' }, endTime: 100,
+        }),
+      });
+
+      const onRejected = vi.fn();
+      const unsubscribe = storageEngine.subscribeToCurrentParticipantRejection(onRejected);
+      await storageEngine.rejectParticipant(session.participantId, 'Timed out');
+      await flushThrottle(storageEngine);
+      unsubscribe();
+
+      const participant = await storageEngine.getParticipantData(session.participantId);
+      expect(participant!.rejected).not.toBe(false);
+      expect(participant!.answers.trial_0.answer).toEqual({ user: 'participant' });
+      expect(onRejected).toHaveBeenCalledOnce();
+    });
+
     test('undo-reject restores participant and preserves all answers', async () => {
       const session = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
 

--- a/src/storage/tests/rejectParticipantConsistency.spec.ts
+++ b/src/storage/tests/rejectParticipantConsistency.spec.ts
@@ -116,15 +116,13 @@ describe('rejectParticipant — local storage baseline behavior', () => {
     // @ts-expect-error accessing protected method
     storageEngine._pushToStorage = vi.fn().mockRejectedValue(new Error('Storage write failed'));
 
-    // Reject should catch the error and not throw
-    await storageEngine.rejectParticipant(session.participantId, 'Test rejection');
+    await expect(storageEngine.rejectParticipant(session.participantId, 'Test rejection'))
+      .rejects.toThrow('Storage write failed');
 
     // Restore the mock
     // @ts-expect-error accessing protected method
     storageEngine._pushToStorage = originalPushToStorage;
 
-    // BUG: The in-memory participantData IS corrupted (rejected is set)
-    // This test should FAIL until the bug is fixed
     // @ts-expect-error accessing protected property
     expect(storageEngine.participantData?.rejected).toEqual(originalRejected);
     // @ts-expect-error accessing protected property
@@ -147,7 +145,8 @@ describe('rejectParticipant — local storage baseline behavior', () => {
     // @ts-expect-error accessing protected method
     storageEngine._rejectParticipantRealtime = vi.fn().mockRejectedValue(new Error('Realtime rejection failed'));
 
-    await storageEngine.rejectParticipant(session.participantId, 'Test rejection');
+    await expect(storageEngine.rejectParticipant(session.participantId, 'Test rejection'))
+      .rejects.toThrow('Realtime rejection failed');
 
     // @ts-expect-error accessing protected method
     storageEngine._rejectParticipantRealtime = originalRejectParticipantRealtime;
@@ -169,7 +168,8 @@ describe('rejectParticipant — local storage baseline behavior', () => {
       throw new Error('Realtime rejection failed after mutation');
     });
 
-    await storageEngine.rejectParticipant(session.participantId, 'Test rejection');
+    await expect(storageEngine.rejectParticipant(session.participantId, 'Test rejection'))
+      .rejects.toThrow('Realtime rejection failed after mutation');
 
     // @ts-expect-error accessing protected method
     storageEngine._rejectParticipantRealtime = originalRejectParticipantRealtime;

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -7,6 +7,7 @@ import { useStorageEngine } from '../../storage/storageEngineHooks';
 import { useRecordingConfig } from './useRecordingConfig';
 import { useStoredAnswer } from './useStoredAnswer';
 import { useIsAnalysis } from './useIsAnalysis';
+import { useIsStartupPreview } from '../../components/StartupPreviewContext';
 import {
   getRmsLevel,
   isSpeakingAtLevel,
@@ -20,6 +21,7 @@ import {
  * When just audio recording is enabled throughout the study, recording is initiated on each screen separately.
  */
 export function useRecording() {
+  const isStartupPreview = useIsStartupPreview();
   const studyConfig = useStudyConfig();
 
   const { recordScreenFPS, recordAudio } = studyConfig.uiConfig;
@@ -125,6 +127,10 @@ export function useRecording() {
 
   // Start screen recording
   const startScreenRecording = useCallback((trialName: string) => {
+    if (isStartupPreview) {
+      return;
+    }
+
     // check if the current stimulus needs combined or just screen
 
     if (!(currentComponentHasAudioRecording || currentComponentHasScreenRecording)) {
@@ -214,7 +220,7 @@ export function useRecording() {
 
     mediaRecorder.start(1000); // 1s chunks
     audioRecorder?.start(1000);
-  }, [currentComponentHasAudioRecording, currentComponentHasScreenRecording, storageEngine, isMuted]);
+  }, [currentComponentHasAudioRecording, currentComponentHasScreenRecording, isStartupPreview, storageEngine, isMuted]);
 
   // Stop screen recording. This does not stop screen capture.
   const stopScreenRecording = useCallback(() => {
@@ -306,7 +312,7 @@ export function useRecording() {
       return;
     }
 
-    if (!studyConfig || studyHasScreenRecording || !studyHasAudioRecording || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
+    if (isStartupPreview || !studyConfig || studyHasScreenRecording || !studyHasAudioRecording || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
       return;
     }
 
@@ -321,11 +327,11 @@ export function useRecording() {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentComponent, identifier, currentComponentHasAudioRecording]);
+  }, [currentComponent, identifier, currentComponentHasAudioRecording, isStartupPreview]);
 
   // For study with screen recording
   useEffect(() => {
-    if (!studyConfig || !(studyHasScreenRecording) || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
+    if (isStartupPreview || !studyConfig || !(studyHasScreenRecording) || !storageEngine || (status && status.endTime > 0) || isAnalysis) {
       return;
     }
 
@@ -344,10 +350,14 @@ export function useRecording() {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentComponent, identifier, currentComponentHasAudioRecording, currentComponentHasScreenRecording, isMediaCapturing]);
+  }, [currentComponent, identifier, currentComponentHasAudioRecording, currentComponentHasScreenRecording, isMediaCapturing, isStartupPreview]);
 
   // Start screen capture. This does not begin recording.
   const startScreenCapture = useCallback(() => {
+    if (isStartupPreview) {
+      return;
+    }
+
     const captureFn = async () => {
       document.title = `RECORD THIS TAB: ${pageTitle}`;
 
@@ -418,7 +428,7 @@ export function useRecording() {
       }
     };
     captureFn();
-  }, [pageTitle, recordAudio, recordScreenFPS, stopScreenCapture, studyHasAudioRecording, studyHasScreenRecording]);
+  }, [isStartupPreview, pageTitle, recordAudio, recordScreenFPS, stopScreenCapture, studyHasAudioRecording, studyHasScreenRecording]);
 
   useEffect(() => {
     audioMediaStream.current?.getAudioTracks().forEach((track) => {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -75,6 +75,10 @@ class TestStorageEngine extends StorageEngine {
 
   protected _claimSequenceAssignment = vi.fn(async () => { });
 
+  protected async _runWithLock<T>(_lockKey: string, operation: () => Promise<T>) {
+    return await operation();
+  }
+
   protected _setModesDocument = vi.fn(async () => { });
 
   protected _getAudioUrl = vi.fn(async () => null);

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,22 @@
+export const DISTINCT_COLOR_PALETTE = [
+  '#F35C34', '#5CC8E7', '#2F853F', '#EF9A8B', '#8F62FF',
+  '#FFBFEC', '#007D92', '#A17854', '#9FED9C', '#8D19E6',
+];
+
+function mixWithWhite(color: string, whiteAmount: number): string {
+  const colorValue = color.slice(1);
+  const channels = [0, 2, 4].map((start) => {
+    const channel = Number.parseInt(colorValue.slice(start, start + 2), 16);
+    return Math.round(channel + ((255 - channel) * whiteAmount));
+  });
+
+  return `#${channels.map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
+}
+
+export function getDistinctColorShade(colorIndex: number, shadeIndex: number, shadeCount: number): string {
+  const baseColor = DISTINCT_COLOR_PALETTE[colorIndex % DISTINCT_COLOR_PALETTE.length];
+  const normalizedIndex = shadeCount <= 1 ? 0.5 : shadeIndex / (shadeCount - 1);
+  const whiteAmount = 0.82 - (normalizedIndex * 0.37);
+
+  return mixWithWhite(baseColor, whiteAmount);
+}

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,3 +1,4 @@
+/** Canonical ReVISit palette for distinct categorical colors across the application. */
 export const DISTINCT_COLOR_PALETTE = [
   '#F35C34', '#5CC8E7', '#2F853F', '#EF9A8B', '#8F62FF',
   '#FFBFEC', '#007D92', '#A17854', '#9FED9C', '#8D19E6',

--- a/src/utils/getStaticFirstComponent.ts
+++ b/src/utils/getStaticFirstComponent.ts
@@ -53,6 +53,13 @@ function getFirstComponentName(block: unknown): string | null {
  * replaces the preview, so no participant input can be lost.
  */
 export function getStaticFirstComponent(studyConfig: StudyConfig): StaticFirstComponentPreview | null {
+  // Assignment can materialize a different config for each between-subjects
+  // condition. Until that assignment exists, even an otherwise fixed first
+  // component is not guaranteed to be the component the participant receives.
+  if ((studyConfig.betweenSubjects?.length ?? 0) > 0) {
+    return null;
+  }
+
   const componentName = getFirstComponentName(studyConfig.sequence);
   if (componentName === null) {
     return null;

--- a/src/utils/getStaticFirstComponent.ts
+++ b/src/utils/getStaticFirstComponent.ts
@@ -1,0 +1,68 @@
+import type {
+  ComponentBlock,
+  ImageComponent,
+  MarkdownComponent,
+  StudyConfig,
+} from '../parser/types';
+import { isFactorPlanBlock, isFactorRuntimePlanBlock } from '../parser/utils';
+import { getComponent } from './handleComponentInheritance';
+
+export type StaticFirstComponent = MarkdownComponent | ImageComponent;
+export type StaticFirstComponentPreview = {
+  componentName: string;
+  component: StaticFirstComponent;
+};
+
+function hasTemplateSyntax(value: string) {
+  return value.includes('{{') || value.includes('}}');
+}
+
+function isFixedBlock(value: unknown): value is ComponentBlock {
+  if (typeof value !== 'object' || value === null
+    || isFactorPlanBlock(value) || isFactorRuntimePlanBlock(value)) {
+    return false;
+  }
+
+  const block = value as Partial<ComponentBlock> & { type?: string };
+  return block.type !== 'factor'
+    && block.order === 'fixed'
+    && Array.isArray(block.components)
+    && block.numSamples === undefined
+    && block.conditional !== true
+    && (block.interruptions === undefined || block.interruptions.length === 0)
+    && (block.skip === undefined || block.skip.length === 0);
+}
+
+function getFirstComponentName(block: unknown): string | null {
+  if (!isFixedBlock(block)) {
+    return null;
+  }
+
+  const [firstComponent] = block.components;
+  if (typeof firstComponent === 'string') {
+    return firstComponent;
+  }
+
+  return firstComponent === undefined ? null : getFirstComponentName(firstComponent);
+}
+
+/**
+ * Returns a component that can be displayed while a new participant's sequence
+ * is assigned. This deliberately accepts only fixed Markdown or image
+ * components. Any responses are rendered disabled until the assigned session
+ * replaces the preview, so no participant input can be lost.
+ */
+export function getStaticFirstComponent(studyConfig: StudyConfig): StaticFirstComponentPreview | null {
+  const componentName = getFirstComponentName(studyConfig.sequence);
+  if (componentName === null) {
+    return null;
+  }
+
+  const component = getComponent(componentName, studyConfig);
+  if ((component?.type !== 'markdown' && component?.type !== 'image')
+    || hasTemplateSyntax(component.path)) {
+    return null;
+  }
+
+  return { componentName, component };
+}

--- a/src/utils/tests/getStaticFirstComponent.spec.ts
+++ b/src/utils/tests/getStaticFirstComponent.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import type { MarkdownComponent, StudyConfig } from '../../parser/types';
+import { makeStudyConfig } from '../../tests/utils';
+import { getStaticFirstComponent } from '../getStaticFirstComponent';
+
+const intro: MarkdownComponent = {
+  type: 'markdown',
+  path: 'test-study/assets/intro.md',
+  response: [],
+};
+
+function makeConfig(sequence: StudyConfig['sequence'], component = intro) {
+  return makeStudyConfig({
+    components: { intro: component },
+    sequence,
+  });
+}
+
+describe('getStaticFirstComponent', () => {
+  test('returns a static Markdown component at the start of fixed blocks', () => {
+    const config = makeConfig({
+      order: 'fixed',
+      components: [{ order: 'fixed', components: ['intro'] }],
+    });
+
+    expect(getStaticFirstComponent(config)).toEqual({ componentName: 'intro', component: intro });
+  });
+
+  test.each([
+    ['random order', { order: 'random', components: ['intro'] }],
+    ['a conditional block', { order: 'fixed', conditional: true, components: ['intro'] }],
+    ['a dynamic block', { order: 'dynamic', components: ['intro'] }],
+    ['a factor block', { type: 'factor', order: 'fixed', components: ['intro'] }],
+    ['an interruption', {
+      order: 'fixed',
+      components: ['intro'],
+      interruptions: [{ firstLocation: 1, spacing: 1, components: ['intro'] }],
+    }],
+  ])('does not preview a sequence with %s', (_, sequence) => {
+    expect(getStaticFirstComponent(makeConfig(sequence as StudyConfig['sequence']))).toBeNull();
+  });
+
+  test('previews a static component with responses, which are disabled until startup finishes', () => {
+    const component: MarkdownComponent = {
+      ...intro,
+      response: [{
+        id: 'answer', type: 'shortText', prompt: 'Answer', location: 'belowStimulus',
+      }],
+    };
+
+    expect(getStaticFirstComponent(makeConfig(
+      { order: 'fixed', components: ['intro'] },
+      component,
+    ))).toEqual({ componentName: 'intro', component });
+  });
+
+  test('does not preview a component that needs templating', () => {
+    expect(getStaticFirstComponent(makeConfig(
+      { order: 'fixed', components: ['intro'] },
+      { ...intro, path: 'test-study/assets/{{condition}}.md' },
+    ))).toBeNull();
+  });
+});

--- a/src/utils/tests/getStaticFirstComponent.spec.ts
+++ b/src/utils/tests/getStaticFirstComponent.spec.ts
@@ -60,4 +60,11 @@ describe('getStaticFirstComponent', () => {
       { ...intro, path: 'test-study/assets/{{condition}}.md' },
     ))).toBeNull();
   });
+
+  test('does not preview studies with between-subjects assignment', () => {
+    const config = makeConfig({ order: 'fixed', components: ['intro'] });
+    config.betweenSubjects = ['condition'];
+
+    expect(getStaticFirstComponent(config)).toBeNull();
+  });
 });

--- a/src/utils/useDisableBrowserBack.tsx
+++ b/src/utils/useDisableBrowserBack.tsx
@@ -5,14 +5,14 @@ import { useCurrentStep } from '../routes/utils';
 import { useIsAnalysis } from '../store/hooks/useIsAnalysis';
 
 // Show the error modal when the participant tries to use the browser back button
-export function useDisableBrowserBack() {
+export function useDisableBrowserBack(disabled = false) {
   const currentStep = useCurrentStep();
   const { setAlertModal } = useStoreActions();
   const storeDispatch = useStoreDispatch();
   const isAnalysis = useIsAnalysis();
 
   useEffect(() => {
-    if (import.meta.env.PROD && !isAnalysis) {
+    if (import.meta.env.PROD && !isAnalysis && !disabled) {
       window.history.pushState(null, '', window.location.href);
       window.onpopstate = () => {
         window.history.pushState(null, '', window.location.href);
@@ -25,5 +25,5 @@ export function useDisableBrowserBack() {
     return () => {
       window.onpopstate = null;
     };
-  }, [currentStep, isAnalysis, setAlertModal, storeDispatch]);
+  }, [currentStep, disabled, isAnalysis, setAlertModal, storeDispatch]);
 }


### PR DESCRIPTION
## Summary
- add admin timeout controls plus stage capacity and between-subject condition management
- prevent stale participant writes from clearing an admin rejection
- show a safe static first page only after it is proven assignment-independent
- keep preview mode free of recording, device, browser-history, route, and timer side effects

## Validation
- yarn typecheck
- yarn lint (pre-existing StepsPanel.tsx hook-dependency warning only)
- focused storage and static-preview Vitest tests

## Known limitation
Stage capacity is enforced for ordinary entry, but exact simultaneous final-slot admission still needs a backend-atomic reservation transaction/RPC that works for both Firebase and Supabase. This PR does not claim to solve that distributed race.

A broader Node-only edge-case run still has two existing Blob/FileReader environment failures in asset-upload tests.