### PR TITLE
Add lazy participant auto-timeouts

### DIFF
--- a/src/analysis/individualStudy/LiveMonitor/LiveMonitorView.tsx
+++ b/src/analysis/individualStudy/LiveMonitor/LiveMonitorView.tsx
@@ -1,5 +1,5 @@
 import {
-  Stack, Group, Card, Text, Title, Badge, ActionIcon, Center, Indicator, Tooltip, Button, Flex,
+  Stack, Group, Card, Text, Title, Badge, ActionIcon, Center, Indicator, Tooltip, Button, Flex, Switch, NumberInput, Modal,
 } from '@mantine/core';
 import {
   useMemo, useEffect, useState, useCallback,
@@ -11,12 +11,14 @@ import { StudyConfig } from '../../../parser/types';
 import { StorageEngine, SequenceAssignment } from '../../../storage/engines/types';
 import { ParticipantSection } from './ParticipantSection';
 import { FirebaseStorageEngine } from '../../../storage/engines/FirebaseStorageEngine';
+import { useAuth } from '../../../store/hooks/useAuth';
 
 export interface LiveMonitorParticipantProgress {
   assignment: SequenceAssignment;
   progress: number;
   isCompleted: boolean;
   isRejected: boolean;
+  isTimedOut?: boolean;
 }
 
 export function getFilteredParticipantProgress(
@@ -29,16 +31,20 @@ export function getFilteredParticipantProgress(
       const progress = assignment.total > 0 ? (assignment.answered.length / assignment.total) * 100 : 0;
       const isCompleted = assignment.completed !== null;
       const isRejected = assignment.rejected;
+      const isTimedOut = assignment.autoTimedOutAt !== undefined;
 
       return {
         assignment,
         progress,
         isCompleted,
         isRejected,
+        isTimedOut,
       };
     })
-    .filter(({ isCompleted, isRejected, assignment }) => {
-      const status = isRejected ? 'rejected' : (isCompleted ? 'completed' : 'inProgress');
+    .filter(({
+      isCompleted, isRejected, isTimedOut, assignment,
+    }) => {
+      const status = isRejected ? 'rejected' : (isTimedOut ? 'timedOut' : (isCompleted ? 'completed' : 'inProgress'));
       const statusMatch = includedParticipants.includes(status);
       const stageMatch = selectedStages.includes('ALL') || selectedStages.includes(assignment.stage || '');
 
@@ -48,11 +54,14 @@ export function getFilteredParticipantProgress(
 }
 
 export function groupParticipantProgress(filteredParticipantProgress: LiveMonitorParticipantProgress[]) {
-  const inProgress = filteredParticipantProgress.filter((participant) => !participant.isCompleted && !participant.isRejected);
-  const completed = filteredParticipantProgress.filter((participant) => participant.isCompleted && !participant.isRejected);
+  const inProgress = filteredParticipantProgress.filter((participant) => !participant.isCompleted && !participant.isRejected && !participant.isTimedOut);
+  const completed = filteredParticipantProgress.filter((participant) => participant.isCompleted && !participant.isRejected && !participant.isTimedOut);
   const rejected = filteredParticipantProgress.filter((participant) => participant.isRejected);
+  const timedOut = filteredParticipantProgress.filter((participant) => participant.isTimedOut && !participant.isRejected);
 
-  return { inProgress, completed, rejected };
+  return {
+    inProgress, completed, rejected, timedOut,
+  };
 }
 
 // Progress label components
@@ -103,11 +112,54 @@ export function LiveMonitorView({
   includedParticipants: string[];
   selectedStages: string[];
 }) {
-  const firebaseStoreageEngine = storageEngine as FirebaseStorageEngine;
+  const isFirebaseEngine = storageEngine?.getEngine() === 'firebase';
+  const firebaseStoreageEngine = isFirebaseEngine ? storageEngine as FirebaseStorageEngine : undefined;
+  const { user } = useAuth();
   const [sequenceAssignments, setSequenceAssignments] = useState<SequenceAssignment[]>([]);
   const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'connecting'>('connecting');
   const [lastUpdateTime, setLastUpdateTime] = useState<Date | null>(null);
   const [isReconnecting, setIsReconnecting] = useState(false);
+  const [autoTimeoutMinutes, setAutoTimeoutMinutes] = useState<number | undefined>();
+  const [autoTimeoutDraftMinutes, setAutoTimeoutDraftMinutes] = useState(60);
+  const [enableConfirmationOpen, setEnableConfirmationOpen] = useState(false);
+  const [timeoutSettingsLoading, setTimeoutSettingsLoading] = useState(true);
+  const [timeoutSettingsSaving, setTimeoutSettingsSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!storageEngine || !studyId) {
+      setTimeoutSettingsLoading(false);
+      return () => { cancelled = true; };
+    }
+    storageEngine.getModes(studyId)
+      .then((modes) => {
+        if (!cancelled) {
+          setAutoTimeoutMinutes(modes.autoTimeoutMinutes);
+          setAutoTimeoutDraftMinutes(modes.autoTimeoutMinutes ?? 60);
+          setTimeoutSettingsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setTimeoutSettingsLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [storageEngine, studyId]);
+
+  const saveAutoTimeout = useCallback(async (minutes: number | undefined) => {
+    if (!storageEngine || !studyId || !user.isAdmin) return;
+    setTimeoutSettingsSaving(true);
+    try {
+      await storageEngine.setAutoTimeoutMinutes(studyId, minutes);
+      setAutoTimeoutMinutes(minutes);
+      if (minutes !== undefined) {
+        setAutoTimeoutDraftMinutes(minutes);
+      }
+    } catch (error) {
+      console.error('Failed to save auto-timeout setting:', error);
+    } finally {
+      setTimeoutSettingsSaving(false);
+    }
+  }, [storageEngine, studyId, user.isAdmin]);
 
   // Function to handle successful data update
   const handleDataUpdate = (assignments: SequenceAssignment[]) => {
@@ -212,126 +264,220 @@ export function LiveMonitorView({
 
   return (
     <Stack gap="sm">
-      <Card
-        shadow="sm"
-        padding="sm"
-        radius="md"
-        withBorder
-        style={{
-          position: 'sticky',
-          top: 0,
-          zIndex: 100,
-          backgroundColor: 'white',
-          marginBottom: '1rem',
-        }}
+      <Modal
+        centered
+        opened={enableConfirmationOpen}
+        onClose={() => setEnableConfirmationOpen(false)}
+        title="Enable auto-timeout?"
       >
-        <Flex justify="space-between" align="center">
-          <Group gap="md">
-            <Title order={5} size="h5">Live Monitor</Title>
-            <Text size="sm" c="dimmed">
-              Total:
-              {' '}
-              {filteredParticipantProgress.length}
-            </Text>
-            <Group gap="xs">
-              <Badge color="green" variant="light" size="sm">
-                {filteredParticipantProgress.filter((p) => p.isCompleted && !p.isRejected).length}
-                {' '}
-                Completed
-              </Badge>
-              <Badge color="orange" variant="light" size="sm">
-                {filteredParticipantProgress.filter((p) => !p.isCompleted && !p.isRejected).length}
-                {' '}
-                Active
-              </Badge>
-              <Badge color="red" variant="light" size="sm">
-                {filteredParticipantProgress.filter((p) => p.isRejected).length}
-                {' '}
-                Rejected
-              </Badge>
-            </Group>
+        <Stack gap="md">
+          <Text size="sm">
+            On the next new participant assignment, participants who started more than
+            {' '}
+            {autoTimeoutDraftMinutes}
+            {' '}
+            minutes ago will no longer count toward participant limits. They can still finish the study normally.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setEnableConfirmationOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => {
+                setEnableConfirmationOpen(false);
+                saveAutoTimeout(autoTimeoutDraftMinutes).catch(() => undefined);
+              }}
+            >
+              Enable auto-timeout
+            </Button>
           </Group>
+        </Stack>
+      </Modal>
+      <Card shadow="sm" padding="sm" radius="md" withBorder>
+        <Group justify="space-between" align="flex-start">
+          <Stack gap={2}>
+            <Title order={5} size="h5">Auto-timeout</Title>
+            <Text size="sm" c="dimmed">
+              When a new participant starts, people who began more than this long ago no longer count toward participant limits. Timed-out participants can still finish normally.
+            </Text>
+          </Stack>
+          <Group align="center" wrap="nowrap">
+            <NumberInput
+              aria-label="Auto-timeout minutes"
+              value={autoTimeoutDraftMinutes}
+              min={1}
+              allowDecimal={false}
+              hideControls
+              suffix=" minutes"
+              disabled={!user.isAdmin || timeoutSettingsLoading || timeoutSettingsSaving}
+              w={125}
+              onChange={(value) => setAutoTimeoutDraftMinutes(
+                typeof value === 'number' ? Math.max(1, Math.floor(value)) : 60,
+              )}
+              onBlur={() => {
+                if (autoTimeoutMinutes !== undefined) {
+                  saveAutoTimeout(autoTimeoutDraftMinutes).catch(() => undefined);
+                }
+              }}
+            />
+            <Switch
+              aria-label="Enable auto-timeout"
+              checked={autoTimeoutMinutes !== undefined}
+              disabled={!user.isAdmin || timeoutSettingsLoading || timeoutSettingsSaving}
+              onChange={(event) => {
+                if (event.currentTarget.checked) {
+                  setEnableConfirmationOpen(true);
+                } else {
+                  saveAutoTimeout(undefined).catch(() => undefined);
+                }
+              }}
+            />
+          </Group>
+        </Group>
+        {!user.isAdmin && <Text size="xs" c="dimmed" mt="xs">Only study administrators can change auto-timeout.</Text>}
+      </Card>
 
-          <Group gap="xs">
-            {connectionStatus === 'disconnected' && (
-              <Button
-                size="xs"
-                variant="light"
-                color="blue"
-                leftSection={<IconRefresh size={12} />}
-                loading={isReconnecting}
-                onClick={handleReconnect}
-                disabled={!firebaseStoreageEngine || !studyId}
-              >
-                Reconnect
-              </Button>
-            )}
+      {!isFirebaseEngine && (
+        <Center py="xl">
+          <Text c="dimmed">Live participant monitoring is currently available with Firebase. Auto-timeout settings are available for this storage engine.</Text>
+        </Center>
+      )}
 
-            <Tooltip
-              label={
+      {isFirebaseEngine ? (
+        <>
+          <Card
+            shadow="sm"
+            padding="sm"
+            radius="md"
+            withBorder
+            style={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 100,
+              backgroundColor: 'white',
+              marginBottom: '1rem',
+            }}
+          >
+            <Flex justify="space-between" align="center">
+              <Group gap="md">
+                <Title order={5} size="h5">Live Monitor</Title>
+                <Text size="sm" c="dimmed">
+                  Total:
+                  {' '}
+                  {filteredParticipantProgress.length}
+                </Text>
+                <Group gap="xs">
+                  <Badge color="green" variant="light" size="sm">
+                    {filteredParticipantProgress.filter((p) => p.isCompleted && !p.isRejected && !p.isTimedOut).length}
+                    {' '}
+                    Completed
+                  </Badge>
+                  <Badge color="orange" variant="light" size="sm">
+                    {filteredParticipantProgress.filter((p) => !p.isCompleted && !p.isRejected && !p.isTimedOut).length}
+                    {' '}
+                    Active
+                  </Badge>
+                  <Badge color="red" variant="light" size="sm">
+                    {filteredParticipantProgress.filter((p) => p.isRejected).length}
+                    {' '}
+                    Rejected
+                  </Badge>
+                  <Badge color="yellow" variant="light" size="sm">
+                    {filteredParticipantProgress.filter((p) => p.isTimedOut && !p.isRejected).length}
+                    {' '}
+                    Timed Out
+                  </Badge>
+                </Group>
+              </Group>
+
+              <Group gap="xs">
+                {connectionStatus === 'disconnected' && (
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="blue"
+                  leftSection={<IconRefresh size={12} />}
+                  loading={isReconnecting}
+                  onClick={handleReconnect}
+                  disabled={!firebaseStoreageEngine || !studyId}
+                >
+                  Reconnect
+                </Button>
+                )}
+
+                <Tooltip
+                  label={
                 connectionStatus === 'connected'
                   ? `Connected${lastUpdateTime ? ` - Last data update: ${lastUpdateTime.toLocaleTimeString()}` : ''}`
                   : connectionStatus === 'connecting'
                     ? 'Connecting...'
                     : 'Disconnected'
               }
-              position="bottom-end"
-            >
-              <Indicator
-                color={
+                  position="bottom-end"
+                >
+                  <Indicator
+                    color={
                   connectionStatus === 'connected'
                     ? 'green'
                     : connectionStatus === 'connecting'
                       ? 'yellow'
                       : 'red'
                 }
-                position="top-end"
-                size={10}
-                withBorder
-              >
-                {connectionStatus === 'connected' ? (
-                  <IconWifi size={22} color="green" />
-                ) : (
-                  <IconWifiOff size={22} color={connectionStatus === 'connecting' ? 'orange' : 'red'} />
-                )}
-              </Indicator>
-            </Tooltip>
-          </Group>
-        </Flex>
-      </Card>
+                    position="top-end"
+                    size={10}
+                    withBorder
+                  >
+                    {connectionStatus === 'connected' ? (
+                      <IconWifi size={22} color="green" />
+                    ) : (
+                      <IconWifiOff size={22} color={connectionStatus === 'connecting' ? 'orange' : 'red'} />
+                    )}
+                  </Indicator>
+                </Tooltip>
+              </Group>
+            </Flex>
+          </Card>
 
-      <Title order={4} mt="lg">Participant Progress</Title>
+          <Title order={4} mt="lg">Participant Progress</Title>
 
-      <Stack gap="md">
-        <ParticipantSection
-          title="In Progress"
-          titleColor="orange"
-          participants={participantGroups.inProgress}
-          showProgressHeatmap
-          showDynamicBadge
-          progressValue={(assignment, progress) => (assignment.isDynamic ? 50 : progress)}
-          progressColor="orange"
-          progressLabel={InProgressLabel}
-        />
+          <Stack gap="md">
+            <ParticipantSection
+              title="In Progress"
+              titleColor="orange"
+              participants={participantGroups.inProgress}
+              showProgressHeatmap
+              showDynamicBadge
+              progressValue={(assignment, progress) => (assignment.isDynamic ? 50 : progress)}
+              progressColor="orange"
+              progressLabel={InProgressLabel}
+            />
 
-        <ParticipantSection
-          title="Completed"
-          titleColor="teal"
-          participants={participantGroups.completed}
-          progressValue={() => 100}
-          progressColor="teal"
-          progressLabel={CompletedLabel}
-        />
+            <ParticipantSection
+              title="Completed"
+              titleColor="teal"
+              participants={participantGroups.completed}
+              progressValue={() => 100}
+              progressColor="teal"
+              progressLabel={CompletedLabel}
+            />
 
-        <ParticipantSection
-          title="Rejected"
-          titleColor="red"
-          participants={participantGroups.rejected}
-          progressValue={(_, progress) => progress}
-          progressColor="red"
-          progressLabel={RejectedLabel}
-        />
-      </Stack>
+            <ParticipantSection
+              title="Rejected"
+              titleColor="red"
+              participants={participantGroups.rejected}
+              progressValue={(_, progress) => progress}
+              progressColor="red"
+              progressLabel={RejectedLabel}
+            />
+            <ParticipantSection
+              title="Timed Out"
+              titleColor="yellow"
+              participants={participantGroups.timedOut}
+              progressValue={(_, progress) => progress}
+              progressColor="yellow"
+              progressLabel={RejectedLabel}
+            />
+          </Stack>
+        </>
+      ) : null}
 
     </Stack>
   );

--- a/src/analysis/individualStudy/LiveMonitor/tests/LiveMonitorView.spec.tsx
+++ b/src/analysis/individualStudy/LiveMonitor/tests/LiveMonitorView.spec.tsx
@@ -33,6 +33,9 @@ vi.mock('@mantine/core', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => <button type="button" onClick={onClick}>{children}</button>,
   Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Modal: ({ children, opened }: { children: ReactNode; opened: boolean }) => (opened ? <div>{children}</div> : null),
+  NumberInput: ({ onChange }: { onChange?: (value: number) => void }) => <input onChange={() => onChange?.(60)} />,
+  Switch: ({ onChange }: { onChange?: () => void }) => <input type="checkbox" onChange={onChange} />,
   Grid: Object.assign(
     ({ children }: { children: ReactNode }) => <div>{children}</div>,
     { Col: ({ children }: { children: ReactNode }) => <div>{children}</div> },
@@ -56,6 +59,10 @@ vi.mock('../../../../storage/engines/FirebaseStorageEngine', () => ({
   FirebaseStorageEngine: class { },
 }));
 
+vi.mock('../../../../store/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { isAdmin: true } }),
+}));
+
 // ── fixture helpers ───────────────────────────────────────────────────────────
 
 function makeAssignment(overrides: Partial<SequenceAssignment> = {}): SequenceAssignment {
@@ -65,6 +72,10 @@ function makeAssignment(overrides: Partial<SequenceAssignment> = {}): SequenceAs
     createdTime: 1_700_000_000_000,
     ...overrides,
   });
+}
+
+function makeFirebaseEngine(overrides: Parameters<typeof makeStorageEngine>[0]) {
+  return makeStorageEngine({ ...overrides, getEngine: () => 'firebase' });
 }
 
 // ── getFilteredParticipantProgress ────────────────────────────────────────────
@@ -167,13 +178,13 @@ afterEach(() => { cleanup(); vi.restoreAllMocks(); });
 describe('LiveMonitorView', () => {
   const baseProps = {
     studyConfig: {} as Parameters<typeof LiveMonitorView>[0]['studyConfig'],
-    includedParticipants: ['inProgress', 'completed', 'rejected'],
+    includedParticipants: ['inProgress', 'completed', 'rejected', 'timedOut'],
     selectedStages: ['ALL'],
   };
 
-  test('renders Live Monitor heading', () => {
+  test('renders auto-timeout settings without a Firebase engine', () => {
     const html = renderToStaticMarkup(<LiveMonitorView {...baseProps} />);
-    expect(html).toContain('Live Monitor');
+    expect(html).toContain('Auto-timeout');
   });
 
   test('shows 0 counts when no storageEngine provided', () => {
@@ -182,35 +193,10 @@ describe('LiveMonitorView', () => {
     expect(html).toContain('0');
   });
 
-  test('shows Completed, Active, Rejected badges', () => {
+  test('explains that the live monitor requires Firebase', () => {
     const html = renderToStaticMarkup(<LiveMonitorView {...baseProps} />);
-    expect(html).toContain('Completed');
-    expect(html).toContain('Active');
-    expect(html).toContain('Rejected');
+    expect(html).toContain('Live participant monitoring is currently available with Firebase');
   });
-
-  test('shows disconnected wifi icon when no storageEngine', () => {
-    const html = renderToStaticMarkup(<LiveMonitorView {...baseProps} />);
-    // Without a Firebase engine, useEffect will set status to 'disconnected'
-    // but renderToStaticMarkup captures initial state ('connecting') — wifioff shown
-    expect(html).toContain('icon-wifioff');
-  });
-
-  test('shows In Progress, Completed, Rejected section titles', () => {
-    const html = renderToStaticMarkup(<LiveMonitorView {...baseProps} />);
-    expect(html).toContain('In Progress');
-    expect(html).toContain('Completed');
-    expect(html).toContain('Rejected');
-  });
-
-  test('sets connectionStatus to disconnected when no storageEngine after effect', async () => {
-    const { container } = await act(async () => render(
-      <LiveMonitorView {...baseProps} />,
-    ));
-    // After effects run, status is 'disconnected' → icon-wifioff shown
-    expect(container.textContent).toContain('icon-wifioff');
-  });
-
   test('sets connectionStatus to connected when listener returns a function', async () => {
     const mockUnsubscribe = vi.fn();
     const mockEngine = {
@@ -221,7 +207,7 @@ describe('LiveMonitorView', () => {
     const { container } = await act(async () => render(
       <LiveMonitorView
         {...baseProps}
-        storageEngine={makeStorageEngine(mockEngine)}
+        storageEngine={makeFirebaseEngine(mockEngine)}
         studyId="test-study"
       />,
     ));
@@ -337,7 +323,7 @@ describe('LiveMonitorView interactive', () => {
       }),
     };
     const { container } = await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     expect(container.textContent).toContain('p-active');
   });
@@ -359,7 +345,7 @@ describe('LiveMonitorView interactive', () => {
       }),
     };
     const { container } = await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     expect(container.textContent).toContain('p-done');
     expect(container.textContent).toContain('p-rej');
@@ -372,7 +358,7 @@ describe('LiveMonitorView interactive', () => {
       _setupSequenceAssignmentListener: vi.fn(() => undefined),
     };
     const { container } = await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     expect(container.textContent).toContain('icon-wifioff');
   });
@@ -384,7 +370,7 @@ describe('LiveMonitorView interactive', () => {
       _setupSequenceAssignmentListener: vi.fn(() => undefined),
     };
     const { getAllByRole } = await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     const reconnectBtn = getAllByRole('button').find((b) => b.textContent?.includes('Reconnect'));
     expect(reconnectBtn).toBeDefined();
@@ -400,7 +386,7 @@ describe('LiveMonitorView interactive', () => {
     };
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     const { getAllByRole } = await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     const reconnectBtn = getAllByRole('button').find((b) => b.textContent?.includes('Reconnect'));
     expect(reconnectBtn).toBeDefined();
@@ -419,7 +405,7 @@ describe('LiveMonitorView interactive', () => {
       }),
     };
     await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     act(() => { window.dispatchEvent(new Event('offline')); });
   });
@@ -431,7 +417,7 @@ describe('LiveMonitorView interactive', () => {
       _setupSequenceAssignmentListener: vi.fn(() => undefined),
     };
     await act(async () => render(
-      <LiveMonitorView {...baseProps} storageEngine={makeStorageEngine(mockEngine)} />,
+      <LiveMonitorView {...baseProps} storageEngine={makeFirebaseEngine(mockEngine)} />,
     ));
     await act(async () => { window.dispatchEvent(new Event('online')); });
     expect(mockEngine.getAllSequenceAssignments).toHaveBeenCalled();

--- a/src/analysis/individualStudy/StudyAnalysisTabs.tsx
+++ b/src/analysis/individualStudy/StudyAnalysisTabs.tsx
@@ -85,7 +85,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   const [studyConfig, setStudyConfig] = useState<ParsedConfig<StudyConfig> | undefined>(undefined);
   const [startupError, setStartupError] = useState<{ error: unknown } | null>(null);
 
-  const [includedParticipants, setIncludedParticipants] = useState<string[]>(['completed', 'inProgress', 'rejected']);
+  const [includedParticipants, setIncludedParticipants] = useState<string[]>(['completed', 'inProgress', 'rejected', 'timedOut']);
 
   const [selectedStages, setSelectedStages] = useState<string[]>(['ALL']);
   const [availableStages, setAvailableStages] = useState<{ value: string; label: string }[]>([{ value: 'ALL', label: 'ALL' }]);
@@ -126,7 +126,11 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
   );
 
   const participantCounts = useMemo(() => {
-    if (!expData) return { completed: 0, inProgress: 0, rejected: 0 };
+    if (!expData) {
+      return {
+        completed: 0, inProgress: 0, rejected: 0, timedOut: 0,
+      };
+    }
     const expList = Object.values(expData);
 
     // Apply config filter before counting
@@ -151,26 +155,31 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
       });
 
     return {
-      completed: conditionFiltered.filter((d) => !d.rejected && d.completed).length,
-      inProgress: conditionFiltered.filter((d) => !d.rejected && !d.completed).length,
+      completed: conditionFiltered.filter((d) => !d.rejected && !d.timedOut && d.completed).length,
+      inProgress: conditionFiltered.filter((d) => !d.rejected && !d.timedOut && !d.completed).length,
       rejected: conditionFiltered.filter((d) => d.rejected).length,
+      timedOut: conditionFiltered.filter((d) => !d.rejected && d.timedOut).length,
     };
   }, [expData, selectedStages, selectedConfigs, selectedConditions, studyUsesConditions]);
 
   const selectedParticipantCounts = useMemo(() => {
-    if (selectedParticipants.length === 0) return { completed: 0, inProgress: 0, rejected: 0 };
+    if (selectedParticipants.length === 0) {
+      return {
+        completed: 0, inProgress: 0, rejected: 0, timedOut: 0,
+      };
+    }
 
     return {
-      completed: selectedParticipants.filter((d) => !d.rejected && d.completed).length,
-      inProgress: selectedParticipants.filter((d) => !d.rejected && !d.completed).length,
+      completed: selectedParticipants.filter((d) => !d.rejected && !d.timedOut && d.completed).length,
+      inProgress: selectedParticipants.filter((d) => !d.rejected && !d.timedOut && !d.completed).length,
       rejected: selectedParticipants.filter((d) => d.rejected).length,
+      timedOut: selectedParticipants.filter((d) => !d.rejected && d.timedOut).length,
     };
   }, [selectedParticipants]);
 
   const currentConfigHash = currentConfigHashValue ?? undefined;
   const isFirebaseEngine = storageEngine?.getEngine() === 'firebase';
   const codingEnabled = isFirebaseEngine && hasAudioRecording;
-  const liveMonitorEnabled = isFirebaseEngine;
 
   const currentConfigLabel = useMemo(() => {
     if (!currentConfigHash) return undefined;
@@ -199,11 +208,12 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
     if (!expData) return [];
     const expList = Object.values(expData);
 
-    const comp = includedParticipants.includes('completed') ? expList.filter((d) => !d.rejected && d.completed) : [];
-    const prog = includedParticipants.includes('inProgress') ? expList.filter((d) => !d.rejected && !d.completed) : [];
+    const comp = includedParticipants.includes('completed') ? expList.filter((d) => !d.rejected && !d.timedOut && d.completed) : [];
+    const prog = includedParticipants.includes('inProgress') ? expList.filter((d) => !d.rejected && !d.timedOut && !d.completed) : [];
     const rej = includedParticipants.includes('rejected') ? expList.filter((d) => d.rejected) : [];
+    const timedOut = includedParticipants.includes('timedOut') ? expList.filter((d) => !d.rejected && d.timedOut) : [];
 
-    const statusFiltered = [...comp, ...prog, ...rej];
+    const statusFiltered = [...comp, ...prog, ...rej, ...timedOut];
 
     // Apply config filter - if "ALL" is selected, show all participants
     const configFiltered = selectedConfigs.includes('ALL')
@@ -575,6 +585,14 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                       size="xs"
                       styles={{ label: { whiteSpace: 'nowrap' } }}
                     />
+                    <Checkbox
+                      value="timedOut"
+                      label={selectedParticipants.length > 0
+                        ? `Timed Out (${selectedParticipantCounts.timedOut} of ${participantCounts.timedOut})`
+                        : `Timed Out (${participantCounts.timedOut})`}
+                      size="xs"
+                      styles={{ label: { whiteSpace: 'nowrap' } }}
+                    />
                   </Group>
                 </Checkbox.Group>
               </Flex>
@@ -609,14 +627,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     <Tabs.Tab value="tagging" leftSection={<IconTags size={16} />} disabled={!codingEnabled} style={{ justifyContent: 'flex-start' }}>Coding</Tabs.Tab>
                   </span>
                 </Tooltip>
-                <Tooltip
-                  label="Live Monitor is only available when using Firebase"
-                  disabled={liveMonitorEnabled}
-                >
-                  <span>
-                    <Tabs.Tab value="live-monitor" leftSection={<IconDashboard size={16} />} disabled={!liveMonitorEnabled} style={{ justifyContent: 'flex-start' }}>Live Monitor</Tabs.Tab>
-                  </span>
-                </Tooltip>
+                <Tabs.Tab value="live-monitor" leftSection={<IconDashboard size={16} />} style={{ justifyContent: 'flex-start' }}>Live Monitor</Tabs.Tab>
                 <Tabs.Tab value="config" leftSection={<IconFileCode size={16} />} style={{ justifyContent: 'flex-start' }}>Config</Tabs.Tab>
                 <Tabs.Tab value="stages" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin} style={{ justifyContent: 'flex-start' }}>Stage Management</Tabs.Tab>
                 <Tabs.Tab value="manage" leftSection={<IconSettings size={16} />} disabled={!user.isAdmin} style={{ justifyContent: 'flex-start' }}>Manage</Tabs.Tab>
@@ -652,13 +663,7 @@ export function StudyAnalysisTabs({ globalConfig }: { globalConfig: GlobalConfig
                     )}
                 </Tabs.Panel>
                 <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="live-monitor" pt="xs">
-                  {studyConfig && liveMonitorEnabled
-                    ? <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />
-                    : (
-                      <Center>
-                        <Text c="dimmed">Live Monitor is only available when using Firebase</Text>
-                      </Center>
-                    )}
+                  {studyConfig && <LiveMonitorView studyConfig={studyConfig} storageEngine={storageEngine} studyId={canonicalStudyId ?? undefined} includedParticipants={includedParticipants} selectedStages={selectedStages} />}
                 </Tabs.Panel>
                 <Tabs.Panel style={{ flex: 1, minHeight: 0, overflow: 'auto' }} value="config" pt="xs">
                   {studyConfig && <ConfigView visibleParticipants={visibleParticipants} studyId={canonicalStudyId ?? undefined} currentConfigHash={currentConfigHash} />}

--- a/src/analysis/individualStudy/management/StageManagementItem.tsx
+++ b/src/analysis/individualStudy/management/StageManagementItem.tsx
@@ -76,7 +76,7 @@ type StageParticipantStatusCounts = Record<string, { completed: number; inProgre
 
 export function getStageParticipantStatusCounts(participants: ParticipantDataWithStatus[]) {
   return participants.reduce<StageParticipantStatusCounts>((counts, participant) => {
-    if (participant.rejected) {
+    if (participant.rejected || participant.timedOut) {
       return counts;
     }
 
@@ -130,12 +130,14 @@ function getBetweenSubjectsCombinationStatusCounts(
   betweenSubjectsFactors: BetweenSubjectsFactor[],
 ) {
   return participants.reduce((counts, participant) => {
-    const matchesCombination = !participant.rejected && participantMatchesBetweenSubjectsCombination(
-      participant,
-      stageName,
-      combination,
-      betweenSubjectsFactors,
-    );
+    const matchesCombination = !participant.rejected
+      && !participant.timedOut
+      && participantMatchesBetweenSubjectsCombination(
+        participant,
+        stageName,
+        combination,
+        betweenSubjectsFactors,
+      );
     if (!matchesCombination) {
       return counts;
     }
@@ -411,6 +413,7 @@ function BetweenSubjectsCombinationTable({
       participants.filter((participant) => (
         !participant.completed
         && !participant.rejected
+        && !participant.timedOut
         && participantMatchesBetweenSubjectsCombination(
           participant,
           stage.stageName,
@@ -442,6 +445,7 @@ function BetweenSubjectsCombinationTable({
     ...(showParticipantLimits ? [{
       accessorKey: 'desiredParticipants',
       header: 'Total / Maximum',
+      size: 240,
       Cell: ({ row }: { row: { original: BetweenSubjectsCombinationRow } }) => renderDesiredParticipantsCell(
         row.original,
         stage,
@@ -490,10 +494,12 @@ function BetweenSubjectsCombinationTable({
     },
     mantineTableContainerProps: { style: { maxWidth: '100%', overflowX: 'auto' } },
     mantineTableProps: { style: { minWidth: 'max-content', width: '100%' } },
+    mantineTableBodyRowProps: { style: { height: 44 } },
     mantineTableBodyCellProps: ({ column, row }) => {
+      const compactCellStyle = { paddingBlock: 4 };
       const factorIndex = betweenSubjectsFactors.findIndex((factor) => factor.factorName === column.id);
       if (factorIndex === -1) {
-        return {};
+        return { style: compactCellStyle };
       }
 
       const factor = betweenSubjectsFactors[factorIndex];
@@ -503,6 +509,7 @@ function BetweenSubjectsCombinationTable({
 
       return {
         style: {
+          ...compactCellStyle,
           backgroundColor: getDistinctColorShade(factorIndex, levelIndex, factor.levels.length),
         },
       };
@@ -1030,7 +1037,10 @@ export function StageManagementItem({ studyId, studyConfig }: { studyId: string;
                       aria-label={`Review ${participantCounts.inProgress} in-progress participant${participantCounts.inProgress === 1 ? '' : 's'}`}
                       color="dark"
                       onClick={() => handleReviewInProgress(participants.filter((participant) => (
-                        participant.stage === stage.stageName && !participant.completed && !participant.rejected
+                        participant.stage === stage.stageName
+                          && !participant.completed
+                          && !participant.rejected
+                          && !participant.timedOut
                       )), `Showing only in-progress participants in the ${stage.stageName} stage — not all in-progress participants in the study.`)}
                       p={0}
                       size="compact-xs"

--- a/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
+++ b/src/analysis/individualStudy/stats/tests/StatsView.spec.tsx
@@ -73,7 +73,7 @@ vi.mock('../../summary/OverviewStats', () => ({
 vi.mock('../../summary/utils', () => ({
   getOverviewStats: vi.fn(() => ({
     participantCounts: {
-      total: 5, completed: 3, inProgress: 1, rejected: 1,
+      total: 5, completed: 3, inProgress: 1, rejected: 1, timedOut: 0,
     },
     startDate: null,
     endDate: null,
@@ -112,6 +112,8 @@ const mockParticipant: ParticipantDataWithStatus = {
     userAgent: '', resolution: { width: 0, height: 0 }, language: '', ip: '',
   },
   completed: true,
+  timedOut: false,
+  completedLate: false,
   rejected: false,
   participantTags: [],
   stage: 'DEFAULT',

--- a/src/analysis/individualStudy/summary/OverviewStats.tsx
+++ b/src/analysis/individualStudy/summary/OverviewStats.tsx
@@ -34,6 +34,10 @@ export function OverviewStats({
           <Text size="sm" c="dimmed">Rejected</Text>
         </Flex>
         <Flex direction="column">
+          <Text size="xl" fw="bold" c="yellow">{overviewData.participantCounts.timedOut ?? 0}</Text>
+          <Text size="sm" c="dimmed">Timed Out</Text>
+        </Flex>
+        <Flex direction="column">
           <Text size="xl" fw="bold">{convertNumberToString(overviewData.startDate, 'date')}</Text>
           <Text size="sm" c="dimmed">Start Date</Text>
         </Flex>

--- a/src/analysis/individualStudy/summary/tests/SummaryView.spec.tsx
+++ b/src/analysis/individualStudy/summary/tests/SummaryView.spec.tsx
@@ -53,7 +53,7 @@ vi.mock('@tabler/icons-react', () => ({
 function makeOverviewData(overrides: Partial<OverviewData> = {}): OverviewData {
   return {
     participantCounts: {
-      total: 10, completed: 7, inProgress: 2, rejected: 1,
+      total: 10, completed: 7, inProgress: 2, rejected: 1, timedOut: 0,
     },
     startDate: new Date('2026-01-01'),
     endDate: new Date('2026-03-01'),

--- a/src/analysis/individualStudy/summary/utils.tsx
+++ b/src/analysis/individualStudy/summary/utils.tsx
@@ -56,9 +56,10 @@ function calculateParticipantCounts(visibleParticipants: ParticipantDataWithStat
   const participantCounts: ParticipantCounts = {
     total: filteredParticipants.length,
     // Include !p.rejected to exclude participants rejected manually after completing the study
-    completed: filteredParticipants.filter((p) => p.completed && !p.rejected).length,
-    inProgress: filteredParticipants.filter((p) => !p.completed && !p.rejected).length,
+    completed: filteredParticipants.filter((p) => p.completed && !p.rejected && !p.timedOut).length,
+    inProgress: filteredParticipants.filter((p) => !p.completed && !p.rejected && !p.timedOut).length,
     rejected: filteredParticipants.filter((p) => p.rejected).length,
+    timedOut: filteredParticipants.filter((p) => !p.rejected && p.timedOut).length,
   };
 
   return participantCounts;

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -92,11 +92,17 @@ export function TableView({
 
           const denominator = Math.max(getSequenceFlatMap(row.sequence).length - 1, 1);
 
-          return { percent: (Object.entries(row.answers).length - incompleteEntries.length) / denominator, completed: row.completed, rejected: row.rejected };
+          return {
+            percent: (Object.entries(row.answers).length - incompleteEntries.length) / denominator,
+            completed: row.completed,
+            rejected: row.rejected,
+            timedOut: !!row.timedOut,
+            completedLate: !!row.completedLate,
+          };
         },
         header: 'Status',
         size: 100,
-        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, { percent: number, completed: boolean, rejected: ParticipantDataWithStatus['rejected'] }> }) => {
+        Cell: ({ cell }: { cell: MrtCell<ParticipantDataWithStatus, { percent: number, completed: boolean, rejected: ParticipantDataWithStatus['rejected'], timedOut: boolean, completedLate: boolean }> }) => {
           const cellValue = cell.getValue();
           return (
             cellValue.rejected ? (
@@ -105,7 +111,13 @@ export function TableView({
                 <Text size="xs" c="dimmed" ta="center">{cellValue.rejected.reason}</Text>
               </Stack>
             )
-              : cellValue.completed ? (
+              : cellValue.timedOut ? (
+                <Stack align="center" justify="center" gap={2} w="100%">
+                  <Tooltip label={cellValue.completedLate ? 'Completed late after timing out' : 'Timed out'}>
+                    <Text size="xs" fw={700} c="orange">{cellValue.completedLate ? 'Late' : 'Timed out'}</Text>
+                  </Tooltip>
+                </Stack>
+              ) : cellValue.completed ? (
                 <Group align="center" justify="center" w="100%">
                   <Tooltip label="Completed"><IconCheck size={30} color="teal" style={{ marginBottom: -3 }} /></Tooltip>
                 </Group>

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -3,6 +3,7 @@ export interface ParticipantCounts {
   completed: number;
   inProgress: number;
   rejected: number;
+  timedOut?: number;
 }
 
 export interface OverviewData {

--- a/src/components/downloader/tests/DownloadButtons.spec.tsx
+++ b/src/components/downloader/tests/DownloadButtons.spec.tsx
@@ -165,6 +165,8 @@ const participant: ParticipantDataWithStatus = {
     userAgent: '', resolution: { width: 0, height: 0 }, language: '', ip: '',
   },
   completed: false,
+  timedOut: false,
+  completedLate: false,
   rejected: false,
   participantTags: [],
   stage: 'DEFAULT',

--- a/src/storage/engines/FirebaseStorageEngine.ts
+++ b/src/storage/engines/FirebaseStorageEngine.ts
@@ -45,6 +45,7 @@ import {
   SequenceAssignment,
   SnapshotDocContent,
   StoredUser,
+  RuntimeStudySettings,
   cleanupModes,
 } from './types';
 import { EditedText, TaglessEditedText } from '../../analysis/individualStudy/thinkAloud/types';
@@ -192,6 +193,7 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
         timestamp: data.timestamp instanceof Timestamp ? data.timestamp.toMillis() : data.timestamp,
         createdTime: data.createdTime instanceof Timestamp ? data.createdTime.toMillis() : data.createdTime,
         completed: data.completed instanceof Timestamp ? data.completed.toMillis() : data.completed,
+        autoTimedOutAt: data.autoTimedOutAt instanceof Timestamp ? data.autoTimedOutAt.toMillis() : data.autoTimedOutAt,
       } as SequenceAssignment))
       .sort((a, b) => a.timestamp - b.timestamp);
   }
@@ -216,6 +218,7 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
           timestamp: data.timestamp instanceof Timestamp ? data.timestamp.toMillis() : data.timestamp,
           createdTime: data.createdTime instanceof Timestamp ? data.createdTime.toMillis() : data.createdTime,
           completed: data.completed instanceof Timestamp ? data.completed.toMillis() : data.completed,
+          autoTimedOutAt: data.autoTimedOutAt instanceof Timestamp ? data.autoTimedOutAt.toMillis() : data.autoTimedOutAt,
         } as SequenceAssignment))
         .sort((a, b) => a.timestamp - b.timestamp);
 
@@ -294,6 +297,7 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
       timestamp: data.timestamp instanceof Timestamp ? data.timestamp.toMillis() : data.timestamp,
       createdTime: data.createdTime instanceof Timestamp ? data.createdTime.toMillis() : data.createdTime,
       completed: data.completed instanceof Timestamp ? data.completed.toMillis() : data.completed,
+      autoTimedOutAt: data.autoTimedOutAt instanceof Timestamp ? data.autoTimedOutAt.toMillis() : data.autoTimedOutAt,
     } as SequenceAssignment;
   }
 
@@ -338,9 +342,32 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
 
     await acquireLock(0);
 
+    let lockRefreshError: unknown;
+    const refreshLock = async () => {
+      const now = Date.now();
+      await runTransaction(this.firestore, async (transaction) => {
+        const snapshot = await transaction.get(lockDocument);
+        const existingLock = snapshot.data()?.[lockKey] as { token?: string } | undefined;
+        if (existingLock?.token !== token) {
+          throw new Error('Study update lock was lost');
+        }
+        transaction.update(lockDocument, { [lockKey]: { token, expiresAt: now + expiresInMs } });
+      });
+    };
+    const refreshTimer = setInterval(() => {
+      refreshLock().catch((error) => {
+        lockRefreshError ??= error;
+      });
+    }, expiresInMs / 3);
+
     try {
-      return await operation();
+      const result = await operation();
+      if (lockRefreshError) {
+        throw lockRefreshError;
+      }
+      return result;
     } finally {
+      clearInterval(refreshTimer);
       await runTransaction(this.firestore, async (transaction) => {
         const snapshot = await transaction.get(lockDocument);
         const existingLock = snapshot.data()?.[lockKey] as { token?: string } | undefined;
@@ -413,13 +440,18 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
         const participantTimestamp = toMillis(participantSequenceAssignment.timestamp);
         return sequenceAssignmentSnapshot.docs.find((docSnapshot) => {
           const docData = docSnapshot.data() as SequenceAssignment;
-          return docData.claimed && toMillis(docData.timestamp) === participantTimestamp;
+          return docSnapshot.id !== participantId
+            && docData.claimed
+            && toMillis(docData.timestamp) === participantTimestamp;
         });
       })();
 
     if (claimedSequenceAssignmentSnapshot) {
       const claimedSequenceAssignmentDoc = doc(sequenceAssignmentCollection, claimedSequenceAssignmentSnapshot.id);
-      await updateDoc(claimedSequenceAssignmentDoc, { claimed: false, rejected: true });
+      const claimedAssignment = claimedSequenceAssignmentSnapshot.data() as SequenceAssignment;
+      await updateDoc(claimedSequenceAssignmentDoc, claimedAssignment.autoTimedOutAt === undefined
+        ? { claimed: false, rejected: true }
+        : { claimed: false });
     }
 
     const participantSequenceAssignmentDoc = doc(
@@ -480,7 +512,10 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
 
       const claimedSequenceAssignment = claimedSequenceAssignmentSnapshot.data() as SequenceAssignment;
       restoredTimestamp = toMillis(claimedSequenceAssignment.timestamp);
-      await updateDoc(claimedSequenceAssignmentDoc, { claimed: true, rejected: true });
+      const claimedAssignment = claimedSequenceAssignmentSnapshot.data() as SequenceAssignment;
+      await updateDoc(claimedSequenceAssignmentDoc, claimedAssignment.autoTimedOutAt === undefined
+        ? { claimed: true, rejected: true }
+        : { claimed: true });
     }
 
     await updateDoc(
@@ -511,6 +546,34 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     );
 
     await updateDoc(participantSequenceAssignmentDoc, { claimed: true });
+  }
+
+  protected async _markSequenceAssignmentTimedOut(participantId: string): Promise<boolean> {
+    if (!this.studyId) {
+      throw new Error('Study ID is not set');
+    }
+    const sequenceAssignmentDoc = doc(this.studyCollection, 'sequenceAssignment');
+    const participantAssignmentDoc = doc(
+      collection(sequenceAssignmentDoc, 'sequenceAssignment'),
+      participantId,
+    );
+
+    return await runTransaction(this.firestore, async (transaction) => {
+      const assignmentSnapshot = await transaction.get(participantAssignmentDoc);
+      if (!assignmentSnapshot.exists()) {
+        throw new Error(`Sequence assignment for participant ${participantId} not found`);
+      }
+      const assignment = assignmentSnapshot.data() as SequenceAssignment;
+      if (
+        assignment.completed !== null
+        || assignment.rejected
+        || assignment.autoTimedOutAt !== undefined
+      ) {
+        return false;
+      }
+      transaction.update(participantAssignmentDoc, { autoTimedOutAt: serverTimestamp() });
+      return true;
+    });
   }
 
   async initializeAnonymousAuth() {
@@ -572,7 +635,7 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     const revisitModesData = await getDoc(revisitModesDoc);
 
     if (revisitModesData.exists()) {
-      const modes = revisitModesData.data() as Record<string, boolean>;
+      const modes = revisitModesData.data() as RuntimeStudySettings;
       const needsUpdate = 'studyNavigatorEnabled' in modes || 'analyticsInterfacePubliclyAccessible' in modes;
 
       if (needsUpdate) {
@@ -604,13 +667,17 @@ export class FirebaseStorageEngine extends CloudStorageEngine {
     return await setDoc(revisitModesDoc, { [mode]: value }, { merge: true });
   }
 
-  protected async _setModesDocument(studyId: string, modesDocument: Record<string, unknown>): Promise<void> {
+  protected async _setModesDocument(studyId: string, modesDocument: RuntimeStudySettings): Promise<void> {
     const revisitModesDoc = doc(
       this.firestore,
       `${this.collectionPrefix}${studyId}`,
       'modes',
     );
-    await setDoc(revisitModesDoc, modesDocument, { merge: true });
+    const firestoreModes: Record<string, unknown> = { ...modesDocument };
+    if (Object.hasOwn(modesDocument, 'autoTimeoutMinutes') && modesDocument.autoTimeoutMinutes === undefined) {
+      firestoreModes.autoTimeoutMinutes = deleteField();
+    }
+    await setDoc(revisitModesDoc, firestoreModes, { merge: true });
   }
 
   protected async _getAudioUrl(

--- a/src/storage/engines/LocalStorageEngine.ts
+++ b/src/storage/engines/LocalStorageEngine.ts
@@ -1,6 +1,6 @@
 import localforage from 'localforage';
 import {
-  REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageEngine, StorageObject, StorageObjectType, cleanupModes,
+  REVISIT_MODE, RuntimeStudySettings, SequenceAssignment, SnapshotDocContent, StorageEngine, StorageObject, StorageObjectType, cleanupModes,
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
 
@@ -139,18 +139,21 @@ export class LocalStorageEngine extends StorageEngine {
       throw new Error('Study ID is not set');
     }
 
-    const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
-    const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
+    const participantId = this.currentParticipantId;
+    await this._runWithLock(`participant-${participantId}`, async () => {
+      const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
+      const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
 
-    if (sequenceAssignments[this.currentParticipantId]) {
-      sequenceAssignments[this.currentParticipantId] = {
-        ...sequenceAssignments[this.currentParticipantId],
-        completed: new Date().getTime(),
-      };
-    } else {
-      throw new Error('Participant sequence assignment not found');
-    }
-    await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
+      if (sequenceAssignments[participantId]) {
+        sequenceAssignments[participantId] = {
+          ...sequenceAssignments[participantId],
+          completed: new Date().getTime(),
+        };
+      } else {
+        throw new Error('Participant sequence assignment not found');
+      }
+      await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
+    });
   }
 
   protected async _rejectParticipantRealtime(participantId: string) {
@@ -164,12 +167,16 @@ export class LocalStorageEngine extends StorageEngine {
     const claimedAssignmentData = participantSequenceAssignment?.claimedParticipantId
       ? sequenceAssignments[participantSequenceAssignment.claimedParticipantId]
       : Object.values(sequenceAssignments).find(
-        (assignment) => assignment.claimed && assignment.timestamp === participantSequenceAssignment.timestamp,
+        (assignment) => assignment.participantId !== participantId
+          && assignment.claimed
+          && assignment.timestamp === participantSequenceAssignment.timestamp,
       );
     if (participantSequenceAssignment && claimedAssignmentData) {
       // Mark the claimed assignment as available again
       claimedAssignmentData.claimed = false;
-      claimedAssignmentData.rejected = true; // Mark it as rejected
+      if (claimedAssignmentData.autoTimedOutAt === undefined) {
+        claimedAssignmentData.rejected = true;
+      }
       await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
 
       // Delete the participant's sequence assignment
@@ -202,7 +209,9 @@ export class LocalStorageEngine extends StorageEngine {
         const claimedAssignmentData = sequenceAssignments[participantSequenceAssignment.claimedParticipantId];
         if (claimedAssignmentData) {
           claimedAssignmentData.claimed = true;
-          claimedAssignmentData.rejected = true;
+          if (claimedAssignmentData.autoTimedOutAt === undefined) {
+            claimedAssignmentData.rejected = true;
+          }
           participantSequenceAssignment.timestamp = claimedAssignmentData.timestamp;
         }
       }
@@ -212,17 +221,37 @@ export class LocalStorageEngine extends StorageEngine {
 
   protected async _claimSequenceAssignment(participantId: string, sequenceAssignment: SequenceAssignment) {
     await this.verifyStudyDatabase();
-    const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
-    const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
-    if (sequenceAssignments[participantId]) {
-      sequenceAssignments[participantId] = {
-        ...sequenceAssignment,
-        claimed: true,
-      };
-      await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
-    } else {
-      throw new Error(`Sequence assignment for participant ${participantId} not found`);
-    }
+    await this._runWithLock(`participant-${participantId}`, async () => {
+      const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
+      const sequenceAssignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
+      if (sequenceAssignments[participantId]) {
+        sequenceAssignments[participantId] = {
+          ...sequenceAssignment,
+          claimed: true,
+        };
+        await this.studyDatabase.setItem(sequenceAssignmentPath, sequenceAssignments);
+      } else {
+        throw new Error(`Sequence assignment for participant ${participantId} not found`);
+      }
+    });
+  }
+
+  protected async _markSequenceAssignmentTimedOut(participantId: string): Promise<boolean> {
+    return await this._runWithLock(`participant-${participantId}`, async () => {
+      await this.verifyStudyDatabase();
+      const sequenceAssignmentPath = `${this.collectionPrefix}${this.studyId}/sequenceAssignment`;
+      const assignments = await this.studyDatabase.getItem<Record<string, SequenceAssignment>>(sequenceAssignmentPath) || {};
+      const assignment = assignments[participantId];
+      if (!assignment) {
+        throw new Error(`Sequence assignment for participant ${participantId} not found`);
+      }
+      if (assignment.completed !== null || assignment.rejected || assignment.autoTimedOutAt !== undefined) {
+        return false;
+      }
+      assignments[participantId] = { ...assignment, autoTimedOutAt: Date.now() };
+      await this.studyDatabase.setItem(sequenceAssignmentPath, assignments);
+      return true;
+    });
   }
 
   async initializeStudyDb(studyId: string) {
@@ -238,7 +267,7 @@ export class LocalStorageEngine extends StorageEngine {
     const key = `${this.collectionPrefix}${studyId}/modes`;
 
     // Get the modes
-    const modes = await this.studyDatabase.getItem(key) as Record<REVISIT_MODE, boolean> | null;
+    const modes = await this.studyDatabase.getItem(key) as RuntimeStudySettings | null;
     if (modes) {
       const cleanedModes = cleanupModes(modes as Record<string, boolean>);
       await this.studyDatabase.setItem(key, cleanedModes);
@@ -258,7 +287,7 @@ export class LocalStorageEngine extends StorageEngine {
     const key = `${this.collectionPrefix}${studyId}/modes`;
 
     // Get the modes
-    const modes = await this.studyDatabase.getItem(key) as Record<REVISIT_MODE, boolean> | null;
+    const modes = await this.studyDatabase.getItem(key) as RuntimeStudySettings | null;
     if (!modes) {
       throw new Error('Modes not initialized');
     }
@@ -268,7 +297,7 @@ export class LocalStorageEngine extends StorageEngine {
     await this.studyDatabase.setItem(key, modes);
   }
 
-  protected async _setModesDocument(studyId: string, modesDocument: Record<string, unknown>): Promise<void> {
+  protected async _setModesDocument(studyId: string, modesDocument: RuntimeStudySettings): Promise<void> {
     const key = `${this.collectionPrefix}${studyId}/modes`;
     await this.studyDatabase.setItem(key, modesDocument);
   }

--- a/src/storage/engines/SupabaseStorageEngine.ts
+++ b/src/storage/engines/SupabaseStorageEngine.ts
@@ -2,7 +2,7 @@ import { AuthError, createClient } from '@supabase/supabase-js';
 import localforage from 'localforage';
 import { v4 as uuidv4 } from 'uuid';
 import {
-  REVISIT_MODE, SequenceAssignment, SnapshotDocContent, StorageObject, StorageObjectType, StoredUser,
+  REVISIT_MODE, RuntimeStudySettings, SequenceAssignment, SnapshotDocContent, StorageObject, StorageObjectType, StoredUser,
   CloudStorageEngine, cleanupModes,
 } from './types';
 import { SnapshotParticipantCounts } from './utils/snapshotParticipantCounts';
@@ -162,7 +162,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     }
 
     // Create a sequence assignment for the participant in the study collection
-    await this.supabase
+    const { data, error } = await this.supabase
       .from('revisit')
       .upsert({
         studyId: `${this.collectionPrefix}${this.studyId}`,
@@ -170,7 +170,11 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
         data: { ...sequenceAssignment, withServerTimestamp },
       })
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('docId', `sequenceAssignment_${participantId}`);
+      .eq('docId', `sequenceAssignment_${participantId}`)
+      .select('docId');
+    if (error || (data?.length ?? 0) !== 1) {
+      throw new Error(`Failed to create sequence assignment for participant ${participantId}`);
+    }
   }
 
   protected async _updateSequenceAssignmentFields(participantId: string, updatedFields: Partial<SequenceAssignment>) {
@@ -295,9 +299,33 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
 
     await acquireLock(0);
 
+    let lockRefreshError: unknown;
+    const refreshLock = async () => {
+      const { data, error } = await this.supabase
+        .from('revisit')
+        .update({ data: { token, expiresAt: Date.now() + expiresInMs } })
+        .eq('studyId', studyId)
+        .eq('docId', lockDocumentId)
+        .eq('data->>token', token)
+        .select('docId');
+      if (error || (data?.length ?? 0) !== 1) {
+        throw error || new Error('Study update lock was lost');
+      }
+    };
+    const refreshTimer = setInterval(() => {
+      refreshLock().catch((error: unknown) => {
+        lockRefreshError ??= error;
+      });
+    }, expiresInMs / 3);
+
     try {
-      return await operation();
+      const result = await operation();
+      if (lockRefreshError) {
+        throw lockRefreshError;
+      }
+      return result;
     } finally {
+      clearInterval(refreshTimer);
       const { error } = await this.supabase
         .from('revisit')
         .delete()
@@ -319,25 +347,28 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       throw new Error('Study ID is not set');
     }
 
-    // Get the sequence assignment for the current participant
-    const { data, error } = await this.supabase
-      .from('revisit')
-      .select('data')
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('docId', `sequenceAssignment_${this.currentParticipantId}`)
-      .single();
+    const participantId = this.currentParticipantId;
+    await this._runWithLock(`participant-${participantId}`, async () => {
+      // Get the sequence assignment for the current participant
+      const { data, error } = await this.supabase
+        .from('revisit')
+        .select('data')
+        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .eq('docId', `sequenceAssignment_${participantId}`)
+        .single();
 
-    if (error || !data) {
-      throw new Error('Failed to retrieve sequence assignment for current participant');
-    }
+      if (error || !data) {
+        throw new Error('Failed to retrieve sequence assignment for current participant');
+      }
 
-    // Update the sequence assignment for the current participant to mark it as completed
-    const sequenceAssignmentPath = `sequenceAssignment_${this.currentParticipantId}`;
-    await this.supabase
-      .from('revisit')
-      .update({ data: { ...data.data, completed: new Date().getTime() } })
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('docId', sequenceAssignmentPath);
+      // Update the sequence assignment for the current participant to mark it as completed
+      const sequenceAssignmentPath = `sequenceAssignment_${participantId}`;
+      await this.supabase
+        .from('revisit')
+        .update({ data: { ...data.data, completed: new Date().getTime() } })
+        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .eq('docId', sequenceAssignmentPath);
+    });
   }
 
   protected async _rejectParticipantRealtime(participantId: string) {
@@ -380,11 +411,14 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
         throw new Error('Failed to retrieve claimed sequence assignment for rejection');
       }
 
-      // Update the claimed sequence assignment to mark it as available again
-      // Also mark as rejected so it doesn't get incorrectly reused
+      // Preserve a timed-out source as timed out when its replacement is rejected.
       await this.supabase
         .from('revisit')
-        .update({ data: { ...claimedData.data, claimed: false, rejected: true } })
+        .update({
+          data: claimedData.data.autoTimedOutAt === undefined
+            ? { ...claimedData.data, claimed: false, rejected: true }
+            : { ...claimedData.data, claimed: false },
+        })
         .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
         .eq('docId', claimedSequenceAssignmentPath);
       return;
@@ -396,6 +430,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .select('data')
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('data->timestamp', data.data.timestamp)
+      .neq('docId', sequenceAssignmentPath)
       .single();
 
     if (claimedError || !claimedData) {
@@ -403,7 +438,11 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     }
     await this.supabase
       .from('revisit')
-      .update({ data: { ...claimedData.data, claimed: false, rejected: true } })
+      .update({
+        data: claimedData.data.autoTimedOutAt === undefined
+          ? { ...claimedData.data, claimed: false, rejected: true }
+          : { ...claimedData.data, claimed: false },
+      })
       .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
       .eq('docId', `sequenceAssignment_${claimedData.data.participantId}`);
   }
@@ -451,7 +490,11 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
 
       await this.supabase
         .from('revisit')
-        .update({ data: { ...claimedData.data, claimed: true, rejected: true } })
+        .update({
+          data: claimedData.data.autoTimedOutAt === undefined
+            ? { ...claimedData.data, claimed: true, rejected: true }
+            : { ...claimedData.data, claimed: true },
+        })
         .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
         .eq('docId', claimedSequenceAssignmentPath);
     }
@@ -474,12 +517,72 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
     }
 
     const sequenceAssignmentPath = `sequenceAssignment_${participantId}`;
-    // Update the sequence assignment for the participant to mark it as claimed
-    await this.supabase
-      .from('revisit')
-      .update({ data: { ...sequenceAssignment, claimed: true } })
-      .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
-      .eq('docId', sequenceAssignmentPath);
+    await this._runWithLock(`participant-${participantId}`, async () => {
+      // Update the sequence assignment for the participant to mark it as claimed.
+      // The participant lock keeps this whole-record JSON update from racing a
+      // late completion on the source assignment.
+      const { data, error } = await this.supabase
+        .from('revisit')
+        .update({ data: { ...sequenceAssignment, claimed: true } })
+        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .eq('docId', sequenceAssignmentPath)
+        .select('docId');
+      if (error || (data?.length ?? 0) !== 1) {
+        throw new Error(`Failed to claim sequence assignment for participant ${participantId}`);
+      }
+    });
+  }
+
+  protected async _markSequenceAssignmentTimedOut(participantId: string): Promise<boolean> {
+    return await this._runWithLock(`participant-${participantId}`, async () => {
+      await this.verifyStudyDatabase();
+      if (!this.studyId) {
+        throw new Error('Study ID is not set');
+      }
+      const sequenceAssignmentPath = `sequenceAssignment_${participantId}`;
+      const { data, error } = await this.supabase
+        .from('revisit')
+        .select('data')
+        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .eq('docId', sequenceAssignmentPath)
+        .single();
+      if (error || !data) {
+        throw new Error(`Failed to retrieve sequence assignment for participant ${participantId}`);
+      }
+
+      const assignment = data.data as SequenceAssignment;
+      if (assignment.completed !== null || assignment.rejected || assignment.autoTimedOutAt !== undefined) {
+        return false;
+      }
+      const { data: updatedRows, error: updateError } = await this.supabase
+        .from('revisit')
+        .update({ data: { ...assignment, autoTimedOutAt: Date.now() } })
+        .eq('studyId', `${this.collectionPrefix}${this.studyId}`)
+        .eq('docId', sequenceAssignmentPath)
+        .eq('data->>rejected', 'false')
+        .is('data->>completed', null)
+        .is('data->>autoTimedOutAt', null)
+        .select('docId');
+      if (updateError) {
+        throw new Error(`Failed to mark participant ${participantId} as timed out`);
+      }
+      if ((updatedRows?.length ?? 0) === 1) {
+        return true;
+      }
+
+      // A zero-row conditional update is only safe when a fresh read confirms
+      // that a concurrent completion, rejection, or timeout won the race.
+      const latestAssignment = await this._getSequenceAssignment(participantId);
+      if (
+        latestAssignment
+        && (latestAssignment.completed !== null
+          || latestAssignment.rejected
+          || latestAssignment.autoTimedOutAt !== undefined)
+      ) {
+        return false;
+      }
+      throw new Error(`Could not confirm timeout status for participant ${participantId}`);
+    });
   }
 
   async initializeStudyDb(studyId: string) {
@@ -539,7 +642,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       // get the metadata field from the data object
       const metadata = data[0].data;
       if (metadata) {
-        const modes = metadata as Record<string, boolean>;
+        const modes = metadata as RuntimeStudySettings;
         const needsUpdate = 'studyNavigatorEnabled' in modes || 'analyticsInterfacePubliclyAccessible' in modes;
 
         if (needsUpdate) {
@@ -561,7 +664,7 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       developmentModeEnabled: true,
       dataSharingEnabled: true,
     };
-    await this.supabase
+    const { error: defaultModesError } = await this.supabase
       .from('revisit')
       .upsert({
         studyId: `${this.collectionPrefix}${studyId}`,
@@ -570,6 +673,9 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       })
       .eq('studyId', `${this.collectionPrefix}${studyId}`)
       .eq('docId', 'metadata');
+    if (defaultModesError) {
+      throw new Error('Failed to update study runtime settings');
+    }
     return defaultModes;
   }
 
@@ -589,8 +695,8 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       .eq('docId', 'metadata');
   }
 
-  protected async _setModesDocument(studyId: string, modesDocument: Record<string, unknown>): Promise<void> {
-    await this.supabase
+  protected async _setModesDocument(studyId: string, modesDocument: RuntimeStudySettings): Promise<void> {
+    const { error } = await this.supabase
       .from('revisit')
       .upsert({
         studyId: `${this.collectionPrefix}${studyId}`,
@@ -599,6 +705,9 @@ export class SupabaseStorageEngine extends CloudStorageEngine {
       })
       .eq('studyId', `${this.collectionPrefix}${studyId}`)
       .eq('docId', 'metadata');
+    if (error) {
+      throw new Error('Failed to update study runtime settings');
+    }
   }
 
   protected async _getAudioUrl(task: string, participantId?: string) {

--- a/src/storage/engines/types.ts
+++ b/src/storage/engines/types.ts
@@ -40,6 +40,8 @@ export type SequenceAssignment = {
   claimed: boolean;
   claimedParticipantId?: string; // The original rejected participant whose slot this assignment is reusing.
   completed: number | null;
+  /** The time this allocation stopped consuming capacity. Unlike rejection, the participant may still finish. */
+  autoTimedOutAt?: number;
   createdTime: number;
   total: number; // Total number of questions/steps
   answered: string[]; // Number of answered questions
@@ -51,8 +53,14 @@ export type SequenceAssignment = {
 
 export type REVISIT_MODE = 'dataCollectionEnabled' | 'developmentModeEnabled' | 'dataSharingEnabled';
 
-export function cleanupModes(modes: Record<string, boolean>): Record<REVISIT_MODE, boolean> {
-  const cleanedModes: Record<string, boolean> = { ...modes };
+export type RuntimeStudySettings = Record<REVISIT_MODE, boolean> & {
+  stage?: StageData;
+  /** Undefined disables lazy participant timeouts. */
+  autoTimeoutMinutes?: number;
+};
+
+export function cleanupModes(modes: Record<string, unknown>): Record<REVISIT_MODE, boolean> {
+  const cleanedModes: Record<string, unknown> = { ...modes };
 
   if ('studyNavigatorEnabled' in modes && !('developmentModeEnabled' in modes)) {
     cleanedModes.developmentModeEnabled = modes.studyNavigatorEnabled;
@@ -109,7 +117,7 @@ interface StageData {
 }
 
 type ModesAndStageData = {
-  modes: Record<REVISIT_MODE, boolean>;
+  modes: Record<REVISIT_MODE, boolean> & { autoTimeoutMinutes?: number };
   stageData: StageData;
 };
 
@@ -122,7 +130,7 @@ const defaultStageColor = DISTINCT_COLOR_PALETTE[0];
 
 export function getStageParticipantCounts(sequenceAssignments: SequenceAssignment[]) {
   return sequenceAssignments.reduce<Record<string, number>>((counts, assignment) => {
-    if (!assignment.rejected) {
+    if (!assignment.rejected && assignment.autoTimedOutAt === undefined) {
       counts[assignment.stage] = (counts[assignment.stage] || 0) + 1;
     }
     return counts;
@@ -399,6 +407,12 @@ export abstract class StorageEngine {
   // Helper function to claim a sequence assignment of the given participant in the realtime database.
   protected abstract _claimSequenceAssignment(participantId: string, sequenceAssignment: SequenceAssignment): Promise<void>;
 
+  /**
+   * Atomically marks an eligible assignment as timed out. Returns false when a
+   * concurrent completion, rejection, or timeout made the assignment ineligible.
+   */
+  protected abstract _markSequenceAssignmentTimedOut(participantId: string): Promise<boolean>;
+
   // Runs an operation while holding a distributed lock for this study. This is used for
   // operations whose correctness depends on multiple reads and writes, such as assigning
   // the final available participant slot or rejecting a participant with a pending save.
@@ -412,13 +426,25 @@ export abstract class StorageEngine {
   abstract connect(): Promise<void>;
 
   // Gets the modes for the given studyId. The modes are stored as a record with the mode name as the key and a boolean value indicating whether the mode is enabled or not.
-  abstract getModes(studyId: string): Promise<Record<REVISIT_MODE, boolean> & { stage?: StageData }>;
+  abstract getModes(studyId: string): Promise<RuntimeStudySettings>;
 
   // Sets the mode for the given studyId. The mode is stored as a record with the mode name as the key and a boolean value indicating whether the mode is enabled or not.
   abstract setMode(studyId: string, mode: REVISIT_MODE, value: boolean): Promise<void>;
 
+  async setAutoTimeoutMinutes(studyId: string, minutes: number | undefined): Promise<void> {
+    if (minutes !== undefined && (!Number.isInteger(minutes) || minutes < 1)) {
+      throw new Error('Auto-timeout must be a whole number of minutes greater than zero');
+    }
+    const modes = await this.getModes(studyId);
+    const updatedModes: RuntimeStudySettings = { ...modes };
+    // Keep the key with `undefined` so merge-based backends can explicitly
+    // remove their stored setting instead of silently retaining an old value.
+    updatedModes.autoTimeoutMinutes = minutes;
+    await this._setModesDocument(studyId, updatedModes);
+  }
+
   // Protected helper: Sets the full modes document (including stage data and mode flags)
-  protected abstract _setModesDocument(studyId: string, modesDocument: Record<REVISIT_MODE, boolean> & { stage?: StageData }): Promise<void>;
+  protected abstract _setModesDocument(studyId: string, modesDocument: RuntimeStudySettings): Promise<void>;
 
   // Gets the audio URL for the given task and participantId. This method is used to fetch the audio file from the storage engine.
   protected abstract _getAudioUrl(task: string, participantId?: string): Promise<string | null>;
@@ -548,7 +574,7 @@ export abstract class StorageEngine {
 
     if (stage) {
       return {
-        modes: modeValues as Record<REVISIT_MODE, boolean>,
+        modes: modeValues as Record<REVISIT_MODE, boolean> & { autoTimeoutMinutes?: number },
         stageData: stage,
       };
     }
@@ -559,12 +585,12 @@ export abstract class StorageEngine {
     };
 
     await this._setModesDocument(studyId, {
-      ...(modeValues as Record<REVISIT_MODE, boolean>),
+      ...(modeValues as Record<REVISIT_MODE, boolean> & { autoTimeoutMinutes?: number }),
       stage: defaultStageData,
     });
 
     return {
-      modes: modeValues as Record<REVISIT_MODE, boolean>,
+      modes: modeValues as Record<REVISIT_MODE, boolean> & { autoTimeoutMinutes?: number },
       stageData: defaultStageData,
     };
   }
@@ -1122,12 +1148,13 @@ export abstract class StorageEngine {
       const combinationCounts: Record<string, number> = {};
       const assignmentsMissingCombinationKey = sequenceAssignments.filter((assignment) => (
         !assignment.rejected
+        && assignment.autoTimedOutAt === undefined
         && assignment.stage === currentStage
         && assignment.betweenSubjectsCombinationKey === undefined
       ));
 
       sequenceAssignments.forEach((assignment) => {
-        if (!assignment.rejected && assignment.stage === currentStage && assignment.betweenSubjectsCombinationKey) {
+        if (!assignment.rejected && assignment.autoTimedOutAt === undefined && assignment.stage === currentStage && assignment.betweenSubjectsCombinationKey) {
           combinationCounts[assignment.betweenSubjectsCombinationKey] = (
             combinationCounts[assignment.betweenSubjectsCombinationKey] || 0
           ) + 1;
@@ -1166,20 +1193,21 @@ export abstract class StorageEngine {
       }
     }
 
-    // Find all rejected documents
-    const rejectedDocs = sequenceAssignments
-      .filter((doc) => doc.rejected && !doc.claimed);
-    if (rejectedDocs.length > 0) {
-      const firstReject = rejectedDocs[0];
-      const firstRejectTime = firstReject.timestamp;
+    // Reuse one released slot. A timed-out participant remains distinct from a
+    // rejected participant, but both no longer consume allocation capacity.
+    const reusableAssignments = sequenceAssignments
+      .filter((doc) => (doc.rejected || doc.autoTimedOutAt !== undefined) && !doc.claimed);
+    if (reusableAssignments.length > 0) {
+      const firstReusableAssignment = reusableAssignments[0];
+      const firstReusableTime = firstReusableAssignment.timestamp;
       if (modes.dataCollectionEnabled) {
         // Make the sequence assignment document for the participant
         const participantSequenceAssignmentData: SequenceAssignment = {
           participantId: this.currentParticipantId,
-          timestamp: firstRejectTime, // Use the timestamp of the first reject
+          timestamp: firstReusableTime, // Preserve the original allocation position.
           rejected: false,
           claimed: false,
-          claimedParticipantId: firstReject.participantId,
+          claimedParticipantId: firstReusableAssignment.participantId,
           completed: null,
           createdTime: new Date().getTime(), // Placeholder, will be set to server timestamp in cloud engines
           total: 0,
@@ -1188,8 +1216,8 @@ export abstract class StorageEngine {
           stage: currentStage,
           ...(conditions ? { conditions } : {}),
         };
-        // Mark the first reject as claimed
-        await this._claimSequenceAssignment(firstReject.participantId, firstReject);
+        // Claim before creating the replacement, so this slot cannot be reused twice.
+        await this._claimSequenceAssignment(firstReusableAssignment.participantId, firstReusableAssignment);
         // Set the participant's sequence assignment document
         await this._createSequenceAssignment(this.currentParticipantId, participantSequenceAssignmentData, false);
       }
@@ -1216,7 +1244,9 @@ export abstract class StorageEngine {
 
     // Get the current row
     const intentIndex = sequenceAssignments.filter(
-      (assignment) => !assignment.rejected && assignment.stage === currentStage,
+      (assignment) => !assignment.rejected
+        && assignment.autoTimedOutAt === undefined
+        && assignment.stage === currentStage,
     ).findIndex(
       (assignment) => assignment.participantId === this.currentParticipantId,
     ) % availableSequenceArray.length;
@@ -1244,6 +1274,35 @@ export abstract class StorageEngine {
     const creationIndex = creationSorted.findIndex((assignment) => assignment.participantId === this.currentParticipantId) + 1;
 
     return { currentRow, creationIndex };
+  }
+
+  private async timeoutExpiredAssignments(
+    modes: ModesAndStageData['modes'],
+  ): Promise<void> {
+    const timeoutMinutes = modes.autoTimeoutMinutes;
+    if (!modes.dataCollectionEnabled || timeoutMinutes === undefined) {
+      return;
+    }
+
+    const deadline = Date.now() - timeoutMinutes * 60_000;
+    const assignments = await this.getAllSequenceAssignments(this.studyId!);
+    const expiredAssignments = assignments.filter((assignment) => (
+      assignment.completed === null
+      && !assignment.rejected
+      && assignment.autoTimedOutAt === undefined
+      && Number.isFinite(assignment.createdTime)
+      && assignment.createdTime <= deadline
+    ));
+
+    // Each storage engine conditionally rechecks eligibility immediately before
+    // updating. A false result means a participant completed or was rejected in
+    // the meantime, so it must continue to consume capacity.
+    for (const assignment of expiredAssignments) {
+      // Process serially so a failed mutation prevents any subsequent capacity
+      // calculation from using an uncertain allocation state.
+      // eslint-disable-next-line no-await-in-loop
+      await this._markSequenceAssignmentTimedOut(assignment.participantId);
+    }
   }
 
   // Initializes or resumes a participant session for the given studyId. This will create a new participant data object if it does not exist, or update the existing one.
@@ -1284,52 +1343,56 @@ export abstract class StorageEngine {
       return participant;
     }
 
-    const initializedParticipant = await this._runWithLock<{
-      participant: ParticipantData;
-      modes: Record<REVISIT_MODE, boolean> | null;
-    }>('participant-assignment', async () => {
-      // Another session may have completed initialization while this session waited
-      // for the lock, so always read the participant record again inside it.
-      const existingParticipant = await this._getFromStorage(
-        `participants/${this.currentParticipantId}`,
-        'participantData',
-      );
-      if (isParticipantData(existingParticipant)) {
-        return { participant: existingParticipant, modes: null };
-      }
-
-      const { modes, stageData } = await this.getModesAndStageData(this.studyId!);
-      const currentStage = stageData.currentStage.stageName;
-      const currentStageInfo = stageData.allStages.find((stage) => stage.stageName === currentStage);
-      if (modes.dataCollectionEnabled && currentStageInfo?.maxParticipants !== undefined) {
-        const stageParticipantCounts = getStageParticipantCounts(await this.getAllSequenceAssignments(this.studyId!));
-        if ((stageParticipantCounts[currentStage] || 0) >= currentStageInfo.maxParticipants) {
-          throw new StageCapacityExceededError(currentStage);
+    const initializedParticipant = await this._runWithLock(
+      'participant-assignment',
+      async (): Promise<{
+        participant: ParticipantData;
+        modes: (Record<REVISIT_MODE, boolean> & { autoTimeoutMinutes?: number }) | null;
+      }> => {
+        // Another session may have completed initialization while this session waited
+        // for the lock, so always read the participant record again inside it.
+        const existingParticipant = await this._getFromStorage(
+          `participants/${this.currentParticipantId}`,
+          'participantData',
+        );
+        if (isParticipantData(existingParticipant)) {
+          return { participant: existingParticipant, modes: null };
         }
-      }
 
-      const participantConfigHash = await hash(JSON.stringify(config));
-      const parsedConditions = parseConditionParam(searchParams.condition);
-      const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
-      const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData }, config);
-      return {
-        participant: {
-          participantId: this.currentParticipantId!,
-          participantConfigHash,
-          sequence: currentRow,
-          participantIndex: creationIndex,
-          answers: {},
-          searchParams,
-          conditions,
-          metadata,
-          rejected: false as const,
-          participantTags: [],
-          stage: currentStage,
-          createdTime: Date.now(),
-        },
-        modes,
-      };
-    });
+        const { modes, stageData } = await this.getModesAndStageData(this.studyId!);
+        await this.timeoutExpiredAssignments(modes);
+        const currentStage = stageData.currentStage.stageName;
+        const currentStageInfo = stageData.allStages.find((stage) => stage.stageName === currentStage);
+        if (modes.dataCollectionEnabled && currentStageInfo?.maxParticipants !== undefined) {
+          const stageParticipantCounts = getStageParticipantCounts(await this.getAllSequenceAssignments(this.studyId!));
+          if ((stageParticipantCounts[currentStage] || 0) >= currentStageInfo.maxParticipants) {
+            throw new StageCapacityExceededError(currentStage);
+          }
+        }
+
+        const participantConfigHash = await hash(JSON.stringify(config));
+        const parsedConditions = parseConditionParam(searchParams.condition);
+        const conditions = parsedConditions.length > 0 ? parsedConditions : undefined;
+        const { currentRow, creationIndex } = await this._getSequence(conditions, { modes, stageData }, config);
+        return {
+          participant: {
+            participantId: this.currentParticipantId!,
+            participantConfigHash,
+            sequence: currentRow,
+            participantIndex: creationIndex,
+            answers: {},
+            searchParams,
+            conditions,
+            metadata,
+            rejected: false as const,
+            participantTags: [],
+            stage: currentStage,
+            createdTime: Date.now(),
+          },
+          modes,
+        };
+      },
+    );
 
     const participantData = initializedParticipant.participant;
     this.participantData = participantData;
@@ -1695,11 +1758,14 @@ export abstract class StorageEngine {
   async getAllParticipantsData(studyId: string): Promise<ParticipantDataWithStatus[]> {
     const participantIds = await this.getAllParticipantIds(studyId);
     const sequenceAssignments = await this.getAllSequenceAssignments(studyId);
-    const completedByParticipantId = new Map(
-      sequenceAssignments.map((assignment) => [assignment.participantId, assignment.completed !== null]),
+    const statusByParticipantId = new Map(
+      sequenceAssignments.map((assignment) => [assignment.participantId, {
+        completed: assignment.completed !== null,
+        timedOut: assignment.autoTimedOutAt !== undefined,
+      }]),
     );
 
-    const participantPulls = participantIds.map(async (participantId) => {
+    const participantPulls: Array<Promise<ParticipantDataWithStatus | null>> = participantIds.map(async (participantId) => {
       const participantData = await this._getFromStorage(
         `participants/${participantId}`,
         'participantData',
@@ -1707,9 +1773,12 @@ export abstract class StorageEngine {
       );
 
       if (isParticipantData(participantData)) {
+        const assignmentStatus = statusByParticipantId.get(participantId);
         return {
           ...participantData,
-          completed: completedByParticipantId.get(participantId) ?? false,
+          completed: assignmentStatus?.completed ?? false,
+          timedOut: assignmentStatus?.timedOut ?? false,
+          completedLate: (assignmentStatus?.completed ?? false) && (assignmentStatus?.timedOut ?? false),
         } satisfies ParticipantDataWithStatus;
       }
       return null;
@@ -1722,15 +1791,17 @@ export abstract class StorageEngine {
   async getParticipantsStatusCounts(studyId: string) {
     const sequenceAssignments = await this.getAllSequenceAssignments(studyId);
 
-    const completed = sequenceAssignments.filter((assignment) => assignment.completed && !assignment.rejected).length;
+    const completed = sequenceAssignments.filter((assignment) => assignment.completed && !assignment.rejected && assignment.autoTimedOutAt === undefined).length;
     const rejected = sequenceAssignments.filter((assignment) => assignment.rejected).length;
-    const inProgress = sequenceAssignments.length - completed - rejected;
+    const timedOut = sequenceAssignments.filter((assignment) => assignment.autoTimedOutAt !== undefined && !assignment.rejected).length;
+    const inProgress = sequenceAssignments.length - completed - rejected - timedOut;
     const minTime = sequenceAssignments.length > 0 ? sequenceAssignments[0].timestamp : null;
     const maxTime = sequenceAssignments.length > 0 ? sequenceAssignments.at(-1)!.timestamp : null;
 
     return {
       completed,
       rejected,
+      timedOut,
       inProgress,
       minTime,
       maxTime,
@@ -1788,15 +1859,17 @@ export abstract class StorageEngine {
     this.pendingProgressDataWrite = progressDataWrite;
 
     try {
-      const existingAssignment = await this._getSequenceAssignment(targetParticipantId);
+      await this._runWithLock(`participant-${targetParticipantId}`, async () => {
+        const existingAssignment = await this._getSequenceAssignment(targetParticipantId);
 
-      if (existingAssignment) {
-        await this._updateSequenceAssignmentFields(targetParticipantId, {
-          total: progressData.total,
-          answered: progressData.answered,
-          isDynamic: progressData.isDynamic,
-        });
-      }
+        if (existingAssignment) {
+          await this._updateSequenceAssignmentFields(targetParticipantId, {
+            total: progressData.total,
+            answered: progressData.answered,
+            isDynamic: progressData.isDynamic,
+          });
+        }
+      });
 
       if (this.pendingProgressDataWrite === progressDataWrite) {
         this.pendingProgressDataWrite = undefined;

--- a/src/storage/tests/highLevel.spec.ts
+++ b/src/storage/tests/highLevel.spec.ts
@@ -836,6 +836,39 @@ describe.each([
     expect(participantIds).toContain(participantId4);
   });
 
+  test('lazy auto-timeout frees an expired allocation without rejecting its participant data', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      await storageEngine.setAutoTimeoutMinutes(studyId, 1);
+      const firstParticipant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+
+      vi.setSystemTime(new Date('2026-01-01T00:01:00.000Z'));
+      await storageEngine.clearCurrentParticipantId();
+      const secondParticipant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+      const assignments = await storageEngine.getAllSequenceAssignments(studyId);
+      const firstAssignment = assignments.find((assignment) => assignment.participantId === firstParticipant.participantId);
+      const secondAssignment = assignments.find((assignment) => assignment.participantId === secondParticipant.participantId);
+
+      expect(firstAssignment?.autoTimedOutAt).toBeDefined();
+      expect(firstAssignment?.rejected).toBe(false);
+      expect(firstAssignment?.claimed).toBe(true);
+      expect(secondAssignment?.claimedParticipantId).toBe(firstParticipant.participantId);
+      const participants = await storageEngine.getAllParticipantsData(studyId);
+      expect(participants.find((participant) => participant.participantId === firstParticipant.participantId)?.rejected).toBe(false);
+
+      await storageEngine.rejectParticipant(firstParticipant.participantId, 'test source rejection');
+      await storageEngine.clearCurrentParticipantId();
+      const thirdParticipant = await storageEngine.initializeParticipantSession({}, configSimple, participantMetadata);
+      const assignmentsAfterSourceRejection = await storageEngine.getAllSequenceAssignments(studyId);
+      expect(assignmentsAfterSourceRejection.find((assignment) => assignment.participantId === firstParticipant.participantId)?.claimed).toBe(true);
+      expect(assignmentsAfterSourceRejection.find((assignment) => assignment.participantId === thirdParticipant.participantId)?.claimedParticipantId)
+        .not.toBe(firstParticipant.participantId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // rejectCurrentParticipant test
 
   // getParticipantStatusCounts test

--- a/src/storage/tests/highLevelFirebase.spec.ts
+++ b/src/storage/tests/highLevelFirebase.spec.ts
@@ -1065,6 +1065,14 @@ describe.each([
     expect(modes.dataSharingEnabled).toBe(false);
   });
 
+  test('setAutoTimeoutMinutes removes the Firebase setting when disabled', async () => {
+    await storageEngine.setAutoTimeoutMinutes(studyId, 60);
+    expect((await storageEngine.getModes(studyId)).autoTimeoutMinutes).toBe(60);
+
+    await storageEngine.setAutoTimeoutMinutes(studyId, undefined);
+    expect((await storageEngine.getModes(studyId)).autoTimeoutMinutes).toBeUndefined();
+  });
+
   // ── URL getters ──────────────────────────────────────────────────────────────
   test('_getAudioUrl returns URL when audio exists', async () => {
     // @ts-expect-error protected

--- a/src/storage/tests/highLevelSupabase.spec.ts
+++ b/src/storage/tests/highLevelSupabase.spec.ts
@@ -1050,6 +1050,14 @@ describe.each([
     expect(modes.dataSharingEnabled).toBe(false);
   });
 
+  test('setAutoTimeoutMinutes persists and removes the setting', async () => {
+    await storageEngine.setAutoTimeoutMinutes(studyId, 60);
+    expect((await storageEngine.getModes(studyId)).autoTimeoutMinutes).toBe(60);
+
+    await storageEngine.setAutoTimeoutMinutes(studyId, undefined);
+    expect((await storageEngine.getModes(studyId)).autoTimeoutMinutes).toBeUndefined();
+  });
+
   // ── URL getters ──────────────────────────────────────────────────────────────
   test('_getAudioUrl returns null when audio does not exist', async () => {
     // _getFromStorage returns {} on error, which is truthy. The real

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -75,4 +75,8 @@ export interface ParticipantData {
 export interface ParticipantDataWithStatus extends ParticipantData {
   /** Whether the participant has completed the study. Derived from sequence assignment status. */
   completed: boolean;
+  /** Allocation timed out and no longer consumes a study slot. */
+  timedOut?: boolean;
+  /** A participant who completed after their allocation had timed out. */
+  completedLate?: boolean;
 }

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -75,6 +75,8 @@ class TestStorageEngine extends StorageEngine {
 
   protected _claimSequenceAssignment = vi.fn(async () => { });
 
+  protected _markSequenceAssignmentTimedOut = vi.fn(async () => false);
+
   protected async _runWithLock<T>(_lockKey: string, operation: () => Promise<T>) {
     return await operation();
   }
@@ -188,6 +190,8 @@ export function makeParticipant(overrides: Partial<ParticipantDataWithStatus> & 
       ip: null,
     },
     completed: false,
+    timedOut: false,
+    completedLate: false,
     rejected: false,
     participantTags: [],
     stage: 'DEFAULT',


### PR DESCRIPTION
## Summary
- Add lazy, admin-configured participant auto-timeouts.
- Keep timed-out assignments excluded from capacity while retaining late participant data.
- Add distinct timed-out and late-completed analysis statuses.

Closes #194