### PR TITLE
Fix homepage when study mode loading fails

### DIFF
--- a/src/components/ConfigSwitcher.tsx
+++ b/src/components/ConfigSwitcher.tsx
@@ -360,6 +360,7 @@ export function ConfigSwitcher({
 
   const [studyVisibility, setStudyVisibility] = useState<Record<string, boolean>>({});
   const [modesByConfig, setModesByConfig] = useState<Record<string, Record<REVISIT_MODE, boolean> | null>>({});
+  const [modeLoadErrors, setModeLoadErrors] = useState<string[]>([]);
   const [isLoadingVisibility, setIsLoadingVisibility] = useState(true);
 
   useEffect(() => {
@@ -374,14 +375,20 @@ export function ConfigSwitcher({
       setIsLoadingVisibility(true);
       const visibility: Record<string, boolean> = {};
       const modesMap: Record<string, Record<REVISIT_MODE, boolean> | null> = {};
+      const failedConfigNames: string[] = [];
       await Promise.all(
         configsList.map(async (configName) => {
           if (storageEngine) {
-            const modes = await storageEngine.getModes(configName);
-            if (isCloudStorageEngine(storageEngine)) {
-              visibility[configName] = modes.dataSharingEnabled;
+            try {
+              const modes = await storageEngine.getModes(configName);
+              if (isCloudStorageEngine(storageEngine)) {
+                visibility[configName] = modes.dataSharingEnabled;
+              }
+              modesMap[configName] = modes;
+            } catch (error) {
+              failedConfigNames.push(configName);
+              console.error(`Error loading modes for study ${configName}:`, error);
             }
-            modesMap[configName] = modes;
           } else {
             modesMap[configName] = null;
           }
@@ -390,6 +397,7 @@ export function ConfigSwitcher({
       if (!isCancelled) {
         setStudyVisibility(visibility);
         setModesByConfig(modesMap);
+        setModeLoadErrors(failedConfigNames);
         setIsLoadingVisibility(false);
       }
     }
@@ -504,6 +512,14 @@ export function ConfigSwitcher({
 
         {!isLoadingStudies && (
           <>
+            {modeLoadErrors.length > 0 && (
+              <Text c="red" role="alert" mb="md">
+                Unable to load study visibility for:
+                {' '}
+                {modeLoadErrors.join(', ')}
+                . Check the storage connection and try again.
+              </Text>
+            )}
             <Tabs variant="outline" defaultValue={firstTab} value={tab} onChange={(value) => navigate(`/?tab=${value}`)}>
               <Tabs.List>
                 {others.length > 0 && (
@@ -578,7 +594,7 @@ export function ConfigSwitcher({
               )}
             </Tabs>
 
-            {configsFiltered.length === 0 && (
+            {configsFiltered.length === 0 && modeLoadErrors.length === 0 && (
               <Text c="dimmed" ta="center" mt="xl">
                 No studies found. Studies can be added in your
                 {' '}

--- a/src/components/tests/ConfigSwitcher.spec.tsx
+++ b/src/components/tests/ConfigSwitcher.spec.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import {
-  render, act, cleanup,
+  render, act, cleanup, waitFor,
 } from '@testing-library/react';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
@@ -11,6 +11,7 @@ import type {
 import { ConfigSwitcher, FACTOR_DEMO_CONFIG_NAMES } from '../ConfigSwitcher';
 import { makeGlobalConfig, makeStorageEngine, makeStudyConfig } from '../../tests/utils';
 import { useStorageEngine } from '../../storage/storageEngineHooks';
+import { useAuth } from '../../store/hooks/useAuth';
 import { getSequenceConditions } from '../../utils/handleConditionLogic';
 
 // ── mocks ─────────────────────────────────────────────────────────────────────
@@ -96,7 +97,7 @@ vi.mock('../../storage/storageEngineHooks', () => ({
 }));
 
 vi.mock('../../store/hooks/useAuth', () => ({
-  useAuth: () => ({ user: { isAdmin: true, determiningStatus: false } }),
+  useAuth: vi.fn(() => ({ user: { isAdmin: true, determiningStatus: false } })),
 }));
 
 vi.mock('../../storage/engines/utils', () => ({
@@ -143,10 +144,25 @@ const studyConfigs: Record<string, ParsedConfig<StudyConfig> | null> = {
   'test-study': parsedStudyConfig,
 };
 
+const makeAuthValue = (isAdmin: boolean): ReturnType<typeof useAuth> => ({
+  user: {
+    user: null,
+    determiningStatus: false,
+    isAdmin,
+    adminVerification: false,
+  },
+  logout: async () => {},
+  triggerAuth: () => {},
+  verifyAdminStatus: async () => false,
+});
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => { vi.clearAllMocks(); });
-afterEach(() => { cleanup(); });
+afterEach(() => {
+  cleanup();
+  vi.mocked(useAuth).mockImplementation(() => makeAuthValue(true));
+});
 
 describe('ConfigSwitcher', () => {
   test('renders without crashing', async () => {
@@ -283,5 +299,67 @@ describe('ConfigSwitcher', () => {
       <ConfigSwitcher globalConfig={globalConfig} studyConfigs={studyConfigs} />,
     ));
     expect(container).toBeDefined();
+  });
+
+  test('settles visibility loading and reports a failed mode lookup', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockEngine = {
+      getModes: vi.fn((studyId: string) => (
+        studyId === 'failed-study'
+          ? Promise.reject(new Error('Firestore unavailable'))
+          : Promise.resolve({ dataCollectionEnabled: true, developmentModeEnabled: true, dataSharingEnabled: true })
+      )),
+      getParticipantsStatusCounts: vi.fn().mockResolvedValue({
+        completed: 0, inProgress: 0, rejected: 0, minTime: null, maxTime: null,
+      }),
+      isCloudEngine: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+    };
+    const multiGlobalConfig = makeGlobalConfig({ configsList: ['healthy-study', 'failed-study'] });
+    const configs = {
+      'healthy-study': parsedStudyConfig,
+      'failed-study': {
+        ...parsedStudyConfig,
+        studyMetadata: { ...parsedStudyConfig.studyMetadata, title: 'Failed Study' },
+      },
+    };
+    vi.mocked(useAuth).mockReturnValue(makeAuthValue(false));
+    vi.mocked(useStorageEngine).mockReturnValue({ storageEngine: makeStorageEngine(mockEngine), setStorageEngine: vi.fn() });
+
+    const { container } = await act(async () => render(
+      <ConfigSwitcher globalConfig={multiGlobalConfig} studyConfigs={configs} />,
+    ));
+
+    await waitFor(() => expect(container.textContent).toContain('Unable to load study visibility for: failed-study.'));
+    expect(container.textContent).toContain('Test Study');
+    expect(container.textContent).toContain('Ready to Collect Data');
+    expect(container.textContent).not.toContain('Failed Study');
+    expect(mockEngine.getModes).toHaveBeenCalledTimes(2);
+    consoleSpy.mockRestore();
+  });
+
+  test('reports all failed mode lookups after loading settles', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockEngine = {
+      getModes: vi.fn().mockRejectedValue(new Error('Firestore unavailable')),
+      isCloudEngine: vi.fn().mockReturnValue(true),
+      getEngine: vi.fn().mockReturnValue('firebase'),
+    };
+    const multiGlobalConfig = makeGlobalConfig({ configsList: ['failed-study-a', 'failed-study-b'] });
+    const configs = { 'failed-study-a': null, 'failed-study-b': null };
+    vi.mocked(useAuth).mockReturnValue(makeAuthValue(false));
+    vi.mocked(useStorageEngine).mockReturnValue({ storageEngine: makeStorageEngine(mockEngine), setStorageEngine: vi.fn() });
+
+    const { container } = await act(async () => render(
+      <ConfigSwitcher globalConfig={multiGlobalConfig} studyConfigs={configs} />,
+    ));
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('failed-study-a');
+      expect(container.textContent).toContain('failed-study-b');
+    });
+    expect(container.textContent).not.toContain('No studies found.');
+    expect(mockEngine.getModes).toHaveBeenCalledTimes(2);
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Why

Fixes #1103. A single rejected Firebase `getModes()` request could leave the homepage catalog loading indefinitely or appearing empty. The original fresh-origin auth-ordering variant was addressed separately in #1108; this change handles the remaining per-study failure path.

## Architecture

`ConfigSwitcher` still loads study modes concurrently, but each study now handles its own rejection and records the failed config name while allowing the aggregate load to settle. Successful mode data continues to populate visibility and card state. Failed cloud visibility is not treated as public, so non-admin users do not see an unverifiable study. The empty-catalog message is suppressed when mode-loading errors are reported.

## User-facing impact

The homepage finishes loading even when one or more mode reads fail. Healthy studies remain usable, and users see which studies could not load plus a storage-connection hint instead of a silent blank catalog. Existing successful local, Supabase, Firebase, and admin paths are unchanged.

## Validation

- `corepack yarn unittest --run src/components/tests/ConfigSwitcher.spec.tsx` — 12 passed
- `corepack yarn unittest --run` — 162 files passed; 2,519 passed, 1 skipped
- `corepack yarn typecheck` — passed
- `corepack yarn lint` — 0 errors; 2 unrelated pre-existing warnings
- `git diff --check` — passed
- Independent adversarial review completed with no remaining findings

## Risk and rollout

No data migration or configuration change. This is a narrow UI error-handling change. Firebase auth, App Check, and security-rule configuration still need to be correct for successful mode reads. If needed, roll back commit `e7bb8b58`.