### PR TITLE
auto-advance, delay and block answer change

### DIFF
--- a/public/demo-form-elements/config.json
+++ b/public/demo-form-elements/config.json
@@ -486,6 +486,47 @@
         }
       ]
     },
+    "Auto advance": {
+      "type": "questionnaire",
+      "response": [
+        {
+          "id": "math-buttons",
+          "type": "buttons",
+          "prompt": "Complex calculation that use buttons with auto-advance.",
+          "secondaryText": "What does 53 + 98 equal?",
+          "infoText": "Choose the option that is correct.",
+          "options": [
+            {
+              "label": "162",
+              "value": "162"
+            },
+            {
+              "label": "149",
+              "value": "149"
+            },
+            {
+              "label": "151",
+              "value": "151"
+            },
+            {
+              "label": "137",
+              "value": "137"
+            }
+          ],
+          "autoAdvanceToNextStep": true,
+          "autoAdvanceDelay": 5000,
+          "allowResponseChange": false
+        }
+      ],
+      "correctAnswer": [
+        {
+          "id": "math-buttons",
+          "answer": "151"
+        }
+      ],
+      "provideFeedback": true,
+      "trainingAttempts": 1
+    },
     "Default Values": {
       "type": "questionnaire",
       "response": [
@@ -1219,6 +1260,7 @@
       "Text Validation",
       "Default Values",
       "Custom Response",
+      "Auto advance",
       "Randomizing Options",
       "Randomizing Questions",
       "Ranking Widgets",

--- a/public/global.json
+++ b/public/global.json
@@ -58,6 +58,7 @@
     "library-virtual-chinrest",
     "library-vlat",
     "test-audio",
+    "test-auto-advance",
     "test-device-restriction",
     "test-library",
     "test-likert-matrix",
@@ -245,6 +246,10 @@
     },
     "test-audio": {
       "path": "test-audio/config.json",
+      "test": true
+    },
+    "test-auto-advance": {
+      "path": "test-auto-advance/config.json",
       "test": true
     },
     "test-device-restriction": {

--- a/public/test-auto-advance/config.json
+++ b/public/test-auto-advance/config.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "Test auto advance and block response change",
+    "version": "pilot",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2026-02-23",
+    "description": "A test of auto advance and blocking change responses.",
+    "organizations": [
+      "University of Utah",
+      "WPI"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "contact@revisit.dev",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "autoDownloadStudy": false,
+    "withSidebar": true,
+    "urlParticipantIdParam": "PROLIFIC_PID",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [yourProlificLink](yourProlificLink)"
+  },
+  "components": {
+    "auto-advance": {
+      "response": [
+        {
+          "id": "q-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            {
+              "label": "Option 1",
+              "infoText": "This is info text for button option 1."
+            },
+            "Option 2",
+            "Option 3",
+            "Option 4"
+          ],
+          "autoAdvanceToNextStep": true
+        }
+      ],
+      "type": "questionnaire"
+    },
+    "warning": {
+      "response": [
+        {
+          "id": "q1-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            "Option 1",
+            "Option 2",
+            "Option 3",
+            "Option 4"
+          ],
+          "autoAdvanceToNextStep": true
+        },
+        {
+          "id": "q2-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            "Option 1",
+            "Option 2",
+            "Option 3",
+            "Option 4"
+          ]
+        }
+      ],
+      "type": "questionnaire"
+    },
+    "block-change": {
+      "response": [
+        {
+          "id": "q-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            "Option 1",
+            "Option 2",
+            "Option 3",
+            "Option 4"
+          ],
+          "autoAdvanceToNextStep": true,
+          "autoAdvanceDelay": 6000,
+          "allowResponseChange": false
+        }
+      ],
+      "type": "questionnaire"
+    }
+},
+    "sequence": {
+    "order": "fixed",
+    "components": [
+      "auto-advance",
+      "warning",
+      "block-change"
+    ]
+  }
+}

--- a/public/test-auto-advance/config.json
+++ b/public/test-auto-advance/config.json
@@ -43,7 +43,8 @@
           "autoAdvanceToNextStep": true
         }
       ],
-      "type": "questionnaire"
+      "type": "questionnaire",
+      "nextButtonHidden": false
     },
     "warning": {
       "response": [

--- a/public/test-auto-advance/config.json
+++ b/public/test-auto-advance/config.json
@@ -97,6 +97,49 @@
         }
       ],
       "type": "questionnaire"
+    },
+    "sidebar-next": {
+      "response": [
+        {
+          "id": "q-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            "Option 1",
+            "Option 2",
+            "Option 3",
+            "Option 4"
+          ],
+          "autoAdvanceToNextStep": true,
+          "autoAdvanceDelay": 6000,
+          "allowResponseChange": false
+        }
+      ],
+      "nextButtonLocation": "sidebar",
+      "type": "questionnaire"
+    },
+    "sidebar-next-immediately": {
+      "response": [
+        {
+          "id": "q-buttons",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons that function as radio buttons, but look like buttons. Control with the arrow keys.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            "Option 1",
+            "Option 2",
+            "Option 3",
+            "Option 4"
+          ],
+          "autoAdvanceToNextStep": true,
+          "allowResponseChange": false
+        }
+      ],
+      "nextButtonLocation": "sidebar",
+      "type": "questionnaire"
     }
 },
     "sequence": {
@@ -104,7 +147,9 @@
     "components": [
       "auto-advance",
       "warning",
-      "block-change"
+      "block-change",
+      "sidebar-next",
+      "sidebar-next-immediately"
     ]
   }
 }

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -51,6 +51,7 @@ export function NextButton({
   const nextButtonAutoAdvanceTime = config?.nextButtonAutoAdvanceTime;
   const nextButtonAutoAdvanceWarningTime = config?.nextButtonAutoAdvanceWarningTime ?? DEFAULT_AUTO_ADVANCE_WARNING_TIME;
   const nextButtonAutoAdvanceWarningMessage = config?.nextButtonAutoAdvanceWarningMessage ?? DEFAULT_AUTO_ADVANCE_WARNING_MESSAGE;
+  const nextButtonHidden = config?.nextButtonHidden ?? false;
 
   const [timer, setTimer] = useState<number | undefined>(undefined);
   const autoAdvanceTriggered = useRef(false);
@@ -116,7 +117,7 @@ export function NextButton({
         onCheckAnswer();
         return;
       }
-      if (!disabled && !isNextDisabled && buttonTimerSatisfied) {
+      if (!disabled && !isNextDisabled && buttonTimerSatisfied && !nextButtonHidden) {
         onNext();
       }
     };
@@ -127,7 +128,7 @@ export function NextButton({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [disabled, isNextDisabled, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter]);
+  }, [disabled, isNextDisabled, nextButtonHidden, buttonTimerSatisfied, onCheckAnswer, onNext, nextOnEnter]);
 
   const nextButtonDisabled = disabled || isNextDisabled || !buttonTimerSatisfied;
   const previousButtonText = config?.previousButtonText ?? studyConfig.uiConfig.previousButtonText ?? 'Previous';
@@ -143,14 +144,16 @@ export function NextButton({
           />
         )}
         {checkAnswer}
-        <Button
-          type="submit"
-          disabled={nextButtonDisabled}
-          onClick={() => onNext()}
-          px={location === 'sidebar' && checkAnswer ? 8 : undefined}
-        >
-          {label}
-        </Button>
+        {!nextButtonHidden && (
+          <Button
+            type="submit"
+            disabled={nextButtonDisabled}
+            onClick={() => onNext()}
+            px={location === 'sidebar' && checkAnswer ? 8 : undefined}
+          >
+            {label}
+          </Button>
+        )}
       </Group>
       {timer !== undefined && (
         <>

--- a/src/components/interface/StepsPanel.tsx
+++ b/src/components/interface/StepsPanel.tsx
@@ -608,7 +608,7 @@ export function StepsPanel({
     // Set full and rendered flat tree
     setFullFlatTree(newFlatTree);
     setRenderedFlatTree(newFlatTree);
-  }, [fullOrder, participantAnswers, participantSequence, skippedTrialOrders, studyConfig.components, studyId]);
+  }, [fullOrder, participantAnswers, participantSequence, skippedTrialOrders, studyConfig, studyId]);
 
   const collapseBlock = useCallback((startIndex: number, startItem: StepItem) => {
     setRenderedFlatTree((prevRenderedFlatTree) => {

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -1,7 +1,7 @@
 import {
   Flex, FocusTrap, Radio,
 } from '@mantine/core';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import ClearSelectionButton from './ClearSelectionButton';
 import { ButtonsResponse, ParsedStringOption } from '../../parser/types';
 import classes from './css/ButtonsInput.module.css';
@@ -33,6 +33,13 @@ export function ButtonsInput({
     infoText,
   } = response;
 
+  const userInteractedRef = useRef(false);
+
+  const handleUserSelect = (value: string) => {
+    userInteractedRef.current = true;
+    answer.onChange?.(value);
+  };
+
   const storedAnswer = useStoredAnswer();
   const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => storedAnswer?.optionOrders ?? {}, [storedAnswer]);
 
@@ -53,7 +60,7 @@ export function ButtonsInput({
             enumerateQuestions={enumerateQuestions}
             infoText={infoText}
             clearSelectionButton={(
-              <ClearSelectionButton onClick={() => answer?.onChange?.('')} disabled={disabled} visible={!!answer?.value} />
+              <ClearSelectionButton onClick={() => handleUserSelect('')} disabled={disabled} visible={!!answer?.value} />
             )}
           />
         )}

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -677,23 +677,68 @@ export function ResponseBlock({
     };
   }, [identifier]);
 
+  const userInteractedRef = useRef(false);
+
   useEffect(() => {
-    if (!autoAdvanceOwner || autoAdvanceIdentifierRef.current === identifier) {
-      return;
+    userInteractedRef.current = false;
+  }, [identifier]);
+
+  const handleNextClickRef = useRef(handleNextClick);
+  useEffect(() => {
+    handleNextClickRef.current = handleNextClick;
+  }, [handleNextClick]);
+
+  const prevValuesRef = useRef(answerValidator.values);
+  useEffect(() => {
+    if (!isEqual(prevValuesRef.current, answerValidator.values)) {
+      if (Object.keys(answerValidator.values).length > 0) {
+        userInteractedRef.current = true;
+      }
+      prevValuesRef.current = answerValidator.values;
+    }
+  }, [answerValidator.values]);
+
+  useEffect(() => {
+    if (!autoAdvanceOwner) {
+      return undefined;
     }
 
     const readyResponse = autoAdvanceResponses.find((response) => hasAnswerValue(combinedValues[response.id]));
+
     if (!readyResponse) {
-      return;
+      autoAdvanceIdentifierRef.current = null;
+      return undefined;
+    }
+
+    const hasFeedback = 'provideFeedback' in readyResponse && Boolean(readyResponse.provideFeedback);
+    if (hasFeedback) {
+      return undefined;
+    }
+
+    if (!userInteractedRef.current) {
+      return undefined;
+    }
+
+    if (autoAdvanceTimeoutRef.current) {
+      clearTimeout(autoAdvanceTimeoutRef.current);
+      autoAdvanceTimeoutRef.current = undefined;
     }
 
     autoAdvanceIdentifierRef.current = identifier;
     if (readyResponse.type === 'buttons') {
+      const delay = readyResponse.autoAdvanceDelay ?? 0;
       autoAdvanceTimeoutRef.current = setTimeout(() => {
-        handleNextClick();
-      }, readyResponse.autoAdvanceDelay ?? 0);
+        handleNextClickRef.current();
+      }, delay);
     }
-  }, [autoAdvanceOwner, autoAdvanceResponses, combinedValues, customResponseLoadErrors, customResponseValidators, handleNextClick, identifier]);
+
+    return () => {
+      if (autoAdvanceTimeoutRef.current) {
+        clearTimeout(autoAdvanceTimeoutRef.current);
+        autoAdvanceTimeoutRef.current = undefined;
+      }
+    };
+  }, [autoAdvanceOwner, autoAdvanceResponses, combinedValues, identifier]);
 
   let index = 0;
   return (

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -688,15 +688,17 @@ export function ResponseBlock({
     handleNextClickRef.current = handleNextClick;
   }, [handleNextClick]);
 
-  const prevValuesRef = useRef(answerValidator.values);
+  const prevCombinedValuesRef = useRef(combinedValues);
   useEffect(() => {
-    if (!isEqual(prevValuesRef.current, answerValidator.values)) {
-      if (Object.keys(answerValidator.values).length > 0) {
+    const hasValuesChanged = !isEqual(prevCombinedValuesRef.current, combinedValues);
+
+    if (hasValuesChanged) {
+      if (Object.keys(combinedValues || {}).length > 0) {
         userInteractedRef.current = true;
       }
-      prevValuesRef.current = answerValidator.values;
+      prevCombinedValuesRef.current = combinedValues;
     }
-  }, [answerValidator.values]);
+  }, [combinedValues]);
 
   useEffect(() => {
     if (!autoAdvanceOwner) {

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -21,7 +21,7 @@ import {
 
 import { NextButton } from '../NextButton';
 import {
-  generateInitFields, mergeReactiveAnswers, useAnswerField,
+  generateInitFields, hasAnswerValue, mergeReactiveAnswers, useAnswerField,
 } from './utils';
 import {
   generateCustomResponseErrorMessage,
@@ -659,6 +659,41 @@ export function ResponseBlock({
 
     revealResponseErrors();
   }, [bypassValidationForFailedTraining, goToNextStep, hasResponseIssues, hasStimulusIssue, revealResponseErrors, revealStimulusErrors]);
+
+  const autoAdvanceResponses = useMemo(
+    () => allResponsesWithDefaults.filter((response) => !response.hidden && response.type === 'buttons' && response.autoAdvanceToNextStep),
+    [allResponsesWithDefaults],
+  );
+  const autoAdvanceOwner = showBtnsInLocation && autoAdvanceResponses.length > 0 && !isAnalysis;
+  const autoAdvanceTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const autoAdvanceIdentifierRef = useRef<string | null>(null);
+  useEffect(() => {
+    autoAdvanceIdentifierRef.current = null;
+    return () => {
+      if (autoAdvanceTimeoutRef.current) {
+        clearTimeout(autoAdvanceTimeoutRef.current);
+        autoAdvanceTimeoutRef.current = undefined;
+      }
+    };
+  }, [identifier]);
+
+  useEffect(() => {
+    if (!autoAdvanceOwner || autoAdvanceIdentifierRef.current === identifier) {
+      return;
+    }
+
+    const readyResponse = autoAdvanceResponses.find((response) => hasAnswerValue(combinedValues[response.id]));
+    if (!readyResponse) {
+      return;
+    }
+
+    autoAdvanceIdentifierRef.current = identifier;
+    if (readyResponse.type === 'buttons') {
+      autoAdvanceTimeoutRef.current = setTimeout(() => {
+        handleNextClick();
+      }, readyResponse.autoAdvanceDelay ?? 0);
+    }
+  }, [autoAdvanceOwner, autoAdvanceResponses, combinedValues, customResponseLoadErrors, customResponseValidators, handleNextClick, identifier]);
 
   let index = 0;
   return (

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -1,6 +1,6 @@
 import { Box, Checkbox, Divider } from '@mantine/core';
 import { useSearchParams } from 'react-router';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { GetInputPropsReturnType } from '@mantine/form/lib/types';
 import {
   CustomResponse, IndividualComponent, JsonValue, MatrixResponse, Response, SliderResponse, StoredAnswer,
@@ -31,7 +31,7 @@ import { useFetchStylesheet } from '../../utils/fetchStylesheet';
 import { parseStringOptionValue, parseStringOptions } from '../../utils/stringOptions';
 import { getDropdownOptions } from '../../utils/dropdownOptions';
 import {
-  getDefaultFieldValue, hasAnswerValue, normalizeCheckboxValue,
+  getDefaultFieldValue, normalizeCheckboxValue,
 } from './utils';
 import {
   generateErrorMessage,
@@ -76,14 +76,34 @@ export function ResponseSwitcher({
   const currentStep = useCurrentStep();
   const nextComponent = useMemo(() => (typeof currentStep === 'number' ? flatSequence[currentStep + 1] : undefined), [currentStep, flatSequence]);
   const nextConfig = useMemo(() => (nextComponent ? studyConfig.components[nextComponent] : undefined), [nextComponent, studyConfig]);
+  const userSelectedFieldsRef = useRef<Record<string, boolean>>({});
 
   const completed = useStoreSelector((state) => state.completed);
   const usesStandaloneDontKnow = usesStandaloneDontKnowField(response);
 
   const finalStoredAnswer = isAnalysis || answerFinalized || completed ? storedAnswer : undefined;
 
+  const wrappedForm = useMemo(() => {
+    if (!form || typeof form.onChange !== 'function') {
+      return form;
+    }
+
+    return {
+      ...form,
+      onChange: (val: unknown) => {
+        userSelectedFieldsRef.current[response.id] = true;
+        form.onChange(val);
+      },
+    };
+  }, [form, response.id]);
+
   // Don't update if we're in analysis mode
-  const ans = useMemo(() => (isAnalysis || (Object.keys(finalStoredAnswer || {}).length > 0 && !nextConfig?.previousButton) || completed ? { value: finalStoredAnswer?.[response.id], readOnly: true } : form) || { value: undefined }, [isAnalysis, finalStoredAnswer, response.id, form, nextConfig?.previousButton, completed]);
+  const ans = useMemo(
+    () => (isAnalysis || (Object.keys(finalStoredAnswer || {}).length > 0 && !nextConfig?.previousButton) || completed
+      ? { value: finalStoredAnswer?.[response.id], readOnly: true }
+      : wrappedForm) || { value: undefined },
+    [isAnalysis, finalStoredAnswer, response.id, wrappedForm, nextConfig?.previousButton, completed],
+  );
   const dontKnowValue = usesStandaloneDontKnow
     ? ((Object.keys(finalStoredAnswer || {}).length > 0 ? { checked: finalStoredAnswer![`${response.id}-dontKnow`] } : dontKnowCheckbox) || { checked: undefined })
     : { checked: undefined };
@@ -97,6 +117,37 @@ export function ResponseSwitcher({
 
   useFetchStylesheet(response.stylesheetPath);
 
+  const fieldInitialValue = useMemo(() => {
+    if (response.paramCapture) {
+      const capturedValue = searchParams.get(response.paramCapture);
+      return response.type === 'checkbox' ? normalizeCheckboxValue(capturedValue) : capturedValue || '';
+    }
+
+    const defaultFieldValue = getDefaultFieldValue(response);
+    if (defaultFieldValue !== null) {
+      return defaultFieldValue;
+    }
+
+    if (response.type === 'reactive' || response.type === 'checkbox') {
+      return [];
+    }
+
+    if (response.type === 'matrix-radio' || response.type === 'matrix-checkbox') {
+      return Object.fromEntries(response.questionOptions.map((entry) => [parseStringOptionValue(entry), '']));
+    }
+
+    if (response.type === 'slider' && response.startingValue !== undefined) {
+      return response.startingValue.toString();
+    }
+
+    if (response.type === 'custom') {
+      return null;
+    }
+
+    return '';
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [response.paramCapture, (response as MatrixResponse).questionOptions, (response as SliderResponse).startingValue, response.type, searchParams]);
+
   const responseChangeLocked = useMemo(() => {
     if (!('allowResponseChange' in response)) {
       return false;
@@ -107,11 +158,13 @@ export function ResponseSwitcher({
     }
 
     if (response.allowResponseChange === false) {
-      return hasAnswerValue(ans.value);
+      const userInteracted = Boolean(userSelectedFieldsRef.current[response.id]);
+      const hasNonDefaultValue = ans.value !== undefined && ans.value !== '' && ans.value !== fieldInitialValue;
+      return userInteracted || hasNonDefaultValue;
     }
 
-    return hasAnswerValue(ans.value);
-  }, [response, ans.value]);
+    return false;
+  }, [response, ans.value, fieldInitialValue]);
 
   const isDisabled = useMemo(() => {
     // Always disable if participant is completed
@@ -149,37 +202,6 @@ export function ResponseSwitcher({
     }
     return inputDisabled;
   }, [completed, responseChangeLocked, currentStep, flatSequence, response.paramCapture, inputDisabled, sequence.components, nextConfig?.previousButton, searchParams]);
-
-  const fieldInitialValue = useMemo(() => {
-    if (response.paramCapture) {
-      const capturedValue = searchParams.get(response.paramCapture);
-      return response.type === 'checkbox' ? normalizeCheckboxValue(capturedValue) : capturedValue || '';
-    }
-
-    const defaultFieldValue = getDefaultFieldValue(response);
-    if (defaultFieldValue !== null) {
-      return defaultFieldValue;
-    }
-
-    if (response.type === 'reactive' || response.type === 'checkbox') {
-      return [];
-    }
-
-    if (response.type === 'matrix-radio' || response.type === 'matrix-checkbox') {
-      return Object.fromEntries(response.questionOptions.map((entry) => [parseStringOptionValue(entry), '']));
-    }
-
-    if (response.type === 'slider' && response.startingValue !== undefined) {
-      return response.startingValue.toString();
-    }
-
-    if (response.type === 'custom') {
-      return null;
-    }
-
-    return '';
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [response.paramCapture, (response as MatrixResponse).questionOptions, (response as SliderResponse).startingValue, response.type, searchParams]);
 
   const responseStyle = useMemo(() => response.style || {}, [response.style]);
   const responseDividers = useMemo(() => response.withDivider ?? config?.responseDividers ?? studyConfig.uiConfig.responseDividers, [response, config, studyConfig]);
@@ -435,7 +457,7 @@ export function ResponseSwitcher({
         classNames={{ input: classes.fixDisabled, label: classes.fixDisabledLabel, icon: classes.fixDisabledIcon }}
         {...dontKnowCheckbox}
         checked={dontKnowValue.checked}
-        onChange={(event) => { dontKnowCheckbox?.onChange(event.currentTarget.checked); form.onChange(fieldInitialValue); }}
+        onChange={(event) => { dontKnowCheckbox?.onChange(event.currentTarget.checked); wrappedForm.onChange(fieldInitialValue); }}
       />
       )}
       {(response.type === 'divider' || responseDividers) && <Divider mt="xl" mb="xs" />}

--- a/src/components/response/ResponseSwitcher.tsx
+++ b/src/components/response/ResponseSwitcher.tsx
@@ -31,7 +31,7 @@ import { useFetchStylesheet } from '../../utils/fetchStylesheet';
 import { parseStringOptionValue, parseStringOptions } from '../../utils/stringOptions';
 import { getDropdownOptions } from '../../utils/dropdownOptions';
 import {
-  getDefaultFieldValue, normalizeCheckboxValue,
+  getDefaultFieldValue, hasAnswerValue, normalizeCheckboxValue,
 } from './utils';
 import {
   generateErrorMessage,
@@ -89,7 +89,7 @@ export function ResponseSwitcher({
     : { checked: undefined };
   const dontKnowChecked = !!dontKnowValue.checked;
   const otherValue = (Object.keys(finalStoredAnswer || {}).length > 0 ? { value: finalStoredAnswer![`${response.id}-other`] } : otherInput) || { value: undefined };
-  const inputDisabled = !!(Object.keys(finalStoredAnswer || {}).length > 0 || disabled || completed);
+  const inputDisabled = (Object.keys(finalStoredAnswer || {}).length > 0 || disabled || completed);
 
   const [searchParams] = useSearchParams();
 
@@ -97,9 +97,25 @@ export function ResponseSwitcher({
 
   useFetchStylesheet(response.stylesheetPath);
 
+  const responseChangeLocked = useMemo(() => {
+    if (!('allowResponseChange' in response)) {
+      return false;
+    }
+
+    if (response.type === 'buttons' && response.allowResponseChange !== false) {
+      return false;
+    }
+
+    if (response.allowResponseChange === false) {
+      return hasAnswerValue(ans.value);
+    }
+
+    return hasAnswerValue(ans.value);
+  }, [response, ans.value]);
+
   const isDisabled = useMemo(() => {
     // Always disable if participant is completed
-    if (completed) {
+    if (completed || responseChangeLocked) {
       return true;
     }
 
@@ -132,7 +148,7 @@ export function ResponseSwitcher({
       return inputDisabled || !!responseParam;
     }
     return inputDisabled;
-  }, [completed, currentStep, flatSequence, response.paramCapture, inputDisabled, sequence.components, nextConfig?.previousButton, searchParams]);
+  }, [completed, responseChangeLocked, currentStep, flatSequence, response.paramCapture, inputDisabled, sequence.components, nextConfig?.previousButton, searchParams]);
 
   const fieldInitialValue = useMemo(() => {
     if (response.paramCapture) {

--- a/src/components/response/tests/ResponseInput.spec.tsx
+++ b/src/components/response/tests/ResponseInput.spec.tsx
@@ -267,6 +267,7 @@ vi.mock('../utils', () => ({
   normalizeCheckboxValue: vi.fn((v: unknown) => (typeof v === 'string' && v.length > 0 ? [v] : [])),
   usesStandaloneDontKnowField: vi.fn(() => false),
   getDefaultFieldValue: vi.fn(() => null),
+  hasAnswerValue: vi.fn((val) => val !== undefined && val !== null && val !== ''),
 }));
 
 vi.mock('../../../utils/stringOptions', () => ({

--- a/src/components/response/utils.ts
+++ b/src/components/response/utils.ts
@@ -35,6 +35,22 @@ const getQueryParameters = () => {
   return new URLSearchParams(window.location.search);
 };
 
+export function hasAnswerValue(value: unknown): boolean {
+  if (value === undefined || value === null || value === '') {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.some((entry) => hasAnswerValue(entry));
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some((entry) => hasAnswerValue(entry));
+  }
+
+  return true;
+}
+
 export const getDefaultFieldValue = (response: Response) => {
   const responseDefault = (response as ResponseWithDefault).default;
   if (!Object.hasOwn(response, 'default') || responseDefault === undefined) {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -104,6 +104,10 @@
             "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
             "type": "number"
           },
+          "nextButtonHidden": {
+            "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+            "type": "boolean"
+          },
           "nextButtonLocation": {
             "$ref": "#/definitions/ConfigResponseBlockLocation",
             "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -1395,6 +1399,10 @@
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
         },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -1678,6 +1686,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -2227,6 +2239,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -2860,6 +2876,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -3527,6 +3547,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -4513,6 +4537,10 @@
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
         },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -4688,6 +4716,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -4873,6 +4905,10 @@
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
         },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -5052,6 +5088,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -265,6 +265,18 @@
       "additionalProperties": false,
       "description": "The ButtonsResponse interface is used to define the properties of a buttons response. ButtonsResponses render as a list of buttons that the participant can click. When a button is clicked, the value of the button is stored in the data file. Participants can cycle through the options using the arrow keys. ```json {   \"id\": \"buttonsResponse\",   \"type\": \"buttons\",   \"prompt\": \"Click a button\",   \"location\": \"belowStimulus\",   \"default\": \"Option 2\",   \"options\": [     \"Option 1\",     \"Option 2\",     \"Option 3\"   ] } ``` In this example, the participant can click one of the buttons labeled \"Option 1\", \"Option 2\", or \"Option 3\".",
       "properties": {
+        "allowResponseChange": {
+          "description": "Controls whether the participant is allowed to change their response after they have selected an answer. Set to `false` to lock the response in as soon as it is provided. Defaults to true.",
+          "type": "boolean"
+        },
+        "autoAdvanceDelay": {
+          "description": "The delay, in milliseconds, to wait after this response is answered before automatically advancing to the next step. Only used when `autoAdvanceToNextStep` is `true`. Defaults to 0.",
+          "type": "number"
+        },
+        "autoAdvanceToNextStep": {
+          "description": "Controls whether the participant is automatically advanced to the next step as soon as this response has been answered. Defaults to false. If a required element besides this one is present on the page a warning is shown.",
+          "type": "boolean"
+        },
         "default": {
           "description": "The default value of the response. Specify one option value as a string.",
           "type": "string"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -286,6 +286,18 @@
       "additionalProperties": false,
       "description": "The ButtonsResponse interface is used to define the properties of a buttons response. ButtonsResponses render as a list of buttons that the participant can click. When a button is clicked, the value of the button is stored in the data file. Participants can cycle through the options using the arrow keys. ```json {   \"id\": \"buttonsResponse\",   \"type\": \"buttons\",   \"prompt\": \"Click a button\",   \"location\": \"belowStimulus\",   \"default\": \"Option 2\",   \"options\": [     \"Option 1\",     \"Option 2\",     \"Option 3\"   ] } ``` In this example, the participant can click one of the buttons labeled \"Option 1\", \"Option 2\", or \"Option 3\".",
       "properties": {
+        "allowResponseChange": {
+          "description": "Controls whether the participant is allowed to change their response after they have selected an answer. Set to `false` to lock the response in as soon as it is provided. Defaults to true.",
+          "type": "boolean"
+        },
+        "autoAdvanceDelay": {
+          "description": "The delay, in milliseconds, to wait after this response is answered before automatically advancing to the next step. Only used when `autoAdvanceToNextStep` is `true`. Defaults to 0.",
+          "type": "number"
+        },
+        "autoAdvanceToNextStep": {
+          "description": "Controls whether the participant is automatically advanced to the next step as soon as this response has been answered. Defaults to false. If a required element besides this one is present on the page a warning is shown.",
+          "type": "boolean"
+        },
         "default": {
           "description": "The default value of the response. Specify one option value as a string.",
           "type": "string"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -104,6 +104,10 @@
             "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
             "type": "number"
           },
+          "nextButtonHidden": {
+            "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+            "type": "boolean"
+          },
           "nextButtonLocation": {
             "$ref": "#/definitions/ConfigResponseBlockLocation",
             "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -1495,6 +1499,10 @@
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
         },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -1778,6 +1786,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -2276,6 +2288,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -2931,6 +2947,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -3598,6 +3618,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -4924,6 +4948,10 @@
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
         },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -5099,6 +5127,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -5284,6 +5316,10 @@
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
         },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
+        },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "The location of the next button. If present, will override the  next button location setting in the uiConfig."
@@ -5463,6 +5499,10 @@
         "nextButtonEnableTime": {
           "description": "The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig.",
           "type": "number"
+        },
+        "nextButtonHidden": {
+          "description": "Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true.",
+          "type": "boolean"
         },
         "nextButtonLocation": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -774,15 +774,17 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
     });
 
   Object.entries(studyConfig.components).forEach(([componentName, component]) => {
-    if (!component.response || !Array.isArray(component.response)) {
-      return;
-    }
+    const resolvedComponent = studyComponentToIndividualComponent(component, studyConfig);
 
-    const hasAutoAdvance = component.response.some(
-      (response) => (response.type === 'buttons' && response.autoAdvanceToNextStep === true),
+    const responses = resolvedComponent.response ?? [];
+    const hasAutoAdvanceButton = responses.some(
+      (response) => response.type === 'buttons' && response.autoAdvanceToNextStep === true,
     );
 
-    if (hasAutoAdvance && component.response.length > 1) {
+    const interactiveResponses = responses.filter(
+      (response) => response.type !== 'textOnly' && response.type !== 'divider',
+    );
+    if (hasAutoAdvanceButton && interactiveResponses.length > 1) {
       warnings.push({
         message: `Component \`${componentName}\` has autoAdvanceToNextStep enabled but contains multiple response elements`,
         instancePath: `/components/${componentName}/`,

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -781,8 +781,7 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
       (response) => response.type === 'buttons' && response.autoAdvanceToNextStep === true,
     );
     const isAutoAdvance = hasAutoAdvanceButton || resolvedComponent.nextButtonAutoAdvanceTime !== undefined;
-    resolvedComponent.nextButtonHidden = resolvedComponent.nextButtonHidden ?? (isAutoAdvance ? true : (studyConfig.uiConfig?.nextButtonHidden ?? false));
-
+    resolvedComponent.nextButtonHidden = resolvedComponent.nextButtonHidden ?? (isAutoAdvance ? true : ((studyConfig.uiConfig as { nextButtonHidden?: boolean })?.nextButtonHidden ?? false));
     const interactiveResponses = responses.filter(
       (response) => response.type !== 'textOnly' && response.type !== 'divider',
     );

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -780,6 +780,8 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
     const hasAutoAdvanceButton = responses.some(
       (response) => response.type === 'buttons' && response.autoAdvanceToNextStep === true,
     );
+    const isAutoAdvance = hasAutoAdvanceButton || resolvedComponent.nextButtonAutoAdvanceTime !== undefined;
+    resolvedComponent.nextButtonHidden = resolvedComponent.nextButtonHidden ?? (isAutoAdvance ? true : (studyConfig.uiConfig?.nextButtonHidden ?? false));
 
     const interactiveResponses = responses.filter(
       (response) => response.type !== 'textOnly' && response.type !== 'divider',

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -773,6 +773,27 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
       });
     });
 
+  Object.entries(studyConfig.components).forEach(([componentName, component]) => {
+    if (!component.response || !Array.isArray(component.response)) {
+      return;
+    }
+
+    const hasAutoAdvance = component.response.some(
+      (response) => (response.type === 'buttons' && response.autoAdvanceToNextStep === true),
+    );
+
+    if (hasAutoAdvance && component.response.length > 1) {
+      warnings.push({
+        message: `Component \`${componentName}\` has autoAdvanceToNextStep enabled but contains multiple response elements`,
+        instancePath: `/components/${componentName}/`,
+        params: {
+          action: 'Ensure auto-advance components only contain a single response element, or split them into separate steps',
+        },
+        category: 'invalid-config',
+      });
+    }
+  });
+
   // Verify skip blocks are well defined
   const missingSkipTargets: string[] = [];
   verifyStudySkip(studyConfig.sequence, missingSkipTargets, errors, warnings);

--- a/src/parser/tests/parser.spec.ts
+++ b/src/parser/tests/parser.spec.ts
@@ -764,6 +764,65 @@ describe('Text response validation config parsing', () => {
   });
 });
 
+describe('Auto-advance multiple elements warning', () => {
+  test('warns when autoAdvanceToNextStep is enabled on a component with multiple responses', async () => {
+    const studyConfig = {
+      $schema: '',
+      studyMetadata: {
+        title: 'Auto Advance Warning Test',
+        version: '1.0',
+        authors: ['Test'],
+        date: '2026-05-14',
+        description: 'Ensures warnings fire when auto-advance is used on multi-element components.',
+        organizations: ['Test Org'],
+      },
+      uiConfig: {
+        contactEmail: 'test@test.com',
+        helpTextPath: '',
+        logoPath: '',
+        withProgressBar: true,
+        autoDownloadStudy: false,
+        withSidebar: true,
+      },
+      components: {
+        question1: {
+          type: 'questionnaire',
+          response: [
+            {
+              id: 'btn-1',
+              type: 'buttons',
+              prompt: 'Select an option',
+              options: ['Option 1', 'Option 2'],
+              autoAdvanceToNextStep: true,
+            },
+            {
+              id: 'btn-2',
+              type: 'buttons',
+              prompt: 'Select an option',
+              options: ['Option 1', 'Option 2'],
+              autoAdvanceToNextStep: true,
+            },
+          ],
+        },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['question1'],
+      },
+    };
+
+    const result = await parseStudyConfig(JSON.stringify(studyConfig));
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        message: 'Component `question1` has autoAdvanceToNextStep enabled but contains multiple response elements',
+        instancePath: '/components/question1/',
+      }),
+    );
+  });
+});
+
 describe('Component auto-advance config parsing', () => {
   test('accepts component-level auto-advance timeout options on a base component', async () => {
     const studyConfig = {
@@ -811,6 +870,102 @@ describe('Component auto-advance config parsing', () => {
     );
     expect(hasAutoAdvanceFieldError).toBe(false);
   });
+
+  test('accepts response-level autoAdvanceToNextStep and autoAdvanceDelay options', async () => {
+    const studyConfig = {
+      $schema: '',
+      studyMetadata: {
+        title: 'Response Auto Advance Test',
+        version: '1.0',
+        authors: ['Test'],
+        date: '2026-05-14',
+        description: 'Ensures response-level auto-advance options are accepted without schema errors.',
+        organizations: ['Test Org'],
+      },
+      uiConfig: {
+        contactEmail: 'test@test.com',
+        helpTextPath: '',
+        logoPath: '',
+        withProgressBar: true,
+        autoDownloadStudy: false,
+        withSidebar: true,
+      },
+      components: {
+        question1: {
+          type: 'questionnaire',
+          response: [
+            {
+              id: 'btn-1',
+              type: 'buttons',
+              prompt: 'Select an option',
+              options: ['Option 1', 'Option 2'],
+              autoAdvanceToNextStep: true,
+            },
+          ],
+        },
+      },
+      sequence: {
+        order: 'fixed',
+        components: ['question1'],
+      },
+    };
+
+    const result = await parseStudyConfig(JSON.stringify(studyConfig));
+
+    const hasAutoAdvanceFieldError = result.errors.some(
+      (error) => error.message?.includes('autoAdvanceToNextStep') || error.message?.includes('autoAdvanceDelay'),
+    );
+    expect(hasAutoAdvanceFieldError).toBe(false);
+  });
+
+  test.each([
+    ['buttons', true],
+    ['buttons', false],
+  ])(
+    'validates %s response with autoAdvanceToNextStep set to %s without errors',
+    async () => {
+      const studyConfig = {
+        $schema: '',
+        studyMetadata: {
+          title: 'Auto Advance Parameter Test',
+          version: '1.0',
+          authors: ['Test'],
+          date: '2026-05-14',
+          description: 'Validates autoAdvanceToNextStep parameter acceptance.',
+          organizations: ['Test Org'],
+        },
+        uiConfig: {
+          contactEmail: 'test@test.com',
+          helpTextPath: '',
+          logoPath: '',
+          withProgressBar: true,
+          autoDownloadStudy: false,
+          withSidebar: true,
+        },
+        components: {
+          question1: {
+            type: 'questionnaire',
+            response: [
+              {
+                id: 'btn-1',
+                type: 'buttons',
+                prompt: 'Select an option',
+                options: ['Option 1', 'Option 2'],
+                autoAdvanceToNextStep: true,
+              },
+            ],
+          },
+        },
+        sequence: {
+          order: 'fixed',
+          components: ['question1'],
+        },
+      };
+
+      const result = await parseStudyConfig(JSON.stringify(studyConfig));
+      expect(result.errors).toEqual([]);
+    },
+  );
 });
 
 describe('Next button alignment config parsing', () => {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1116,6 +1116,12 @@ export interface ButtonsResponse extends BaseResponse {
   default?: string;
   /** The order in which the buttons are displayed. Defaults to fixed. */
   optionOrder?: 'fixed' | 'random';
+  /** Controls whether the participant is automatically advanced to the next step as soon as this response has been answered. Defaults to false. If a required element besides this one is present on the page a warning is shown. */
+  autoAdvanceToNextStep?: boolean;
+  /** The delay, in milliseconds, to wait after this response is answered before automatically advancing to the next step. Only used when `autoAdvanceToNextStep` is `true`. Defaults to 0. */
+  autoAdvanceDelay?: number;
+  /** Controls whether the participant is allowed to change their response after they have selected an answer. Set to `false` to lock the response in as soon as it is provided. Defaults to true. */
+  allowResponseChange?: boolean;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1272,6 +1272,8 @@ export interface BaseIndividualComponent {
   nextButtonAlignment?: NextButtonAlignment;
   /** The time in milliseconds to wait before the next button is enabled. If present, will override the next button enable time setting in the uiConfig. */
   nextButtonEnableTime?: number;
+  /** Whether to hide the next button. Defaults to false, if autoAdvance is enabled it will default to true. */
+  nextButtonHidden?: boolean;
   /** The time in milliseconds to wait before the next button is disabled. If present, will override the next button disable time setting in the uiConfig. */
   nextButtonDisableTime?: number;
   /** The time in milliseconds after which the participant is automatically advanced to the next component without saving answers from the current component. */

--- a/src/store/hooks/tests/useNextStep.spec.tsx
+++ b/src/store/hooks/tests/useNextStep.spec.tsx
@@ -344,6 +344,72 @@ describe('useNextStep', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/study-1/1');
   });
 
+  test('advances to next step when auto-advance trigger executes navigation without collectData', async () => {
+    mockSaveAnswers.mockResolvedValueOnce(undefined);
+    mockSequence = {
+      id: 'root',
+      orderPath: 'root',
+      order: 'fixed',
+      components: ['intro', 'followup'],
+      skip: [],
+    };
+    mockFlatSequence = ['intro', 'followup'];
+    mockStudyConfig = {
+      components: {
+        intro: {
+          type: 'questionnaire',
+          response: [
+            {
+              id: 'btn-1',
+              type: 'buttons',
+              autoAdvanceToNextStep: true,
+              autoAdvanceDelay: 500,
+            },
+          ],
+        },
+        followup: {},
+      },
+    };
+
+    renderToStaticMarkup(<HookHarness />);
+
+    await capturedGoToNextStep?.(true);
+    await Promise.resolve();
+
+    expect(mockSaveTrialAnswer).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/study-1/1');
+  });
+
+  test('respects auto-advance delay timing before calling next step navigation', async () => {
+    vi.useFakeTimers();
+    mockSaveAnswers.mockResolvedValueOnce(undefined);
+
+    renderToStaticMarkup(<HookHarness />);
+
+    const delay = 300;
+    let autoAdvanceTriggered = false;
+
+    const timeoutId = setTimeout(() => {
+      capturedGoToNextStep?.(true);
+      autoAdvanceTriggered = true;
+    }, delay);
+
+    expect(autoAdvanceTriggered).toBe(false);
+
+    vi.advanceTimersByTime(200);
+    expect(autoAdvanceTriggered).toBe(false);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    await Promise.resolve();
+
+    expect(autoAdvanceTriggered).toBe(true);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+
+    clearTimeout(timeoutId);
+    vi.useRealTimers();
+  });
+
   test('excludes timed out answers from block skip conditions', async () => {
     mockSaveAnswers.mockResolvedValueOnce(undefined);
     mockSequence = {

--- a/src/store/hooks/tests/useNextStep.spec.tsx
+++ b/src/store/hooks/tests/useNextStep.spec.tsx
@@ -410,6 +410,72 @@ describe('useNextStep', () => {
     vi.useRealTimers();
   });
 
+  test('retains default field values without locking response change on initial render', () => {
+    mockStoredAnswer = {
+      ...mockStoredAnswer,
+      answer: {
+        'btn-1': 'Option A',
+      },
+    };
+
+    mockStudyConfig = {
+      components: {
+        intro: {
+          type: 'questionnaire',
+          response: [
+            {
+              id: 'btn-1',
+              type: 'buttons',
+              options: ['Option A', 'Option B'],
+              default: 'Option A',
+              allowResponseChange: false,
+            },
+          ],
+        },
+      },
+    };
+
+    renderToStaticMarkup(<HookHarness />);
+
+    // Verification: isNextDisabled should remain active/accessible
+    // and form interactions are not disabled on mount merely because of default values
+    expect(capturedIsNextDisabled).toBe(false);
+  });
+
+  test('locks option selection after explicit user interaction when allowResponseChange is false', async () => {
+    mockSaveAnswers.mockResolvedValueOnce(undefined);
+
+    mockStudyConfig = {
+      components: {
+        intro: {
+          type: 'questionnaire',
+          response: [
+            {
+              id: 'btn-1',
+              type: 'buttons',
+              options: ['Option A', 'Option B'],
+              allowResponseChange: false,
+            },
+          ],
+        },
+      },
+    };
+
+    renderToStaticMarkup(<HookHarness />);
+
+    await capturedGoToNextStep?.(true);
+    await Promise.resolve();
+
+    expect(mockSaveTrialAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: 'intro_0',
+        answer: expect.objectContaining({
+          response: 'saved-answer',
+        }),
+      }),
+    );
+  });
+
   test('excludes timed out answers from block skip conditions', async () => {
     mockSaveAnswers.mockResolvedValueOnce(undefined);
     mockSequence = {
@@ -455,5 +521,64 @@ describe('useNextStep', () => {
       timedOut: true,
     }));
     expect(mockNavigate).toHaveBeenCalledWith('/study-1/1');
+  });
+
+  test('locks response options immediately during autoAdvanceDelay before navigation occurs', async () => {
+    vi.useFakeTimers();
+    mockSaveAnswers.mockResolvedValueOnce(undefined);
+
+    mockStudyConfig = {
+      components: {
+        intro: {
+          type: 'questionnaire',
+          response: [
+            {
+              id: 'btn-1',
+              type: 'buttons',
+              options: ['Option A', 'Option B'],
+              default: 'Option A',
+              allowResponseChange: false,
+              autoAdvanceToNextStep: true,
+              autoAdvanceDelay: 500,
+            },
+          ],
+        },
+        followup: {},
+      },
+    };
+
+    renderToStaticMarkup(<HookHarness />);
+
+    // Simulating user interaction changing value from default 'Option A' to 'Option B'
+    mockTrialValidation = {
+      intro_0: {
+        ...(mockTrialValidation.intro_0 as Record<string, unknown>),
+        belowStimulus: { valid: true, values: { 'btn-1': 'Option B' } },
+      },
+    };
+
+    // Re-render to simulate the state update during the delay
+    renderToStaticMarkup(<HookHarness />);
+    let stepTriggered = false;
+    setTimeout(() => {
+      capturedGoToNextStep?.(true);
+      stepTriggered = true;
+    }, 500);
+
+    // Advance time partially (250ms out of 500ms delay)
+    vi.advanceTimersByTime(250);
+
+    // Verify navigation has NOT happened yet...
+    expect(stepTriggered).toBe(false);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(capturedIsNextDisabled).toBe(false);
+
+    // Complete remaining delay
+    vi.advanceTimersByTime(250);
+    await Promise.resolve();
+
+    expect(stepTriggered).toBe(true);
+    expect(mockNavigate).toHaveBeenCalledWith('/study-1/1');
+    vi.useRealTimers();
   });
 });

--- a/src/store/hooks/useRecording.ts
+++ b/src/store/hooks/useRecording.ts
@@ -221,7 +221,7 @@ export function useRecording() {
 
     mediaRecorder.start(1000); // 1s chunks
     audioRecorder?.start(1000);
-  }, [currentComponentHasAudioRecording, currentComponentHasScreenRecording, storageEngine, isMuted]);
+  }, [currentComponentHasAudioRecording, currentComponentHasScreenRecording, storageEngine, isMuted, dataCollectionEnabled]);
 
   // Stop screen recording. This does not stop screen capture.
   const stopScreenRecording = useCallback(() => {

--- a/tests/demo-form-elements.spec.ts
+++ b/tests/demo-form-elements.spec.ts
@@ -81,7 +81,6 @@ async function advanceToSidebarFormElements(page: Page) {
 }
 
 test('Test questionnaire component with responses and randomizing questions and responses', async ({ page }) => {
-  test.setTimeout(120000);
   await page.setViewportSize({
     width: 1400,
     height: 900,

--- a/tests/demo-form-elements.spec.ts
+++ b/tests/demo-form-elements.spec.ts
@@ -81,6 +81,7 @@ async function advanceToSidebarFormElements(page: Page) {
 }
 
 test('Test questionnaire component with responses and randomizing questions and responses', async ({ page }) => {
+  test.setTimeout(120000);
   await page.setViewportSize({
     width: 1400,
     height: 900,
@@ -228,6 +229,13 @@ test('Test questionnaire component with responses and randomizing questions and 
   await expect(page.getByText('"chartType":"Bar"')).toBeVisible();
   await expect(customResponseNextButton).toBeEnabled();
   await nextClick(page);
+
+  // Auto-advance page
+  await expect(page.getByText('What does 53 + 98 equal?')).toBeVisible();
+  await page.getByRole('radio', { name: '151', exact: true }).click();
+  await page.getByRole('button', { name: 'Check Answer', exact: true }).click();
+  await expect(page.getByRole('alert').getByText('Correct Answer', { exact: true })).toBeVisible();
+  await expect(page.locator('#q-multi-satisfaction')).toBeVisible({ timeout: 10000 });
 
   // Fill the survey: Randomizing Options
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1447 

### Give a longer description of what this PR addresses and why it's needed
This PR adds the options autoAdvanceToNextStep, autoAdvanceDelay and allowResponseChange to the ButtonsResponse. Studies sometimes want the user to automatically navigate to the next page/question if some input was given especially when a button is pressed. The options introduced allow to automatically proceed to the next page. This procedure can be delayed and the given answer can be locked so it cannot be changed even if the delay is active and the next question is not shown immediately.