### PR TITLE
Prevent recursive Pages redirect encoding

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -29,13 +29,16 @@
     var pathSegmentsToKeep = nestedDeploymentFound ? 2 : 1;
 
     var l = window.location;
-    l.replace(
-      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-      l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
-      l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-      (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-      l.hash
-    );
+    // Do not recursively encode a redirect when its deployment root is also missing.
+    if (l.search[1] !== '/') {
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    }
 
   </script>
 </head>


### PR DESCRIPTION
## Why

The GitHub Pages 404 shim can receive its own encoded redirect when a nested deployment root is missing. Each pass re-encodes the existing query, producing an indefinitely growing URL containing repeated `~and~` segments.

## Architecture

This is a one-file guard around the existing redirect. The shim still converts ordinary deep links into the `?/...` format consumed by `index.html`. If the query already begins with `?/`, the shim now recognizes that the redirect protocol has already run and does not call `location.replace` again.

This deliberately does not make a missing deployment available. It only prevents the 404 recovery mechanism from recursively redirecting when the expected deployment index is absent.

## User-facing impact

URLs for missing Pages deployments stop growing indefinitely. Working deployment deep links continue to preserve their route, query, and hash.

## Validation

- Focused redirect simulation — passed for a normal nested deep link and an already encoded retry.
- Headless Chromium Pages smoke — passed for a working nested deployment and a missing deployment; the missing root stopped after two document requests at the short `?/` URL.
- `corepack yarn build` — passed.
- `git diff --check origin/dev...HEAD` — passed.
- Independent adversarial review — no findings.

## Risk and rollout

No migration or configuration change is required. The main risk is misclassifying a query beginning with `?/`, but that prefix is already the redirect marker recognized by `index.html`. Normal Pages deployment is sufficient; fixing an absent deployment remains a separate operational task.
