### PR TITLE
Fix analysis crashes for legacy participant data

### DIFF
--- a/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
+++ b/src/analysis/individualStudy/replay/AllTasksTimeline.tsx
@@ -211,7 +211,7 @@ export function AllTasksTimeline({
       const resolvedComponent = component && studyConfig
         ? studyComponentToIndividualComponent(component, studyConfig)
         : undefined;
-      const correctAnswers = answer.correctAnswer.length > 0
+      const correctAnswers = answer.correctAnswer?.length
         ? answer.correctAnswer
         : resolvedComponent?.correctAnswer;
       const answerStatus = getComponentAnswerStatus(answer, correctAnswers, resolvedComponent?.response);

--- a/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
+++ b/src/analysis/individualStudy/replay/tests/AllTasksTimeline.spec.tsx
@@ -233,6 +233,27 @@ describe('AllTasksTimeline', () => {
     expect(html).toContain('Response recorded; correctness not configured.');
   });
 
+  test('handles legacy answers without correctAnswer', () => {
+    const legacyAnswer = makeAnswer({ answer: { q1: 'yes' } });
+    delete (legacyAnswer as Partial<StoredAnswer>).correctAnswer;
+    const participant = makeParticipant({
+      answers: { trial1_0: legacyAnswer },
+    });
+
+    const html = renderToStaticMarkup(
+      <AllTasksTimeline
+        participantData={participant}
+        width={600}
+        studyId="test-study"
+        studyConfig={emptyConfig}
+        maxLength={undefined}
+      />,
+    );
+
+    expect(html).toContain('trial1_0');
+    expect(html).toContain('Response recorded; correctness not configured.');
+  });
+
   test('handles participant with incomplete answer (startTime === 0)', () => {
     const participant = makeParticipant({
       answers: {

--- a/src/analysis/individualStudy/table/TableView.tsx
+++ b/src/analysis/individualStudy/table/TableView.tsx
@@ -216,7 +216,7 @@ export function TableView({
       },
       {
         accessorFn: (row: ParticipantDataWithStatus) => Object.values(row.answers)
-          .filter((answer) => answer.correctAnswer.length > 0 && answer.endTime > 0)
+          .filter((answer) => (answer.correctAnswer?.length ?? 0) > 0 && answer.endTime > 0)
           .map((answer) => {
             const componentConfig = studyConfig.components[answer.componentName];
             const component = componentConfig ? studyComponentToIndividualComponent(componentConfig, studyConfig) : undefined;

--- a/src/analysis/individualStudy/table/tests/TableView.spec.tsx
+++ b/src/analysis/individualStudy/table/tests/TableView.spec.tsx
@@ -7,7 +7,7 @@ import { useParams } from 'react-router';
 import { StudyConfig } from '../../../../parser/types';
 import { ParticipantDataWithStatus } from '../../../../storage/types';
 import { createMockStudyConfig } from '../../../tests/testUtils';
-import { makeParticipant as _makeParticipant } from '../../../../tests/utils';
+import { makeParticipant as _makeParticipant, makeStoredAnswer } from '../../../../tests/utils';
 import { TableView } from '../TableView';
 import { MetaCell } from '../MetaCell';
 
@@ -15,6 +15,7 @@ import { MetaCell } from '../MetaCell';
 
 type MrtColumn = {
   header: string;
+  accessorFn?: (row: ParticipantDataWithStatus) => unknown;
   Cell: ({ cell }: { cell: { getValue(): unknown } }) => ReactNode;
 };
 
@@ -270,6 +271,19 @@ describe('TableView', () => {
     const html = renderToStaticMarkup(col.Cell({ cell: { getValue: () => [true, true, false] } }));
     expect(html).toContain('2'); // correct count
     expect(html).toContain('1'); // incorrect count
+  });
+
+  test('Correct Answers accessor excludes legacy answers without correctAnswer', () => {
+    const legacyAnswer = makeStoredAnswer({ endTime: 2 });
+    delete (legacyAnswer as Partial<typeof legacyAnswer>).correctAnswer;
+    const participant = makeParticipant({ answers: { legacyAnswer } });
+
+    renderToStaticMarkup(
+      <TableView {...defaultProps} visibleParticipants={[participant]} />,
+    );
+    const col = capturedTableOptions!.columns.find((c) => c.header === 'Correct Answers')!;
+
+    expect(col.accessorFn!(participant)).toEqual([]);
   });
 
   // ── Metadata column ────────────────────────────────────────────────────────

--- a/src/components/downloader/DownloadTidy.tsx
+++ b/src/components/downloader/DownloadTidy.tsx
@@ -207,7 +207,7 @@ function participantDataToRows(
         }
         if (properties.includes('correctAnswer')) {
           const configCorrectAnswer = completeComponent?.correctAnswer?.find((ans) => ans.id === key)?.answer;
-          const answerCorrectAnswer = trialAnswer.correctAnswer.find((ans) => ans.id === key)?.answer;
+          const answerCorrectAnswer = trialAnswer.correctAnswer?.find((ans) => ans.id === key)?.answer;
           const correctAnswer = answerCorrectAnswer ?? configCorrectAnswer;
           tidyRow.correctAnswer = typeof correctAnswer === 'object' ? JSON.stringify(correctAnswer) : correctAnswer;
         }

--- a/src/components/downloader/tests/DownloadTidy.spec.tsx
+++ b/src/components/downloader/tests/DownloadTidy.spec.tsx
@@ -9,6 +9,7 @@ import { DownloadTidy, getTableData } from '../DownloadTidy';
 import type { StudyConfig } from '../../../parser/types';
 import type { StorageEngine } from '../../../storage/engines/types';
 import type { ParticipantDataWithStatus } from '../../../storage/types';
+import type { StoredAnswer } from '../../../store/types';
 import testConfigSimple from '../../../storage/tests/testConfigSimple.json';
 
 const storageEngineHookMock = vi.hoisted(() => ({
@@ -148,6 +149,46 @@ describe('getTableData', () => {
       responseMax: 10,
       parameters_speed: 'fast',
     }));
+  });
+
+  test('falls back to the stored config when a legacy answer omits correctAnswer', async () => {
+    const configWithCorrectAnswer = {
+      ...configWithComponentMetadata,
+      components: {
+        ...configWithComponentMetadata.components,
+        testComponent: {
+          ...configWithComponentMetadata.components.testComponent,
+          correctAnswer: [{ id: 'response', answer: 'config answer' }],
+        },
+      },
+    } as StudyConfig;
+    const participant = makeParticipant();
+    delete (participant.answers.testComponent_0 as Partial<StoredAnswer>).correctAnswer;
+    const storageEngine = makeStorageEngine({ 'hash-1': configWithCorrectAnswer });
+
+    const tableData = await getTableData(
+      ['correctAnswer'],
+      [participant],
+      storageEngine,
+      'test-study',
+    );
+
+    expect(tableData.rows[0].correctAnswer).toBe('config answer');
+  });
+
+  test('exports a legacy answer without correctAnswer when its config is missing', async () => {
+    const participant = makeParticipant({ participantConfigHash: 'missing-hash' });
+    delete (participant.answers.testComponent_0 as Partial<StoredAnswer>).correctAnswer;
+    const storageEngine = makeStorageEngine({});
+
+    const tableData = await getTableData(
+      ['correctAnswer'],
+      [participant],
+      storageEngine,
+      'test-study',
+    );
+
+    expect(tableData.rows[0].correctAnswer).toBeUndefined();
   });
 
   test('keeps participant-derived rows when configs are missing', async () => {

--- a/src/components/interface/StepsPanel.utils.ts
+++ b/src/components/interface/StepsPanel.utils.ts
@@ -86,7 +86,7 @@ function shouldShowSkipConditionForBlock(condition: SkipConditions[number], sequ
 }
 
 export function getSkipConditionSummariesForBlock(sequence: Sequence) {
-  return sequence.skip
+  return (sequence.skip ?? [])
     .filter((condition) => shouldShowSkipConditionForBlock(condition, sequence))
     .map(formatSkipConditionSummary);
 }
@@ -139,7 +139,7 @@ export function getSkippedTrialOrders(
     }
 
     const answersForSkipEvaluation = getAnswersForSkipEvaluation(participantAnswers, step);
-    const skipConditions = blocksForStep.flatMap((block) => block.currentBlock.skip.map((condition) => ({
+    const skipConditions = blocksForStep.flatMap((block) => (block.currentBlock.skip ?? []).map((condition) => ({
       ...condition,
       firstIndex: block.firstIndex,
       lastIndex: step,

--- a/src/components/interface/tests/StepsPanel.utils.spec.tsx
+++ b/src/components/interface/tests/StepsPanel.utils.spec.tsx
@@ -251,6 +251,19 @@ describe('StepsPanel skip summaries', () => {
     ]);
   });
 
+  test('returns no summaries when a legacy block omits skip conditions', () => {
+    const block: Sequence = {
+      order: 'fixed',
+      orderPath: 'root-0',
+      components: ['trial1'],
+      skip: [],
+      interruptions: [],
+    };
+    delete (block as Partial<Sequence>).skip;
+
+    expect(getSkipConditionSummariesForBlock(block)).toEqual([]);
+  });
+
   test('keeps imported library skip logic readable after references are resolved', () => {
     const block: Sequence = {
       id: '$testLib.sequences.librarySequence',
@@ -354,6 +367,39 @@ describe('StepsPanel skipped trial detection', () => {
       orderPath: 'root',
       components: [
         'trial1',
+        'targetComponent',
+      ],
+      skip: [],
+      interruptions: [],
+    };
+
+    const skippedTrialOrders = getSkippedTrialOrders(
+      sequence,
+      {
+        trial1_0: buildStoredAnswer('trial1', 0, { q1: 'Blue' }),
+        targetComponent_1: buildStoredAnswer('targetComponent', 1, {}),
+      },
+      buildStudyConfig(sequence),
+    );
+
+    expect([...skippedTrialOrders]).toEqual([]);
+  });
+
+  test('does not evaluate skip conditions when a legacy block omits skip', () => {
+    const legacyBlock: Sequence = {
+      order: 'fixed',
+      orderPath: 'root-0',
+      components: ['trial1'],
+      skip: [],
+      interruptions: [],
+    };
+    delete (legacyBlock as Partial<Sequence>).skip;
+
+    const sequence: Sequence = {
+      order: 'fixed',
+      orderPath: 'root',
+      components: [
+        legacyBlock,
         'targetComponent',
       ],
       skip: [],


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #1354 

### Give a longer description of what this PR addresses and why it's needed
Fix analysis crashes for legacy participant data

Issues:
- StepsPanel crashes when a sequence block has no skip
- Analysis TableView crashes when an answer has no correctAnswer