### PR TITLE
Align adversarial review with implementation principles

### DIFF
--- a/.agents/skills/adversarial-review/SKILL.md
+++ b/.agents/skills/adversarial-review/SKILL.md
@@ -5,7 +5,7 @@ description: Launch an independent, exhaustive adversarial review subagent on gp
 
 # Adversarial Review
 
-Launch exactly one independent, read-only reviewer. Give it the concrete artifacts and constraints needed to review from evidence, then validate and synthesize its findings.
+Launch exactly one independent, read-only reviewer. Give it the concrete artifacts and constraints needed to review from evidence, then validate and synthesize its findings. Review the work against the same implementation principles that govern a good change: correctness first, then simplicity, minimal scope, appropriate reuse, and meaningful tests.
 
 ## Prepare the handoff
 
@@ -13,6 +13,7 @@ Identify the review target from the request and current task. Gather enough conc
 
 - Objective and acceptance criteria
 - Repository and relevant paths, or artifact locations
+- Applicable repository instructions, current working-tree state, and relevant callers, state, storage, and consumers
 - Exact comparison scope such as base, head, merge base, diff, plan, or document
 - Important constraints and domain invariants
 - Validation already performed and any known failures
@@ -26,6 +27,18 @@ Include the raw Codex feedback and its verification status in the reviewer hando
 
 Frame YAGNI against the stated objective and current acceptance criteria, not hypothetical future needs. Preserve complexity required for correctness, security, compatibility, or explicitly required extensibility.
 
+## Review principles
+
+Apply these principles in order, with correctness and required contracts taking precedence over brevity:
+
+- **Correctness:** Check the actual behavior across relevant callers, state transitions, failure paths, and consumers. Verify that the change preserves domain invariants and required security, compatibility, and operational behavior, and that it addresses the cause at the appropriate ownership boundary rather than only masking symptoms.
+- **YAGNI:** Judge every abstraction, dependency, configuration option, compatibility path, test, and documentation change against the current objective and acceptance criteria. Flag speculative future-proofing, scope expansion, and unnecessary churn, but do not call correctness, security, compatibility, or explicitly required extensibility overengineering.
+- **KISS:** Prefer direct control flow, existing conventions, and the fewest concepts needed to explain the behavior. Identify speculative frameworks, layers, indirection, fallback chains, and defensive branches for impossible states; propose the smallest safe simplification.
+- **DRY:** Check whether business rules and invariants use their canonical implementation. Recommend reuse or extraction only when it reduces real duplication within the same responsibility; similar-looking code alone is not enough.
+- **TDA:** Check that behavior remains with the component that owns the relevant state and invariants. Prefer intent-revealing operations over callers reading internal state, deciding, and writing it back, without forcing an unnecessary object-oriented redesign.
+- **Conciseness:** Review the complete diff for the fewest changed files and lines that clearly satisfy the request. Flag unrelated formatting, renaming, cleanup, clever compression, and comments that do not explain a non-obvious constraint.
+- **Test adequacy:** Check coverage of changed observable behavior and meaningful invariants at the lowest faithful test level, including relevant negative and boundary cases. Flag tests tied to incidental implementation details, redundant combinations, broad snapshots, framework behavior, or coverage-driven infrastructure.
+
 ## Launch the reviewer
 
 Call `collaboration.spawn_agent` directly with:
@@ -38,7 +51,7 @@ Call `collaboration.spawn_agent` directly with:
 
 Use this review contract:
 
-> Act as an independent adversarial reviewer performing an exhaustive code review. Inspect the supplied artifacts and relevant surrounding code or context yourself. Challenge correctness first, then apply YAGNI: every abstraction, dependency, configuration surface, compatibility path, test, and documentation change must serve the stated objective or current acceptance criteria. Flag speculative future-proofing, scope expansion, unnecessary complexity, and churn; propose the smallest safe simplification. Do not label work required for correctness, security, compatibility, or explicit extensibility as overengineering. Cover the complete changed surface and relevant consumers, including success and failure paths, state transitions, concurrency, persistence, authorization, compatibility, boundary values, error handling, tests, and operational or documentation contracts as applicable. After the initial pass, keep looking for additional findings using fresh targeted passes over different risk dimensions and re-checking the surrounding code; do not stop after the first batch. Continue until a complete follow-up pass finds no new evidence-backed issue. Verify suspected issues before reporting them and deduplicate findings. Do not edit files, push changes, post comments, or mutate external state. Return only evidence-backed findings ordered by severity, with precise file and line references when available and a suggested resolution for each; include the review passes or risk dimensions covered and any residual risks or verification gaps.
+> Act as an independent adversarial reviewer performing an exhaustive code review. Inspect the supplied artifacts and relevant surrounding code or context yourself. Challenge correctness first, then apply YAGNI, KISS, DRY, TDA, and conciseness: every abstraction, dependency, configuration surface, compatibility path, test, and documentation change must serve the stated objective or current acceptance criteria; shared rules should use canonical ownership; and the solution should use the fewest clear concepts and changed lines that safely meet the request. Flag speculative future-proofing, scope expansion, unnecessary complexity, and churn; propose the smallest safe simplification. Do not label work required for correctness, security, compatibility, or explicit extensibility as overengineering. Cover the complete changed surface and relevant consumers, including success and failure paths, state transitions, concurrency, persistence, authorization, compatibility, boundary values, error handling, test fidelity and adequacy, and operational or documentation contracts as applicable. After the initial pass, keep looking for additional findings using fresh targeted passes over different risk dimensions and re-checking the surrounding code; do not stop after the first batch. Continue until a complete follow-up pass finds no new evidence-backed issue. Verify suspected issues before reporting them and deduplicate findings. Do not edit files, push changes, post comments, or mutate external state. Return only evidence-backed findings ordered by severity, with precise file and line references when available and a suggested resolution for each; include the review passes or risk dimensions covered and any residual risks or verification gaps.
 
 If subagents are unavailable, say that plainly and perform a local adversarial pass without implying that an independent reviewer ran.
 
@@ -46,7 +59,7 @@ If subagents are unavailable, say that plainly and perform a local adversarial p
 
 Continue useful local work while the reviewer runs when the tasks do not conflict. Wait for the reviewer before presenting a final correctness judgment.
 
-Independently confirm each reported issue against the current artifacts. Reject false positives and stale-scope findings. Do not implement fixes, post review feedback, or change external state unless the user's request separately authorizes those actions.
+Independently confirm each reported issue against the current artifacts and trace it to the owning code path. Reject false positives and stale-scope findings. Do not implement fixes, post review feedback, or change external state unless the user's request separately authorizes those actions.
 
 For a pull request, combine the independently reviewed findings with the verified Codex feedback from the PR. Deduplicate by underlying defect, resolve conflicts by current-head evidence, and report the disposition of every Codex item (confirmed, fixed or stale, duplicate, unsupported, or unverified). Keep formal GitHub thread state separate from the current correctness judgment.
 


### PR DESCRIPTION
## Why

Keep the adversarial-review workflow aligned with the personal implementation guidance so callers do not need to restate those principles for each review.

## Architecture

The repository-local skill now matches the updated personal skill. It adds explicit review guidance for correctness, YAGNI, KISS, DRY, TDA, conciseness, code ownership, relevant consumers, and meaningful test adequacy. The existing independent, read-only, no-mutation review contract remains unchanged.

## User-facing impact

No product user-facing changes. Future adversarial reviews will receive the implementation principles by default.

## Validation

- quick_validate.py on the repository-local skill — passed for both copies.
- git diff --check — passed for both branches.
- Compared both repository copies with the personal skill — identical.

## Risk and rollout

No special rollout is needed. This changes reviewer instructions only; the main risk is unintended review scope, which is bounded by the existing acceptance-criteria and read-only constraints.