### PR TITLE
Infer Pages base path from repository name

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-VITE_BASE_PATH="/study/"
 VITE_FIREBASE_CONFIG='
 {
   apiKey: "AIzaSyAm9QtUgx1lYPDeE0vKLN-lK17WfUGVkLo",
@@ -17,4 +16,3 @@ VITE_SUPABASE_URL="https://supabase.revisit.dev"
 VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzYwNjgwODAwLCJleHAiOjE5MTg0NDcyMDB9.IohiSvWUtjylJgn4gMrK3aYfnbz-hUmyb3h87DrQvTc"
 
 VITE_OPENAI_API_URL="https://apps.vdl.sci.utah.edu/openai-proxy" # Your proxy URL for OpenAI API requests
-

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Build main Firebase deployment
         run: yarn build
         env:
-          VITE_BASE_PATH: "/study/"
+          VITE_BASE_PATH: "/${{ github.event.repository.name }}/"
           VITE_STORAGE_ENGINE: firebase
 
       - uses: actions/checkout@v7
@@ -48,7 +48,7 @@ jobs:
       - name: Build main Supabase deployment
         run: yarn build
         env:
-          VITE_BASE_PATH: "/study/supabase/"
+          VITE_BASE_PATH: "/${{ github.event.repository.name }}/supabase/"
           VITE_STORAGE_ENGINE: supabase
 
       - name: Deploy current-only main Supabase snapshot
@@ -72,7 +72,7 @@ jobs:
       - name: Build dev Firebase deployment
         run: yarn build
         env:
-          VITE_BASE_PATH: "/study/dev/"
+          VITE_BASE_PATH: "/${{ github.event.repository.name }}/dev/"
           VITE_STORAGE_ENGINE: firebase
 
       - uses: actions/checkout@v7
@@ -87,7 +87,7 @@ jobs:
       - name: Build dev Supabase deployment
         run: yarn build
         env:
-          VITE_BASE_PATH: "/study/dev-supabase/"
+          VITE_BASE_PATH: "/${{ github.event.repository.name }}/dev-supabase/"
           VITE_STORAGE_ENGINE: supabase
 
       - name: Deploy current-only dev Supabase snapshot
@@ -125,7 +125,7 @@ jobs:
         run: VITE_STORAGE_ENGINE=$VITE_STORAGE_ENGINE VITE_BASE_PATH=$VITE_BASE_PATH yarn build
         env:
           VITE_STORAGE_ENGINE: ${{ vars.VITE_STORAGE_ENGINE }}
-          VITE_BASE_PATH: "/study/PR${{ github.event.number }}/"
+          VITE_BASE_PATH: "/${{ github.event.repository.name }}/PR${{ github.event.number }}/"
 
       - uses: actions/checkout@v7
         with:
@@ -143,4 +143,4 @@ jobs:
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
           id: deploy-preview
-          message: "A preview of ${{ github.event.after }} is uploaded and can be seen here:\n\n ✨ https://revisit.dev/study/PR${{ github.event.number }} ✨\n\nChanges may take a few minutes to propagate."
+          message: "A preview of ${{ github.event.after }} is uploaded and can be seen here:\n\n ✨ https://revisit.dev/${{ github.event.repository.name }}/PR${{ github.event.number }} ✨\n\nChanges may take a few minutes to propagate."

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN yarn build
 
-RUN node -e "const fs=require('node:fs');const key='VITE_BASE_PATH=';const lines=fs.readFileSync('.env','utf8').split(/\\r?\\n/);let v='';for(const line of lines){if(line.startsWith(key)) v=line.slice(key.length);}v=v.trim();if((v.startsWith('\"')&&v.endsWith('\"'))||(v.startsWith(\"'\")&&v.endsWith(\"'\"))){v=v.slice(1,-1);}if(!v){throw new Error('VITE_BASE_PATH must be defined in .env');}fs.writeFileSync('/tmp/base_path',v);"
+RUN node -e "const fs=require('node:fs');const key='VITE_BASE_PATH=';const lines=fs.readFileSync('.env','utf8').split(/\\r?\\n/);let v='';for(const line of lines){if(line.startsWith(key)) v=line.slice(key.length);}v=v.trim();if((v.startsWith('\"')&&v.endsWith('\"'))||(v.startsWith(\"'\")&&v.endsWith(\"'\"))){v=v.slice(1,-1);}if(!v){v='/';}fs.writeFileSync('/tmp/base_path',v);"
 
 FROM nginx:stable AS runtime
 

--- a/src/utils/Prefix.ts
+++ b/src/utils/Prefix.ts
@@ -1,3 +1,3 @@
 export const PREFIX = import.meta.env.PROD
-  ? import.meta.env.VITE_BASE_PATH
+  ? (import.meta.env.VITE_BASE_PATH || '/')
   : '/';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,11 @@ import react from '@vitejs/plugin-react-swc';
 import { coverageConfigDefaults } from 'vitest/config';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd());
 
   return {
-    base: env.VITE_BASE_PATH || '/',
+    base: command === 'build' ? (env.VITE_BASE_PATH || '/') : '/',
     plugins: [
       react({ devTarget: 'es2022' }),
     ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,11 @@ import react from '@vitejs/plugin-react-swc';
 import { coverageConfigDefaults } from 'vitest/config';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command, mode }) => {
+export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
 
   return {
-    base: command === 'build' ? env.VITE_BASE_PATH : '/',
+    base: env.VITE_BASE_PATH || '/',
     plugins: [
       react({ devTarget: 'es2022' }),
     ],


### PR DESCRIPTION
## Summary
- derive Firebase, Supabase, dev, and PR Pages base paths from `github.event.repository.name`
- default local builds and runtime prefixes to `/` when `VITE_BASE_PATH` is absent
- preserve root behavior during development even when a base path is supplied
- make Docker use `/` when the local base-path entry is absent
- preserve the existing `gh-pages` snapshot destinations and PR preview URL host
- remove the obsolete local `.env` base-path default

Fixes #1425

## Verification
- YAML parse and workflow path assertions passed
- `corepack yarn typecheck` passed
- `corepack yarn lint` passed
- local production build without `VITE_BASE_PATH` passed and generated root-relative asset URLs
- representative build with `VITE_BASE_PATH=/example-study/PR1234/` passed and generated correctly prefixed asset URLs
- Vite development config resolves `/` with a supplied base-path variable
- Docker base-path parser falls back to `/`
- `git diff --check` passed

A full Docker image build was not run because the local Docker daemon was unavailable.