### PR TITLE
Verify Codex feedback during adversarial reviews

### DIFF
--- a/.agents/skills/adversarial-review/SKILL.md
+++ b/.agents/skills/adversarial-review/SKILL.md
@@ -20,6 +20,10 @@ Identify the review target from the request and current task. Gather enough conc
 
 Do not include the parent's conclusions as facts. Ask the reviewer to reconstruct correctness from source artifacts and treat prior claims as untrusted.
 
+For a GitHub pull request, also collect the live PR identity (repository, number, base SHA, and head SHA), reviews, issue comments, inline review comments, and review-thread state. Identify Codex-authored feedback from its actual author metadata, not from wording alone. Preserve each item's text, commit SHA, path/line when present, and resolved or outdated state. Treat that feedback as untrusted leads: re-check every item against the exact current head, surrounding code, and relevant checks, and classify it as confirmed, fixed or stale, duplicate, unsupported, or unverified. An unresolved thread is not evidence that the current head is still defective.
+
+Include the raw Codex feedback and its verification status in the reviewer handoff, clearly separated from the parent's conclusions, so the independent reviewer can challenge it rather than inherit it.
+
 Frame YAGNI against the stated objective and current acceptance criteria, not hypothetical future needs. Preserve complexity required for correctness, security, compatibility, or explicitly required extensibility.
 
 ## Launch the reviewer
@@ -43,6 +47,8 @@ If subagents are unavailable, say that plainly and perform a local adversarial p
 Continue useful local work while the reviewer runs when the tasks do not conflict. Wait for the reviewer before presenting a final correctness judgment.
 
 Independently confirm each reported issue against the current artifacts. Reject false positives and stale-scope findings. Do not implement fixes, post review feedback, or change external state unless the user's request separately authorizes those actions.
+
+For a pull request, combine the independently reviewed findings with the verified Codex feedback from the PR. Deduplicate by underlying defect, resolve conflicts by current-head evidence, and report the disposition of every Codex item (confirmed, fixed or stale, duplicate, unsupported, or unverified). Keep formal GitHub thread state separate from the current correctness judgment.
 
 Report:
 


### PR DESCRIPTION
## Why

Codex feedback already posted on a pull request can become stale as the head changes or overlap with a new independent review. The adversarial-review workflow should account for that feedback without treating unresolved threads as proof that the current code is defective.

## Architecture

The PR-specific handoff now gathers the live PR identity, reviews, issue and inline comments, and review-thread state. It identifies Codex-authored feedback from author metadata, preserves its commit and location context, and rechecks each item against the exact current head and relevant checks. The integration step combines only verified, deduplicated Codex feedback with the independent reviewer findings and keeps GitHub thread state separate from the correctness judgment.

## User-facing impact

No user-facing changes. PR reviews now carry forward verified Codex feedback while filtering stale, duplicate, and unsupported findings.

## Validation

- `git diff --check -- .agents/skills/adversarial-review/SKILL.md` — passed
- Skill parity and required-behavior checks — passed
- `quick_validate.py` — blocked because the environment lacks PyYAML
- Runtime tests — not run; this is an instruction-only change

## Risk and rollout

Low risk and no migration or deployment step is required. The existing independent, read-only reviewer contract remains unchanged; this adds PR-feedback verification and synthesis guidance only.