### PR TITLE
keyboard input controls supported with keymapper

### DIFF
--- a/public/demo-form-elements/config.json
+++ b/public/demo-form-elements/config.json
@@ -234,6 +234,20 @@
           ]
         },
         {
+          "id": "q-buttons-color-keybind",
+          "type": "buttons",
+          "prompt": "Buttons example",
+          "secondaryText": "Buttons with keymappings, can be controlled with the corresponding key.",
+          "infoText": "Choose the option that best represents your answer.",
+          "options": [
+            { "label": "RED", "value": "red", "key": "r" },
+            { "label": "ORANGE", "value": "orange", "key": "o" },
+            { "label": "YELLOW", "value": "yellow", "key": "y" },
+            { "label": "GREEN", "value": "green", "key": "g" },
+            { "label": "BLUE", "value": "blue", "key": "b" }
+          ]
+        },
+        {
           "id": "divider1",
           "type": "divider"
         },

--- a/public/global.json
+++ b/public/global.json
@@ -57,6 +57,7 @@
     "library-umux-lite",
     "library-virtual-chinrest",
     "library-vlat",
+    "test-keymapping",
     "test-audio",
     "test-device-restriction",
     "test-library",
@@ -241,6 +242,10 @@
     },
     "library-vlat": {
       "path": "library-vlat/config.json",
+      "test": true
+    },
+    "test-keymapping": {
+      "path": "test-keymapping/config.json",
       "test": true
     },
     "test-audio": {

--- a/public/test-keymapping/config.json
+++ b/public/test-keymapping/config.json
@@ -23,7 +23,7 @@
     "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [yourProlificLink](yourProlificLink)"
   },
   "components": {
-    "mapper-component": {
+    "color-mapper": {
       "response": [
         {
           "id": "color-response",
@@ -40,6 +40,24 @@
           "keyMapping": ["1", "2", "3", "4", "5"]
         },
         {
+          "id": "color-response2",
+          "type": "buttons",
+          "prompt": "Select the ink color",
+          "location": "belowStimulus",
+          "options": [
+            "RED",
+            "ORANGE",
+            "YELLOW",
+            "GREEN",
+            "BLUE"
+          ],
+          "keyMapping": ["1", "2", "3", "4", "5"]
+        }],
+      "type": "questionnaire"
+    },
+    "letter-mapper":{
+      "response": [
+        {
           "id": "letter-response",
           "type": "buttons",
           "prompt": "Indicate correlation direction",
@@ -51,9 +69,13 @@
             "F"
           ],
           "keyMapping": ["a", "s", "d", "f"]
-        },
+        }],
+      "type": "questionnaire"
+    },
+    "special-mapper":{
+      "response": [
         {
-          "id": "direction-response",
+          "id": "letter-response",
           "type": "buttons",
           "prompt": "Indicate correlation direction",
           "location": "belowStimulus",
@@ -65,11 +87,16 @@
             "Space"
           ],
           "keyMapping": ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"]
-        },
+        }],
+      "type": "questionnaire"
+    },
+    "mapper-mapper":{
+      "response": [
         {
-          "id": "stroop-response",
+          "id": "letter-response",
           "type": "buttons",
-          "prompt": "Select ink color",
+          "prompt": "Indicate correlation direction",
+          "location": "belowStimulus",
           "options": [
             { "label": "RED", "value": "red" },
             { "label": "GREEN", "value": "green" },
@@ -80,15 +107,17 @@
             "g": "green",
             "b": "blue"
           }
-        }
-      ],
+        }],
       "type": "questionnaire"
     }
   },
     "sequence": {
     "order": "fixed",
     "components": [
-      "mapper-component"
+      "special-mapper",
+      "letter-mapper",
+      "color-mapper",
+      "mapper-mapper"
     ]
   }
 }

--- a/public/test-keymapping/config.json
+++ b/public/test-keymapping/config.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://raw.githubusercontent.com/revisit-studies/study/v2.4.3/src/parser/StudyConfigSchema.json",
+  "studyMetadata": {
+    "title": "Test Keymapper",
+    "version": "pilot",
+    "authors": [
+      "The reVISit Team"
+    ],
+    "date": "2026-02-23",
+    "description": "A test of keymapping.",
+    "organizations": [
+      "University of Utah",
+      "WPI"
+    ]
+  },
+  "uiConfig": {
+    "contactEmail": "contact@revisit.dev",
+    "logoPath": "revisitAssets/revisitLogoSquare.svg",
+    "withProgressBar": true,
+    "autoDownloadStudy": false,
+    "withSidebar": true,
+    "urlParticipantIdParam": "PROLIFIC_PID",
+    "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [yourProlificLink](yourProlificLink)"
+  },
+  "components": {
+    "mapper-component": {
+      "response": [
+        {
+          "id": "color-response",
+          "type": "buttons",
+          "prompt": "Select the ink color",
+          "location": "belowStimulus",
+          "options": [
+            "RED",
+            "ORANGE",
+            "YELLOW",
+            "GREEN",
+            "BLUE"
+          ],
+          "keyMapping": ["1", "2", "3", "4", "5"]
+        },
+        {
+          "id": "letter-response",
+          "type": "buttons",
+          "prompt": "Indicate correlation direction",
+          "location": "belowStimulus",
+          "options": [
+            "A",
+            "S",
+            "D",
+            "F"
+          ],
+          "keyMapping": ["a", "s", "d", "f"]
+        },
+        {
+          "id": "direction-response",
+          "type": "buttons",
+          "prompt": "Indicate correlation direction",
+          "location": "belowStimulus",
+          "options": [
+            "Left",
+            "Right",
+            "Up",
+            "Down",
+            "Space"
+          ],
+          "keyMapping": ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"]
+        },
+        {
+          "id": "stroop-response",
+          "type": "buttons",
+          "prompt": "Select ink color",
+          "options": [
+            { "label": "RED", "value": "red" },
+            { "label": "GREEN", "value": "green" },
+            { "label": "BLUE", "value": "blue" }
+          ],
+          "keyMapping": {
+            "r": "red",
+            "g": "green",
+            "b": "blue"
+          }
+        }
+      ],
+      "type": "questionnaire"
+    }
+  },
+    "sequence": {
+    "order": "fixed",
+    "components": [
+      "mapper-component"
+    ]
+  }
+}

--- a/public/test-keymapping/config.json
+++ b/public/test-keymapping/config.json
@@ -23,37 +23,6 @@
     "studyEndMsg": "**Thank you for completing the study. You may click this link and return to Prolific**: [yourProlificLink](yourProlificLink)"
   },
   "components": {
-    "color-mapper": {
-      "response": [
-        {
-          "id": "color-response",
-          "type": "buttons",
-          "prompt": "Select the ink color",
-          "location": "belowStimulus",
-          "options": [
-            { "label": "RED", "value": "red", "key": "r" },
-            { "label": "ORANGE", "value": "orange", "key": "o" },
-            { "label": "YELLOW", "value": "yellow", "key": "y" },
-            { "label": "GREEN", "value": "green", "key": "g" },
-            { "label": "BLUE", "value": "blue", "key": "b" }
-          ]
-        },
-        {
-          "id": "color-response2",
-          "type": "buttons",
-          "prompt": "Select the ink color",
-          "location": "belowStimulus",
-          "options": [
-            { "label": "RED", "value": "red", "key": "r" },
-            { "label": "ORANGE", "value": "orange", "key": "o" },
-            { "label": "YELLOW", "value": "yellow", "key": "y" },
-            { "label": "GREEN", "value": "green", "key": "g" },
-            { "label": "BLUE", "value": "blue", "key": "b" }
-          ],
-          "hideKeyVisual": true
-        }],
-      "type": "questionnaire"
-    },
     "letter-mapper":{
       "response": [
         {
@@ -65,7 +34,8 @@
             { "label": "A", "value": "a", "key": "a" },
             { "label": "S", "value": "s", "key": "s" },
             { "label": "D", "value": "d", "key": "d" },
-            { "label": "F", "value": "f", "key": "f" }
+            { "label": "F", "value": "f", "key": "f" },
+            { "label": "shift+r", "value": "shift+r", "key": "shift+r" }
           ]
         }],
       "type": "questionnaire",
@@ -88,30 +58,13 @@
         }],
       "type": "questionnaire",
       "nextOnEnter": true
-    },
-    "math-mapper":{
-      "response": [
-        {
-          "id": "letter-response",
-          "type": "buttons",
-          "prompt": "What is 10+4",
-          "location": "belowStimulus",
-          "options": [
-            { "label": "14", "value": "14", "key": "14" },
-            { "label": "1", "value": "1", "key": "1" },
-            { "label": "4", "value": "4", "key": "4" }
-          ]
-        }],
-      "type": "questionnaire"
     }
   },
     "sequence": {
     "order": "fixed",
     "components": [
       "special-mapper",
-      "letter-mapper",
-      "color-mapper",
-      "math-mapper"
+      "letter-mapper"
     ]
   }
 }

--- a/public/test-keymapping/config.json
+++ b/public/test-keymapping/config.json
@@ -52,8 +52,7 @@
           ],
           "hideKeyVisual": true
         }],
-      "type": "questionnaire",
-      "nextOnEnter": true
+      "type": "questionnaire"
     },
     "letter-mapper":{
       "response": [
@@ -69,7 +68,8 @@
             { "label": "F", "value": "f", "key": "f" }
           ]
         }],
-      "type": "questionnaire"
+      "type": "questionnaire",
+      "nextOnEnter": true
     },
     "special-mapper":{
       "response": [

--- a/public/test-keymapping/config.json
+++ b/public/test-keymapping/config.json
@@ -31,13 +31,12 @@
           "prompt": "Select the ink color",
           "location": "belowStimulus",
           "options": [
-            "RED",
-            "ORANGE",
-            "YELLOW",
-            "GREEN",
-            "BLUE"
-          ],
-          "keyMapping": ["1", "2", "3", "4", "5"]
+            { "label": "RED", "value": "red", "key": "r" },
+            { "label": "ORANGE", "value": "orange", "key": "o" },
+            { "label": "YELLOW", "value": "yellow", "key": "y" },
+            { "label": "GREEN", "value": "green", "key": "g" },
+            { "label": "BLUE", "value": "blue", "key": "b" }
+          ]
         },
         {
           "id": "color-response2",
@@ -45,15 +44,16 @@
           "prompt": "Select the ink color",
           "location": "belowStimulus",
           "options": [
-            "RED",
-            "ORANGE",
-            "YELLOW",
-            "GREEN",
-            "BLUE"
+            { "label": "RED", "value": "red", "key": "r" },
+            { "label": "ORANGE", "value": "orange", "key": "o" },
+            { "label": "YELLOW", "value": "yellow", "key": "y" },
+            { "label": "GREEN", "value": "green", "key": "g" },
+            { "label": "BLUE", "value": "blue", "key": "b" }
           ],
-          "keyMapping": ["1", "2", "3", "4", "5"]
+          "hideKeyVisual": true
         }],
-      "type": "questionnaire"
+      "type": "questionnaire",
+      "nextOnEnter": true
     },
     "letter-mapper":{
       "response": [
@@ -63,12 +63,11 @@
           "prompt": "Indicate correlation direction",
           "location": "belowStimulus",
           "options": [
-            "A",
-            "S",
-            "D",
-            "F"
-          ],
-          "keyMapping": ["a", "s", "d", "f"]
+            { "label": "A", "value": "a", "key": "a" },
+            { "label": "S", "value": "s", "key": "s" },
+            { "label": "D", "value": "d", "key": "d" },
+            { "label": "F", "value": "f", "key": "f" }
+          ]
         }],
       "type": "questionnaire"
     },
@@ -80,33 +79,28 @@
           "prompt": "Indicate correlation direction",
           "location": "belowStimulus",
           "options": [
-            "Left",
-            "Right",
-            "Up",
-            "Down",
-            "Space"
-          ],
-          "keyMapping": ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"]
+            { "label": "Left", "value": "arrowleft", "key": "ArrowLeft" },
+            { "label": "Right", "value": "ArrowRight", "key": "ArrowRight" },
+            { "label": "Up", "value": "ARROWUP", "key": "ArrowUp" },
+            { "label": "Down", "value": "arrowDown", "key": "ArrowDown" },
+            { "label": "Space", "value": "space", "key": "space" }
+          ]
         }],
-      "type": "questionnaire"
+      "type": "questionnaire",
+      "nextOnEnter": true
     },
-    "mapper-mapper":{
+    "math-mapper":{
       "response": [
         {
           "id": "letter-response",
           "type": "buttons",
-          "prompt": "Indicate correlation direction",
+          "prompt": "What is 10+4",
           "location": "belowStimulus",
           "options": [
-            { "label": "RED", "value": "red" },
-            { "label": "GREEN", "value": "green" },
-            { "label": "BLUE", "value": "blue" }
-          ],
-          "keyMapping": {
-            "r": "red",
-            "g": "green",
-            "b": "blue"
-          }
+            { "label": "14", "value": "14", "key": "14" },
+            { "label": "1", "value": "1", "key": "1" },
+            { "label": "4", "value": "4", "key": "4" }
+          ]
         }],
       "type": "questionnaire"
     }
@@ -117,7 +111,7 @@
       "special-mapper",
       "letter-mapper",
       "color-mapper",
-      "mapper-mapper"
+      "math-mapper"
     ]
   }
 }

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -1,4 +1,6 @@
-import { Alert, Button, Group } from '@mantine/core';
+import {
+  Alert, Button, Group, Kbd,
+} from '@mantine/core';
 import {
   JSX, useEffect, useMemo, useRef, useState,
 } from 'react';
@@ -148,6 +150,7 @@ export function NextButton({
           disabled={nextButtonDisabled}
           onClick={() => onNext()}
           px={location === 'sidebar' && checkAnswer ? 8 : undefined}
+          rightSection={nextOnEnter ? <Kbd size="xs">↵ Enter</Kbd> : undefined}
         >
           {label}
         </Button>

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -110,7 +110,7 @@ export function NextButton({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter' || shouldIgnoreEnter(event.target)) {
+      if (event.key !== 'Enter' || event.defaultPrevented || (event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled || shouldIgnoreEnter(event.target)) {
         return;
       }
 
@@ -150,7 +150,35 @@ export function NextButton({
           disabled={nextButtonDisabled}
           onClick={() => onNext()}
           px={location === 'sidebar' && checkAnswer ? 8 : undefined}
-          rightSection={nextOnEnter ? <Kbd size="xs">↵ Enter</Kbd> : undefined}
+          aria-label={label}
+          rightSection={nextOnEnter && !onCheckAnswer ? (
+            <Kbd
+              size="xs"
+              aria-hidden="true"
+              style={{
+                backgroundColor: 'transparent',
+                color: 'inherit',
+                boxShadow: 'none',
+                border: 'none',
+                fontSize: '11px',
+                fontWeight: 600,
+              }}
+            >
+              ↵
+            </Kbd>
+          ) : undefined}
+          styles={{
+            inner: { alignItems: 'stretch' },
+            section: nextOnEnter && !onCheckAnswer ? {
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '0 10px',
+              marginRight: -16,
+              marginBlock: -1,
+              borderLeft: '1px solid rgba(255, 255, 255, 0.25)',
+              backgroundColor: 'rgba(0, 0, 0, 0.08)',
+            } : undefined,
+          }}
         >
           {label}
         </Button>

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -9,6 +9,7 @@ import { useStoredAnswer } from '../../store/hooks/useStoredAnswer';
 import { InputLabel } from './InputLabel';
 import { OptionLabel } from './OptionLabel';
 import { parseStringOptions } from '../../utils/stringOptions';
+import { KeyMapper } from './KeyMapper';
 
 export function ButtonsInput({
   response,
@@ -65,6 +66,12 @@ export function ButtonsInput({
         errorProps={{ c: required ? 'red' : 'orange', fz: 'sm', mt: 'xs' }}
         style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
       >
+        <KeyMapper
+          options={orderedOptions}
+          keys={response.keyMapping}
+          onSelect={(val) => answer?.onChange?.(val)}
+          disabled={disabled}
+        />
         <Flex justify="space-between" align="center" gap="xl" mt="xs">
           {orderedOptions.map((radio, idx) => (
             <Radio.Card

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -1,5 +1,5 @@
 import {
-  Flex, FocusTrap, Radio,
+  Flex, FocusTrap, Kbd, Radio,
 } from '@mantine/core';
 import { useMemo } from 'react';
 import ClearSelectionButton from './ClearSelectionButton';
@@ -10,6 +10,17 @@ import { InputLabel } from './InputLabel';
 import { OptionLabel } from './OptionLabel';
 import { parseStringOptions } from '../../utils/stringOptions';
 import { KeyMapper } from './KeyMapper';
+
+// could use this if we want the arrow symbols instead of mantine default
+// function formatKeyForDisplay(key: string): string {
+//   const k = key.toLowerCase();
+//   if (k === 'arrowleft') return '←';
+//   if (k === 'arrowright') return '→';
+//   if (k === 'arrowup') return '↑';
+//   if (k === 'arrowdown') return '↓';
+//   if (k === 'space' || k === ' ') return 'Space';
+//   return key.toUpperCase();
+// }
 
 export function ButtonsInput({
   response,
@@ -32,6 +43,7 @@ export function ButtonsInput({
     secondaryText,
     options,
     infoText,
+    hideKeyVisual = false,
   } = response;
 
   const storedAnswer = useStoredAnswer();
@@ -68,23 +80,33 @@ export function ButtonsInput({
       >
         <KeyMapper
           options={orderedOptions}
-          keys={response.keyMapping}
           onSelect={(val) => answer?.onChange?.(val)}
           disabled={disabled}
         />
         <Flex justify="space-between" align="center" gap="xl" mt="xs">
-          {orderedOptions.map((radio, idx) => (
-            <Radio.Card
-              key={`radio-${idx}`}
-              value={radio.value}
-              disabled={disabled}
-              ta="center"
-              className={classes.root}
-              p="xs"
-            >
-              <OptionLabel label={radio.label} infoText={radio.infoText} button />
-            </Radio.Card>
-          ))}
+          {orderedOptions.map((radio, idx) => {
+            const hasKeyVisual = !hideKeyVisual && Boolean(radio.key);
+
+            return (
+              <Radio.Card
+                key={`radio-${idx}`}
+                value={radio.value}
+                disabled={disabled}
+                ta="center"
+                className={classes.root}
+                p="xs"
+              >
+                <Flex align="center" justify="center" gap="xs">
+                  <OptionLabel label={radio.label} infoText={radio.infoText} button />
+                  {hasKeyVisual && (
+                    <Kbd size="xs">
+                      {radio.key?.toUpperCase()}
+                    </Kbd>
+                  )}
+                </Flex>
+              </Radio.Card>
+            );
+          })}
         </Flex>
       </Radio.Group>
     </FocusTrap>

--- a/src/components/response/ButtonsInput.tsx
+++ b/src/components/response/ButtonsInput.tsx
@@ -1,7 +1,7 @@
 import {
   Flex, FocusTrap, Kbd, Radio,
 } from '@mantine/core';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import ClearSelectionButton from './ClearSelectionButton';
 import { ButtonsResponse, ParsedStringOption } from '../../parser/types';
 import classes from './css/ButtonsInput.module.css';
@@ -12,15 +12,57 @@ import { parseStringOptions } from '../../utils/stringOptions';
 import { KeyMapper } from './KeyMapper';
 
 // could use this if we want the arrow symbols instead of mantine default
-// function formatKeyForDisplay(key: string): string {
-//   const k = key.toLowerCase();
-//   if (k === 'arrowleft') return '←';
-//   if (k === 'arrowright') return '→';
-//   if (k === 'arrowup') return '↑';
-//   if (k === 'arrowdown') return '↓';
-//   if (k === 'space' || k === ' ') return 'Space';
-//   return key.toUpperCase();
-// }
+function formatKeyForDisplay(key: string): string {
+  const k = key.toLowerCase().trim();
+  if (k.includes('+')) {
+    return k
+      .split('+')
+      .map((part) => formatKeyForDisplay(part))
+      .join('+');
+  }
+
+  switch (k) {
+    case 'arrowleft':
+      return '←';
+    case 'arrowright':
+      return '→';
+    case 'arrowup':
+      return '↑';
+    case 'arrowdown':
+      return '↓';
+    case 'enter':
+    case 'return':
+      return '↵';
+    case 'backspace':
+      return '⌫';
+    case 'delete':
+    case 'del':
+      return '⌦';
+    case 'escape':
+    case 'esc':
+      return 'Esc';
+    case 'tab':
+      return '⇥';
+    case 'space':
+      return '␣';
+    case 'capslock':
+    case 'caps':
+      return '⇪';
+    case 'shift':
+      return '⇧';
+    case 'control':
+    case 'ctrl':
+      return 'Ctrl';
+    case 'alt':
+      return 'Alt';
+    case 'meta':
+    case 'cmd':
+    case 'command':
+      return '⌘';
+    default:
+      return key.toUpperCase();
+  }
+}
 
 export function ButtonsInput({
   response,
@@ -32,7 +74,7 @@ export function ButtonsInput({
 }: {
   response: ButtonsResponse;
   disabled: boolean;
-  answer: { value?: string; onChange?: (value: string) => void };
+  answer: { value?: string; onChange?: (value: string) => void; onInteraction?: (source: 'keyboard' | 'click') => void };
   error?: string | null;
   index: number;
   enumerateQuestions: boolean;
@@ -47,6 +89,7 @@ export function ButtonsInput({
   } = response;
 
   const storedAnswer = useStoredAnswer();
+  const groupRef = useRef<HTMLDivElement>(null);
   const optionOrders: Record<string, ParsedStringOption[]> = useMemo(() => storedAnswer?.optionOrders ?? {}, [storedAnswer]);
 
   const orderedOptions = useMemo(
@@ -54,9 +97,16 @@ export function ButtonsInput({
     [optionOrders, options, response.id],
   );
 
+  const handleValueChange = (value: string, source: 'keyboard' | 'click' = 'click') => {
+    answer?.onInteraction?.(source);
+    answer?.onChange?.(value);
+    // answer?.onChange?.(value);
+  };
+
   return (
     <FocusTrap>
       <Radio.Group
+        ref={groupRef}
         name={`radioInput${response.id}`}
         label={prompt.length > 0 && (
           <InputLabel
@@ -66,22 +116,23 @@ export function ButtonsInput({
             enumerateQuestions={enumerateQuestions}
             infoText={infoText}
             clearSelectionButton={(
-              <ClearSelectionButton onClick={() => answer?.onChange?.('')} disabled={disabled} visible={!!answer?.value} />
+              <ClearSelectionButton onClick={() => handleValueChange('')} disabled={disabled} visible={!!answer?.value} />
             )}
           />
         )}
         description={secondaryText}
         key={response.id}
         value={answer?.value}
-        onChange={answer?.onChange}
+        onChange={(value) => handleValueChange(value, 'click')}
         error={error}
         errorProps={{ c: required ? 'red' : 'orange', fz: 'sm', mt: 'xs' }}
         style={{ '--input-description-size': 'calc(var(--mantine-font-size-md) - calc(0.125rem * var(--mantine-scale)))' }}
       >
         <KeyMapper
           options={orderedOptions}
-          onSelect={(val) => answer?.onChange?.(val)}
+          onSelect={(val, source) => handleValueChange(val, source ?? 'keyboard')}
           disabled={disabled}
+          focusRootRef={groupRef}
         />
         <Flex justify="space-between" align="center" gap="xl" mt="xs">
           {orderedOptions.map((radio, idx) => {
@@ -92,18 +143,57 @@ export function ButtonsInput({
                 key={`radio-${idx}`}
                 value={radio.value}
                 disabled={disabled}
-                ta="center"
                 className={classes.root}
-                p="xs"
+                style={{
+                  overflow: 'hidden',
+                  padding: 0,
+                }}
               >
-                <Flex align="center" justify="center" gap="xs">
-                  <OptionLabel label={radio.label} infoText={radio.infoText} button />
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'stretch',
+                    minHeight: '100%',
+                  }}
+                >
+                  <Flex
+                    align="center"
+                    justify="center"
+                    gap="xs"
+                    style={{ flex: 1, padding: '10px 12px' }}
+                  >
+                    <OptionLabel label={radio.label} infoText={radio.infoText} button />
+                  </Flex>
+
                   {hasKeyVisual && (
-                    <Kbd size="xs">
-                      {radio.key?.toUpperCase()}
-                    </Kbd>
+                    <Flex
+                      align="center"
+                      justify="center"
+                      style={{
+                        flexShrink: 0,
+                        padding: '0 12px',
+                        borderLeft: '1px solid rgba(255, 255, 255, 0.25)',
+                        backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                      }}
+                    >
+                      <Kbd
+                        size="xs"
+                        aria-hidden="true"
+                        style={{
+                          backgroundColor: 'transparent',
+                          color: 'inherit',
+                          boxShadow: 'none',
+                          border: 'none',
+                          fontSize: '10px',
+                          fontWeight: 600,
+                          padding: 0,
+                        }}
+                      >
+                        {formatKeyForDisplay(radio.key?.toLowerCase() as never)}
+                      </Kbd>
+                    </Flex>
                   )}
-                </Flex>
+                </div>
               </Radio.Card>
             );
           })}

--- a/src/components/response/KeyMapper.tsx
+++ b/src/components/response/KeyMapper.tsx
@@ -21,32 +21,47 @@ export function KeyMapper({
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (disabled || !autoFocus) {
-      return undefined;
-    }
-
-    const focusTimer = setTimeout(() => {
-      const { activeElement } = document;
-
-      if (activeElement && activeElement !== document.body && typeof (activeElement as HTMLElement).blur === 'function') {
-        (activeElement as HTMLElement).blur();
-      }
-
-      const container = containerRef.current;
-      if (container) {
-        container.focus({ preventScroll: true });
+    const hasKeys = keys && (typeof keys === 'string' || Object.keys(keys).length > 0);
+    const timer = setTimeout(() => {
+      if (autoFocus && hasKeys && containerRef.current) {
+        containerRef.current.focus();
       }
     }, 50);
 
-    return () => clearTimeout(focusTimer);
-  }, [disabled, autoFocus, options]);
+    return () => clearTimeout(timer);
+  }, [keys, autoFocus]);
 
   useEffect(() => {
     if (disabled || !options || options.length === 0 || !keys) {
       return undefined;
     }
 
+    const isInteractiveElement = (node: EventTarget | null): boolean => {
+      if (!node || !(node instanceof Element) || node === document.body) {
+        return false;
+      }
+
+      const tagName = node.tagName.toLowerCase();
+      const isInput = ['input', 'textarea', 'select', 'button', 'a'].includes(tagName);
+      const isRoleButton = node.getAttribute?.('role') === 'button';
+      const isContentEditable = (node as HTMLElement).isContentEditable ?? false;
+
+      if (isInput || isRoleButton || isContentEditable) {
+        const isInsideMapperContainer = containerRef.current?.contains(node) ?? false;
+        return !isInsideMapperContainer;
+      }
+
+      return false;
+    };
+
     const handleKeyDown = (event: KeyboardEvent) => {
+      const activeEl = document.activeElement;
+      const eventTarget = event.target;
+
+      if (isInteractiveElement(eventTarget) || isInteractiveElement(activeEl)) {
+        return;
+      }
+
       if ((event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled) {
         return;
       }
@@ -55,33 +70,17 @@ export function KeyMapper({
         return;
       }
 
-      const target = event.target as HTMLElement | null;
-      if (target && typeof target.getAttribute === 'function') {
-        const tagName = target.tagName ? target.tagName.toUpperCase() : '';
-
-        const isInsideContainer = containerRef.current
-          ? containerRef.current.contains(target)
-          : false;
-
-        const isTextInput = ['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName) || Boolean(target.isContentEditable);
-        const isExternalInteractive = !isInsideContainer && ['BUTTON', 'A'].includes(tagName);
-
-        if (isTextInput || isExternalInteractive) {
-          return;
-        }
-      }
-
       const pressedKey = (event.key || '').toLowerCase();
       const isSpacePress = pressedKey === ' ' || pressedKey === 'spacebar' || pressedKey === 'space';
 
-      const stopEvent = () => {
+      const handleMatchedSelection = (selectedValue: string) => {
         (event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled = true;
-        if (typeof event.stopImmediatePropagation === 'function') {
-          event.stopImmediatePropagation();
-        }
+
         if (typeof event.preventDefault === 'function') {
           event.preventDefault();
         }
+
+        onSelect(selectedValue);
       };
 
       const isKeyMatch = (configKey: string) => {
@@ -93,7 +92,7 @@ export function KeyMapper({
       };
 
       const findMatchingOptionValue = (targetVal: string): string | null => {
-        const targetLower = String(targetVal).toLowerCase();
+        const targetString = String(targetVal);
 
         const foundOption = options.find((opt) => {
           if (opt === undefined || opt === null) {
@@ -103,7 +102,7 @@ export function KeyMapper({
             ? String(opt.value)
             : String(opt);
 
-          return optValue.toLowerCase() === targetLower;
+          return optValue === targetString;
         });
 
         if (foundOption) {
@@ -120,8 +119,7 @@ export function KeyMapper({
           if (isKeyMatch(configKey)) {
             const matchedValue = findMatchingOptionValue(targetValue);
             if (matchedValue !== null) {
-              stopEvent();
-              onSelect(matchedValue);
+              handleMatchedSelection(matchedValue);
               return;
             }
           }
@@ -144,8 +142,7 @@ export function KeyMapper({
           ? String(selectedOption.value)
           : String(selectedOption);
 
-        stopEvent();
-        onSelect(selectedValue);
+        handleMatchedSelection(selectedValue);
       }
     };
 

--- a/src/components/response/KeyMapper.tsx
+++ b/src/components/response/KeyMapper.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import type { ParsedStringOption } from '../../parser/types';
+
+interface KeyMapperProps {
+  options: ParsedStringOption[];
+  keys?: string | string[] | Record<string, string>;
+  onSelect: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function KeyMapper({
+  options, keys, onSelect, disabled = false,
+}: KeyMapperProps) {
+  useEffect(() => {
+    if (disabled || !options || options.length === 0 || !keys) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) || target.isContentEditable) {
+        return;
+      }
+
+      const pressedKey = event.key.toLowerCase();
+      const isSpace = pressedKey === ' ' || pressedKey === 'spacebar';
+
+      // 1. Handle Key-to-Value Mapping Object: { "r": "red", "g": "green" }
+      if (typeof keys === 'object' && !Array.isArray(keys)) {
+        Object.entries(keys).forEach(([configKey, targetValue]) => {
+          const keyLower = configKey.toLowerCase();
+          const matches = keyLower === pressedKey || ((keyLower === 'space' || keyLower === ' ') && isSpace);
+
+          const isValidOption = options.some((opt) => opt.value === targetValue);
+
+          if (matches && isValidOption) {
+            event.preventDefault();
+            onSelect(targetValue);
+          }
+        });
+        return;
+      }
+
+      // 2. Handle Sequential Mapping: Array ["1", "2"] or single string "Enter"
+      const keyList = Array.isArray(keys) ? keys : [keys];
+
+      keyList.forEach((k: string, index: number) => {
+        const configKey = k.toLowerCase();
+        const matches = configKey === pressedKey || ((configKey === 'space' || configKey === ' ') && isSpace);
+
+        if (matches && options[index]) {
+          event.preventDefault();
+          onSelect(options[index].value);
+        }
+      });
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [options, keys, onSelect, disabled]);
+
+  return null;
+}

--- a/src/components/response/KeyMapper.tsx
+++ b/src/components/response/KeyMapper.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import type { ParsedStringOption } from '../../parser/types';
 
 interface KeyMapperProps {
@@ -6,58 +6,160 @@ interface KeyMapperProps {
   keys?: string | string[] | Record<string, string>;
   onSelect: (value: string) => void;
   disabled?: boolean;
+  children?: React.ReactNode;
+  autoFocus?: boolean;
 }
 
 export function KeyMapper({
-  options, keys, onSelect, disabled = false,
+  options,
+  keys,
+  onSelect,
+  disabled = false,
+  children,
+  autoFocus = true,
 }: KeyMapperProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (disabled || !autoFocus) {
+      return undefined;
+    }
+
+    const focusTimer = setTimeout(() => {
+      const { activeElement } = document;
+
+      if (activeElement && activeElement !== document.body && typeof (activeElement as HTMLElement).blur === 'function') {
+        (activeElement as HTMLElement).blur();
+      }
+
+      const container = containerRef.current;
+      if (container) {
+        container.focus({ preventScroll: true });
+      }
+    }, 50);
+
+    return () => clearTimeout(focusTimer);
+  }, [disabled, autoFocus, options]);
+
   useEffect(() => {
     if (disabled || !options || options.length === 0 || !keys) {
       return undefined;
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement;
-      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) || target.isContentEditable) {
+      if ((event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled) {
         return;
       }
 
-      const pressedKey = event.key.toLowerCase();
-      const isSpace = pressedKey === ' ' || pressedKey === 'spacebar';
+      if (event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
 
-      // 1. Handle Key-to-Value Mapping Object: { "r": "red", "g": "green" }
-      if (typeof keys === 'object' && !Array.isArray(keys)) {
-        Object.entries(keys).forEach(([configKey, targetValue]) => {
-          const keyLower = configKey.toLowerCase();
-          const matches = keyLower === pressedKey || ((keyLower === 'space' || keyLower === ' ') && isSpace);
+      const target = event.target as HTMLElement | null;
+      if (target && typeof target.getAttribute === 'function') {
+        const tagName = target.tagName ? target.tagName.toUpperCase() : '';
 
-          const isValidOption = options.some((opt) => opt.value === targetValue);
+        const isInsideContainer = containerRef.current
+          ? containerRef.current.contains(target)
+          : false;
 
-          if (matches && isValidOption) {
-            event.preventDefault();
-            onSelect(targetValue);
+        const isTextInput = ['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName) || Boolean(target.isContentEditable);
+        const isExternalInteractive = !isInsideContainer && ['BUTTON', 'A'].includes(tagName);
+
+        if (isTextInput || isExternalInteractive) {
+          return;
+        }
+      }
+
+      const pressedKey = (event.key || '').toLowerCase();
+      const isSpacePress = pressedKey === ' ' || pressedKey === 'spacebar' || pressedKey === 'space';
+
+      const stopEvent = () => {
+        (event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled = true;
+        if (typeof event.stopImmediatePropagation === 'function') {
+          event.stopImmediatePropagation();
+        }
+        if (typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+      };
+
+      const isKeyMatch = (configKey: string) => {
+        const keyLower = String(configKey).toLowerCase();
+        if (keyLower === 'space' || keyLower === ' ' || keyLower === 'spacebar') {
+          return isSpacePress;
+        }
+        return keyLower === pressedKey;
+      };
+
+      const findMatchingOptionValue = (targetVal: string): string | null => {
+        const targetLower = String(targetVal).toLowerCase();
+
+        const foundOption = options.find((opt) => {
+          if (opt === undefined || opt === null) {
+            return false;
           }
+          const optValue = typeof opt === 'object' && 'value' in opt
+            ? String(opt.value)
+            : String(opt);
+
+          return optValue.toLowerCase() === targetLower;
         });
+
+        if (foundOption) {
+          return typeof foundOption === 'object' && 'value' in foundOption
+            ? String(foundOption.value)
+            : String(foundOption);
+        }
+
+        return null;
+      };
+
+      if (typeof keys === 'object' && !Array.isArray(keys)) {
+        for (const [configKey, targetValue] of Object.entries(keys)) {
+          if (isKeyMatch(configKey)) {
+            const matchedValue = findMatchingOptionValue(targetValue);
+            if (matchedValue !== null) {
+              stopEvent();
+              onSelect(matchedValue);
+              return;
+            }
+          }
+        }
         return;
       }
 
-      // 2. Handle Sequential Mapping: Array ["1", "2"] or single string "Enter"
       const keyList = Array.isArray(keys) ? keys : [keys];
+      let matchedIndex = -1;
 
       keyList.forEach((k: string, index: number) => {
-        const configKey = k.toLowerCase();
-        const matches = configKey === pressedKey || ((configKey === 'space' || configKey === ' ') && isSpace);
-
-        if (matches && options[index]) {
-          event.preventDefault();
-          onSelect(options[index].value);
+        if (isKeyMatch(k) && options[index]) {
+          matchedIndex = index;
         }
       });
+
+      if (matchedIndex !== -1) {
+        const selectedOption = options[matchedIndex];
+        const selectedValue = typeof selectedOption === 'object' && selectedOption !== null && 'value' in selectedOption
+          ? String(selectedOption.value)
+          : String(selectedOption);
+
+        stopEvent();
+        onSelect(selectedValue);
+      }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [options, keys, onSelect, disabled]);
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [options, onSelect, disabled, keys]);
 
-  return null;
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      style={{ display: 'block', outline: 'none' }}
+    >
+      {children}
+    </div>
+  );
 }

--- a/src/components/response/KeyMapper.tsx
+++ b/src/components/response/KeyMapper.tsx
@@ -58,6 +58,9 @@ export function KeyMapper({
     const handleKeyDown = (event: KeyboardEvent) => {
       const activeEl = document.activeElement;
       const eventTarget = event.target;
+      if (event.repeat) {
+        return;
+      }
 
       if (isInteractiveElement(eventTarget) || isInteractiveElement(activeEl)) {
         return;
@@ -109,6 +112,31 @@ export function KeyMapper({
       tabIndex={-1}
       style={{ display: 'block', outline: 'none' }}
     >
+      {/* Screen-reader accessible hidden buttons for keyboard options */}
+      {options
+        ?.filter((option) => option.key)
+        .map((option) => (
+          <button
+            key={option.key}
+            type="button"
+            disabled={disabled}
+            style={{
+              position: 'absolute',
+              width: '1px',
+              height: '1px',
+              padding: 0,
+              margin: '-1px',
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+              border: 0,
+            }}
+            onClick={() => onSelect?.(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+
       {children}
     </div>
   );

--- a/src/components/response/KeyMapper.tsx
+++ b/src/components/response/KeyMapper.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useRef } from 'react';
 import type { ParsedStringOption } from '../../parser/types';
+import { keyEventMatchesMapping } from '../../utils/keyMapping';
 
 interface KeyMapperProps {
   options: ParsedStringOption[];
-  onSelect: (value: string) => void;
+  onSelect: (value: string, source?: 'keyboard' | 'click') => void;
   disabled?: boolean;
   children?: React.ReactNode;
   autoFocus?: boolean;
+  focusRootRef?: React.RefObject<HTMLElement | null>;
 }
 
 export function KeyMapper({
@@ -14,55 +16,51 @@ export function KeyMapper({
   onSelect,
   disabled = false,
   children,
-  autoFocus = true,
+  autoFocus = false,
+  focusRootRef,
 }: KeyMapperProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const hasInlineKeys = options?.some(
-      (opt) => typeof opt === 'object' && opt !== null && Boolean(opt.key),
-    );
+    if (!autoFocus || !options?.some((opt) => typeof opt === 'object' && opt !== null && Boolean(opt.key))) {
+      return undefined;
+    }
 
     const timer = setTimeout(() => {
-      if (autoFocus && hasInlineKeys && containerRef.current) {
+      const { activeElement } = document;
+      if (containerRef.current && (!activeElement || !(activeElement instanceof HTMLElement) || !focusRootRef?.current?.contains(activeElement))) {
         containerRef.current.focus();
       }
     }, 50);
 
     return () => clearTimeout(timer);
-  }, [options, autoFocus]);
+  }, [autoFocus, focusRootRef, options]);
 
   useEffect(() => {
     if (disabled || !options || options.length === 0) {
       return undefined;
     }
 
-    const isInteractiveElement = (node: EventTarget | null): boolean => {
-      if (!node || !(node instanceof Element) || node === document.body) {
+    const isOwnedTarget = (target: EventTarget | null): boolean => {
+      if (!(target instanceof Element)) {
         return false;
       }
+      return Boolean(focusRootRef?.current && focusRootRef.current.contains(target));
+    };
 
-      const tagName = node.tagName.toLowerCase();
-      const isInput = ['input', 'textarea', 'select', 'button', 'a'].includes(tagName);
-      const isRoleButton = node.getAttribute?.('role') === 'button';
-      const isContentEditable = (node as HTMLElement).isContentEditable ?? false;
-
-      if (isInput || isRoleButton || isContentEditable) {
-        const isInsideMapperContainer = containerRef.current?.contains(node) ?? false;
-        return !isInsideMapperContainer;
+    const isEditableOrInteractiveTarget = (target: EventTarget | null): boolean => {
+      if (!(target instanceof HTMLElement)) {
+        return false;
       }
-
-      return false;
+      if (target.isContentEditable) {
+        return true;
+      }
+      return ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(target.tagName);
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      const activeEl = document.activeElement;
-      const eventTarget = event.target;
-      if (event.repeat) {
-        return;
-      }
-
-      if (isInteractiveElement(eventTarget) || isInteractiveElement(activeEl)) {
+      // currently ctrl win, meta, command and ctrl are not supported
+      if (event.repeat || event.ctrlKey || event.metaKey) {
         return;
       }
 
@@ -70,32 +68,23 @@ export function KeyMapper({
         return;
       }
 
-      if (event.ctrlKey || event.metaKey || event.altKey) {
+      if (isEditableOrInteractiveTarget(event.target)) {
         return;
       }
 
-      const pressedKey = (event.key || '').toLowerCase();
-      const isSpacePress = pressedKey === ' ' || pressedKey === 'spacebar' || pressedKey === 'space';
+      if (isOwnedTarget(event.target) || isOwnedTarget(document.activeElement)) {
+        return;
+      }
 
-      const isKeyMatch = (configKey: string) => {
-        const keyLower = String(configKey).toLowerCase();
-        if (keyLower === 'space' || keyLower === ' ' || keyLower === 'spacebar') {
-          return isSpacePress;
-        }
-        return keyLower === pressedKey;
-      };
-
-      // Find the first option whose inline `key` matches the physical key press
       for (const option of options) {
         if (typeof option === 'object' && option !== null && option.key) {
-          if (isKeyMatch(option.key)) {
+          if (keyEventMatchesMapping(option.key, event)) {
             (event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled = true;
 
             if (typeof event.preventDefault === 'function') {
               event.preventDefault();
             }
-
-            onSelect(String(option.value));
+            onSelect(String(option.value), 'keyboard');
             return;
           }
         }
@@ -104,40 +93,7 @@ export function KeyMapper({
 
     window.addEventListener('keydown', handleKeyDown, true);
     return () => window.removeEventListener('keydown', handleKeyDown, true);
-  }, [options, onSelect, disabled]);
+  }, [disabled, focusRootRef, onSelect, options]);
 
-  return (
-    <div
-      ref={containerRef}
-      tabIndex={-1}
-      style={{ display: 'block', outline: 'none' }}
-    >
-      {/* Screen-reader accessible hidden buttons for keyboard options */}
-      {options
-        ?.filter((option) => option.key)
-        .map((option) => (
-          <button
-            key={option.key}
-            type="button"
-            disabled={disabled}
-            style={{
-              position: 'absolute',
-              width: '1px',
-              height: '1px',
-              padding: 0,
-              margin: '-1px',
-              overflow: 'hidden',
-              clip: 'rect(0, 0, 0, 0)',
-              whiteSpace: 'nowrap',
-              border: 0,
-            }}
-            onClick={() => onSelect?.(option.value)}
-          >
-            {option.label}
-          </button>
-        ))}
-
-      {children}
-    </div>
-  );
+  return <div>{children}</div>;
 }

--- a/src/components/response/KeyMapper.tsx
+++ b/src/components/response/KeyMapper.tsx
@@ -3,7 +3,6 @@ import type { ParsedStringOption } from '../../parser/types';
 
 interface KeyMapperProps {
   options: ParsedStringOption[];
-  keys?: string | string[] | Record<string, string>;
   onSelect: (value: string) => void;
   disabled?: boolean;
   children?: React.ReactNode;
@@ -12,7 +11,6 @@ interface KeyMapperProps {
 
 export function KeyMapper({
   options,
-  keys,
   onSelect,
   disabled = false,
   children,
@@ -21,18 +19,21 @@ export function KeyMapper({
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const hasKeys = keys && (typeof keys === 'string' || Object.keys(keys).length > 0);
+    const hasInlineKeys = options?.some(
+      (opt) => typeof opt === 'object' && opt !== null && Boolean(opt.key),
+    );
+
     const timer = setTimeout(() => {
-      if (autoFocus && hasKeys && containerRef.current) {
+      if (autoFocus && hasInlineKeys && containerRef.current) {
         containerRef.current.focus();
       }
     }, 50);
 
     return () => clearTimeout(timer);
-  }, [keys, autoFocus]);
+  }, [options, autoFocus]);
 
   useEffect(() => {
-    if (disabled || !options || options.length === 0 || !keys) {
+    if (disabled || !options || options.length === 0) {
       return undefined;
     }
 
@@ -73,16 +74,6 @@ export function KeyMapper({
       const pressedKey = (event.key || '').toLowerCase();
       const isSpacePress = pressedKey === ' ' || pressedKey === 'spacebar' || pressedKey === 'space';
 
-      const handleMatchedSelection = (selectedValue: string) => {
-        (event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled = true;
-
-        if (typeof event.preventDefault === 'function') {
-          event.preventDefault();
-        }
-
-        onSelect(selectedValue);
-      };
-
       const isKeyMatch = (configKey: string) => {
         const keyLower = String(configKey).toLowerCase();
         if (keyLower === 'space' || keyLower === ' ' || keyLower === 'spacebar') {
@@ -91,64 +82,26 @@ export function KeyMapper({
         return keyLower === pressedKey;
       };
 
-      const findMatchingOptionValue = (targetVal: string): string | null => {
-        const targetString = String(targetVal);
+      // Find the first option whose inline `key` matches the physical key press
+      for (const option of options) {
+        if (typeof option === 'object' && option !== null && option.key) {
+          if (isKeyMatch(option.key)) {
+            (event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled = true;
 
-        const foundOption = options.find((opt) => {
-          if (opt === undefined || opt === null) {
-            return false;
-          }
-          const optValue = typeof opt === 'object' && 'value' in opt
-            ? String(opt.value)
-            : String(opt);
-
-          return optValue === targetString;
-        });
-
-        if (foundOption) {
-          return typeof foundOption === 'object' && 'value' in foundOption
-            ? String(foundOption.value)
-            : String(foundOption);
-        }
-
-        return null;
-      };
-
-      if (typeof keys === 'object' && !Array.isArray(keys)) {
-        for (const [configKey, targetValue] of Object.entries(keys)) {
-          if (isKeyMatch(configKey)) {
-            const matchedValue = findMatchingOptionValue(targetValue);
-            if (matchedValue !== null) {
-              handleMatchedSelection(matchedValue);
-              return;
+            if (typeof event.preventDefault === 'function') {
+              event.preventDefault();
             }
+
+            onSelect(String(option.value));
+            return;
           }
         }
-        return;
-      }
-
-      const keyList = Array.isArray(keys) ? keys : [keys];
-      let matchedIndex = -1;
-
-      keyList.forEach((k: string, index: number) => {
-        if (isKeyMatch(k) && options[index]) {
-          matchedIndex = index;
-        }
-      });
-
-      if (matchedIndex !== -1) {
-        const selectedOption = options[matchedIndex];
-        const selectedValue = typeof selectedOption === 'object' && selectedOption !== null && 'value' in selectedOption
-          ? String(selectedOption.value)
-          : String(selectedOption);
-
-        handleMatchedSelection(selectedValue);
       }
     };
 
     window.addEventListener('keydown', handleKeyDown, true);
     return () => window.removeEventListener('keydown', handleKeyDown, true);
-  }, [options, onSelect, disabled, keys]);
+  }, [options, onSelect, disabled]);
 
   return (
     <div

--- a/src/components/response/ResponseBlock.tsx
+++ b/src/components/response/ResponseBlock.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Button, Group, Text, ThemeIcon,
+  Box, Button, Group, Kbd, Text, ThemeIcon,
 } from '@mantine/core';
 
 import React, {
@@ -128,11 +128,13 @@ export function ResponseBlock({
     return response;
   }), [allResponses]);
   // Set up trrack to store provenance graph of the answerValidator status
+  const lastInteractionSourceRef = useRef<'keyboard' | 'click'>('click');
   const { actions, registry } = useMemo(() => {
     const reg = Registry.create();
 
-    const updateFormAction = reg.register('update', (state, payload: StoredAnswer['answer']) => {
-      state.form = payload;
+    const updateFormAction = reg.register('update', (state, payload: { values: StoredAnswer['answer']; interactionSource: 'keyboard' | 'click' }) => {
+      state.form = payload.values;
+      state.interactionSource = payload.interactionSource;
       return state;
     });
     const updateShowResponseErrorsAction = reg.register('show-response-errors', (state, payload: boolean) => {
@@ -161,6 +163,7 @@ export function ResponseBlock({
     initialState: {
       form: null,
       showResponseErrors: false,
+      interactionSource: 'click',
     },
   }, reportProvenance, identifier);
 
@@ -393,6 +396,13 @@ export function ResponseBlock({
     customResponseValidators,
     customResponseLoadErrors,
   );
+  const trackInputChange = useCallback((responseId: string, value: unknown, source: 'keyboard' | 'click' = 'click') => {
+    lastInteractionSourceRef.current = source;
+    const targetValue = typeof value === 'object' && value !== null && 'target' in value && value.target && typeof value.target === 'object' && 'value' in value.target
+      ? value.target.value
+      : value;
+    answerValidator.setFieldValue(responseId, targetValue as never);
+  }, [answerValidator]);
   const revealResponseErrors = useCallback(() => {
     storeDispatch(setResponseSubmitAttempt({ identifier, attempted: true }));
     answerValidator.validate();
@@ -457,7 +467,11 @@ export function ResponseBlock({
   }, [matrixAnswers, rankingAnswers]);
 
   useEffect(() => {
-    trrack.apply('Update form field', actions.updateFormAction(structuredClone(answerValidator.values)));
+    const interactionSource = lastInteractionSourceRef.current;
+    trrack.apply(`Update form field (${interactionSource})`, actions.updateFormAction({
+      values: structuredClone(answerValidator.values),
+      interactionSource,
+    }));
 
     storeDispatch(
       updateResponseBlockValidation({
@@ -691,6 +705,7 @@ export function ResponseBlock({
                       answerFinalized={!!status && status.endTime !== -1}
                       form={{
                         ...answerValidator.getInputProps(response.id),
+                        onChange: (value: unknown, source: 'keyboard' | 'click' = 'click') => trackInputChange(response.id, value, source),
                       }}
                       dontKnowCheckbox={usesStandaloneDontKnowField(response)
                         ? {
@@ -777,6 +792,8 @@ export function ResponseBlock({
               disabled={disabledAttempts}
               onClick={() => checkAnswerProvideFeedback()}
               px={location === 'sidebar' ? 8 : undefined}
+              aria-label="Check Answer"
+              rightSection={(config?.nextOnEnter ?? studyConfig.uiConfig.nextOnEnter) ? <Kbd size="xs" aria-hidden="true">↵ Enter</Kbd> : undefined}
             >
               Check Answer
             </Button>

--- a/src/components/response/tests/KeyMapper.spec.tsx
+++ b/src/components/response/tests/KeyMapper.spec.tsx
@@ -1,0 +1,231 @@
+import { render, fireEvent } from '@testing-library/react';
+import {
+  describe, expect, test, vi,
+} from 'vitest';
+import { KeyMapper } from '../KeyMapper';
+import type { ParsedStringOption } from '../../../parser/types';
+
+describe('KeyMapper Component', () => {
+  const sampleOptions: ParsedStringOption[] = [
+    { label: 'Option A', value: 'a' },
+    { label: 'Option B', value: 'b' },
+    { label: 'Option C', value: 'c' },
+  ];
+
+  test('triggers onSelect with correct value when configured key is pressed', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={sampleOptions}
+        keys={['1', '2', '3']}
+        onSelect={onSelectMock}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: '2' });
+    expect(onSelectMock).toHaveBeenCalledTimes(1);
+    expect(onSelectMock).toHaveBeenCalledWith('b');
+  });
+
+  test('handles case-insensitive letter keypresses', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={sampleOptions}
+        keys={['a', 'b', 'c']}
+        onSelect={onSelectMock}
+      />,
+    );
+
+    // Pressing uppercase 'A' should match configured lowercase 'a'
+    fireEvent.keyDown(window, { key: 'A' });
+    expect(onSelectMock).toHaveBeenCalledWith('a');
+  });
+
+  test('supports special keys like Arrow keys and Spacebar', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={sampleOptions}
+        keys={['ArrowLeft', 'ArrowRight', 'Space']}
+        onSelect={onSelectMock}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(onSelectMock).toHaveBeenCalledWith('b');
+
+    fireEvent.keyDown(window, { key: ' ' });
+    expect(onSelectMock).toHaveBeenCalledWith('c');
+  });
+
+  test('does not trigger onSelect when component is disabled', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={sampleOptions}
+        keys={['1', '2', '3']}
+        onSelect={onSelectMock}
+        disabled
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: '1' });
+    expect(onSelectMock).not.toHaveBeenCalled();
+  });
+
+  test('ignores keypresses coming from form input or text area elements', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <div>
+        <input data-testid="text-input" type="text" />
+        <KeyMapper
+          options={sampleOptions}
+          keys={['1', '2', '3']}
+          onSelect={onSelectMock}
+        />
+      </div>,
+    );
+
+    const input = document.querySelector('input')!;
+
+    fireEvent.keyDown(input, { key: '1' });
+    expect(onSelectMock).not.toHaveBeenCalled();
+  });
+
+  test('handles a single string key for single-option setups', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={[{ label: 'Continue', value: 'next' }]}
+        keys="Enter"
+        onSelect={onSelectMock}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onSelectMock).toHaveBeenCalledWith('next');
+  });
+
+  test('does nothing when unmounted', () => {
+    const onSelectMock = vi.fn();
+
+    const { unmount } = render(
+      <KeyMapper
+        options={sampleOptions}
+        keys={['1', '2', '3']}
+        onSelect={onSelectMock}
+      />,
+    );
+
+    unmount();
+
+    fireEvent.keyDown(window, { key: '1' });
+    expect(onSelectMock).not.toHaveBeenCalled();
+  });
+
+  // --- Tests for Object Key-to-Value Mapping ---
+
+  describe('Object Key-to-Value Mapping', () => {
+    const stroopOptions: ParsedStringOption[] = [
+      { label: 'RED', value: 'red' },
+      { label: 'GREEN', value: 'green' },
+      { label: 'BLUE', value: 'blue' },
+    ];
+
+    const keyMap = {
+      r: 'red',
+      g: 'green',
+      b: 'blue',
+    };
+
+    test('triggers onSelect with mapped value when configured object key is pressed', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={stroopOptions}
+          keys={keyMap}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: 'r' });
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      expect(onSelectMock).toHaveBeenCalledWith('red');
+
+      fireEvent.keyDown(window, { key: 'g' });
+      expect(onSelectMock).toHaveBeenCalledTimes(2);
+      expect(onSelectMock).toHaveBeenCalledWith('green');
+    });
+
+    test('handles case-insensitive keypresses with object mappings', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={stroopOptions}
+          keys={keyMap}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: 'B' });
+      expect(onSelectMock).toHaveBeenCalledWith('blue');
+    });
+
+    test('ignores unmapped random keys in object mode', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={stroopOptions}
+          keys={keyMap}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: 'x' });
+      fireEvent.keyDown(window, { key: '9' });
+      fireEvent.keyDown(window, { key: 'Enter' });
+
+      expect(onSelectMock).not.toHaveBeenCalled();
+    });
+
+    test('supports Spacebar key mapping in object mode', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={stroopOptions}
+          keys={{ Space: 'blue' }}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: ' ' });
+      expect(onSelectMock).toHaveBeenCalledWith('blue');
+    });
+
+    test('ignores keypress if mapped value does not exist in options', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={stroopOptions}
+          keys={{ y: 'yellow' }}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: 'y' });
+      expect(onSelectMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/response/tests/KeyMapper.spec.tsx
+++ b/src/components/response/tests/KeyMapper.spec.tsx
@@ -1,20 +1,23 @@
 import {
-  cleanup, render, fireEvent,
+  cleanup, render, fireEvent, act,
 } from '@testing-library/react';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
+import React from 'react';
 import { KeyMapper } from '../KeyMapper';
 import type { ParsedStringOption } from '../../../parser/types';
 
 describe('KeyMapper Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useRealTimers();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     cleanup();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -137,7 +140,7 @@ describe('KeyMapper Component', () => {
     expect(onSelectMock).not.toHaveBeenCalled();
   });
 
-  test('prevents multiple KeyMapper components from answering the same keypress', () => {
+  test('prevents multiple KeyMapper components from answering the same keypress using event tagging', () => {
     const onSelectMock1 = vi.fn();
     const onSelectMock2 = vi.fn();
 
@@ -163,7 +166,7 @@ describe('KeyMapper Component', () => {
     expect(onSelectMock2).not.toHaveBeenCalled();
   });
 
-  test('stops event propagation in capture phase to prevent secondary global listeners', () => {
+  test('preserves keydown events for secondary global instrumentation listeners', () => {
     const onSelectMock = vi.fn();
     const secondaryWindowListener = vi.fn();
 
@@ -177,10 +180,12 @@ describe('KeyMapper Component', () => {
       />,
     );
 
-    fireEvent.keyDown(window, { key: 'Enter' });
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    window.dispatchEvent(event);
 
     expect(onSelectMock).toHaveBeenCalledWith('a');
-    expect(secondaryWindowListener).not.toHaveBeenCalled();
+    expect(secondaryWindowListener).toHaveBeenCalledTimes(1);
+    expect((event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled).toBe(true);
 
     window.removeEventListener('keydown', secondaryWindowListener);
   });
@@ -198,6 +203,31 @@ describe('KeyMapper Component', () => {
 
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(onSelectMock).toHaveBeenCalledWith('next');
+  });
+
+  test('does not steal focus or autofocus when keys configuration is absent or empty', () => {
+    const onSelectMock = vi.fn();
+
+    const { container } = render(
+      <div>
+        <input data-testid="external-input" />
+        <KeyMapper
+          options={sampleOptions}
+          keys={undefined}
+          onSelect={onSelectMock}
+        />
+      </div>,
+    );
+
+    const input = container.querySelector('input')!;
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(document.activeElement).toBe(input);
   });
 
   test('does nothing when unmounted', () => {
@@ -231,6 +261,27 @@ describe('KeyMapper Component', () => {
       g: 'green',
       b: 'blue',
     };
+
+    test('matches exact case-sensitive option values when object target is mapped', () => {
+      const onSelectMock = vi.fn();
+      const caseSensitiveOptions: ParsedStringOption[] = [
+        { label: 'Lower', value: 'foo' },
+        { label: 'Upper', value: 'FOO' },
+      ];
+
+      render(
+        <KeyMapper
+          options={caseSensitiveOptions}
+          keys={{ x: 'FOO' }}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: 'x' });
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      expect(onSelectMock).toHaveBeenCalledWith('FOO');
+      expect(onSelectMock).not.toHaveBeenCalledWith('foo');
+    });
 
     test('triggers onSelect with mapped value when configured object key is pressed', () => {
       const onSelectMock = vi.fn();

--- a/src/components/response/tests/KeyMapper.spec.tsx
+++ b/src/components/response/tests/KeyMapper.spec.tsx
@@ -1,11 +1,23 @@
-import { render, fireEvent } from '@testing-library/react';
 import {
-  describe, expect, test, vi,
+  cleanup, render, fireEvent,
+} from '@testing-library/react';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { KeyMapper } from '../KeyMapper';
 import type { ParsedStringOption } from '../../../parser/types';
 
 describe('KeyMapper Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
   const sampleOptions: ParsedStringOption[] = [
     { label: 'Option A', value: 'a' },
     { label: 'Option B', value: 'b' },
@@ -39,7 +51,6 @@ describe('KeyMapper Component', () => {
       />,
     );
 
-    // Pressing uppercase 'A' should match configured lowercase 'a'
     fireEvent.keyDown(window, { key: 'A' });
     expect(onSelectMock).toHaveBeenCalledWith('a');
   });
@@ -78,12 +89,14 @@ describe('KeyMapper Component', () => {
     expect(onSelectMock).not.toHaveBeenCalled();
   });
 
-  test('ignores keypresses coming from form input or text area elements', () => {
+  test('ignores keypresses coming from form inputs, text areas, buttons, or links', () => {
     const onSelectMock = vi.fn();
 
     render(
       <div>
         <input data-testid="text-input" type="text" />
+        <button type="button" data-testid="next-btn">Next</button>
+        <a href="#test" data-testid="link">Link</a>
         <KeyMapper
           options={sampleOptions}
           keys={['1', '2', '3']}
@@ -93,9 +106,83 @@ describe('KeyMapper Component', () => {
     );
 
     const input = document.querySelector('input')!;
+    const button = document.querySelector('button')!;
+    const link = document.querySelector('a')!;
 
     fireEvent.keyDown(input, { key: '1' });
     expect(onSelectMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(button, { key: '2' });
+    expect(onSelectMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(link, { key: '3' });
+    expect(onSelectMock).not.toHaveBeenCalled();
+  });
+
+  test('ignores keypresses with modifier keys (Ctrl, Alt, Meta)', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={sampleOptions}
+        keys={['a', 'b', 'c']}
+        onSelect={onSelectMock}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'a', ctrlKey: true });
+    fireEvent.keyDown(window, { key: 'a', altKey: true });
+    fireEvent.keyDown(window, { key: 'a', metaKey: true });
+
+    expect(onSelectMock).not.toHaveBeenCalled();
+  });
+
+  test('prevents multiple KeyMapper components from answering the same keypress', () => {
+    const onSelectMock1 = vi.fn();
+    const onSelectMock2 = vi.fn();
+
+    render(
+      <div>
+        <KeyMapper
+          options={sampleOptions}
+          keys={['1', '2', '3']}
+          onSelect={onSelectMock1}
+        />
+        <KeyMapper
+          options={sampleOptions}
+          keys={['1', '2', '3']}
+          onSelect={onSelectMock2}
+        />
+      </div>,
+    );
+
+    fireEvent.keyDown(window, { key: '1' });
+
+    expect(onSelectMock1).toHaveBeenCalledTimes(1);
+    expect(onSelectMock1).toHaveBeenCalledWith('a');
+    expect(onSelectMock2).not.toHaveBeenCalled();
+  });
+
+  test('stops event propagation in capture phase to prevent secondary global listeners', () => {
+    const onSelectMock = vi.fn();
+    const secondaryWindowListener = vi.fn();
+
+    window.addEventListener('keydown', secondaryWindowListener);
+
+    render(
+      <KeyMapper
+        options={sampleOptions}
+        keys="Enter"
+        onSelect={onSelectMock}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(onSelectMock).toHaveBeenCalledWith('a');
+    expect(secondaryWindowListener).not.toHaveBeenCalled();
+
+    window.removeEventListener('keydown', secondaryWindowListener);
   });
 
   test('handles a single string key for single-option setups', () => {
@@ -177,7 +264,8 @@ describe('KeyMapper Component', () => {
       );
 
       fireEvent.keyDown(window, { key: 'B' });
-      expect(onSelectMock).toHaveBeenCalledWith('blue');
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      expect(onSelectMock).toHaveBeenLastCalledWith('blue');
     });
 
     test('ignores unmapped random keys in object mode', () => {

--- a/src/components/response/tests/KeyMapper.spec.tsx
+++ b/src/components/response/tests/KeyMapper.spec.tsx
@@ -1,5 +1,5 @@
 import {
-  cleanup, render, fireEvent, act, screen,
+  cleanup, render, fireEvent, act,
 } from '@testing-library/react';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
@@ -39,7 +39,7 @@ describe('KeyMapper Component', () => {
 
     fireEvent.keyDown(window, { key: '2' });
     expect(onSelectMock).toHaveBeenCalledTimes(1);
-    expect(onSelectMock).toHaveBeenCalledWith('b');
+    expect(onSelectMock).toHaveBeenCalledWith('b', 'keyboard');
   });
 
   test('handles case-insensitive letter keypresses', () => {
@@ -58,7 +58,7 @@ describe('KeyMapper Component', () => {
     );
 
     fireEvent.keyDown(window, { key: 'A' });
-    expect(onSelectMock).toHaveBeenCalledWith('a');
+    expect(onSelectMock).toHaveBeenCalledWith('a', 'keyboard');
   });
 
   test('supports special keys like Arrow keys and Spacebar', () => {
@@ -77,10 +77,49 @@ describe('KeyMapper Component', () => {
     );
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
-    expect(onSelectMock).toHaveBeenCalledWith('b');
+    expect(onSelectMock).toHaveBeenCalledWith('b', 'keyboard');
 
-    fireEvent.keyDown(window, { key: ' ' });
-    expect(onSelectMock).toHaveBeenCalledWith('c');
+    fireEvent.keyDown(window, { key: 'space' });
+    expect(onSelectMock).toHaveBeenCalledWith('c', 'keyboard');
+  });
+
+  test('matches canonical Shift+X combinations without swallowing plain x', () => {
+    const onSelectMock = vi.fn();
+
+    render(
+      <KeyMapper
+        options={[{ label: 'Option A', value: 'a', key: 'Shift+X' }]}
+        onSelect={onSelectMock}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'x' });
+    expect(onSelectMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(window, { key: 'X', shiftKey: true });
+    expect(onSelectMock).toHaveBeenCalledTimes(1);
+    expect(onSelectMock).toHaveBeenCalledWith('a', 'keyboard');
+  });
+
+  test('ignores keyboard shortcuts while focus is on a response option inside the same group', () => {
+    const onSelectMock = vi.fn();
+    const focusRootRef = { current: null as HTMLDivElement | null };
+
+    const { container } = render(
+      <div ref={(node) => { focusRootRef.current = node; }}>
+        <button type="button">Visible option</button>
+        <KeyMapper
+          options={[{ label: 'Option B', value: 'b', key: 'b' }]}
+          onSelect={onSelectMock}
+          focusRootRef={focusRootRef}
+        />
+      </div>,
+    );
+
+    const option = container.querySelector('button')!;
+    option.focus();
+    fireEvent.keyDown(window, { key: 'b' });
+    expect(onSelectMock).not.toHaveBeenCalled();
   });
 
   test('does not trigger onSelect when component is disabled', () => {
@@ -169,7 +208,7 @@ describe('KeyMapper Component', () => {
     fireEvent.keyDown(window, { key: '1' });
 
     expect(onSelectMock1).toHaveBeenCalledTimes(1);
-    expect(onSelectMock1).toHaveBeenCalledWith('a');
+    expect(onSelectMock1).toHaveBeenCalledWith('a', 'keyboard');
     expect(onSelectMock2).not.toHaveBeenCalled();
   });
 
@@ -189,7 +228,7 @@ describe('KeyMapper Component', () => {
     const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
     window.dispatchEvent(event);
 
-    expect(onSelectMock).toHaveBeenCalledWith('next');
+    expect(onSelectMock).toHaveBeenCalledWith('next', 'keyboard');
     expect(secondaryWindowListener).toHaveBeenCalledTimes(1);
     expect((event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled).toBe(true);
 
@@ -207,7 +246,7 @@ describe('KeyMapper Component', () => {
     );
 
     fireEvent.keyDown(window, { key: 'Enter' });
-    expect(onSelectMock).toHaveBeenCalledWith('next');
+    expect(onSelectMock).toHaveBeenCalledWith('next', 'keyboard');
   });
 
   test('does not steal focus or autofocus when option keys are absent', () => {
@@ -275,11 +314,11 @@ describe('KeyMapper Component', () => {
 
       fireEvent.keyDown(window, { key: 'r' });
       expect(onSelectMock).toHaveBeenCalledTimes(1);
-      expect(onSelectMock).toHaveBeenCalledWith('red');
+      expect(onSelectMock).toHaveBeenCalledWith('red', 'keyboard');
 
       fireEvent.keyDown(window, { key: 'g' });
       expect(onSelectMock).toHaveBeenCalledTimes(2);
-      expect(onSelectMock).toHaveBeenCalledWith('green');
+      expect(onSelectMock).toHaveBeenCalledWith('green', 'keyboard');
     });
 
     test('handles case-insensitive keypresses with inline option keys', () => {
@@ -294,7 +333,7 @@ describe('KeyMapper Component', () => {
 
       fireEvent.keyDown(window, { key: 'B' });
       expect(onSelectMock).toHaveBeenCalledTimes(1);
-      expect(onSelectMock).toHaveBeenLastCalledWith('blue');
+      expect(onSelectMock).toHaveBeenLastCalledWith('blue', 'keyboard');
     });
 
     test('ignores unmapped keys', () => {
@@ -314,7 +353,7 @@ describe('KeyMapper Component', () => {
       expect(onSelectMock).not.toHaveBeenCalled();
     });
 
-    test('supports Spacebar key mapping', () => {
+    test('supports Space key mapping', () => {
       const onSelectMock = vi.fn();
       const optionsWithSpace: ParsedStringOption[] = [
         { label: 'BLUE', value: 'blue', key: 'Space' },
@@ -327,85 +366,8 @@ describe('KeyMapper Component', () => {
         />,
       );
 
-      fireEvent.keyDown(window, { key: ' ' });
-      expect(onSelectMock).toHaveBeenCalledWith('blue');
-    });
-  });
-
-  // --- Tests for Accessibility & Hidden Key Buttons ---
-
-  describe('Accessibility & Hidden Key Buttons', () => {
-    test('renders screen-reader accessible elements for options with keys', () => {
-      const onSelectMock = vi.fn();
-
-      render(
-        <KeyMapper
-          options={sampleOptions}
-          onSelect={onSelectMock}
-        />,
-      );
-
-      const buttons = screen.getAllByRole('button', { hidden: true });
-      expect(buttons).toHaveLength(3);
-      expect(buttons[0].textContent).toBe('Option A');
-      expect(buttons[1].textContent).toBe('Option B');
-      expect(buttons[2].textContent).toBe('Option C');
-    });
-
-    test('triggers onSelect when screen-reader accessible button is clicked directly', () => {
-      const onSelectMock = vi.fn();
-
-      render(
-        <KeyMapper
-          options={sampleOptions}
-          onSelect={onSelectMock}
-        />,
-      );
-
-      const buttons = screen.getAllByRole('button', { hidden: true });
-      fireEvent.click(buttons[1]);
-
-      expect(onSelectMock).toHaveBeenCalledTimes(1);
-      expect(onSelectMock).toHaveBeenCalledWith('b');
-    });
-
-    test('disables interactive screen-reader buttons when component is disabled', () => {
-      const onSelectMock = vi.fn();
-
-      render(
-        <KeyMapper
-          options={sampleOptions}
-          onSelect={onSelectMock}
-          disabled
-        />,
-      );
-
-      const buttons = screen.getAllByRole('button', { hidden: true });
-      buttons.forEach((button) => {
-        expect((button as HTMLButtonElement).disabled).toBe(true);
-      });
-
-      fireEvent.click(buttons[0]);
-      expect(onSelectMock).not.toHaveBeenCalled();
-    });
-
-    test('does not render accessible buttons for options without mapped keys', () => {
-      const onSelectMock = vi.fn();
-      const mixedOptions: ParsedStringOption[] = [
-        { label: 'Mapped Option', value: 'mapped', key: '1' },
-        { label: 'Unmapped Option', value: 'unmapped' },
-      ];
-
-      render(
-        <KeyMapper
-          options={mixedOptions}
-          onSelect={onSelectMock}
-        />,
-      );
-
-      const buttons = screen.getAllByRole('button', { hidden: true });
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0].textContent).toBe('Mapped Option');
+      fireEvent.keyDown(window, { key: 'space' });
+      expect(onSelectMock).toHaveBeenCalledWith('blue', 'keyboard');
     });
   });
 
@@ -440,7 +402,7 @@ describe('KeyMapper Component', () => {
       );
 
       fireEvent.keyDown(window, { key: '1' });
-      expect(onSelectMock).toHaveBeenLastCalledWith('a');
+      expect(onSelectMock).toHaveBeenLastCalledWith('a', 'keyboard');
 
       const updatedOptions: ParsedStringOption[] = [
         { label: 'New Option X', value: 'x', key: '1' },
@@ -454,7 +416,17 @@ describe('KeyMapper Component', () => {
       );
 
       fireEvent.keyDown(window, { key: '1' });
-      expect(onSelectMock).toHaveBeenLastCalledWith('x');
+      expect(onSelectMock).toHaveBeenLastCalledWith('x', 'keyboard');
+    });
+
+    test('does not render any extra controls for options with keys', () => {
+      const onSelectMock = vi.fn();
+      const { container } = render(
+        <KeyMapper options={sampleOptions} onSelect={onSelectMock} />,
+      );
+      expect(container.querySelectorAll('button')).toHaveLength(0);
+      expect(container.firstChild).toBeInstanceOf(HTMLDivElement);
+      expect(container.firstChild?.textContent).toBe('');
     });
   });
 });

--- a/src/components/response/tests/KeyMapper.spec.tsx
+++ b/src/components/response/tests/KeyMapper.spec.tsx
@@ -1,5 +1,5 @@
 import {
-  cleanup, render, fireEvent, act,
+  cleanup, render, fireEvent, act, screen,
 } from '@testing-library/react';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
@@ -22,9 +22,9 @@ describe('KeyMapper Component', () => {
   });
 
   const sampleOptions: ParsedStringOption[] = [
-    { label: 'Option A', value: 'a' },
-    { label: 'Option B', value: 'b' },
-    { label: 'Option C', value: 'c' },
+    { label: 'Option A', value: 'a', key: '1' },
+    { label: 'Option B', value: 'b', key: '2' },
+    { label: 'Option C', value: 'c', key: '3' },
   ];
 
   test('triggers onSelect with correct value when configured key is pressed', () => {
@@ -33,7 +33,6 @@ describe('KeyMapper Component', () => {
     render(
       <KeyMapper
         options={sampleOptions}
-        keys={['1', '2', '3']}
         onSelect={onSelectMock}
       />,
     );
@@ -45,11 +44,15 @@ describe('KeyMapper Component', () => {
 
   test('handles case-insensitive letter keypresses', () => {
     const onSelectMock = vi.fn();
+    const letterOptions: ParsedStringOption[] = [
+      { label: 'Option A', value: 'a', key: 'a' },
+      { label: 'Option B', value: 'b', key: 'b' },
+      { label: 'Option C', value: 'c', key: 'c' },
+    ];
 
     render(
       <KeyMapper
-        options={sampleOptions}
-        keys={['a', 'b', 'c']}
+        options={letterOptions}
         onSelect={onSelectMock}
       />,
     );
@@ -60,11 +63,15 @@ describe('KeyMapper Component', () => {
 
   test('supports special keys like Arrow keys and Spacebar', () => {
     const onSelectMock = vi.fn();
+    const specialOptions: ParsedStringOption[] = [
+      { label: 'Option A', value: 'a', key: 'ArrowLeft' },
+      { label: 'Option B', value: 'b', key: 'ArrowRight' },
+      { label: 'Option C', value: 'c', key: 'Space' },
+    ];
 
     render(
       <KeyMapper
-        options={sampleOptions}
-        keys={['ArrowLeft', 'ArrowRight', 'Space']}
+        options={specialOptions}
         onSelect={onSelectMock}
       />,
     );
@@ -82,7 +89,6 @@ describe('KeyMapper Component', () => {
     render(
       <KeyMapper
         options={sampleOptions}
-        keys={['1', '2', '3']}
         onSelect={onSelectMock}
         disabled
       />,
@@ -102,7 +108,6 @@ describe('KeyMapper Component', () => {
         <a href="#test" data-testid="link">Link</a>
         <KeyMapper
           options={sampleOptions}
-          keys={['1', '2', '3']}
           onSelect={onSelectMock}
         />
       </div>,
@@ -124,11 +129,15 @@ describe('KeyMapper Component', () => {
 
   test('ignores keypresses with modifier keys (Ctrl, Alt, Meta)', () => {
     const onSelectMock = vi.fn();
+    const letterOptions: ParsedStringOption[] = [
+      { label: 'Option A', value: 'a', key: 'a' },
+      { label: 'Option B', value: 'b', key: 'b' },
+      { label: 'Option C', value: 'c', key: 'c' },
+    ];
 
     render(
       <KeyMapper
-        options={sampleOptions}
-        keys={['a', 'b', 'c']}
+        options={letterOptions}
         onSelect={onSelectMock}
       />,
     );
@@ -148,12 +157,10 @@ describe('KeyMapper Component', () => {
       <div>
         <KeyMapper
           options={sampleOptions}
-          keys={['1', '2', '3']}
           onSelect={onSelectMock1}
         />
         <KeyMapper
           options={sampleOptions}
-          keys={['1', '2', '3']}
           onSelect={onSelectMock2}
         />
       </div>,
@@ -174,8 +181,7 @@ describe('KeyMapper Component', () => {
 
     render(
       <KeyMapper
-        options={sampleOptions}
-        keys="Enter"
+        options={[{ label: 'Continue', value: 'next', key: 'Enter' }]}
         onSelect={onSelectMock}
       />,
     );
@@ -183,20 +189,19 @@ describe('KeyMapper Component', () => {
     const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
     window.dispatchEvent(event);
 
-    expect(onSelectMock).toHaveBeenCalledWith('a');
+    expect(onSelectMock).toHaveBeenCalledWith('next');
     expect(secondaryWindowListener).toHaveBeenCalledTimes(1);
     expect((event as unknown as { __keyMapperHandled?: boolean }).__keyMapperHandled).toBe(true);
 
     window.removeEventListener('keydown', secondaryWindowListener);
   });
 
-  test('handles a single string key for single-option setups', () => {
+  test('handles a single option setup with mapped key', () => {
     const onSelectMock = vi.fn();
 
     render(
       <KeyMapper
-        options={[{ label: 'Continue', value: 'next' }]}
-        keys="Enter"
+        options={[{ label: 'Continue', value: 'next', key: 'Enter' }]}
         onSelect={onSelectMock}
       />,
     );
@@ -205,15 +210,18 @@ describe('KeyMapper Component', () => {
     expect(onSelectMock).toHaveBeenCalledWith('next');
   });
 
-  test('does not steal focus or autofocus when keys configuration is absent or empty', () => {
+  test('does not steal focus or autofocus when option keys are absent', () => {
     const onSelectMock = vi.fn();
+    const optionsWithoutKeys: ParsedStringOption[] = [
+      { label: 'Option A', value: 'a' },
+      { label: 'Option B', value: 'b' },
+    ];
 
     const { container } = render(
       <div>
         <input data-testid="external-input" />
         <KeyMapper
-          options={sampleOptions}
-          keys={undefined}
+          options={optionsWithoutKeys}
           onSelect={onSelectMock}
         />
       </div>,
@@ -236,7 +244,6 @@ describe('KeyMapper Component', () => {
     const { unmount } = render(
       <KeyMapper
         options={sampleOptions}
-        keys={['1', '2', '3']}
         onSelect={onSelectMock}
       />,
     );
@@ -247,49 +254,21 @@ describe('KeyMapper Component', () => {
     expect(onSelectMock).not.toHaveBeenCalled();
   });
 
-  // --- Tests for Object Key-to-Value Mapping ---
+  // --- Tests for Inline Key Mappings ---
 
-  describe('Object Key-to-Value Mapping', () => {
+  describe('Inline Key Mappings', () => {
     const stroopOptions: ParsedStringOption[] = [
-      { label: 'RED', value: 'red' },
-      { label: 'GREEN', value: 'green' },
-      { label: 'BLUE', value: 'blue' },
+      { label: 'RED', value: 'red', key: 'r' },
+      { label: 'GREEN', value: 'green', key: 'g' },
+      { label: 'BLUE', value: 'blue', key: 'b' },
     ];
 
-    const keyMap = {
-      r: 'red',
-      g: 'green',
-      b: 'blue',
-    };
-
-    test('matches exact case-sensitive option values when object target is mapped', () => {
-      const onSelectMock = vi.fn();
-      const caseSensitiveOptions: ParsedStringOption[] = [
-        { label: 'Lower', value: 'foo' },
-        { label: 'Upper', value: 'FOO' },
-      ];
-
-      render(
-        <KeyMapper
-          options={caseSensitiveOptions}
-          keys={{ x: 'FOO' }}
-          onSelect={onSelectMock}
-        />,
-      );
-
-      fireEvent.keyDown(window, { key: 'x' });
-      expect(onSelectMock).toHaveBeenCalledTimes(1);
-      expect(onSelectMock).toHaveBeenCalledWith('FOO');
-      expect(onSelectMock).not.toHaveBeenCalledWith('foo');
-    });
-
-    test('triggers onSelect with mapped value when configured object key is pressed', () => {
+    test('matches exact option values when inline key is pressed', () => {
       const onSelectMock = vi.fn();
 
       render(
         <KeyMapper
           options={stroopOptions}
-          keys={keyMap}
           onSelect={onSelectMock}
         />,
       );
@@ -303,13 +282,12 @@ describe('KeyMapper Component', () => {
       expect(onSelectMock).toHaveBeenCalledWith('green');
     });
 
-    test('handles case-insensitive keypresses with object mappings', () => {
+    test('handles case-insensitive keypresses with inline option keys', () => {
       const onSelectMock = vi.fn();
 
       render(
         <KeyMapper
           options={stroopOptions}
-          keys={keyMap}
           onSelect={onSelectMock}
         />,
       );
@@ -319,13 +297,12 @@ describe('KeyMapper Component', () => {
       expect(onSelectMock).toHaveBeenLastCalledWith('blue');
     });
 
-    test('ignores unmapped random keys in object mode', () => {
+    test('ignores unmapped keys', () => {
       const onSelectMock = vi.fn();
 
       render(
         <KeyMapper
           options={stroopOptions}
-          keys={keyMap}
           onSelect={onSelectMock}
         />,
       );
@@ -337,13 +314,15 @@ describe('KeyMapper Component', () => {
       expect(onSelectMock).not.toHaveBeenCalled();
     });
 
-    test('supports Spacebar key mapping in object mode', () => {
+    test('supports Spacebar key mapping', () => {
       const onSelectMock = vi.fn();
+      const optionsWithSpace: ParsedStringOption[] = [
+        { label: 'BLUE', value: 'blue', key: 'Space' },
+      ];
 
       render(
         <KeyMapper
-          options={stroopOptions}
-          keys={{ Space: 'blue' }}
+          options={optionsWithSpace}
           onSelect={onSelectMock}
         />,
       );
@@ -351,20 +330,131 @@ describe('KeyMapper Component', () => {
       fireEvent.keyDown(window, { key: ' ' });
       expect(onSelectMock).toHaveBeenCalledWith('blue');
     });
+  });
 
-    test('ignores keypress if mapped value does not exist in options', () => {
+  // --- Tests for Accessibility & Hidden Key Buttons ---
+
+  describe('Accessibility & Hidden Key Buttons', () => {
+    test('renders screen-reader accessible elements for options with keys', () => {
       const onSelectMock = vi.fn();
 
       render(
         <KeyMapper
-          options={stroopOptions}
-          keys={{ y: 'yellow' }}
+          options={sampleOptions}
           onSelect={onSelectMock}
         />,
       );
 
-      fireEvent.keyDown(window, { key: 'y' });
+      const buttons = screen.getAllByRole('button', { hidden: true });
+      expect(buttons).toHaveLength(3);
+      expect(buttons[0].textContent).toBe('Option A');
+      expect(buttons[1].textContent).toBe('Option B');
+      expect(buttons[2].textContent).toBe('Option C');
+    });
+
+    test('triggers onSelect when screen-reader accessible button is clicked directly', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={sampleOptions}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      const buttons = screen.getAllByRole('button', { hidden: true });
+      fireEvent.click(buttons[1]);
+
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      expect(onSelectMock).toHaveBeenCalledWith('b');
+    });
+
+    test('disables interactive screen-reader buttons when component is disabled', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={sampleOptions}
+          onSelect={onSelectMock}
+          disabled
+        />,
+      );
+
+      const buttons = screen.getAllByRole('button', { hidden: true });
+      buttons.forEach((button) => {
+        expect((button as HTMLButtonElement).disabled).toBe(true);
+      });
+
+      fireEvent.click(buttons[0]);
       expect(onSelectMock).not.toHaveBeenCalled();
+    });
+
+    test('does not render accessible buttons for options without mapped keys', () => {
+      const onSelectMock = vi.fn();
+      const mixedOptions: ParsedStringOption[] = [
+        { label: 'Mapped Option', value: 'mapped', key: '1' },
+        { label: 'Unmapped Option', value: 'unmapped' },
+      ];
+
+      render(
+        <KeyMapper
+          options={mixedOptions}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      const buttons = screen.getAllByRole('button', { hidden: true });
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0].textContent).toBe('Mapped Option');
+    });
+  });
+
+  // --- Edge Cases & Additional Behaviors ---
+
+  describe('Edge Cases', () => {
+    test('ignores held key repetition (repeat = true)', () => {
+      const onSelectMock = vi.fn();
+
+      render(
+        <KeyMapper
+          options={sampleOptions}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: '1', repeat: false });
+      fireEvent.keyDown(window, { key: '1', repeat: true });
+      fireEvent.keyDown(window, { key: '1', repeat: true });
+
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('updates key bindings dynamically when options prop changes', () => {
+      const onSelectMock = vi.fn();
+
+      const { rerender } = render(
+        <KeyMapper
+          options={sampleOptions}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: '1' });
+      expect(onSelectMock).toHaveBeenLastCalledWith('a');
+
+      const updatedOptions: ParsedStringOption[] = [
+        { label: 'New Option X', value: 'x', key: '1' },
+      ];
+
+      rerender(
+        <KeyMapper
+          options={updatedOptions}
+          onSelect={onSelectMock}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: '1' });
+      expect(onSelectMock).toHaveBeenLastCalledWith('x');
     });
   });
 });

--- a/src/components/response/tests/ResponseBlock.spec.tsx
+++ b/src/components/response/tests/ResponseBlock.spec.tsx
@@ -60,6 +60,7 @@ vi.mock('@mantine/core', () => ({
   Group: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Text: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
   ThemeIcon: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Kbd: ({ children }: { children?: ReactNode }) => <kbd>{children}</kbd>,
 }));
 
 vi.mock('react-router', () => ({

--- a/src/components/tests/NextButton.spec.tsx
+++ b/src/components/tests/NextButton.spec.tsx
@@ -78,6 +78,11 @@ vi.mock('@mantine/core', () => ({
   Group: ({ children, justify }: { children: ReactNode; justify?: string }) => (
     <div data-justify={justify}>{children}</div>
   ),
+  Kbd: ({ children }: { children: ReactNode }) => <kbd>{children}</kbd>,
+  Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ActionIcon: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
 }));
 
 vi.mock('@tabler/icons-react', () => ({

--- a/src/components/tests/NextButton.spec.tsx
+++ b/src/components/tests/NextButton.spec.tsx
@@ -69,10 +69,11 @@ vi.mock('@mantine/core', () => ({
     </div>
   ),
   Button: ({
-    children, disabled, onClick, type,
-  }: { children: ReactNode; disabled?: boolean; onClick?: () => void; type?: string }) => (
-    <button type={type === 'submit' ? 'submit' : 'button'} disabled={disabled} onClick={onClick}>
+    children, disabled, onClick, type, rightSection, 'aria-label': ariaLabel,
+  }: { children: ReactNode; disabled?: boolean; onClick?: () => void; type?: string; rightSection?: ReactNode; 'aria-label'?: string }) => (
+    <button type={type === 'submit' ? 'submit' : 'button'} disabled={disabled} onClick={onClick} aria-label={ariaLabel}>
       {children}
+      {rightSection}
     </button>
   ),
   Group: ({ children, justify }: { children: ReactNode; justify?: string }) => (
@@ -328,6 +329,28 @@ describe('NextButton', () => {
     } finally {
       document.body.removeChild(textarea);
     }
+  });
+
+  test('nextOnEnter: defaultPrevented Enter events are ignored', async () => {
+    const onNext = vi.fn();
+    mockStudyConfig = { uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true } };
+    await act(async () => {
+      render(<NextButton checkAnswer={null} onNext={onNext} />);
+    });
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    event.preventDefault();
+    await act(async () => { window.dispatchEvent(event); });
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  test('nextOnEnter: preserves the accessible name while showing the visual hint', async () => {
+    mockStudyConfig = { uiConfig: { ...mockStudyConfig.uiConfig, nextOnEnter: true } };
+    await act(async () => {
+      render(<NextButton checkAnswer={null} onNext={vi.fn()} />);
+    });
+    const button = screen.getByRole('button', { name: 'Next' });
+    expect(button.getAttribute('aria-label')).toBe('Next');
+    expect(screen.getByText('↵')).toBeTruthy();
   });
 
   test('nextOnEnter: Enter on a focused button is left to its synthesized click', async () => {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -285,6 +285,26 @@
           "description": "The description that is displayed when the participant hovers over the response. This does not accept markdown.",
           "type": "string"
         },
+        "keyMapping": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "description": "A keyboard mapping to buttons. Supports string array [\"1\", \"2\"] or key-to-value map object { \"r\": \"red\" }."
+        },
         "location": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -2488,7 +2488,7 @@
           "type": "string"
         },
         "key": {
-          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\"). Can also use combinations see https://www.digitala11y.com/aria-properties/.",
           "type": "string"
         },
         "label": {
@@ -4055,7 +4055,7 @@
           "type": "string"
         },
         "key": {
-          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\"). Can also use combinations see https://www.digitala11y.com/aria-properties/.",
           "type": "string"
         },
         "label": {

--- a/src/parser/LibraryConfigSchema.json
+++ b/src/parser/LibraryConfigSchema.json
@@ -277,6 +277,10 @@
           "description": "Controls whether the response is hidden.",
           "type": "boolean"
         },
+        "hideKeyVisual": {
+          "description": "Set to true to hide keybinding indicators on buttons. Defaults to false when keymapping is active, else false.",
+          "type": "boolean"
+        },
         "id": {
           "description": "The id of the response. This is used to identify the response in the data file.",
           "type": "string"
@@ -284,26 +288,6 @@
         "infoText": {
           "description": "The description that is displayed when the participant hovers over the response. This does not accept markdown.",
           "type": "string"
-        },
-        "keyMapping": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            }
-          ],
-          "description": "A keyboard mapping to buttons. Supports string array [\"1\", \"2\"] or key-to-value map object { \"r\": \"red\" }."
         },
         "location": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -2503,6 +2487,10 @@
           "description": "The description that is displayed when the participant hovers over the option. This does not accept markdown.",
           "type": "string"
         },
+        "key": {
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
+          "type": "string"
+        },
         "label": {
           "description": "The label displayed to participants. Markdown is supported.",
           "type": "string"
@@ -4064,6 +4052,10 @@
       "properties": {
         "infoText": {
           "description": "The description that is displayed when the participant hovers over the option. This does not accept markdown.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
           "type": "string"
         },
         "label": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -306,6 +306,26 @@
           "description": "The description that is displayed when the participant hovers over the response. This does not accept markdown.",
           "type": "string"
         },
+        "keyMapping": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "description": "A keyboard mapping to buttons. Supports string array [\"1\", \"2\"] or key-to-value map object { \"r\": \"red\" }."
+        },
         "location": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
           "description": "Controls the response location. These might be the same for all responses, or differ across responses. Defaults to `belowStimulus`"

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -298,6 +298,10 @@
           "description": "Controls whether the response is hidden.",
           "type": "boolean"
         },
+        "hideKeyVisual": {
+          "description": "Set to true to hide keybinding indicators on buttons. Defaults to false when keymapping is active, else false.",
+          "type": "boolean"
+        },
         "id": {
           "description": "The id of the response. This is used to identify the response in the data file.",
           "type": "string"
@@ -305,26 +309,6 @@
         "infoText": {
           "description": "The description that is displayed when the participant hovers over the response. This does not accept markdown.",
           "type": "string"
-        },
-        "keyMapping": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            }
-          ],
-          "description": "A keyboard mapping to buttons. Supports string array [\"1\", \"2\"] or key-to-value map object { \"r\": \"red\" }."
         },
         "location": {
           "$ref": "#/definitions/ConfigResponseBlockLocation",
@@ -2552,6 +2536,10 @@
           "description": "The description that is displayed when the participant hovers over the option. This does not accept markdown.",
           "type": "string"
         },
+        "key": {
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
+          "type": "string"
+        },
         "label": {
           "description": "The label displayed to participants. Markdown is supported.",
           "type": "string"
@@ -4135,6 +4123,10 @@
       "properties": {
         "infoText": {
           "description": "The description that is displayed when the participant hovers over the option. This does not accept markdown.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
           "type": "string"
         },
         "label": {

--- a/src/parser/StudyConfigSchema.json
+++ b/src/parser/StudyConfigSchema.json
@@ -2537,7 +2537,7 @@
           "type": "string"
         },
         "key": {
-          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\"). Can also use combinations see https://www.digitala11y.com/aria-properties/.",
           "type": "string"
         },
         "label": {
@@ -4126,7 +4126,7 @@
           "type": "string"
         },
         "key": {
-          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\")",
+          "description": "Optional keyboard key shortcut mapped to this option (e.g., \"r\", \"ArrowLeft\", \"Space\"). Can also use combinations see https://www.digitala11y.com/aria-properties/.",
           "type": "string"
         },
         "label": {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -617,6 +617,42 @@ function hasConditionalBlockInsideRestrictedOrderAncestor(
   ));
 }
 
+const ALLOWED_SPECIAL_KEYS = new Set([
+  'space', 'spacebar', 'enter', 'tab', 'escape', 'backspace', 'delete',
+  'arrowleft', 'arrowright', 'arrowup', 'arrowdown', 'home', 'end', 'pageup', 'pagedown',
+]);
+
+function verifyKeyMappings(
+  basePath: string,
+  component: Partial<IndividualComponent>,
+  warnings: ParsedConfig<StudyConfig>['warnings'],
+) {
+  if (!component.response || !Array.isArray(component.response)) return;
+
+  component.response.forEach((res, resIdx) => {
+    if ('options' in res && Array.isArray(res.options)) {
+      res.options.forEach((opt, optIdx) => {
+        if (typeof opt === 'object' && opt !== null && 'key' in opt && opt.key) {
+          const rawKey = String(opt.key).trim();
+          const lowerKey = rawKey.toLowerCase();
+
+          const isSingleChar = rawKey.length === 1;
+          const isSpecialKey = ALLOWED_SPECIAL_KEYS.has(lowerKey);
+
+          if (!isSingleChar && !isSpecialKey) {
+            warnings.push({
+              message: `Invalid key mapping \`${rawKey}\` in option \`${opt.label || opt.value}\`. Key mappings must be a single character or a valid key name (e.g., "ArrowRight", "Space").`,
+              instancePath: `${basePath}/response/${resIdx}/options/${optIdx}/key`,
+              params: { action: 'Use a single key character or valid key string like ArrowRight, ArrowLeft, or Space (case-insensitive)' },
+              category: 'invalid-config',
+            });
+          }
+        }
+      });
+    }
+  });
+}
+
 // This function verifies the study config file satisfies conditions that are not covered by the schema
 function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Record<string, LibraryConfig>) {
   const errors: ParsedConfig<StudyConfig>['errors'] = [];
@@ -628,12 +664,14 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
     verifyTextResponseConstraints(`/baseComponents/${componentName}`, component, errors, warnings);
     verifyDateTimeResponseConstraints(`/baseComponents/${componentName}`, component, errors);
     verifyDropdownResponseConstraints(`/baseComponents/${componentName}`, component, errors);
+    verifyKeyMappings(`/baseComponents/${componentName}`, component, warnings);
   });
   Object.entries(studyConfig.components).forEach(([componentName, component]) => {
     const mergedComponent = studyComponentToIndividualComponent(component, studyConfig);
     verifyTextResponseConstraints(`/components/${componentName}`, mergedComponent, errors, warnings);
     verifyDateTimeResponseConstraints(`/components/${componentName}`, mergedComponent, errors);
     verifyDropdownResponseConstraints(`/components/${componentName}`, mergedComponent, errors);
+    verifyKeyMappings(`/components/${componentName}`, mergedComponent, warnings);
   });
 
   const hasConditional = hasConditionalBlock(studyConfig.sequence);

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -32,6 +32,7 @@ import {
 } from '../utils/dateTimeValidation';
 import { checkBuiltInValidation } from '../components/response/builtInValidation';
 import { getDropdownOptions } from '../utils/dropdownOptions';
+import { normalizeKeyMapping } from '../utils/keyMapping';
 
 const modules = import.meta.glob(
   [
@@ -617,39 +618,47 @@ function hasConditionalBlockInsideRestrictedOrderAncestor(
   ));
 }
 
-const ALLOWED_SPECIAL_KEYS = new Set([
-  'space', 'spacebar', 'enter', 'tab', 'escape', 'backspace', 'delete',
-  'arrowleft', 'arrowright', 'arrowup', 'arrowdown', 'home', 'end', 'pageup', 'pagedown',
-]);
-
 function verifyKeyMappings(
   basePath: string,
   component: Partial<IndividualComponent>,
-  warnings: ParsedConfig<StudyConfig>['warnings'],
+  errors: ParsedConfig<StudyConfig>['errors'],
 ) {
   if (!component.response || !Array.isArray(component.response)) return;
 
+  const seenMappings = new Map<string, { responseIndex: number; optionIndex: number; label: string }>();
+
   component.response.forEach((res, resIdx) => {
-    if ('options' in res && Array.isArray(res.options)) {
-      res.options.forEach((opt, optIdx) => {
-        if (typeof opt === 'object' && opt !== null && 'key' in opt && opt.key) {
-          const rawKey = String(opt.key).trim();
-          const lowerKey = rawKey.toLowerCase();
-
-          const isSingleChar = rawKey.length === 1;
-          const isSpecialKey = ALLOWED_SPECIAL_KEYS.has(lowerKey);
-
-          if (!isSingleChar && !isSpecialKey) {
-            warnings.push({
-              message: `Invalid key mapping \`${rawKey}\` in option \`${opt.label || opt.value}\`. Key mappings must be a single character or a valid key name (e.g., "ArrowRight", "Space").`,
-              instancePath: `${basePath}/response/${resIdx}/options/${optIdx}/key`,
-              params: { action: 'Use a single key character or valid key string like ArrowRight, ArrowLeft, or Space (case-insensitive)' },
-              category: 'invalid-config',
-            });
-          }
-        }
-      });
+    if (!('options' in res) || !Array.isArray(res.options)) {
+      return;
     }
+
+    res.options.forEach((opt, optIdx) => {
+      if (typeof opt !== 'object' || opt === null || !('key' in opt)) {
+        return;
+      }
+
+      const normalizedKey = normalizeKeyMapping(String(opt.key));
+      if (normalizedKey === null) {
+        errors.push({
+          message: `Invalid key mapping \`${String(opt.key)}\` in option \`${opt.label || opt.value}\`. Key mappings must use a single character, a known named key (for example "ArrowRight" or "Space"), or a modifier-plus-key combination such as "Shift+X".`,
+          instancePath: `${basePath}/response/${resIdx}/options/${optIdx}/key`,
+          params: { action: 'Use a single printable key, a valid named key, or a canonical modifier-plus-key value like Shift+X' },
+          category: 'invalid-config',
+        });
+        return;
+      }
+
+      const previous = seenMappings.get(normalizedKey);
+      if (previous) {
+        errors.push({
+          message: `Duplicate key mapping \`${normalizedKey}\` in option \`${opt.label || opt.value}\`. A component cannot assign the same key to multiple responses.`,
+          instancePath: `${basePath}/response/${resIdx}/options/${optIdx}/key`,
+          params: { action: `Remove or rename the duplicate mapping for \`${normalizedKey}\`` },
+          category: 'invalid-config',
+        });
+      }
+      seenMappings.set(normalizedKey, { responseIndex: resIdx, optionIndex: optIdx, label: String(opt.label || opt.value) });
+    });
   });
 }
 
@@ -664,14 +673,14 @@ function verifyStudyConfig(studyConfig: StudyConfig, importedLibrariesData: Reco
     verifyTextResponseConstraints(`/baseComponents/${componentName}`, component, errors, warnings);
     verifyDateTimeResponseConstraints(`/baseComponents/${componentName}`, component, errors);
     verifyDropdownResponseConstraints(`/baseComponents/${componentName}`, component, errors);
-    verifyKeyMappings(`/baseComponents/${componentName}`, component, warnings);
+    verifyKeyMappings(`/baseComponents/${componentName}`, component, errors);
   });
   Object.entries(studyConfig.components).forEach(([componentName, component]) => {
     const mergedComponent = studyComponentToIndividualComponent(component, studyConfig);
     verifyTextResponseConstraints(`/components/${componentName}`, mergedComponent, errors, warnings);
     verifyDateTimeResponseConstraints(`/components/${componentName}`, mergedComponent, errors);
     verifyDropdownResponseConstraints(`/components/${componentName}`, mergedComponent, errors);
-    verifyKeyMappings(`/components/${componentName}`, mergedComponent, warnings);
+    verifyKeyMappings(`/components/${componentName}`, mergedComponent, errors);
   });
 
   const hasConditional = hasConditionalBlock(studyConfig.sequence);

--- a/src/parser/tests/parser.spec.ts
+++ b/src/parser/tests/parser.spec.ts
@@ -81,6 +81,81 @@ describe('Text response validation config parsing', () => {
     },
   );
 
+  test.each(['', '   ', '14', 'RightKeyboardArrow', 'Shift+14', 'Shift+foo', 'Shift+'])('rejects invalid key mapping %p', async (key) => {
+    const studyConfig = {
+      $schema: '',
+      studyMetadata: {
+        title: 'Key Validation Test',
+        version: '1.0',
+        authors: ['Test'],
+        date: '2026-08-20',
+        description: 'Ensures key mappings are validated.',
+        organizations: ['Test Org'],
+      },
+      uiConfig: {
+        contactEmail: '',
+        logoPath: '',
+        withProgressBar: true,
+        withSidebar: false,
+      },
+      components: {
+        question1: {
+          type: 'questionnaire',
+          response: [{
+            id: 'buttons',
+            prompt: 'Choose a response',
+            type: 'buttons',
+            options: [{ label: 'A', value: 'a', key }],
+          }],
+        },
+      },
+      sequence: { order: 'fixed', components: ['question1'] },
+    } as const;
+
+    const result = await parseStudyConfig(JSON.stringify(studyConfig));
+
+    expect(result.errors.some((error) => error.instancePath.includes('/key'))).toBe(true);
+  });
+
+  test('rejects duplicate key mappings within a component', async () => {
+    const studyConfig = {
+      $schema: '',
+      studyMetadata: {
+        title: 'Duplicate Key Validation Test',
+        version: '1.0',
+        authors: ['Test'],
+        date: '2026-08-20',
+        description: 'Ensures duplicate key mappings are rejected.',
+        organizations: ['Test Org'],
+      },
+      uiConfig: {
+        contactEmail: '',
+        logoPath: '',
+        withProgressBar: true,
+        withSidebar: false,
+      },
+      components: {
+        question1: {
+          type: 'questionnaire',
+          response: [{
+            id: 'buttons',
+            prompt: 'Choose a response',
+            type: 'buttons',
+            options: [
+              { label: 'A', value: 'a', key: 'Shift+X' },
+              { label: 'B', value: 'b', key: 'shift+x' },
+            ],
+          }],
+        },
+      },
+      sequence: { order: 'fixed', components: ['question1'] },
+    };
+
+    const result = await parseStudyConfig(JSON.stringify(studyConfig));
+
+    expect(result.errors.some((error) => error.message.includes('Duplicate key mapping'))).toBe(true);
+  });
+
   test.each(['email', 'phoneNumber', 'usPhoneNumber', 'url'])('accepts the %s built-in validation for short text responses', async (builtInValidation) => {
     const studyConfig = makeStudyConfig('contains');
     Object.assign(studyConfig.components.question1.response[0], { builtInValidation });

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1116,6 +1116,8 @@ export interface ButtonsResponse extends BaseResponse {
   default?: string;
   /** The order in which the buttons are displayed. Defaults to fixed. */
   optionOrder?: 'fixed' | 'random';
+  /** A keyboard mapping to buttons. Supports string array ["1", "2"] or key-to-value map object { "r": "red" }. */
+  keyMapping?: string | string[] | Record<string, string>;
 }
 
 /**

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -349,7 +349,7 @@ export interface StringOption {
   value?: string;
   /** The description that is displayed when the participant hovers over the option. This does not accept markdown. */
   infoText?: string;
-  /** Optional keyboard key shortcut mapped to this option (e.g., "r", "ArrowLeft", "Space") */
+  /** Optional keyboard key shortcut mapped to this option (e.g., "r", "ArrowLeft", "Space"). Can also use combinations see https://www.digitala11y.com/aria-properties/. */
   key?: string;
 }
 

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -349,6 +349,8 @@ export interface StringOption {
   value?: string;
   /** The description that is displayed when the participant hovers over the option. This does not accept markdown. */
   infoText?: string;
+  /** Optional keyboard key shortcut mapped to this option (e.g., "r", "ArrowLeft", "Space") */
+  key?: string;
 }
 
 /**
@@ -1116,8 +1118,8 @@ export interface ButtonsResponse extends BaseResponse {
   default?: string;
   /** The order in which the buttons are displayed. Defaults to fixed. */
   optionOrder?: 'fixed' | 'random';
-  /** A keyboard mapping to buttons. Supports string array ["1", "2"] or key-to-value map object { "r": "red" }. */
-  keyMapping?: string | string[] | Record<string, string>;
+  /** Set to true to hide keybinding indicators on buttons. Defaults to false when keymapping is active, else false. */
+  hideKeyVisual?: boolean;
 }
 
 /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -249,6 +249,7 @@ export interface Sequence {
 export type FormElementProvenance = {
   form: StoredAnswer['answer'];
   showResponseErrors?: boolean;
+  interactionSource?: 'keyboard' | 'click';
 };
 export type AlertModalState = { show: boolean, message: string, title: string };
 export interface StoreState {

--- a/src/utils/keyMapping.ts
+++ b/src/utils/keyMapping.ts
@@ -1,0 +1,127 @@
+const MODIFIER_ALIASES: Record<string, string> = {
+  shift: 'Shift',
+  alt: 'Alt',
+  option: 'Alt',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  meta: 'Meta',
+  cmd: 'Meta',
+  command: 'Meta',
+  win: 'Meta',
+};
+
+const SPECIAL_KEY_ALIASES: Record<string, string> = {
+  space: 'Space',
+  enter: 'Enter',
+  tab: 'Tab',
+  escape: 'Escape',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  arrowleft: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+  arrowup: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+};
+
+const MODIFIER_ORDER = ['Shift', 'Alt', 'Ctrl', 'Meta'] as const;
+
+export function normalizeMappingKeyToken(token: string): string | null {
+  const value = token.trim();
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase();
+  if (SPECIAL_KEY_ALIASES[lower]) {
+    return SPECIAL_KEY_ALIASES[lower];
+  }
+
+  if (value.length === 1) {
+    return value.toUpperCase();
+  }
+
+  return null;
+}
+
+function normalizeModifierToken(token: string): string | null {
+  const value = token.trim();
+  if (!value) {
+    return null;
+  }
+
+  const normalized = MODIFIER_ALIASES[value.toLowerCase()];
+  return normalized ?? null;
+}
+
+export function normalizeKeyMapping(rawKey: string): string | null {
+  const value = rawKey.trim();
+  if (!value) {
+    return null;
+  }
+
+  const parts = value.split('+').map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) {
+    return null;
+  }
+
+  if (parts.length === 1) {
+    const key = normalizeMappingKeyToken(parts[0]);
+    return key ?? null;
+  }
+
+  const modifiers: string[] = [];
+  const lastToken = parts[parts.length - 1];
+  const baseKey = normalizeMappingKeyToken(lastToken);
+  if (!baseKey) {
+    return null;
+  }
+
+  // in case we have multiple key mappings due to mac and windows e.g.
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const modifier = normalizeModifierToken(parts[index]);
+    if (!modifier) {
+      return null;
+    }
+    modifiers.push(modifier);
+  }
+
+  const sortedModifiers = MODIFIER_ORDER.filter((modifier) => modifiers.includes(modifier));
+  return [...sortedModifiers, baseKey].join('+');
+}
+
+export function getCanonicalEventKey(event: Pick<KeyboardEvent, 'key' | 'shiftKey' | 'altKey' | 'ctrlKey' | 'metaKey'>): string {
+  const key = event.key ?? '';
+  const modifiers = MODIFIER_ORDER.filter((modifier) => {
+    if (modifier === 'Shift') return event.shiftKey;
+    if (modifier === 'Alt') return event.altKey;
+    if (modifier === 'Ctrl') return event.ctrlKey;
+    if (modifier === 'Meta') return event.metaKey;
+    return false;
+  });
+
+  const normalizedKey = (() => {
+    const lower = key.toLowerCase();
+    if (SPECIAL_KEY_ALIASES[lower]) {
+      return SPECIAL_KEY_ALIASES[lower];
+    }
+    if (key.length === 1) {
+      return key.toUpperCase();
+    }
+    return key;
+  })();
+
+  return [...modifiers, normalizedKey].join('+');
+}
+
+export function keyEventMatchesMapping(
+  rawKey: string,
+  event: Pick<KeyboardEvent, 'key' | 'shiftKey' | 'altKey' | 'ctrlKey' | 'metaKey'>,
+): boolean {
+  const expected = normalizeKeyMapping(rawKey);
+  const actual = getCanonicalEventKey(event);
+  return expected !== null && actual === expected;
+}

--- a/tests/demo-form-elements.spec.ts
+++ b/tests/demo-form-elements.spec.ts
@@ -154,6 +154,9 @@ test('Test questionnaire component with responses and randomizing questions and 
   // Button
   await page.getByRole('radio', { name: 'Option 4' }).nth(0).click();
 
+  // Buttons with keymapping (Using configured key mapping)
+  await page.keyboard.press('r');
+
   // Likert scale
   await page.getByRole('radio', { name: '5' }).nth(0).click();
 


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1448 

### Give a longer description of what this PR addresses and why it's needed
Custom keyboard controls are not easily accessible in the config files but are really usefull especially when buttons are involved in the questions. Thie PR enables the user to define a mapping or a list in the json to link buttons to keys on the keyboard and on keypress the linked button is selected. 