### PR TITLE
Add shared pull request writing skill

### DIFF
--- a/.agents/skills/write-pull-request/SKILL.md
+++ b/.agents/skills/write-pull-request/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: write-pull-request
+description: Draft or revise repository-grounded pull request titles and descriptions for senior engineering review, using a fixed architecture-first template and natural human tone. Use when asked to write, create, or update PR copy; do not use for reviewing someone else's code.
+---
+
+# Write Pull Request
+
+Write the PR as the engineer responsible for the change. Optimize for a senior reviewer who needs to understand why the change exists, how responsibilities and data or control flow moved, and where the remaining risk is.
+
+## Ground the Draft
+
+Before writing:
+
+- Read the repository instructions and its existing PR conventions.
+- Compare the exact head against the intended base. Trace the changed runtime paths, tests, configuration, migrations, and generated artifacts that affect the final behavior.
+- For an existing PR, refresh its current head, base, title, body, and check state. Describe the final implementation, not abandoned iterations.
+- Separate verified local results, remote checks, pending checks, and work that was not run. Never infer a passing result from the presence of a test or workflow.
+- Do not invent motivation, tradeoffs, UI behavior, rollout needs, issue links, or validation. State an unknown plainly when the available evidence cannot resolve it.
+
+Draft locally unless the user has authorized creating or updating the remote PR. When creating a PR, open it as a draft unless the user explicitly asks for it to be ready for review or otherwise non-draft. When publishing is authorized, preserve unrelated PR metadata and read back the resulting title and body.
+
+## Title
+
+Follow an established repository convention when one exists. Otherwise, use a concise imperative title that names the outcome or system boundary, not the implementation chore. Avoid ticket prefixes unless the repository uses them.
+
+## Description Template
+
+Use these headings in this order:
+
+```markdown
+## Why
+
+<What problem or constraint prompted the change, why it matters now, and any relevant issue or operational context.>
+
+## Architecture
+
+<Explain the previous path and the new path. Describe ownership, boundaries, data or control flow, important invariants, and the reasoning behind material decisions. Call out compatibility constraints, deliberate non-goals, or meaningful tradeoffs when supported by evidence.>
+
+## User-facing impact
+
+<Briefly describe what a user will notice. Say "No user-facing changes." when accurate. Include screenshots only when they exist and materially help review.>
+
+## Validation
+
+- `<command or check>` — <result>
+- <manual or remote check> — <result or current status>
+
+## Risk and rollout
+
+<Identify concrete regression risks and any migration, configuration, deployment, observability, rollback, or sequencing requirements. If no special rollout is needed, say so and briefly explain the remaining risk.>
+```
+
+Keep all five sections. Give `Architecture` the most detail when the change is architectural. For a genuinely small or non-architectural change, say that directly instead of inflating it. Keep `User-facing impact` shorter than the architectural explanation unless the PR is primarily a UI change.
+
+## Tone and Style
+
+- Sound like a thoughtful engineer talking to peers: direct, specific, calm, and appropriately candid about uncertainty.
+- Prefer active voice, concrete verbs, and short paragraphs. Use bullets only for information that is easier to scan as a list.
+- Explain behavior and design decisions rather than narrating files or restating the diff. Mention identifiers and paths only when they help a reviewer follow the architecture.
+- Make causal links explicit: what changed, why this layer owns it, and what downstream behavior follows.
+- Use `we` only for an actual shared decision. Do not refer to yourself as an assistant or describe the writing process.
+- Avoid promotional or synthetic phrasing such as "This PR aims to," "leverages," "seamless," "robust," "comprehensive," "enhances," and "ensures" when a concrete statement would be clearer.
+- Avoid canned openings, repetitive sentence shapes, exhaustive file inventories, decorative emoji, and a concluding summary that merely repeats the body.
+- Calibrate confidence to the evidence. Prefer "The focused unit suite passed" over "This is fully tested," and identify anything pending or not run.
+
+Use the shortest description that gives a senior reviewer the architectural context, behavioral impact, validation evidence, and operational risk needed to make a decision.

--- a/.agents/skills/write-pull-request/agents/openai.yaml
+++ b/.agents/skills/write-pull-request/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write Pull Request"
+  short_description: "Write human, architecture-first PR descriptions"
+  default_prompt: "Use $write-pull-request to draft a repository-grounded title and PR description for my current branch."


### PR DESCRIPTION
## Why

Pull request descriptions in this repository do not currently have a shared writing contract. That leaves architectural context, validation evidence, and rollout risk dependent on the individual author even though those are the details senior reviewers need most.

This adds the pull request writing skill we developed as a repository-scoped workflow so Codex and other compatible agents can apply the same standard consistently.

## Architecture

The skill lives under `.agents/skills/write-pull-request`, alongside the repository's existing shared agent workflows. `SKILL.md` is the behavioral entrypoint: it requires the writer to inspect the exact head and base, trace the affected runtime paths, distinguish local validation from remote or pending checks, and describe the final implementation rather than abandoned iterations. Remote creation remains an explicit user-authorized action, and newly created PRs default to draft unless the user asks otherwise.

The description uses a fixed five-section structure: why, architecture, user-facing impact, validation, and risk and rollout. Architecture receives the most detail by default, including ownership, boundaries, data or control flow, invariants, compatibility constraints, and supported tradeoffs. The UI section stays intentionally brief unless the change is primarily user-facing.

`agents/openai.yaml` supplies the Codex-facing name, description, and invocation prompt. The package has no scripts, dependencies, or repository runtime integration; discovery and execution remain part of the existing agent skill mechanism.

## User-facing impact

No ReVISit application behavior changes. Contributors can invoke `$write-pull-request` to produce repository-grounded PR titles and descriptions with a consistent, human tone.

## Validation

- Skill frontmatter and `agents/openai.yaml` parsing — Passed
- Installed-skill comparison — Passed; the repository package matches the iterated personal skill exactly
- `git diff --check origin/dev...HEAD` — Passed
- Bundled `quick_validate.py` — Not run because its Python environment does not provide PyYAML; equivalent path, metadata, placeholder, and YAML checks passed manually
- Application tests — Not run; this change contains agent instructions and metadata only

## Risk and rollout

No application rollout or migration is required. The main risk is over-triggering the skill for general code-review requests; the discovery description explicitly limits it to writing, creating, or updating PR copy and excludes reviewing someone else's code. The skill will become available through the repository's existing `.agents/skills` discovery path after merge.
